### PR TITLE
GNB - zIndex 수정

### DIFF
--- a/src/layout/GNB/GNB.styled.ts
+++ b/src/layout/GNB/GNB.styled.ts
@@ -3,7 +3,7 @@ import { styled } from '../../styling/Theme'
 import GNBProps from './GNB.types'
 
 const GNB = styled.div<GNBProps>`
-  z-index: 10000;
+  z-index: 10001;
   display: flex;
   flex: none;
   align-items: center;


### PR DESCRIPTION
# Description
변경사항 개요를 작성해주세요. Github 이슈, Notion 등 연관 문서가 있다면 첨부해주세요.
[https://github.com/channel-io/ch-desk-web/issues/5855](https://github.com/channel-io/ch-desk-web/issues/5855)

## Changes Detail
GNB가 Navigation과 동일한 z-index를 가져서 GNB에 포함된 모달들이 Navigation 아래로 잡힘
ㄴ Navigation의 z-index보다 1높게 설정

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
