### PR TITLE
Deprecation / Change 대응

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -11,6 +11,9 @@ module.exports = {
     '@storybook/addon-controls',
     '@storybook/addon-backgrounds',
   ],
+  features: {
+    postcss: false,
+  },
   webpackFinal: async (config) => {
     config.module.rules.push({
       test: /\.scss$/,

--- a/babel.config.js
+++ b/babel.config.js
@@ -8,6 +8,7 @@ module.exports = {
       ],
       plugins: [
         '@babel/plugin-transform-runtime',
+        ['@babel/plugin-proposal-private-property-in-object', { loose: false }],
         ['@babel/plugin-proposal-class-properties', { loose: false }],
       ],
     },
@@ -19,6 +20,7 @@ module.exports = {
       ],
       plugins: [
         '@babel/plugin-transform-runtime',
+        ['@babel/plugin-proposal-private-property-in-object', { loose: false }],
         ['@babel/plugin-proposal-class-properties', { loose: false }],
       ],
     },


### PR DESCRIPTION
# Description
babel/preset-env 업데이트 및 storybook 6.2 업데이트에 따른 변경사항을 대응합니다.

## Changes Detail
* Storybook 7 부터 deprecate 되는 postcss feature 를 disable 처리 (사용하지 않음)
* babel/preset-env 업데이트에 따른 private property in class 의 loose mode 를 false 로 변경

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
