### PR TITLE
overlay에 마우스 클릭시 기본이벤트 막음

### DIFF
--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -214,6 +214,10 @@ function Overlay(
     }
   }, [onHide])
 
+  const handleMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault()
+  }, [])
+
   const overlay = useMemo(() => (
     <Container
       ref={containerRef}
@@ -223,6 +227,7 @@ function Overlay(
     >
       <Wrapper data-testid={wrapperTestId}>
         <StyledOverlay
+          data-testid={testId}
           as={as}
           className={className}
           isHidden={isHidden}
@@ -231,7 +236,7 @@ function Overlay(
             ...(overlayStyle || {}),
           }}
           ref={mergedRef}
-          data-testid={testId}
+          onMouseDown={handleMouseDown}
           {...otherProps}
         >
           { children }
@@ -251,6 +256,7 @@ function Overlay(
     wrapperTestId,
     testId,
     mergedRef,
+    handleMouseDown,
     otherProps,
   ])
 


### PR DESCRIPTION
# Description
Overlay에 마우스 클릭시 기본이벤트 없앰
데스크 이모지 셀렉터같은 경우 이모지 선택시 마우스이벤트가 뒷쪽까지 클릭이 되어 메세지에디터의 focus가 풀리는 문제 개선

https://github.com/channel-io/ch-desk-web/pull/6212

## Changes Detail
* Overlay클릭시 preventDefault로 기본이벤트 막음

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
