### PR TITLE
ListItem이 active시에도 클릭 이벤트가 일어나도록 수정

### DIFF
--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -67,11 +67,8 @@ function ListItemComponent({
   ])
 
   const handleClick = useCallback((e) => {
-    if (!active) {
-      onClick(e, name)
-    }
+    onClick(e, name)
   }, [
-    active,
     name,
     onClick,
   ])


### PR DESCRIPTION
# Description

기존에 ListItem이 active시엔 onClick 이벤트가 무시되었습니다. ListItem이 이곳저곳 사용되면서, 토글 기능(데스크의 Select 에서)이 사용될 필요가 생겼습니다. 범용성을 위해 active 조건을 제거합니다.

## Changes Detail

* ListItem을 사용하고 있던 데스크 좌측 네비게이션 메뉴들의 active시 onClick 로직 확인이 필요합니다. 

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
