### PR TITLE
Dependabot configuration 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+    reviewers:
+      - "jwoo0122"
+    commit-message:
+      prefix: "[Dependency Updates] - "
+    labels:
+      - "dependency updates"


### PR DESCRIPTION
# Description
Dependency 업데이트를 자동으로 추적하기 위해 dependabot config 를 추가합니다.

## Changes Detail
- 매일 오전 11시 (UTC 02:00)에 dependency 를 체크합니다. 이는 초기 dependabot 의 효용성 파악을 위해 설정한 짧은 주기로, 효과가 입증되면 1주일 주기로 늘려볼 생각입니다.
- `dependency updates` 라벨이 붙은 PR 을 올리며, Commit 은 `[Dependency Updates] - ` 라는 string 이 prefix 로 붙습니다.
- Reviewer 로 @jwoo0122 를 지정합니다.