### PR TITLE
overlay의 화면 넘어갔을때 자동위치조정 옵셔널 가능하도록 변경

### DIFF
--- a/src/components/Overlay/Overlay.stories.tsx
+++ b/src/components/Overlay/Overlay.stories.tsx
@@ -132,5 +132,5 @@ Primary.args = {
   placement: OverlayPosition.BottomCenter,
   marginX: 0,
   marginY: 0,
-  enableAutoPosition: false,
+  keepInContainer: false,
 }

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -59,7 +59,7 @@ function getOverlayTranslation({
   placement,
   marginX,
   marginY,
-  enableAutoPosition,
+  keepInContainer,
 }: GetOverlayTranslatationProps): React.CSSProperties {
   if (target) {
     const {
@@ -121,7 +121,7 @@ function getOverlayTranslation({
         break
     }
 
-    if (enableAutoPosition) {
+    if (keepInContainer) {
       const isOverTop = targetTop + translateY < rootTop
       const isOverBottom = targetTop + translateY + overlayHeight > rootTop + rootHeight
       const isOverLeft = targetLeft + translateX < rootLeft
@@ -147,11 +147,11 @@ function getOverlayStyle({
   placement,
   marginX,
   marginY,
-  enableAutoPosition,
+  keepInContainer,
 }: GetOverlayStyleProps): React.CSSProperties {
   if (target) {
     const overlayPositionStyle = getOverlayPosition({ target })
-    const overlayTranslateStyle = getOverlayTranslation({ target, overlay, placement, marginX, marginY, enableAutoPosition })
+    const overlayTranslateStyle = getOverlayTranslation({ target, overlay, placement, marginX, marginY, keepInContainer })
 
     const combinedStyle = {
       ...overlayPositionStyle,
@@ -179,7 +179,7 @@ function Overlay(
     placement = OverlayPosition.LeftCenter,
     marginX = 0,
     marginY = 0,
-    enableAutoPosition = false,
+    keepInContainer = false,
     children,
     onHide = noop,
     ...otherProps
@@ -278,7 +278,7 @@ function Overlay(
         placement,
         marginX,
         marginY,
-        enableAutoPosition,
+        keepInContainer,
       })
       setOverlayStyle(tempOverlayStyle)
       setIsHidden(false)
@@ -289,7 +289,7 @@ function Overlay(
       }
     }
     return noop
-  }, [show, marginX, marginY, placement, target, enableAutoPosition])
+  }, [show, marginX, marginY, placement, target, keepInContainer])
 
   if (!show) return null
 

--- a/src/components/Overlay/Overlay.types.ts
+++ b/src/components/Overlay/Overlay.types.ts
@@ -12,7 +12,7 @@ export default interface OverlayProps extends UIComponentProps, ChildrenComponen
   placement?: OverlayPosition
   marginX?: number
   marginY?: number
-  enableAutoPosition?: boolean
+  keepInContainer?: boolean
   onHide?: () => void
 }
 
@@ -22,7 +22,7 @@ export interface GetOverlayStyleProps {
   placement: OverlayPosition
   marginX: number
   marginY: number
-  enableAutoPosition: boolean
+  keepInContainer: boolean
 }
 
 export interface GetOverlayPositionProps {
@@ -35,7 +35,7 @@ export interface GetOverlayTranslatationProps {
   placement: OverlayPosition
   marginX: number
   marginY: number
-  enableAutoPosition: boolean
+  keepInContainer: boolean
 }
 
 export interface StyledOverlayProps {


### PR DESCRIPTION
# Description
overlay가 화면을 넘어갔을때 위치를 변경해주는 기능을 옵셔널하게 사용할 수 있도록 변경

## Changes Detail
* 변경1 세부사항
* 변경2 세부사항

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [x] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
