### PR TITLE
Overlay에 transition props 추가

### DIFF
--- a/src/components/Overlay/Overlay.styled.ts
+++ b/src/components/Overlay/Overlay.styled.ts
@@ -20,7 +20,15 @@ export const Wrapper = styled.div`
 
 export const StyledOverlay = styled.div<StyledOverlayProps>`
   position: absolute;
-  ${props => props.isHidden && css`
+
+  ${({ isHidden }) => isHidden && css`
     visibility: hidden;
   `}
+
+  ${({ transition, foundation }) => transition && (
+    foundation?.transition?.getTransitionsCSS(
+      ['top, left'],
+      foundation?.transition?.TransitionDuration.M,
+    )
+  )}
 `

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -140,7 +140,6 @@ function getOverlayStyle({
   marginX,
   marginY,
   keepInContainer,
-  transition,
 }: GetOverlayStyleProps): React.CSSProperties {
   if (containerRect && targetRect) {
     const overlayPositionStyle = getOverlayPosition({ containerRect, targetRect })
@@ -158,10 +157,6 @@ function getOverlayStyle({
       ...overlayPositionStyle,
       ...overlayTranslateStyle,
       willChange: 'left, top',
-    }
-
-    if (transition) {
-      combinedStyle.transition = 'top 0.3s, left 0.3s'
     }
 
     return combinedStyle
@@ -223,6 +218,7 @@ function Overlay(
           as={as}
           className={className}
           isHidden={isHidden}
+          transition={transition}
           style={{
             ...(style || {}),
             ...(overlayStyle || {}),
@@ -247,6 +243,7 @@ function Overlay(
             as={as}
             className={className}
             isHidden={isHidden}
+            transition={transition}
             style={{
               ...(style || {}),
               ...(overlayStyle || {}),
@@ -268,6 +265,7 @@ function Overlay(
     containerStyle,
     container,
     isHidden,
+    transition,
     overlayStyle,
     children,
     containerTestId,
@@ -345,7 +343,6 @@ function Overlay(
         marginX,
         marginY,
         keepInContainer,
-        transition,
       })
       setOverlayStyle(tempOverlayStyle)
       setIsHidden(false)
@@ -364,7 +361,6 @@ function Overlay(
     marginY,
     placement,
     keepInContainer,
-    transition,
   ])
 
   if (!show) return null

--- a/src/components/Overlay/Overlay.types.ts
+++ b/src/components/Overlay/Overlay.types.ts
@@ -44,7 +44,6 @@ export interface GetOverlayStyleProps {
   marginX: number
   marginY: number
   keepInContainer: boolean
-  transition: boolean
 }
 
 export interface GetOverlayPositionProps {
@@ -64,6 +63,7 @@ export interface GetOverlayTranslatationProps {
 
 export interface StyledOverlayProps {
   isHidden: boolean
+  transition: boolean
 }
 
 export enum OverlayPosition {


### PR DESCRIPTION
# Description
Overlay에 transition props추가하여 Overlay가 target의 style가 변경될때 동적으로 따라갈수 있도록 변경

- 데스크에서는 통계쪽에서 사용됨

https://user-images.githubusercontent.com/55433950/113810457-451f2880-97a5-11eb-9d26-ef4ce531b206.mov



## Changes Detail
* 변경1 세부사항
* 변경2 세부사항

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
