### PR TITLE
SidePanelContent에 ref 추가, KeyValueListItem이 HTMLArrtibutes를 extends하게 변경

### DIFF
--- a/src/components/KeyValueListItem/KeyValueListItem.types.ts
+++ b/src/components/KeyValueListItem/KeyValueListItem.types.ts
@@ -17,7 +17,7 @@ export type KeyValueActionProps = {
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void
 } | React.ReactElement
 
-export interface KeyValueListItemProps extends ChildrenComponentProps {
+export interface KeyValueListItemProps extends ChildrenComponentProps, React.HTMLAttributes<HTMLDivElement> {
   multiline?: boolean
   keyIcon?: IconName
   keyContent?: string

--- a/src/layout/Side/SidePanelContent/SidePanelContent.tsx
+++ b/src/layout/Side/SidePanelContent/SidePanelContent.tsx
@@ -18,7 +18,7 @@ function SidePanelContent(
     children,
     onChangeSideWidth = noop,
   }: SidePanelContentProps,
-  forwardedRef: Ref<any>,
+  forwardedRef: Ref<HTMLDivElement>,
 ) {
   const dispatch = useLayoutDispatch()
 

--- a/src/layout/Side/SidePanelContent/SidePanelContent.tsx
+++ b/src/layout/Side/SidePanelContent/SidePanelContent.tsx
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React, { useEffect } from 'react'
+import React, { forwardRef, Ref, useEffect } from 'react'
 import { noop } from 'lodash-es'
 
 /* Internal dependencies */
@@ -12,11 +12,14 @@ import SidePanelContentProps from './SidePanelContent.types'
 // TODO: 테스트 코드 작성
 const SIDE_PANEL_CONTENT_TEST_ID = 'bezier-react-side-panel-content'
 
-function SidePanelContent({
-  testId = SIDE_PANEL_CONTENT_TEST_ID,
-  children,
-  onChangeSideWidth = noop,
-}: SidePanelContentProps) {
+function SidePanelContent(
+  {
+    testId = SIDE_PANEL_CONTENT_TEST_ID,
+    children,
+    onChangeSideWidth = noop,
+  }: SidePanelContentProps,
+  forwardedRef: Ref<any>,
+) {
   const dispatch = useLayoutDispatch()
 
   useEffect(() => {
@@ -34,6 +37,7 @@ function SidePanelContent({
 
   return (
     <SideArea
+      ref={forwardedRef}
       sideType={LayoutSideType.SidePanel}
       data-testid={testId}
       onChangeSideWidth={onChangeSideWidth}
@@ -43,4 +47,4 @@ function SidePanelContent({
   )
 }
 
-export default SidePanelContent
+export default forwardRef(SidePanelContent)


### PR DESCRIPTION
## Changes Detail
- SidePanelContent에 ref를 추가했습니다(UserChatSidePanel에서 사용되고 있음)
- KeyValueListITem이 HTMLAttr을 extend하게 변경했습니다

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
