### PR TITLE
사이드 뷰 너비 초기화 버그 수정 및 navi 색상 변경

### DIFF
--- a/src/layout/Client/utils/LayoutReducer.ts
+++ b/src/layout/Client/utils/LayoutReducer.ts
@@ -116,7 +116,7 @@ function LayoutReducer(state: LayoutState = defaultState, action: LayoutAction):
     case ActionType.SET_SIDE_WIDTH: {
       return {
         ...state,
-        sideWidth: action.payload,
+        sideWidth: state.showSideView ? state.sideWidth : action.payload,
       }
     }
 

--- a/src/layout/Navigations/NavigationArea/NavigationArea.styled.ts
+++ b/src/layout/Navigations/NavigationArea/NavigationArea.styled.ts
@@ -51,7 +51,6 @@ export const NavigationContainer = styled.div<NavigationContainerProps>`
   width: ${({ showNavigation }) => (showNavigation === false ? '0px' : 'inherit')};
   height: 100%;
   user-select: none;
-  background-color: ${({ foundation }) => foundation?.theme?.['bg-navi']};
   ${({ foundation }) =>
     foundation?.transition?.getTransitionsCSS(
       'width',
@@ -82,7 +81,7 @@ export const NavigationPresenter = styled.div<NavigationPresenterProps>`
   height: 100%;
   pointer-events: auto;
   /* TODO: Hovering Color Prop 추가 */
-  background-color: ${({ showNavigation }) => (showNavigation === false && 'white')};
+  background-color: ${({ foundation }) => foundation?.theme?.['bg-navi']};
   border-radius: 0 ${({ showNavigation }) => !showNavigation && '10px 10px'} 0;
   opacity:
     ${({ showNavigation, isHover }) => (


### PR DESCRIPTION
# Description
사이드 너비 초기화 버그 수정, 네비게이션 색상 문제 수정

## Changes Detail
* 사이드 뷰가 열려있을 경우 사이드 너비를 초기화 하지 않음
* 네비게시연 색상이 white 로 고정인 문제 수정

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
