### PR TITLE
OutlineItem active 작동하게 수정

### DIFF
--- a/src/components/OutlineItem/OutlineItem.stories.tsx
+++ b/src/components/OutlineItem/OutlineItem.stories.tsx
@@ -64,7 +64,7 @@ const Template: Story<OutlineItemProps> = ({ ...otherOutlineItemProps }) => {
         />
         <OutlineItem
           open={open}
-          selectedMenuItemIndex={idx}
+          selectedOutlineItemIndex={idx}
           onClick={handleClickGroup}
           onClickArrow={handleToggle}
           onChangeOption={handleClickItem}

--- a/src/components/OutlineItem/OutlineItem.styled.ts
+++ b/src/components/OutlineItem/OutlineItem.styled.ts
@@ -27,7 +27,7 @@ export const GroupItemWrapper = styled.div<StyledWrapperProps & OutlineItemProps
   border-radius: 6px;
 
   &:hover {
-    background-color: ${props => (isNil(props.currentMenuItemIndex) && props.foundation?.theme?.['bg-black-lighter'])};
+    background-color: ${props => (isNil(props.currentOutlineItemIndex) && props.foundation?.theme?.['bg-black-lighter'])};
   }
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'color'])};

--- a/src/components/OutlineItem/OutlineItem.test.tsx
+++ b/src/components/OutlineItem/OutlineItem.test.tsx
@@ -43,7 +43,7 @@ describe('OutlineItem', () => {
   it(
     'should have index on "data-active-index" attr when "selectedOptionIndex" given',
     () => {
-      const { getAllByTestId } = renderComponent({ selectedMenuItemIndex: 2 })
+      const { getAllByTestId } = renderComponent({ selectedOutlineItemIndex: 2 })
       const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
 
       expect(rendered[0]).toHaveAttribute('data-active-index', '2')

--- a/src/components/OutlineItem/OutlineItem.tsx
+++ b/src/components/OutlineItem/OutlineItem.tsx
@@ -51,7 +51,7 @@ function OutlineItemComponent(
     onOpen = noop,
     onClickArrow = noop,
     /* OptionMenuHost Props */
-    selectedMenuItemIndex = null,
+    selectedOutlineItemIndex = null,
     onChangeOption = noop,
     /* HTMLAttribute props */
     onClick: givenOnClick = noop,
@@ -60,25 +60,25 @@ function OutlineItemComponent(
   }: OutlineItemProps,
   forwardedRef: React.Ref<HTMLElement>,
 ) {
-  const [currentMenuItemIndex, setCurrentMenuItemIndex] = useState<number | null>(selectedMenuItemIndex)
+  const [currentOutlineItemIndex, setCurrentOutlineItemIndex] = useState<number | null>(selectedOutlineItemIndex)
 
   useEffect(() => {
     const childs = React.Children.toArray(children)
-    if (isNil(selectedMenuItemIndex)
-      || (selectedMenuItemIndex < childs.length && selectedMenuItemIndex < 0)) {
-      setCurrentMenuItemIndex(null)
+    if (isNil(selectedOutlineItemIndex)
+      || (selectedOutlineItemIndex < childs.length && selectedOutlineItemIndex < 0)) {
+      setCurrentOutlineItemIndex(null)
       return
     }
 
-    const element = childs[selectedMenuItemIndex]
+    const element = childs[selectedOutlineItemIndex]
 
     if (React.isValidElement(element) && isNil(element.props.children)) {
       if (element.props.href) { return }
 
-      setCurrentMenuItemIndex(selectedMenuItemIndex)
+      setCurrentOutlineItemIndex(selectedOutlineItemIndex)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedMenuItemIndex])
+  }, [selectedOutlineItemIndex])
 
   useEffect(() => {
     if (open) {
@@ -198,7 +198,7 @@ function OutlineItemComponent(
 
       const passedContext = {
         ...context,
-        active: currentMenuItemIndex === index,
+        active: currentOutlineItemIndex === index,
         onClick: () => handleClickItem(index, element.props.optionKey),
       }
 
@@ -211,7 +211,7 @@ function OutlineItemComponent(
   ), [
     children,
     context,
-    currentMenuItemIndex,
+    currentOutlineItemIndex,
     handleClickItem,
   ])
 
@@ -231,10 +231,10 @@ function OutlineItemComponent(
           interpolation={interpolation}
           open={open}
           active={false}
-          currentMenuItemIndex={currentMenuItemIndex}
+          currentOutlineItemIndex={currentOutlineItemIndex}
           onClick={handleClickGroup}
           data-testid={testId}
-          data-active-index={currentMenuItemIndex}
+          data-active-index={currentOutlineItemIndex}
           paddingLeft={paddingLeft}
           {...otherProps}
         >
@@ -257,10 +257,10 @@ function OutlineItemComponent(
         interpolation={interpolation}
         open={open}
         active={active}
-        currentMenuItemIndex={currentMenuItemIndex}
+        currentOutlineItemIndex={currentOutlineItemIndex}
         onClick={handleClickGroup}
         data-testid={testId}
-        data-active-index={currentMenuItemIndex}
+        data-active-index={currentOutlineItemIndex}
         paddingLeft={paddingLeft}
         {...otherProps}
       >

--- a/src/components/OutlineItem/OutlineItem.tsx
+++ b/src/components/OutlineItem/OutlineItem.tsx
@@ -67,6 +67,15 @@ function OutlineItemComponent(
     if (isNil(selectedMenuItemIndex)
       || (selectedMenuItemIndex < childs.length && selectedMenuItemIndex < 0)) {
       setCurrentMenuItemIndex(null)
+      return
+    }
+
+    const element = childs[selectedMenuItemIndex]
+
+    if (React.isValidElement(element) && isNil(element.props.children)) {
+      if (element.props.href) { return }
+
+      setCurrentMenuItemIndex(selectedMenuItemIndex)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedMenuItemIndex])

--- a/src/components/OutlineItem/OutlineItem.types.ts
+++ b/src/components/OutlineItem/OutlineItem.types.ts
@@ -41,15 +41,15 @@ export default interface OutlineItemProps extends ContentComponentProps, Childre
   onOpen?: (name?: string) => void
   onClick?: (e?: React.MouseEvent, name?: string) => void
   onClickArrow?: (name?: string) => void
-  /* OptionItemHost for Sidebar Menu - nullable selectedMenuItemIndex */
-  selectedMenuItemIndex?: number | null
+  /* OptionItemHost for Sidebar Menu - nullable selectedOutlineItemIndex */
+  selectedOutlineItemIndex?: number | null
   onChangeOption?: (name?: string, optionKey?: string, optionIndex?: number) => void
 }
 
 export interface StyledWrapperProps extends ContentComponentProps {
   open?: boolean
   rightContent?: React.ReactNode
-  currentMenuItemIndex?: number | null
+  currentOutlineItemIndex?: number | null
   chevronClassName?: string
   selectedOptionIndex?: number
   selected?: boolean
@@ -58,5 +58,5 @@ export interface StyledWrapperProps extends ContentComponentProps {
 
 export interface StyledContentWrapperProps extends ContentComponentProps {
   open?: boolean
-  currentMenuItemIndex?: number | null
+  currentOutlineItemIndex?: number | null
 }


### PR DESCRIPTION
# Description
setCurrentMenuItemIndex를 되살려 OutlineItem select 시 active 상태가 제대로 들어가도록 수정합니다.

[#359 issue](https://github.com/channel-io/design-system/pull/359#discussion_r631559924)에서 paul이 알려주신 버그입니다.

#359 에서 OutlineItem과 ListItem을 분리하는 과정에서, `if (isListItem(element)) {` 블럭 내의 코드가 ListItem 관련 코드라고 판단하여 지웠었습니다.

그러나 해당 코드는 OutlineItem 리스트 중 leaf(자식이 없는 Item)에 해당하는 Item에 대해 처리하는 로직이었습니다.
따라서 해당 코드 OutlineItem에 맞게 동작하도록 수정하여 되살립니다.

## Changes Detail
* OutlineItem이 leaf일 경우 setCurrentMenuItemIndex가 동작하도록 수정
  * (href일 경우 동작 안함 - 기존 로직)

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
