### PR TITLE
tooltip위에서 click시 이벤트가 전달되지 않도록 변경

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -5,6 +5,7 @@ import { isEmpty, isString, isArray } from 'lodash-es'
 
 /* Internal dependencies */
 import useMergeRefs from '../../hooks/useMergeRefs'
+import useEventHandler from '../../hooks/useEventHandler'
 import { rootElement } from '../../utils/domUtils'
 import { Typography } from '../../foundation'
 import { Text } from '../Text'
@@ -116,6 +117,10 @@ function Tooltip(
     })
   ), [])
 
+  const handleClickTooltip = useCallback((event: HTMLElementEventMap['click']) => {
+    event.stopPropagation()
+  }, [])
+
   const ContentComponent = useMemo(() => {
     if (!show) {
       return null
@@ -170,6 +175,8 @@ function Tooltip(
     mergedRef,
     testId,
   ])
+
+  useEventHandler(tooltipRef.current, 'click', handleClickTooltip, show)
 
   useEffect(() => {
     if (show && tooltipRef.current) {


### PR DESCRIPTION
# Description
tooltip위에서 마우스 클릭시 이벤트가 전달되어 아래와 같은 문제가 있어 이벹트를 전달하지 않도록 변경

https://user-images.githubusercontent.com/55433950/113813594-27ed5880-97ab-11eb-9692-e1d2539713f1.mov


## Changes Detail
* 변경1 세부사항
* 변경2 세부사항

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
