### PR TITLE
SectionLabel의 right action button default 렌더링을 Button으로 하도록 변경

### DIFF
--- a/src/components/SectionLabel/SectionLabel.test.tsx
+++ b/src/components/SectionLabel/SectionLabel.test.tsx
@@ -1,0 +1,142 @@
+/* External dependencies */
+import React from 'react'
+import { LightFoundation } from '../../foundation'
+
+/* Internal dependencies */
+import { render } from '../../utils/testUtils'
+import { BUTTON_TEST_ID } from '../Button/Button'
+import { ICON_TEST_ID } from '../Icon/Icon'
+import SectionLabel, {
+  SECTION_LABEL_TEST_CONTENT_ID,
+  SECTION_LABEL_TEST_LEFT_CONTENT_ID,
+  SECTION_LABEL_TEST_RIGHT_CONTENT_ID,
+} from './SectionLabel'
+import type SectionLabelProps from './SectionLabel.types'
+
+describe('SectionLabel', () => {
+  const defaultProps: SectionLabelProps = {}
+
+  function renderComponent(props?: Partial<SectionLabelProps>) {
+    return render(<SectionLabel {...defaultProps} {...props} />)
+  }
+
+  it('renders string content as bold Text with Typography.Size13', () => {
+    const { getByTestId } = renderComponent({ content: 'hi' })
+    const content = getByTestId(SECTION_LABEL_TEST_CONTENT_ID)
+
+    expect(content.children.length).toBe(1)
+    expect(content.children.item(0)).toHaveStyle('font-weight: bold;')
+    expect(content.children.item(0)).toHaveStyle('font-size: 13px;')
+  })
+
+  it('renders number content as bold text with Typography.Size13', () => {
+    const { getByTestId } = renderComponent({ content: 123 })
+    const content = getByTestId(SECTION_LABEL_TEST_CONTENT_ID)
+
+    expect(content.children.length).toBe(1)
+    expect(content.children.item(0)).toHaveStyle('font-weight: bold;')
+    expect(content.children.item(0)).toHaveStyle('font-size: 13px;')
+  })
+
+  it('renders element content as it is', () => {
+    const { getByTestId } = renderComponent({ content: <div id="i-am-sectionlabel-content-id" /> })
+    const content = getByTestId(SECTION_LABEL_TEST_CONTENT_ID)
+
+    expect(content.children.length).toBe(1)
+    expect(content.children.item(0)?.id).toBe('i-am-sectionlabel-content-id')
+  })
+
+  it('does not render left content if given null', () => {
+    const { getByTestId } = renderComponent()
+    expect(() => getByTestId(SECTION_LABEL_TEST_LEFT_CONTENT_ID)).toThrowError()
+  })
+
+  it('renders left content with specified icon and default icon color', () => {
+    const { getByTestId } = renderComponent({ leftContent: { icon: 'tag' } })
+    const leftContent = getByTestId(SECTION_LABEL_TEST_LEFT_CONTENT_ID)
+
+    expect(leftContent.children.length).toBe(1)
+
+    const leftIcon = leftContent.children.item(0)
+
+    expect(leftIcon).toHaveAttribute('data-testid', ICON_TEST_ID)
+    expect(leftIcon).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']};`)
+  })
+
+  it('renders left content with specified icon and icon color', () => {
+    const { getByTestId } = renderComponent({ leftContent: { icon: 'tag', iconColor: 'bgtxt-orange-normal' } })
+    const leftContent = getByTestId(SECTION_LABEL_TEST_LEFT_CONTENT_ID)
+
+    expect(leftContent.children.length).toBe(1)
+
+    const leftIcon = leftContent.children.item(0)
+
+    expect(leftIcon).toHaveAttribute('data-testid', ICON_TEST_ID)
+    expect(leftIcon).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-orange-normal']};`)
+  })
+
+  it('renders left content as it is', () => {
+    const { getByTestId } = renderComponent({ leftContent: <div id="foo" /> })
+    const leftContent = getByTestId(SECTION_LABEL_TEST_LEFT_CONTENT_ID)
+
+    expect(leftContent.children.length).toBe(1)
+
+    const leftIcon = leftContent.children.item(0)
+    expect(leftIcon?.id).toBe('foo')
+  })
+
+  it('does not render right content if given null', () => {
+    const { getByTestId } = renderComponent()
+    expect(() => getByTestId(SECTION_LABEL_TEST_RIGHT_CONTENT_ID)).toThrowError()
+  })
+
+  it('does not render right content if given empty array', () => {
+    const { getByTestId } = renderComponent({ rightContent: [] })
+    expect(() => getByTestId(SECTION_LABEL_TEST_RIGHT_CONTENT_ID)).toThrowError()
+  })
+
+  it('renders right content as button if only icon is specified', () => {
+    const { getByTestId } = renderComponent({ rightContent: { icon: 'tag' } })
+    const rightContent = getByTestId(SECTION_LABEL_TEST_RIGHT_CONTENT_ID)
+
+    expect(rightContent.children.length).toBe(1)
+
+    const rightButton = rightContent.children.item(0)
+
+    expect(rightButton).toHaveAttribute('data-testid', BUTTON_TEST_ID)
+    expect(rightButton).toHaveStyle('height: 20px') // NOTE: ButtonSize.XS
+  })
+
+  it('renders multiple right contents, and item with iconColor is not rendered as button', () => {
+    const { getByTestId } = renderComponent({
+      rightContent: [
+        { icon: 'tag' },
+        { icon: 'tool', iconColor: 'bgtxt-green-normal' },
+      ],
+    })
+    const rightContent = getByTestId(SECTION_LABEL_TEST_RIGHT_CONTENT_ID)
+
+    expect(rightContent.children.length).toBe(2)
+
+    expect(rightContent.children.item(0)).toHaveAttribute('data-testid', BUTTON_TEST_ID)
+
+    expect(rightContent.children.item(1)).not.toHaveAttribute('data-testid', BUTTON_TEST_ID)
+  })
+
+  it('renders right content as it is', () => {
+    const { getByTestId } = renderComponent({
+      rightContent: [
+        <div id="foo" />,
+        <div id="bar" />,
+        <div id="foobar" />,
+      ],
+    })
+    const rightContent = getByTestId(SECTION_LABEL_TEST_RIGHT_CONTENT_ID)
+
+    expect(rightContent.children.length).toBe(3)
+
+    expect(rightContent.children.item(0)?.id).toBe('foo')
+    expect(rightContent.children.item(1)?.id).toBe('bar')
+    expect(rightContent.children.item(2)?.id).toBe('foobar')
+  })
+})

