### PR TITLE
NavigationContent 하위 마진 제거

### DIFF
--- a/src/layout/Navigations/NavigationContent/NavigationContent.styled.ts
+++ b/src/layout/Navigations/NavigationContent/NavigationContent.styled.ts
@@ -35,10 +35,6 @@ export const StyledContentWrapper = styled.div<StyledContentWrapperProps>`
   height: 100%;
   overflow-x: hidden;
   overflow-y: ${({ withScroll }) => (withScroll ? 'auto' : 'hidden')};
-
-  & > *:last-child {
-    margin-bottom: 40px !important;
-  }
 `
 
 export const StyledFooterWrapper = styled.div`


### PR DESCRIPTION
# Description
Navigation 컨텐츠의 마지막 element 에 대해 margin bottom 을 강제로 주던 것 취소

## Changes Detail
* margin-bottom 값 제거, 사용처에서 필요한 경우 직접 스타일을 걸도록 변경

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
