### PR TITLE
TextField state에 따른 color 로직 수정

### DIFF
--- a/src/components/Input/TextField/TextField.styled.ts
+++ b/src/components/Input/TextField/TextField.styled.ts
@@ -28,7 +28,6 @@ export const placeholderStyle = (themeKey: SemanticNames = 'txt-black-dark') => 
 interface InputProps {
   disabled: boolean
   readOnly: boolean
-  color: SemanticNames
 }
 
 const Input = styled.input<InputProps>`
@@ -37,7 +36,7 @@ const Input = styled.input<InputProps>`
   ${Typography.Size14}
   padding: 0;
 
-  color: ${({ foundation, color }) => foundation?.theme?.[color]};
+  color: ${({ foundation }) => foundation?.theme?.['txt-black-darkest']};
 
   background-color: transparent;
   border: none;

--- a/src/components/Input/TextField/TextField.test.tsx
+++ b/src/components/Input/TextField/TextField.test.tsx
@@ -4,7 +4,8 @@ import React from 'react'
 /* Internal dependencies */
 import { render } from '../../../utils/testUtils'
 import TextField, { TEXT_INPUT_TEST_ID } from './TextField'
-import { TextFieldProps } from './TextField.types'
+import { TextFieldProps, TextFieldVariant } from './TextField.types'
+import { getProperTextFieldBgColor } from './TextFieldUtils'
 
 describe('TextField', () => {
   let props: TextFieldProps
@@ -53,5 +54,35 @@ describe('TextField', () => {
     const rendered = getByTestId(TEXT_INPUT_TEST_ID)
     const inputElement = rendered.getElementsByTagName('input')[0]
     expect(inputElement).toHaveAttribute('maxLength', '5')
+  })
+
+  it('sholud have the correct background-color according to the state.', () => {
+    expect(getProperTextFieldBgColor({
+      variant: TextFieldVariant.Primary,
+      focused: false,
+      hasError: false,
+      readOnly: false,
+    })).toBe('bg-grey-lightest')
+
+    expect(getProperTextFieldBgColor({
+      variant: TextFieldVariant.Primary,
+      focused: true,
+      hasError: false,
+      readOnly: false,
+    })).toBe('bg-white-normal')
+
+    expect(getProperTextFieldBgColor({
+      variant: TextFieldVariant.Primary,
+      focused: false,
+      hasError: true,
+      readOnly: false,
+    })).toBe('bg-white-normal')
+
+    expect(getProperTextFieldBgColor({
+      variant: TextFieldVariant.Primary,
+      focused: false,
+      hasError: false,
+      readOnly: true,
+    })).toBe('bg-grey-lighter')
   })
 })

