### PR TITLE
Navigation Handle 의 width 를 16px 로 늘리고 가운데 정렬

### DIFF
--- a/src/layout/Navigation/Navigation.styled.ts
+++ b/src/layout/Navigation/Navigation.styled.ts
@@ -30,9 +30,9 @@ export const StyledHandle = styled.div<StyledHandleProps>`
   position: absolute;
   top: 0;
   bottom: 0;
-  right: 0;
+  right: -8px;
   z-index: 10000;
-  width: 8px;
+  width: 16px;
   height: 100%;
   margin: 0 auto;
   cursor: ${props => (props.disable ? 'auto' : 'col-resize')};
@@ -42,7 +42,7 @@ export const StyledHandle = styled.div<StyledHandleProps>`
     position: absolute;
     top: 0;
     bottom: 0;
-    left: 6px;
+    left: 7px;
     width: 2px;
     height: 100%;
     opacity: 0;


### PR DESCRIPTION
# Description
Handle의 너비를 16px로 늘려서, Navigation 바깥에서도 작동시킬 수 있도록 변경했습니다.

## Changes Detail
* NavigationHandle 의 width 를 16px 로 변경
* Hover 시 나오는 line 을 가운데로 정확하게 맞춤

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
