### PR TITLE
overlay열려있을때 target를 누르면 다시 닫히지 않는 문제 수정, children 변하면 위치 재계산

### DIFF
--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -295,9 +295,11 @@ function Overlay(
       scrollTop: container ? container.scrollTop : 0,
       scrollLeft: container ? container.scrollLeft : 0,
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     show,
     container,
+    children,
   ])
 
   const targetRect = useMemo(() => {
@@ -316,9 +318,11 @@ function Overlay(
       clientTop,
       clientLeft,
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     show,
     target,
+    children,
   ])
 
   useEventHandler(document, 'click', handleHideOverlay, show, true)


### PR DESCRIPTION
# Description
<img width="394" alt="스크린샷 2021-03-31 오후 6 23 18" src="https://user-images.githubusercontent.com/55433950/113122553-b6fbed00-924e-11eb-800c-bcc602c22648.png">

위 이미지에서 **담당자배정** 클릭시 오버레이 열림 => 오버레이 밖을 클릭시 잘 사라지지만 열린상태에서 담당자 배정을 다시 누르면 닫혔다 바로 다시 열려서 안닫히는것처럼 보임

원인은 오버레이 밖을 클릭시 document에 click이벤트가 capturing으로 발생하며 오버레이가 닫히는 로직이 있고
target(담당자배정)을 클릭하면 오버레이가 열리는 로직이 있는데 target에 연결된 inline이벤트보다 document에 연결된 click이벤트가 우선순위가 높아 닫혔더 다시 열리는 문제가 생겼음
#280 의 사이드이펙트

## Changes Detail
* 변경1 세부사항
* 변경2 세부사항

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
