### PR TITLE
Status를 사용처에서 사용할 수 있도록 변경

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export * from './components/Tooltip'
 export * from './components/SectionLabel'
 export * from './components/Avatars/Avatar'
 export * from './components/Avatars/AvatarGroup'
+export * from './components/Status'
 export * from './components/SegmentedControl'
 
 // TODO: Antlr 문제 수정 후 export (Cannot read property RuleContext of undefined)


### PR DESCRIPTION
# Description

index 파일에서 Status export를 안해주고 있었습니다. export 하도록 변경했습니다.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
