### PR TITLE
v0.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@channel.io/design-system",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@channel.io/design-system",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Design System by Channel",
   "repository": {
     "type": "git",

--- a/src/worklets/EnableCSSHoudini.ts
+++ b/src/worklets/EnableCSSHoudini.ts
@@ -8,6 +8,9 @@ interface EnableCSSHoudiniOptions {
 export default function EnalbeCSSHoudini({
   smoothCorners = false,
 }: EnableCSSHoudiniOptions) {
+  // NOTE: CSS namespace 에 접근 가능할 경우에만 사용
+  if (typeof CSS === 'undefined') { return }
+
   if ('paintWorklet' in CSS) {
     if (smoothCorners) {
       const workletURL = URL.createObjectURL(new Blob([SmoothCornersScript], { type: 'application/javascript' }))


### PR DESCRIPTION
# Bugfix
* CSS Houdini 는 CSS namespace 에 접근 가능할 때만 작동하도록 수정