### PR TITLE
TextField 컴포넌트 확장 및 리팩토링

### DIFF
--- a/src/components/Input/TextField/TextField.styled.ts
+++ b/src/components/Input/TextField/TextField.styled.ts
@@ -25,7 +25,7 @@ export const placeholderStyle = (themeKey: SemanticNames = 'txt-black-dark') => 
   }
 `
 
-interface InputProps {
+interface InputProps extends WithInterpolation {
   disabled: boolean
   readOnly: boolean
   color: SemanticNames
@@ -44,6 +44,8 @@ const Input = styled.input<InputProps>`
   outline: none;
 
   ${placeholderStyle()}
+
+  ${({ interpolation }) => interpolation}
 `
 
 const LeftIcon = styled(Icon)<ClickableElementProps>`

--- a/src/components/Input/TextField/TextField.tsx
+++ b/src/components/Input/TextField/TextField.tsx
@@ -47,6 +47,8 @@ function TextFieldComponent({
   rightContent,
   disableLeftWrapper = false,
   disableRightWrapper = false,
+  inputClassName,
+  inputInterpolation,
   wrapperClassName,
   wrapperInterpolation,
   leftWrapperClassName,
@@ -340,6 +342,8 @@ function TextFieldComponent({
     >
       { leftComponent }
       <Styled.Input
+        className={inputClassName}
+        interpolation={inputInterpolation}
         ref={inputRef}
         name={name}
         size={size}

--- a/src/components/Input/TextField/TextField.tsx
+++ b/src/components/Input/TextField/TextField.tsx
@@ -57,6 +57,8 @@ function TextFieldComponent({
   onBlur,
   onFocus,
   onChange,
+  onKeyDown,
+  onKeyUp,
   ...otherProps
 }: TextFieldProps, forwardedRef: Ref<TextFieldRef>) {
   const [focused, setFocused] = useState(false)
@@ -71,13 +73,17 @@ function TextFieldComponent({
     isNil(value) ? undefined : toString(value)
   ), [value])
 
-  const activeClear = useMemo(() => (
-    !disabled
-    && !readOnly
-    && allowClear
+  const activeInput = useMemo(() => (
+    !disabled && !readOnly
   ), [
     disabled,
     readOnly,
+  ])
+
+  const activeClear = useMemo(() => (
+    activeInput && allowClear
+  ), [
+    activeInput,
     allowClear,
   ])
 
@@ -156,7 +162,7 @@ function TextFieldComponent({
   }, [])
 
   const handleFocus = useCallback((event: React.FocusEvent<HTMLInputElement>) => {
-    if (!disabled && !readOnly) {
+    if (activeInput) {
       setFocused(true)
       if (selectAllOnFocus) { selectAll() }
       if (onFocus) { onFocus(event) }
@@ -164,8 +170,7 @@ function TextFieldComponent({
   }, [
     selectAllOnFocus,
     selectAll,
-    readOnly,
-    disabled,
+    activeInput,
     onFocus,
   ])
 
@@ -175,27 +180,41 @@ function TextFieldComponent({
   }, [onBlur])
 
   const handleChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    if (!readOnly && !disabled && onChange) {
+    if (activeInput && onChange) {
       onChange(event)
     }
   }, [
-    readOnly,
-    disabled,
+    activeInput,
     onChange,
+  ])
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (activeInput && onKeyDown) {
+      onKeyDown(event)
+    }
+  }, [
+    activeInput,
+    onKeyDown,
+  ])
+
+  const handleKeyUp = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (activeInput && onKeyUp) {
+      onKeyUp(event)
+    }
+  }, [
+    activeInput,
+    onKeyUp,
   ])
 
   const handleClear = useCallback(() => {
     const input = inputRef.current
-    if (!readOnly && !disabled && input) {
+    if (activeInput && input) {
       const setValue = Object?.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
       const event = new Event('input', { bubbles: true })
       setValue?.call(input, '')
       input.dispatchEvent(event)
     }
-  }, [
-    readOnly,
-    disabled,
-  ])
+  }, [activeInput])
 
   const renderLeftItem = useCallback((item: TextFieldItemProps) => (
     'icon' in item
@@ -326,6 +345,8 @@ function TextFieldComponent({
         onFocus={handleFocus}
         onBlur={handleBlur}
         onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
         {...otherProps}
       />
       { activeClear && clearComponent }

--- a/src/components/Input/TextField/TextField.tsx
+++ b/src/components/Input/TextField/TextField.tsx
@@ -77,19 +77,8 @@ function TextFieldComponent({
     isNil(value) ? undefined : toString(value)
   ), [value])
 
-  const activeInput = useMemo(() => (
-    !disabled && !readOnly
-  ), [
-    disabled,
-    readOnly,
-  ])
-
-  const activeClear = useMemo(() => (
-    activeInput && allowClear
-  ), [
-    activeInput,
-    allowClear,
-  ])
+  const activeInput = !disabled && !readOnly
+  const activeClear = activeInput && allowClear
 
   const inputRef = useRef<HTMLInputElement | null>(null)
 

--- a/src/components/Input/TextField/TextField.tsx
+++ b/src/components/Input/TextField/TextField.tsx
@@ -45,8 +45,8 @@ function TextFieldComponent({
   selectAllOnFocus = false,
   leftContent,
   rightContent,
-  disableLeftWrapper = false,
-  disableRightWrapper = false,
+  withoutLeftContentWrapper = false,
+  withoutRightContentWrapper = false,
   inputClassName,
   inputInterpolation,
   wrapperClassName,
@@ -229,7 +229,7 @@ function TextFieldComponent({
 
     const item = renderLeftItem(leftContent)
 
-    if (isNil(item) || disableLeftWrapper) { return item }
+    if (isNil(item) || withoutLeftContentWrapper) { return item }
 
     return (
       <Styled.LeftContentWrapper
@@ -241,7 +241,7 @@ function TextFieldComponent({
     )
   }, [
     leftContent,
-    disableLeftWrapper,
+    withoutLeftContentWrapper,
     leftWrapperClassName,
     leftWrapperInterpolation,
     renderLeftItem,
@@ -275,7 +275,7 @@ function TextFieldComponent({
       ? rightContent.map((item) => renderRightItem(item, uuid()))
       : renderRightItem(rightContent)
 
-    if (disableRightWrapper) { return items }
+    if (withoutRightContentWrapper) { return items }
 
     return (
       <Styled.RightContentWrapper
@@ -287,7 +287,7 @@ function TextFieldComponent({
     )
   }, [
     rightContent,
-    disableRightWrapper,
+    withoutRightContentWrapper,
     rightWrapperClassName,
     rightWrapperInterpolation,
     renderRightItem,

--- a/src/components/Input/TextField/TextField.tsx
+++ b/src/components/Input/TextField/TextField.tsx
@@ -45,6 +45,8 @@ function TextFieldComponent({
   selectAllOnFocus = false,
   leftContent,
   rightContent,
+  disableLeftWrapper = false,
+  disableRightWrapper = false,
   wrapperClassName,
   wrapperInterpolation,
   leftWrapperClassName,
@@ -235,7 +237,10 @@ function TextFieldComponent({
     }
 
     const item = renderLeftItem(leftContent)
-    return !isNil(item) && (
+
+    if (isNil(item) || disableLeftWrapper) { return item }
+
+    return (
       <Styled.LeftContentWrapper
         className={leftWrapperClassName}
         interpolation={leftWrapperInterpolation}
@@ -245,6 +250,7 @@ function TextFieldComponent({
     )
   }, [
     leftContent,
+    disableLeftWrapper,
     leftWrapperClassName,
     leftWrapperInterpolation,
     renderLeftItem,
@@ -278,6 +284,8 @@ function TextFieldComponent({
       ? rightContent.map((item) => renderRightItem(item, uuid()))
       : renderRightItem(rightContent)
 
+    if (disableRightWrapper) { return items }
+
     return (
       <Styled.RightContentWrapper
         className={rightWrapperClassName}
@@ -288,6 +296,7 @@ function TextFieldComponent({
     )
   }, [
     rightContent,
+    disableRightWrapper,
     rightWrapperClassName,
     rightWrapperInterpolation,
     renderRightItem,

--- a/src/components/Input/TextField/TextField.types.ts
+++ b/src/components/Input/TextField/TextField.types.ts
@@ -61,6 +61,8 @@ export default interface TextFieldProps
   rightContent?: TextFieldItemProps | TextFieldItemProps[]
   disableLeftWrapper?: boolean
   disableRightWrapper?: boolean
+  inputClassName?: string
+  inputInterpolation?: InjectedInterpolation
   wrapperClassName?: string
   wrapperInterpolation?: InjectedInterpolation
   leftWrapperClassName?: string

--- a/src/components/Input/TextField/TextField.types.ts
+++ b/src/components/Input/TextField/TextField.types.ts
@@ -59,8 +59,8 @@ export default interface TextFieldProps
   selectAllOnFocus?: boolean
   leftContent?: TextFieldItemProps
   rightContent?: TextFieldItemProps | TextFieldItemProps[]
-  disableLeftWrapper?: boolean
-  disableRightWrapper?: boolean
+  withoutLeftContentWrapper?: boolean
+  withoutRightContentWrapper?: boolean
   inputClassName?: string
   inputInterpolation?: InjectedInterpolation
   wrapperClassName?: string

--- a/src/components/Input/TextField/TextField.types.ts
+++ b/src/components/Input/TextField/TextField.types.ts
@@ -59,6 +59,8 @@ export default interface TextFieldProps
   selectAllOnFocus?: boolean
   leftContent?: TextFieldItemProps
   rightContent?: TextFieldItemProps | TextFieldItemProps[]
+  disableLeftWrapper?: boolean
+  disableRightWrapper?: boolean
   wrapperClassName?: string
   wrapperInterpolation?: InjectedInterpolation
   leftWrapperClassName?: string
@@ -67,4 +69,6 @@ export default interface TextFieldProps
   rightWrapperInterpolation?: InjectedInterpolation
   onFocus?: React.ChangeEventHandler<HTMLInputElement>
   onChange?: React.ChangeEventHandler<HTMLInputElement>
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>
+  onKeyUp?: React.KeyboardEventHandler<HTMLInputElement>
 }


### PR DESCRIPTION
# Description

데스크의 TagInput을 제작하며 TextField 내부 엘리먼트의 스타일을 조작/키 이벤트를 감지해야하는 상황이 생겼습니다. input 등의 스타일을 직접 수정할 수 있게 하고, keyup, keydown 이벤트 핸들러등을 추가할 수 있게 인터페이스를 수정합니다.

## Changes Detail

* 리팩토링: input active 상태를 변수로 분리 
* disableLeftWrapper, disableRightWrapper : TagInput UI가 가능해지기 위해선 LeftContent로 들어가는 Tag들과 Input이 sibling 관계에 있어야 합니다. 현재 구조에선 LeftContent가 들어가면 LeftWrapper가 무조건 감싸게 되므로, 해당 속성을 추가했습니다. (disableRightWrapper는 짝을 맞추기위해 추가. 당장 필요한 기능은 아닙니다)
* input에 className 및 interpolation 속성 추가

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
