### PR TITLE
IconSize 추가

### DIFF
--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -7,11 +7,13 @@ import { UIComponentProps } from '../../types/ComponentProps'
 import { IconName } from './generated'
 
 export enum IconSize {
+  XL = 44,
   L = 34,
   Normal = 24,
   S = 20,
   XS = 16,
   XXS = 12,
+  XXXS = 10,
 }
 
 export default interface IconProps extends Omit<UIComponentProps, 'as'> {


### PR DESCRIPTION
# Description
[Desk#7214](https://github.com/channel-io/ch-desk-web/pull/7214) 에서 XXXS가 필요하게 되어 IconSize를 추가합니다.
하는 김에 XL도 추가합니다.

[Figma size guide](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=966%3A4) 참조
<img width="285" alt="스크린샷 2021-05-12 오전 11 19 48" src="https://user-images.githubusercontent.com/16368822/117908752-f91b5280-b313-11eb-92eb-8ace46b11466.png">


## Changes Detail
추가
* XL = 44
* XXXS = 10

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
