### PR TITLE
Dependabot commit msg prefix 가 15글자를 넘으면 안되는 문제 수정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
     reviewers:
       - "jwoo0122"
     commit-message:
-      prefix: "[Dependency Updates] - "
+      prefix: "[Dependency]"
     labels:
       - "dependency updates"


### PR DESCRIPTION
# Description
dependabot config 에 문제가 있어 동작하지 않던 점을 수정합니다.

## Changes Detail
* commit msg prefix 가 15글자를 넘으면 안되는 문제를 수정

# References
<img width="917" alt="스크린샷 2021-05-10 오후 1 49 43" src="https://user-images.githubusercontent.com/29848729/117607391-d7e12780-b196-11eb-964a-7f414c1b3b86.png">