### PR TITLE
Button active 스타일이 focus pseudo selector 에서는 활성화되지 않도록 수정

### DIFF
--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -63,8 +63,7 @@ function monochromeVariantConverter(styleVariant?: ButtonStyleVariant, disabled?
           background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
 
           ${!disabled && css`
-            &:hover,
-            &:focus {
+            &:hover {
               background-color: ${({ foundation }) => foundation?.theme?.['bg-black-light']};
             }
           `}
@@ -75,8 +74,7 @@ function monochromeVariantConverter(styleVariant?: ButtonStyleVariant, disabled?
           background-color: transparent;
 
           ${!disabled && css`
-            &:hover,
-            &:focus {
+            &:hover {
               background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lightest']};
             }
           `}
@@ -87,8 +85,7 @@ function monochromeVariantConverter(styleVariant?: ButtonStyleVariant, disabled?
           ${({ foundation }) => foundation?.elevation?.ev3()};
 
           ${!disabled && css`
-            &:hover,
-            &:focus {
+            &:hover {
               ${({ foundation }) => foundation?.elevation?.ev4()};
             }
           `}
@@ -100,8 +97,7 @@ function monochromeVariantConverter(styleVariant?: ButtonStyleVariant, disabled?
           background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-absolute-black-lightest']};
 
           ${!disabled && css`
-            &:hover,
-            &:focus {
+            &:hover {
               background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-absolute-black-lighter']};
             }
           `}
@@ -137,8 +133,7 @@ function monochromeVariantConverter(styleVariant?: ButtonStyleVariant, disabled?
     ${colorCSS};
     ${active && activeCSS};
 
-    &:hover,
-    &:focus {
+    &:hover {
       ${activeCSS};
     }
   `
@@ -153,8 +148,7 @@ function getEffectCSSFromVariant(styleVariant?: ButtonStyleVariant, size?: Butto
         overflow: hidden;
         border-radius: 1000px;
 
-        &:hover,
-        &:focus {
+        &:hover {
           ${({ foundation }) => foundation?.elevation?.ev4()};
         }
       `
@@ -253,8 +247,7 @@ function getCSSFromVariant({
     ${colorCSS};
     ${active && activeCSS};
 
-    &:hover,
-    &:focus {
+    &:hover {
       ${activeCSS};
     }
   `


### PR DESCRIPTION
# Description
Button 의 active 스타일이 focus selector 에도 걸리는 문제를 수정합니다.

## Changes Detail
https://github.com/channel-io/bezier-react/pull/89#discussion_r627929043 에서 focus 시의 스타일로 activeCSS 를 제안했는데, 이는 버튼 클릭 후 active 스타일이 빠지지 않는 문제가 있었습니다. 따라서 focus 시에는 activeCSS 를 제외하며, 추후 다른 스타일로 보강할 필요가 있습니다.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
