### PR TITLE
Circle Ci 에서 npm install 대신 npm ci 쓰도록 변경

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - restore_cache:
           keys:
           - design-system-dependencies-{{ checksum "package.json" }}
-      - run: npm install
+      - run: npm ci
       - save_cache:
           paths:
             - node_modules


### PR DESCRIPTION
# Description
CI 설정에서 npm install 을 npm ci 로 대체

## Changes Detail
* npm ci 는 package-lock.json 을 존중하여 package.json 과 lock.json 사이에 incompatible 한 부분이 있을 경우 에러를 발생시킴. 또한 package.json 을 따른 node_modules 결과에 맞춰서 package-lock.json 을 override 하지도 않음. circle ci 에서 커밋을 하는 경우는 없긴 하지만, 더 깔끔한 CI 환경을 위해 명령어를 변경함.
* See more info: https://docs.npmjs.com/cli/ci.html#description