### PR TITLE
GlobalHeader 의 webkit-app-region css 속성 삭제

### DIFF
--- a/src/layout/GlobalHeader/GlobalHeader.styled.ts
+++ b/src/layout/GlobalHeader/GlobalHeader.styled.ts
@@ -13,6 +13,4 @@ export const StyledGlobalHeader = styled.div<GlobalHeaderProps>`
   background-color: ${props => props.theme?.colors?.background1};
   box-shadow: inset 0 -1px 0 0 ${props => props.theme?.colors?.background3};
   transition: background-color 200ms ease-in-out;
-  -webkit-app-region: drag;
-  -webkit-user-select: none; /* stylelint-disable-line property-no-vendor-prefix */
 `


### PR DESCRIPTION
# Description
webkit-app-region 삭제

## Changes Detail
* Desk 에서 webkit-app-region 을 직접 지정하고 있습니다. GlobalHeader 에서 직접 지정해줄 경우, 자식 DOM 이 아닌 DOM 이 GlobalHeader 의 영역에 있을 경우 Click 이 무시되는 이슈가 있습니다. 때문에 이를 제거해야 합니다.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [X] Chrome - Blink
- [X] Edge - Blink
- [X] Firefox - Gecko (Option)
### macOS
- [X] Chrome - Blink
- [X] Edge - Blink
- [X] Safari - WebKit
- [X] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
