### PR TITLE
ListItem leftContent 추가 시 description indent 되도록 수정

### DIFF
--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -58,7 +58,7 @@ interface IconWrapperProps {
   disableIconActive?: boolean
 }
 
-const IconSpacing = css`
+const leftSpacing = css`
   flex-shrink: 0;
   width: 20px;
   margin-right: 8px;
@@ -72,13 +72,13 @@ export const StyledIcon = styled(Icon)<IconWrapperProps>`
 `
 
 export const LeftContentWrapper = styled.div`
-  ${IconSpacing}
+  ${leftSpacing}
   display: flex;
   align-items: center;
 `
 
-export const IconMargin = styled.div`
-  ${IconSpacing}
+export const LeftMargin = styled.div`
+  ${leftSpacing}
 `
 
 export interface StyledWrapperProps {

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -155,7 +155,7 @@ function ListItemComponent({
     <DescriptionWrapper
       active={active}
     >
-      { leftIcon && <IconMargin /> }
+      { (leftIcon || leftContent) && <IconMargin /> }
       <Description descriptionMaxLines={descriptionMaxLines}>
         {
           isString(description)
@@ -170,6 +170,7 @@ function ListItemComponent({
     descriptionMaxLines,
     getNewLineComponenet,
     leftIcon,
+    leftContent,
   ])
 
   const rightComponent = useMemo(() => (

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -15,7 +15,7 @@ import {
   ContentWrapper,
   LeftContentWrapper,
   StyledIcon,
-  IconMargin,
+  LeftMargin,
   TitleWrapper,
   Title,
   DescriptionWrapper,
@@ -155,7 +155,7 @@ function ListItemComponent({
     <DescriptionWrapper
       active={active}
     >
-      { (leftIcon || leftContent) && <IconMargin /> }
+      { (leftIcon || leftContent) && <LeftMargin /> }
       <Description descriptionMaxLines={descriptionMaxLines}>
         {
           isString(description)


### PR DESCRIPTION
# Description
아래와 같은 화면에서 leftIcon이 아니라 leftContent가 와도 description이 indent 되도록 합니다.

<img width="576" alt="스크린샷 2021-05-14 오후 4 37 57" src="https://user-images.githubusercontent.com/16368822/118237894-be134d80-b4d2-11eb-934d-f1bbe7e6f5bc.png">

**현재**
<img width="436" alt="스크린샷 2021-05-14 오후 4 41 26" src="https://user-images.githubusercontent.com/16368822/118238252-3d088600-b4d3-11eb-9a89-e9ad79774d4e.png">

## Changes Detail
* 왼쪽 margin을 표시하는 조건문에 leftContent 추가
* leftIcon & leftContent 포괄하도록 스타일 변수 네이밍 수정

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
