### PR TITLE
outlineItem 아이콘 align 안 맞는 문제 수정

### DIFF
--- a/src/components/OutlineItem/OutlineItem.styled.ts
+++ b/src/components/OutlineItem/OutlineItem.styled.ts
@@ -50,6 +50,8 @@ export const ChevronWrapper = styled.div`
 `
 
 export const LeftContentWrapper = styled.div`
+  display: flex;
+  align-items: center;
   margin-right: 8px;
 `
 


### PR DESCRIPTION
# Description
outlineItem의 아이콘이 center align 되지 않던 레이아웃을 바로잡습니다.

## Changes Detail
| as-is | to-be |
|---|---|
|<img width="547" alt="스크린샷 2021-05-07 오후 6 31 02" src="https://user-images.githubusercontent.com/16368822/117429994-92d4af80-af62-11eb-9a87-a7913cd53820.png">|<img width="547" alt="스크린샷 2021-05-07 오후 6 30 57" src="https://user-images.githubusercontent.com/16368822/117429984-90725580-af62-11eb-8869-4ef7418e0a04.png">|

비교

https://user-images.githubusercontent.com/16368822/117430406-12fb1500-af63-11eb-816a-c0c022c8d740.mov

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
