### PR TITLE
dom element의 dataset을 lowercase로 변경(data-testId => data-testid)

### DIFF
--- a/src/layout/Main/Main.tsx
+++ b/src/layout/Main/Main.tsx
@@ -30,7 +30,7 @@ function Main(
 
   return (
     <MainWrapper
-      data-testId={testId}
+      data-testid={testId}
       ref={forwardedRef}
       hasHeader={hasHeader}
       hasSide={hasSide}

--- a/src/layout/Side/SideArea/SideArea.tsx
+++ b/src/layout/Side/SideArea/SideArea.tsx
@@ -83,7 +83,7 @@ function SideArea(
 
   return (
     <SideAreaWrapper
-      data-testId={testId}
+      data-testid={testId}
       ref={forwardedRef}
       sideType={sideType}
       showSideView={showSideView}

--- a/src/layout/Side/SidePanelContent/SidePanelContent.tsx
+++ b/src/layout/Side/SidePanelContent/SidePanelContent.tsx
@@ -34,7 +34,7 @@ function SidePanelContent({
   return (
     <SideArea
       sideType={LayoutSideType.SidePanel}
-      data-testId={testId}
+      data-testid={testId}
       onChangeSideWidth={onChangeSideWidth}
     >
       { children }

--- a/src/layout/Side/SideViewContent/SideViewContent.tsx
+++ b/src/layout/Side/SideViewContent/SideViewContent.tsx
@@ -33,7 +33,7 @@ function SideViewContent({
 
   return (
     <SideArea
-      data-testId={testId}
+      data-testid={testId}
       sideType={LayoutSideType.SideView}
       onChangeSideWidth={onChangeSideWidth}
     >


### PR DESCRIPTION
# Description
dom element의 data타입은 lowercase를 써주기때문에 이에 맞게 변경.(desk에서 뜨는 에러를 해결)
<img width="464" alt="스크린샷 2021-03-22 오전 2 23 24" src="https://user-images.githubusercontent.com/55433950/111914515-a6f94600-8ab5-11eb-81eb-3f9770591e7f.png">


## Changes Detail
* 변경1 세부사항
* 변경2 세부사항

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
