### PR TITLE
ListItem, ListMenuGroup에서 content 부분에 ellipsis 적용

### DIFF
--- a/src/components/List/ListItem/ListItem.styled.ts
+++ b/src/components/List/ListItem/ListItem.styled.ts
@@ -1,5 +1,5 @@
 /* Internal dependencies */
-import { css, styled } from '../../../foundation'
+import { css, ellipsis, styled } from '../../../foundation'
 import { SemanticNames } from '../../../foundation/Colors/Theme'
 import { Icon } from '../../Icon'
 import { StyledWrapperProps } from './ListItem.types'
@@ -47,7 +47,5 @@ export const StyledIcon = styled(Icon)<StyledIconProps>`
 export const ContentWrapper = styled.div`
   flex: 1;
 
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  ${ellipsis()}
 `

--- a/src/components/List/ListMenuGroup/ListMenuGroup.styled.ts
+++ b/src/components/List/ListMenuGroup/ListMenuGroup.styled.ts
@@ -2,7 +2,7 @@
 import { isNil } from 'lodash-es'
 
 /* Internal dependencies */
-import { css, styled } from '../../../foundation'
+import { css, ellipsis, styled } from '../../../foundation'
 import { WithInterpolation } from '../../../types/InjectedInterpolation'
 import { SemanticNames } from '../../../foundation/Colors/Theme'
 import { Icon } from '../../Icon'
@@ -60,9 +60,7 @@ export const StyledIcon = styled(Icon)<StyledIconProps>`
 export const ContentWrapper = styled.div<WithInterpolation>`
   flex: 1;
 
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  ${ellipsis()}
 
   ${({ interpolation }) => interpolation}
 `


### PR DESCRIPTION
# Description

ListItem, ListMenuGroup 컴포넌트에서 텍스트가 영역을 벗어난 경우를 고려하여 ellipsis를 적용합니다.

## Changes Detail

<img width="348" alt="스크린샷 2021-04-26 오후 12 57 45" src="https://user-images.githubusercontent.com/25701854/116027244-4e5a3180-a68f-11eb-869b-764a1767c495.png">

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