--- a/src/components/Input/TextField/TextField.tsx
+++ b/src/components/Input/TextField/TextField.tsx
@@ -62,8 +62,32 @@ function TextFieldComponent({
   const [focused, setFocused] = useState(false)
   const [hovered, setHovered] = useState(false)
 
-  const wrapperBgColorSemanticName = useMemo(() => (getProperTextFieldBgColor(variant, readOnly)), [variant, readOnly])
-  const inputColorSemanticName = useMemo(() => (getProperTextFieldInputColor(disabled, readOnly)), [disabled, readOnly])
+  const wrapperBgColorSemanticName = useMemo(() => (
+    getProperTextFieldBgColor({
+      variant,
+      focused,
+      hasError,
+      readOnly,
+    })
+  ), [
+    variant,
+    focused,
+    hasError,
+    readOnly,
+  ])
+  const inputColorSemanticName = useMemo(() => (
+    getProperTextFieldInputColor({
+      focused,
+      hasError,
+      readOnly,
+      disabled,
+    })
+  ), [
+    focused,
+    hasError,
+    readOnly,
+    disabled,
+  ])
   const focusTimeout = useRef<ReturnType<typeof setTimeout>>()
   const blurTimeout = useRef<ReturnType<typeof setTimeout>>()
 

--- a/src/components/Input/TextField/TextField.tsx
+++ b/src/components/Input/TextField/TextField.tsx
@@ -25,7 +25,7 @@ import {
   TextFieldSize,
   TextFieldVariant,
 } from './TextField.types'
-import { getProperTextFieldInputColor, getProperTextFieldBgColor } from './TextFieldUtils'
+import { getProperTextFieldBgColor } from './TextFieldUtils'
 
 export const TEXT_INPUT_TEST_ID = 'ch-design-system-text-input'
 
@@ -75,19 +75,7 @@ function TextFieldComponent({
     hasError,
     readOnly,
   ])
-  const inputColorSemanticName = useMemo(() => (
-    getProperTextFieldInputColor({
-      focused,
-      hasError,
-      readOnly,
-      disabled,
-    })
-  ), [
-    focused,
-    hasError,
-    readOnly,
-    disabled,
-  ])
+
   const focusTimeout = useRef<ReturnType<typeof setTimeout>>()
   const blurTimeout = useRef<ReturnType<typeof setTimeout>>()
 
@@ -339,7 +327,6 @@ function TextFieldComponent({
         ref={inputRef}
         name={name}
         size={size}
-        color={inputColorSemanticName}
         autoComplete={autoComplete}
         type={type}
         readOnly={readOnly}

--- a/src/components/Input/TextField/TextFieldUtils.ts
+++ b/src/components/Input/TextField/TextFieldUtils.ts
@@ -20,22 +20,3 @@ export function getProperTextFieldBgColor({
   if (variant === TextFieldVariant.Primary && (focused || hasError)) { return 'bg-white-normal' }
   return 'bg-grey-lightest'
 }
-
-interface TextColorProps {
-  focused: boolean
-  readOnly: boolean
-  hasError: boolean
-  disabled: boolean
-}
-
-export function getProperTextFieldInputColor({
-  focused,
-  hasError,
-  readOnly,
-  disabled,
-}: TextColorProps): SemanticNames {
-  if (focused || hasError) { return 'txt-black-darkest' }
-  if (readOnly) { return 'txt-black-darker' }
-  if (disabled) { return 'txt-black-dark' }
-  return 'txt-black-dark'
-}

--- a/src/components/Input/TextField/TextFieldUtils.ts
+++ b/src/components/Input/TextField/TextFieldUtils.ts
@@ -2,14 +2,40 @@
 import { SemanticNames } from '../../../foundation/Colors/Theme'
 import { TextFieldVariant } from './TextField.types'
 
-export function getProperTextFieldBgColor(variant: TextFieldVariant, readOnly: boolean): SemanticNames {
-  if (variant === TextFieldVariant.Primary && readOnly) { return 'bg-grey-lighter' }
-  if (variant === TextFieldVariant.Secondary) { return 'bg-black-lightest' }
-  return 'bg-white-normal'
+interface BackgroundColorProps {
+  variant: TextFieldVariant
+  focused: boolean
+  hasError: boolean
+  readOnly: boolean
 }
 
-export function getProperTextFieldInputColor(disabled: boolean, readOnly: boolean): SemanticNames {
-  if (disabled) { return 'txt-black-dark' }
+export function getProperTextFieldBgColor({
+  variant,
+  focused,
+  hasError,
+  readOnly,
+}: BackgroundColorProps): SemanticNames {
+  if (variant === TextFieldVariant.Secondary) { return 'bg-black-lightest' }
+  if (variant === TextFieldVariant.Primary && readOnly) { return 'bg-grey-lighter' }
+  if (variant === TextFieldVariant.Primary && (focused || hasError)) { return 'bg-white-normal' }
+  return 'bg-grey-lightest'
+}
+
+interface TextColorProps {
+  focused: boolean
+  readOnly: boolean
+  hasError: boolean
+  disabled: boolean
+}
+
+export function getProperTextFieldInputColor({
+  focused,
+  hasError,
+  readOnly,
+  disabled,
+}: TextColorProps): SemanticNames {
+  if (focused || hasError) { return 'txt-black-darkest' }
   if (readOnly) { return 'txt-black-darker' }
-  return 'txt-black-darkest'
+  if (disabled) { return 'txt-black-dark' }
+  return 'txt-black-dark'
 }


### PR DESCRIPTION
# Description
[Figma Spec](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=6818%3A52495)

state에 따른 color 분기 처리를 수정합니다.

<img width="785" alt="스크린샷 2021-05-14 오후 8 01 51" src="https://user-images.githubusercontent.com/16368822/118261988-3ab42500-b4ef-11eb-8ede-0f12fa7adb3f.png">


## Changes Detail
* state에 따른 background color 분기 처리를 수정합니다.
* text color 분기 처리를 단순화 합니다. (제이미와 싱크함)
   * placeholder는 `txt-black-dark`, contents는 `txt-black-darkest`

# Tests
- [x] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
