### PR TITLE
Icon component의 css 깨지는 문제 수정 (channel-io/ch-desk-web#6840)

### DIFF
--- a/src/components/Icon/Icon.styled.ts
+++ b/src/components/Icon/Icon.styled.ts
@@ -14,7 +14,7 @@ function getMargin({
 const Icon = styled.svg<IconStyledProps>`
   margin: ${getMargin};
   color: ${({ foundation, color }) => (color && foundation?.theme?.[color]) || 'inherit'};
-  transition: ${({ foundation }) => foundation?.transition?.getTransitionsCSS('color')};
+  ${({ foundation }) => foundation?.transition?.getTransitionsCSS('color')}
 `
 
 export default Icon


### PR DESCRIPTION
# Description

<img width="324" alt="스크린샷 2021-03-22 오후 2 34 57" src="https://user-images.githubusercontent.com/25701854/111944800-c7f48200-8b1b-11eb-8bec-a9842dd864f2.png">

`Icon` component의 css가 깨지는 현상을 수정합니다.

* 관련 버그: https://github.com/channel-io/ch-desk-web/issues/6840#issuecomment-803766697

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
