### PR TITLE
SectionLabel 추가 수정사항 (extra props)

### DIFF
--- a/src/components/SectionLabel/SectionLabel.styled.ts
+++ b/src/components/SectionLabel/SectionLabel.styled.ts
@@ -28,7 +28,6 @@ const LeftContentWrapper = styled.div<WithInterpolation>`
 
 const ContentText = styled(Text)`
   overflow: hidden;
-  font-weight: 600;
   color: ${({ foundation }) => foundation?.theme?.['txt-black-dark']};
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/components/SectionLabel/SectionLabel.tsx
+++ b/src/components/SectionLabel/SectionLabel.tsx
@@ -36,7 +36,7 @@ function SectionLabel({
     >
       { isString(givenContent)
         ? (
-          <Styled.ContentText typo={Typography.Size13}>
+          <Styled.ContentText bold typo={Typography.Size13}>
             { givenContent }
           </Styled.ContentText>
         ) : givenContent }


### PR DESCRIPTION
# Description

SectionLabel에 몇 가지 minor 수정사항을 추가합니다.

## Changes Detail
* SectionLabelProps 확장 - `React.HTMLAttributes<HTMLDivElement>` 를 extend 하여 onMouseEnter 같은 것이 그대로 넘어가도록
* ~font-weight 잘못된 점 수정 (bold -> 600)~

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
