### PR TITLE
ListItem CSS grid 사용하게 수정

### DIFF
--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -21,6 +21,8 @@ export const RightContent = styled.div`
 
 export const TitleWrapper = styled.div`
   display: flex;
+  grid-row: 1;
+  grid-column: 2;
   align-items: center;
 `
 
@@ -30,6 +32,8 @@ interface DescriptionProps {
 
 export const DescriptionWrapper = styled.div<DescriptionProps>`
   display: flex;
+  grid-row: 2;
+  grid-column: 2;
   align-items: center;
   width: 100%;
   margin-top: 2px;
@@ -66,6 +70,8 @@ export const StyledIcon = styled(Icon)<IconWrapperProps>`
 
 export const LeftContentWrapper = styled.div`
   display: flex;
+  grid-row: 1;
+  grid-column: 1;
   align-items: center;
   margin-right: 8px;
 `

--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -1,5 +1,5 @@
 /* Internal dependencies */
-import { css, ellipsis, styled } from '../../foundation'
+import { css, ellipsis, LineHeightAbsoluteNumber, styled } from '../../foundation'
 import { SemanticNames } from '../../foundation/Colors/Theme'
 import { Icon } from '../Icon'
 import { ListItemSize } from './ListItem.types'
@@ -48,7 +48,7 @@ interface DescriptionProps {
 }
 
 export const Description = styled.div<DescriptionProps>`
-  ${({ descriptionMaxLines }) => descriptionMaxLines && ellipsis(descriptionMaxLines)}
+  ${({ descriptionMaxLines }) => descriptionMaxLines && ellipsis(descriptionMaxLines, LineHeightAbsoluteNumber.Lh16)}
 `
 
 interface IconWrapperProps {
@@ -72,7 +72,6 @@ export const LeftContentWrapper = styled.div`
 
 export const ContentWrapper = styled.div`
   display: grid;
-  grid-template-rows: fit-content(100%) fit-content(100%);
   grid-template-columns: fit-content(100%) minmax(0, 1fr);
   width: 100%;
 `

--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -15,12 +15,6 @@ const ActiveItemStyle = css<StyledWrapperProps>`
   background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-blue-lightest']};
 `
 
