### PR TITLE
ListItem description Size 수정

### DIFF
--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -80,7 +80,7 @@ function ListItemComponent({
     desc.split('\n').map((str, index) => {
       if (index === 0) {
         return (
-          <Text key={uuid()} typo={Typography.Size14}>
+          <Text key={uuid()} typo={Typography.Size12}>
             { str }
           </Text>
         )
@@ -89,9 +89,7 @@ function ListItemComponent({
       return (
         <Fragment key={uuid()}>
           <br />
-          <Text
-            typo={Typography.Size14}
-          >
+          <Text typo={Typography.Size12}>
             { str }
           </Text>
         </Fragment>
@@ -163,13 +161,9 @@ function ListItemComponent({
       { leftIcon && <IconMargin /> }
       <Description descriptionMaxLines={descriptionMaxLines}>
         {
-          isString(description) ? (
-            <Text
-              typo={Typography.Size14}
-            >
-              { getNewLineComponenet(description) }
-            </Text>
-          ) : description
+          isString(description)
+            ? getNewLineComponenet(description)
+            : description
         }
       </Description>
     </DescriptionWrapper>


### PR DESCRIPTION
# Description
ListItem 작업 중 놓친 디자인 스펙이 있어서 반영합니다.

| **as-is** |<img width="440" alt="스크린샷 2021-05-10 오후 1 30 09" src="https://user-images.githubusercontent.com/16368822/117605975-e2e68880-b193-11eb-8b7a-f65e8ec3208e.png">|
|---|---|
| **to-be** |<img width="440" alt="스크린샷 2021-05-10 오후 1 28 57" src="https://user-images.githubusercontent.com/16368822/117605973-e11cc500-b193-11eb-9517-077ec1e84278.png">|

## Changes Detail
* 불필요한 Text 컴포넌트 삭제
* description typo Size14 -> Size12로 변경

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
