### PR TITLE
Button의 onClick event parameter type 수정

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -147,7 +147,7 @@ function Button(
   const handleMouseEnter = useCallback(() => { setIsHovered(true) }, [])
   const handleMouseLeave = useCallback(() => { setIsHovered(false) }, [])
 
-  const handleClick = useCallback((event: MouseEvent) => {
+  const handleClick = useCallback((event: React.MouseEvent) => {
     if (!disabled) { onClick(event) }
     return null
   }, [

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -35,5 +35,5 @@ export default interface ButtonProps extends UIComponentProps {
   colorVariant?: ButtonColorVariant
   leftComponent?: IconName | React.ReactNode
   rightComponent?: IconName | React.ReactNode
-  onClick?: (event: MouseEvent) => void
+  onClick?: (event: React.MouseEvent) => void
 }


### PR DESCRIPTION
# Description

다른 컴포넌트는 모두 onClick의 event type을 `React.MouseEvent`로 받고 있는데 Button 컴포넌트만 native event type으로 받고 있어 괴리가 있는 점을 수정합니다.

## Changes Detail
* Button의 onClick prop type을 `(e: MouseEvent) => void` 에서 `(e: React.MouseEvent) => void`으로 수정

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.

(해당사항 없음)

### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