-export const ContentWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-`
-
 export const RightContent = styled.div`
   margin-left: 8px;
 `
@@ -63,12 +57,6 @@ interface IconWrapperProps {
   disableIconActive?: boolean
 }
 
-const IconSpacing = css`
-  flex-shrink: 0;
-  width: 20px;
-  margin-right: 8px;
-`
-
 export const StyledIcon = styled(Icon)<IconWrapperProps>`
   color: ${props => {
     if (!props.disableIconActive && props.active) { return props.foundation?.theme['bgtxt-blue-normal'] }
@@ -77,13 +65,16 @@ export const StyledIcon = styled(Icon)<IconWrapperProps>`
 `
 
 export const LeftContentWrapper = styled.div`
-  ${IconSpacing}
   display: flex;
   align-items: center;
+  margin-right: 8px;
 `
 
-export const IconMargin = styled.div`
-  ${IconSpacing}
+export const ContentWrapper = styled.div`
+  display: grid;
+  grid-template-rows: fit-content(100%) fit-content(100%);
+  grid-template-columns: fit-content(100%) minmax(0, 1fr);
+  width: 100%;
 `
 
 export const Wrapper = styled.div<StyledWrapperProps>`

--- a/src/components/ListItem/ListItem.test.tsx
+++ b/src/components/ListItem/ListItem.test.tsx
@@ -1,10 +1,11 @@
 /* External dependencies */
 import React from 'react'
+import { getWindow, getDocument } from 'ssr-window'
 
 /* Internal dependencies */
 import { render } from '../../utils/testUtils'
 import ListItem, { LIST_ITEM_TEST_ID } from './ListItem'
-import ListItemProps from './ListItem.types'
+import ListItemProps, { ListItemSize } from './ListItem.types'
 
 describe('ListItem', () => {
   let props: ListItemProps
@@ -41,5 +42,84 @@ describe('ListItem', () => {
     expect(rendered).toHaveAttribute('href', 'https://naver.com')
     expect(rendered).toHaveAttribute('rel', 'noopener noreferrer')
     expect(rendered).toHaveAttribute('target', '_blank')
+  })
+
+  it('sholud not to be in the Document when "hide" prop is true', () => {
+    const { queryByTestId } = renderComponent({ hide: true })
+    const rendered = queryByTestId(LIST_ITEM_TEST_ID)
+    expect(rendered).not.toBeInTheDocument()
+  })
+
+  describe('should have correct style of "size"', () => {
+    it('size S', () => {
+      const { getByTestId } = renderComponent({ size: ListItemSize.S })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle('padding-top: 4px')
+      expect(rendered).toHaveStyle('padding-bottom: 4px')
+      expect(rendered).toHaveStyle('border-radius: 6px')
+    })
+
+    it('size M', () => {
+      const { getByTestId } = renderComponent({ size: ListItemSize.M })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle('padding-top: 6px')
+      expect(rendered).toHaveStyle('padding-bottom: 6px')
+      expect(rendered).toHaveStyle('border-radius: 6px')
+    })
+
+    it('size L', () => {
+      const { getByTestId } = renderComponent({ size: ListItemSize.L })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle('padding-top: 8px')
+      expect(rendered).toHaveStyle('padding-bottom: 8px')
+      expect(rendered).toHaveStyle('border-radius: 8px')
+    })
+
+    it('size XL', () => {
+      const { getByTestId } = renderComponent({ size: ListItemSize.XL })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle('padding-top: 10px')
+      expect(rendered).toHaveStyle('padding-bottom: 10px')
+      expect(rendered).toHaveStyle('border-radius: 12px')
+    })
+  })
+
+  /* icon, text 등 contents와 padding에 따라 height 변합니다. */
+  describe('should render correct height according to "size"', () => {
+    it('size S', () => {
+      renderComponent({ content: 'test', leftIcon: 'check', size: ListItemSize.S })
+      const rendered = getDocument().querySelector(`div[data-testid=${LIST_ITEM_TEST_ID}]`)
+      if (rendered) {
+        const style = getWindow().getComputedStyle(rendered)
+        setTimeout(() => expect(style.height).toBe('28px'), 0)
+      }
+    })
+
+    it('size M', () => {
+      renderComponent({ content: 'test', leftIcon: 'check', size: ListItemSize.M })
+      const rendered = getDocument().querySelector(`div[data-testid=${LIST_ITEM_TEST_ID}]`)
+      if (rendered) {
+        const style = getWindow().getComputedStyle(rendered)
+        setTimeout(() => expect(style.height).toBe('32px'), 0)
+      }
+    })
+
+    it('size L', () => {
+      renderComponent({ content: 'test', leftIcon: 'check', size: ListItemSize.L })
+      const rendered = getDocument().querySelector(`div[data-testid=${LIST_ITEM_TEST_ID}]`)
+      if (rendered) {
+        const style = getWindow().getComputedStyle(rendered)
+        setTimeout(() => expect(style.height).toBe('36px'), 0)
+      }
+    })
+
+    it('size XL', () => {
+      renderComponent({ content: 'test', leftIcon: 'check', size: ListItemSize.XL })
+      const rendered = getDocument().querySelector(`div[data-testid=${LIST_ITEM_TEST_ID}]`)
+      if (rendered) {
+        const style = getWindow().getComputedStyle(rendered)
+        setTimeout(() => expect(style.height).toBe('44px'), 0)
+      }
+    })
   })
 })

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -114,7 +114,7 @@ function ListItem({
       )
     }
 
-    return null
+    return <div />
   }, [
     active,
     disableIconActive,

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -114,7 +114,7 @@ function ListItem({
       )
     }
 
-    return <div />
+    return null
   }, [
     active,
     disableIconActive,
@@ -148,7 +148,6 @@ function ListItem({
 
   const descriptionComponent = useMemo(() => (
     <>
-      <div />
       <DescriptionWrapper
         active={active}
       >

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -147,19 +147,17 @@ function ListItem({
   ])
 
   const descriptionComponent = useMemo(() => (
-    <>
-      <DescriptionWrapper
-        active={active}
-      >
-        <Description descriptionMaxLines={descriptionMaxLines}>
-          {
-            isString(description)
-              ? getNewLineComponenet(description)
-              : description
-          }
-        </Description>
-      </DescriptionWrapper>
-    </>
+    <DescriptionWrapper
+      active={active}
+    >
+      <Description descriptionMaxLines={descriptionMaxLines}>
+        {
+          isString(description)
+            ? getNewLineComponenet(description)
+            : description
+        }
+      </Description>
+    </DescriptionWrapper>
   ), [
     active,
     description,

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -12,15 +12,14 @@ import { Typography } from '../../foundation'
 import ListItemProps, { ListItemSize } from './ListItem.types'
 import {
   Wrapper,
-  ContentWrapper,
   LeftContentWrapper,
   StyledIcon,
-  IconMargin,
   TitleWrapper,
   Title,
   DescriptionWrapper,
   Description,
   RightContent,
+  ContentWrapper,
 } from './ListItem.styled'
 
 export const LIST_ITEM_TEST_ID = 'bezier-react-list-menu-item'
@@ -99,6 +98,7 @@ function ListItem({
         </LeftContentWrapper>
       )
     }
+
     if (!isNil(leftIcon) && isIconName(leftIcon)) {
       return (
         <LeftContentWrapper>
@@ -126,7 +126,6 @@ function ListItem({
 
   const titleComponent = useMemo(() => (
     <TitleWrapper className={contentClassName}>
-      { leftComponent }
       <Title>
         {
           isString(content) ? (
@@ -142,31 +141,31 @@ function ListItem({
       </Title>
     </TitleWrapper>
   ), [
-    leftComponent,
     content,
     contentClassName,
     size,
   ])
 
   const descriptionComponent = useMemo(() => (
-    <DescriptionWrapper
-      active={active}
-    >
-      { leftIcon && <IconMargin /> }
-      <Description descriptionMaxLines={descriptionMaxLines}>
-        {
-          isString(description)
-            ? getNewLineComponenet(description)
-            : description
-        }
-      </Description>
-    </DescriptionWrapper>
+    <>
+      <div />
+      <DescriptionWrapper
+        active={active}
+      >
+        <Description descriptionMaxLines={descriptionMaxLines}>
+          {
+            isString(description)
+              ? getNewLineComponenet(description)
+              : description
+          }
+        </Description>
+      </DescriptionWrapper>
+    </>
   ), [
     active,
     description,
     descriptionMaxLines,
     getNewLineComponenet,
-    leftIcon,
   ])
 
   const rightComponent = useMemo(() => (
@@ -178,12 +177,14 @@ function ListItem({
   const ContentComponent = useMemo(() => (
     <>
       <ContentWrapper>
+        { leftComponent }
         { titleComponent }
         { description && descriptionComponent }
       </ContentWrapper>
       { rightContent && rightComponent }
     </>
   ), [
+    leftComponent,
     titleComponent,
     description,
     descriptionComponent,


### PR DESCRIPTION
# Description
아래와 같은 화면에서 leftIcon이 아니라 leftContent가 와도 description이 indent 되도록 합니다.

<img width="576" alt="스크린샷 2021-05-14 오후 4 37 57" src="https://user-images.githubusercontent.com/16368822/118237894-be134d80-b4d2-11eb-934d-f1bbe7e6f5bc.png">

**현재**
<img width="436" alt="스크린샷 2021-05-14 오후 4 41 26" src="https://user-images.githubusercontent.com/16368822/118238252-3d088600-b4d3-11eb-9a89-e9ad79774d4e.png">

## Changes Detail
* CSS grid 사용하여 레이아웃 수정

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
