### PR TITLE
Light/Dark에서 반대로 된 bdr-white 색깔 수정

### DIFF
--- a/src/foundation/Theme/presets/DarkTheme.ts
+++ b/src/foundation/Theme/presets/DarkTheme.ts
@@ -107,7 +107,7 @@ const DarkTheme: ThemeType = {
   // Border
   'bdr-black-light': Palette.white_12,
   'bdr-grey-light': Palette.grey700,
-  'bdr-white': Palette.white,
+  'bdr-white': Palette.grey900,
 
   // Shadow
   'shdw-xlarge': Palette.black_60,

--- a/src/foundation/Theme/presets/LightTheme.ts
+++ b/src/foundation/Theme/presets/LightTheme.ts
@@ -106,7 +106,7 @@ const LightTheme: ThemeType = {
   // Border
   'bdr-black-light': Palette.black_8,
   'bdr-grey-light': Palette.grey200,
-  'bdr-white': Palette.grey900,
+  'bdr-white': Palette.white,
 
   // Shadow
   'shdw-xlarge': Palette.black_20,


### PR DESCRIPTION
# Description

<img width="504" alt="스크린샷 2021-04-01 오후 2 10 42" src="https://user-images.githubusercontent.com/25701854/113246713-8b334280-92f4-11eb-9be3-cc017a2bb0fe.png">


# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
