### PR TITLE
target을 클릭할때 overlay가 닫히도록 변경

### DIFF
--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -205,6 +205,11 @@ function Overlay(
     }
   }, [onHide])
 
+  const handleClickTarget = useCallback((event: HTMLElementEventMap['click']) => {
+    onHide()
+    event.stopPropagation()
+  }, [onHide])
+
   const handleKeydown = useCallback((event: HTMLElementEventMap['keyup']) => {
     if (event.key === ESCAPE_KEY) {
       onHide()
@@ -331,6 +336,7 @@ function Overlay(
 
   useEventHandler(document, 'click', handleHideOverlay, show, true)
   useEventHandler(document, 'keyup', handleKeydown, show)
+  useEventHandler(target, 'click', handleClickTarget, show)
   useEventHandler(containerRef.current, 'wheel', handleBlockMouseWheel, show)
 
   useEffect(() => {


### PR DESCRIPTION
# Description
target을 클릭하여 overlay가 열려있는 상태에서 target을 다시 클릭하면 overlay가 hide되도록 변경.
#293 에서 불필요한 로직으로 생각하고 삭제했으나 Overlay가 동시에 2개이상 떠있을경우 오동작하여 다시 추가함

## Changes Detail
* 변경1 세부사항
* 변경2 세부사항

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
