### PR TITLE
Icon color transition이 제대로 적용이 되지 않은 점 수정

### DIFF
--- a/src/components/Icon/Icon.styled.ts
+++ b/src/components/Icon/Icon.styled.ts
@@ -14,7 +14,7 @@ function getMargin({
 const Icon = styled.svg<IconStyledProps>`
   margin: ${getMargin};
   color: ${({ color }) => color || 'inherit'};
-  transition: ${({ foundation }) => foundation?.transition?.getTransitionsCSS('color')};
+  ${({ foundation }) => foundation?.transition?.getTransitionsCSS('color')};
 `
 
 export default Icon


### PR DESCRIPTION
# Description
<img width="394" alt="스크린샷 2021-03-03 오후 3 46 54" src="https://user-images.githubusercontent.com/33291896/109765292-fd523200-7c37-11eb-9a2d-0278abe39e15.png">

getTransitionsCSS는 앞에 `transition: ` property name을 붙이지 않고 사용하는데, 이 부분이 잘못 기입되어있어 `transition: transition-property: color;`로 지정되고 있었음.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [x] Firefox - Gecko (Option)
