### PR TITLE
Text의 display: flex 삭제

### DIFF
--- a/src/components/Input/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Input/Select/__snapshots__/Select.test.tsx.snap
@@ -18,10 +18,6 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
 }
 
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   font-size: 14px;
   line-height: 18px;
   margin: 0px 0px 0px 0px;

--- a/src/components/Text/Text.styled.ts
+++ b/src/components/Text/Text.styled.ts
@@ -20,7 +20,6 @@ function getMargin({
 }
 
 const Text = styled.span<TextProps & TextStyledProps>`
-  display: flex;
   ${props => props.typo};
   margin: ${getMargin};
   font-style: ${props => (props.italic ? 'italic' : 'normal')};


### PR DESCRIPTION
# Description

이전 PR에서 추가되었던 Text 컴포넌트의 `display: flex` 속성을 삭제합니다.
인라인 스타일이 블록 스타일로 변경되면서 예기치 못한 사이드 이펙트가 많아서 제거합니다.

## Changes Detail
* 변경1 세부사항
* 변경2 세부사항

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