--- a/src/components/SectionLabel/SectionLabel.tsx
+++ b/src/components/SectionLabel/SectionLabel.tsx
@@ -5,10 +5,52 @@ import { v4 as uuid } from 'uuid'
 
 /* Internal dependencies */
 import { Typography } from '../../foundation'
+import { Button, ButtonColorVariant, ButtonSize, ButtonStyleVariant } from '../Button'
 import { Icon, IconSize } from '../Icon'
 import { Tooltip } from '../Tooltip'
 import Styled from './SectionLabel.styled'
 import SectionLabelProps, { SectionLabelItemProps } from './SectionLabel.types'
+
+function renderSectionLabelActionItem(props: SectionLabelItemProps, key?: string): React.ReactElement {
+  if (!('icon' in props)) {
+    return React.cloneElement(props, { key })
+  }
+
+  const { icon, iconColor, onClick } = props
+
+  if (!isNil(iconColor)) {
+    /*
+     * NOTE: backward compatibility를 위해 iconColor attribute를 지원하지만,
+     * iconColor를 사용할 경우 ButtonColorVariant와 일치하지 않기 때문에 Icon을 사용합니다.
+     */
+    return (
+      <Styled.RightItemWrapper
+        key={key}
+        clickable={!isNil(onClick)}
+        onClick={onClick}
+      >
+        <Icon
+          name={icon}
+          size={IconSize.XS}
+          color={iconColor ?? 'txt-black-dark'}
+        />
+      </Styled.RightItemWrapper>
+    )
+  }
+
+  return (
+    <Button
+      size={ButtonSize.XS}
+      styleVariant={ButtonStyleVariant.Tertiary}
+      colorVariant={ButtonColorVariant.Monochrome}
+      leftComponent={icon}
+      // FIXME: Button의 onClick event 타입이 React.MouseEvent가 아니라 MouseEvent로 되어 있어 ts-ignore 함.
+      // 올바르게 변경 이후 ts-ignore 삭제.
+      // @ts-ignore
+      onClick={onClick}
+    />
+  )
+}
 
 function SectionLabel({
   content: givenContent,
@@ -83,33 +125,14 @@ function SectionLabel({
     renderLeftItem,
   ])
 
-  const renderRightItem = useCallback((item: SectionLabelItemProps, key?: string) => (
-    'icon' in item ? (
-      <Styled.RightItemWrapper
-        key={key}
-        clickable={!isNil(item.onClick)}
-        onClick={item.onClick}
-      >
-        <Icon
-          name={item.icon}
-          size={IconSize.XS}
-          color={item.iconColor ?? 'txt-black-dark'}
-        />
-      </Styled.RightItemWrapper>
-    ) : React.cloneElement(
-      item,
-      { key },
-    )
-  ), [])
-
   const rightComponent = useMemo(() => {
     if (isNil(rightContent) || isEmpty(rightContent)) {
       return null
     }
 
     const items = isArray(rightContent)
-      ? rightContent.map((item) => renderRightItem(item, uuid()))
-      : renderRightItem(rightContent)
+      ? rightContent.map((item) => renderSectionLabelActionItem(item, uuid()))
+      : renderSectionLabelActionItem(rightContent)
 
     return (
       <Styled.RightContentWrapper
@@ -123,7 +146,6 @@ function SectionLabel({
     rightContent,
     rightWrapperClassName,
     rightWrapperInterpolation,
-    renderRightItem,
   ])
 
   const helpContent = useMemo(() => !isNil(help) && (

--- a/src/components/SectionLabel/SectionLabel.tsx
+++ b/src/components/SectionLabel/SectionLabel.tsx
@@ -1,6 +1,6 @@
 /* External dependencies */
 import React, { useCallback, useMemo } from 'react'
-import { isNil, isArray, isEmpty, isString } from 'lodash-es'
+import { isNil, isArray, isEmpty, isString, isNumber } from 'lodash-es'
 import { v4 as uuid } from 'uuid'
 
 /* Internal dependencies */
@@ -10,6 +10,10 @@ import { Icon, IconSize } from '../Icon'
 import { Tooltip } from '../Tooltip'
 import Styled from './SectionLabel.styled'
 import SectionLabelProps, { SectionLabelItemProps } from './SectionLabel.types'
+
+export const SECTION_LABEL_TEST_CONTENT_ID = 'bezier-react-section-label-content'
+export const SECTION_LABEL_TEST_LEFT_CONTENT_ID = 'bezier-react-section-label-left-content'
+export const SECTION_LABEL_TEST_RIGHT_CONTENT_ID = 'bezier-react-section-label-right-content'
 
 function renderSectionLabelActionItem(props: SectionLabelItemProps, key?: string): React.ReactElement {
   if (!('icon' in props)) {
@@ -32,7 +36,7 @@ function renderSectionLabelActionItem(props: SectionLabelItemProps, key?: string
         <Icon
           name={icon}
           size={IconSize.XS}
-          color={iconColor ?? 'txt-black-dark'}
+          color={iconColor}
         />
       </Styled.RightItemWrapper>
     )
@@ -40,6 +44,7 @@ function renderSectionLabelActionItem(props: SectionLabelItemProps, key?: string
 
   return (
     <Button
+      key={key}
       size={ButtonSize.XS}
       styleVariant={ButtonStyleVariant.Tertiary}
       colorVariant={ButtonColorVariant.Monochrome}
@@ -75,8 +80,9 @@ function SectionLabel({
     <Styled.ContentWrapper
       className={contentWrapperClassName}
       interpolation={contentWrapperInterpolation}
+      data-testid={SECTION_LABEL_TEST_CONTENT_ID}
     >
-      { isString(givenContent)
+      { isString(givenContent) || isNumber(givenContent)
         ? (
           <Styled.ContentText bold typo={Typography.Size13}>
             { givenContent }
@@ -114,6 +120,7 @@ function SectionLabel({
       <Styled.LeftContentWrapper
         className={leftWrapperClassName}
         interpolation={leftWrapperInterpolation}
+        data-testid={SECTION_LABEL_TEST_LEFT_CONTENT_ID}
       >
         { item }
       </Styled.LeftContentWrapper>
@@ -138,6 +145,7 @@ function SectionLabel({
       <Styled.RightContentWrapper
         className={rightWrapperClassName}
         interpolation={rightWrapperInterpolation}
+        data-testid={SECTION_LABEL_TEST_RIGHT_CONTENT_ID}
       >
         { items }
       </Styled.RightContentWrapper>


### PR DESCRIPTION
# Description

버튼 컴포넌트 작성 이후 SectionLabel에서 right action에 해당하는 부분에 간략하게 prop을 던질 경우 알아서 Button으로 그리도록 로직을 변경합니다.

## Changes Detail
* `icon`, `onClick`만 줄 경우 Button 컴포넌트를 사용하여 그려냅니다. (Tertiary, Monochrome)
* `iconColor`를 사용하고 있는 경우 Button의 color variant와 일치하기 않기 때문에 기존 로직 유지

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
