### PR TITLE
ListItem disabled, color props추가

### DIFF
--- a/src/components/ListItem/ListItem.stories.tsx
+++ b/src/components/ListItem/ListItem.stories.tsx
@@ -8,7 +8,10 @@ import {
   getTitle,
 } from '../../utils/storyUtils'
 import ListItem from './ListItem'
-import { ListItemSize } from './ListItem.types'
+import {
+  ListItemSize,
+  ListItemColorVariant,
+} from './ListItem.types'
 
 export default {
   title: getTitle(base),
@@ -23,7 +26,14 @@ export default {
       },
     },
     disabled: { control: { type: 'boolean' } },
-    color: { control: { type: 'select', options: ['bgtxt-red-normal', 'bgtxt-green-normal', 'txt-black-darkest'] } },
+    colorVariant: {
+      control: {
+        type: 'radio',
+        options: [
+          ...Object.values(ListItemColorVariant),
+        ],
+      },
+    },
     active: { control: { type: 'boolean' } },
     leftIcon: { control: { type: 'select', options: [...iconList, undefined] } },
     size: { control: { type: 'select', options: ListItemSize } },

--- a/src/components/ListItem/ListItem.stories.tsx
+++ b/src/components/ListItem/ListItem.stories.tsx
@@ -22,6 +22,8 @@ export default {
         step: 1,
       },
     },
+    disabled: { control: { type: 'boolean' } },
+    color: { control: { type: 'select', options: ['bgtxt-red-normal', 'bgtxt-green-normal', 'txt-black-darkest'] } },
     active: { control: { type: 'boolean' } },
     leftIcon: { control: { type: 'select', options: [...iconList, undefined] } },
     size: { control: { type: 'select', options: ListItemSize } },

--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -1,5 +1,11 @@
 /* Internal dependencies */
-import { css, ellipsis, LineHeightAbsoluteNumber, styled } from '../../foundation'
+import disabledOpacity from '../../constants/DisabledOpacity'
+import {
+  css,
+  ellipsis,
+  LineHeightAbsoluteNumber,
+  styled,
+} from '../../foundation'
 import { SemanticNames } from '../../foundation/Colors/Theme'
 import { Icon } from '../Icon'
 import { ListItemSize } from './ListItem.types'
@@ -13,7 +19,7 @@ interface StyledWrapperProps {
 }
 
 const ActiveItemStyle = css<StyledWrapperProps>`
-  color: ${({ foundation, color }) => (color ? foundation?.theme?.[color] : foundation?.theme?.['bgtxt-blue-normal'])};
+  color: ${({ foundation, color }) => (foundation?.theme?.[color ?? 'bgtxt-blue-normal'])};
   background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-blue-lightest']};
 `
 
@@ -28,20 +34,14 @@ export const TitleWrapper = styled.div`
   align-items: center;
 `
 
-interface DescriptionProps {
-  active?: boolean
-}
-
-export const DescriptionWrapper = styled.div<DescriptionProps>`
+export const DescriptionWrapper = styled.div`
   display: flex;
   grid-row: 2;
   grid-column: 2;
   align-items: center;
   width: 100%;
   margin-top: 2px;
-  color: ${({ foundation, active }) => (active
-    ? foundation?.theme['bgtxt-blue-normal']
-    : foundation?.theme['txt-black-darker'])
+  color: ${({ foundation }) => (foundation?.theme['txt-black-darker'])
 };
 `
 
@@ -60,7 +60,6 @@ export const Description = styled.div<DescriptionProps>`
 interface IconWrapperProps {
   color?: SemanticNames
   active?: boolean
-  disableIconActive?: boolean
 }
 
 export const StyledIcon = styled(Icon)<IconWrapperProps>`
@@ -68,7 +67,7 @@ export const StyledIcon = styled(Icon)<IconWrapperProps>`
     if (props.color) {
       return props.foundation?.theme?.[props.color]
     }
-    if (!props.disableIconActive && props.active) { return props.foundation?.theme['bgtxt-blue-normal'] }
+    if (props.active) { return props.foundation?.theme['bgtxt-blue-normal'] }
     return props.foundation?.theme?.['txt-black-dark']
   }};
 `
@@ -94,7 +93,7 @@ export const Wrapper = styled.div<StyledWrapperProps>`
   color: ${({ foundation, color }) => foundation?.theme?.[color || 'txt-black-darkest']};
   text-decoration: none;
   cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
-  opacity: ${({ disabled }) => (disabled ? 0.4 : 1)};
+  opacity: ${({ disabled }) => (disabled ? disabledOpacity : 1)};
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'color'])};
 
@@ -109,11 +108,11 @@ export const Wrapper = styled.div<StyledWrapperProps>`
     if (color) {
       return foundation?.theme?.[color]
     }
-    if (!disabled) {
-      return active ? foundation?.theme?.['bgtxt-blue-normal'] : foundation?.theme?.['txt-black-darkest']
+    if (active) {
+      return foundation?.theme?.['bgtxt-blue-normal']
     }
 
-    return foundation?.theme?.['txt-black-dark']
+    return disabled ? foundation?.theme?.['txt-black-dark'] : foundation?.theme?.['txt-black-darkest']
   }}
   }
 

--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -8,10 +8,12 @@ import { getStyleOfSize } from './utils'
 interface StyledWrapperProps {
   size?: ListItemSize
   active?: boolean
+  disabled?: boolean
+  color?: SemanticNames
 }
 
 const ActiveItemStyle = css<StyledWrapperProps>`
-  color: ${({ foundation }) => foundation?.theme?.['bgtxt-blue-normal']};
+  color: ${({ foundation, color }) => (color ? foundation?.theme?.[color] : foundation?.theme?.['bgtxt-blue-normal'])};
   background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-blue-lightest']};
 `
 
@@ -63,8 +65,11 @@ interface IconWrapperProps {
 
 export const StyledIcon = styled(Icon)<IconWrapperProps>`
   color: ${props => {
+    if (props.color) {
+      return props.foundation?.theme?.[props.color]
+    }
     if (!props.disableIconActive && props.active) { return props.foundation?.theme['bgtxt-blue-normal'] }
-    return props.foundation?.theme?.[props.color || 'txt-black-dark']
+    return props.foundation?.theme?.['txt-black-dark']
   }};
 `
 
@@ -86,23 +91,30 @@ export const Wrapper = styled.div<StyledWrapperProps>`
   display: flex;
   align-items: center;
   ${({ size }) => getStyleOfSize(size)}
-  color: ${({ foundation }) => foundation?.theme?.['txt-black-darkest']};
+  color: ${({ foundation, color }) => foundation?.theme?.[color || 'txt-black-darkest']};
   text-decoration: none;
-  cursor: pointer;
+  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
+  opacity: ${({ disabled }) => (disabled ? 0.4 : 1)};
+
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'color'])};
 
   &:hover {
-    ${({ foundation, active }) => (!active && `
+    ${({ foundation, disabled, active }) => (!disabled && !active && `
       background-color: ${foundation?.theme?.['bg-black-lighter']};
     `)}
   }
 
   &:hover ${StyledIcon} {
-    color: ${({ foundation, active, color }) => (
-    active
-      ? foundation?.theme['bgtxt-blue-normal']
-      : foundation?.theme?.[color || 'txt-black-darkest']
-  )};
+    color: ${({ disabled, foundation, active, color }) => {
+    if (color) {
+      return foundation?.theme?.[color]
+    }
+    if (!disabled) {
+      return active ? foundation?.theme?.['bgtxt-blue-normal'] : foundation?.theme?.['txt-black-darkest']
+    }
+
+    return foundation?.theme?.['txt-black-dark']
+  }}
   }
 
   ${({ active }) => (active && ActiveItemStyle)}

--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -8,18 +8,41 @@ import {
 } from '../../foundation'
 import { SemanticNames } from '../../foundation/Colors/Theme'
 import { Icon } from '../Icon'
-import { ListItemSize } from './ListItem.types'
+import {
+  ListItemColorVariant,
+  ListItemSize,
+} from './ListItem.types'
 import { getStyleOfSize } from './utils'
 
 interface StyledWrapperProps {
   size?: ListItemSize
   active?: boolean
   disabled?: boolean
-  color?: SemanticNames
+  colorVariant: ListItemColorVariant
+}
+
+const getColorFromColorVariantWithDefaultValue = (
+  colorVariant: ListItemColorVariant,
+  defaultValue: SemanticNames,
+): SemanticNames => {
+  switch (colorVariant) {
+    case (ListItemColorVariant.Blue):
+      return 'bgtxt-blue-normal'
+    case (ListItemColorVariant.Red):
+      return 'bgtxt-red-normal'
+    case (ListItemColorVariant.Green):
+      return 'bgtxt-green-normal'
+    case (ListItemColorVariant.Cobalt):
+      return 'bgtxt-cobalt-normal'
+    default:
+      return defaultValue
+  }
 }
 
 const ActiveItemStyle = css<StyledWrapperProps>`
-  color: ${({ foundation, color }) => (foundation?.theme?.[color ?? 'bgtxt-blue-normal'])};
+  color: ${({ foundation, colorVariant }) => (
+    foundation?.theme?.[getColorFromColorVariantWithDefaultValue(colorVariant, 'bgtxt-blue-normal')]
+  )};
   background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-blue-lightest']};
 `
 
@@ -58,18 +81,14 @@ export const Description = styled.div<DescriptionProps>`
 `
 
 interface IconWrapperProps {
-  color?: SemanticNames
+  colorVariant: ListItemColorVariant
   active?: boolean
 }
 
 export const StyledIcon = styled(Icon)<IconWrapperProps>`
-  color: ${props => {
-    if (props.color) {
-      return props.foundation?.theme?.[props.color]
-    }
-    if (props.active) { return props.foundation?.theme['bgtxt-blue-normal'] }
-    return props.foundation?.theme?.['txt-black-dark']
-  }};
+  color: ${({ foundation, colorVariant, active }) => (
+    foundation?.theme?.[getColorFromColorVariantWithDefaultValue(colorVariant, active ? 'bgtxt-blue-normal' : 'txt-black-dark')]
+  )};
 `
 
 export const LeftContentWrapper = styled.div`
@@ -90,7 +109,9 @@ export const Wrapper = styled.div<StyledWrapperProps>`
   display: flex;
   align-items: center;
   ${({ size }) => getStyleOfSize(size)}
-  color: ${({ foundation, color }) => foundation?.theme?.[color || 'txt-black-darkest']};
+  color: ${({ foundation, colorVariant }) => (
+    foundation?.theme?.[getColorFromColorVariantWithDefaultValue(colorVariant, 'txt-black-darkest')]
+  )};
   text-decoration: none;
   cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
   opacity: ${({ disabled }) => (disabled ? disabledOpacity : 1)};
@@ -104,16 +125,12 @@ export const Wrapper = styled.div<StyledWrapperProps>`
   }
 
   &:hover ${StyledIcon} {
-    color: ${({ disabled, foundation, active, color }) => {
-    if (color) {
-      return foundation?.theme?.[color]
-    }
-    if (active) {
-      return foundation?.theme?.['bgtxt-blue-normal']
-    }
-
-    return disabled ? foundation?.theme?.['txt-black-dark'] : foundation?.theme?.['txt-black-darkest']
-  }}
+    color: ${({ foundation, active, colorVariant }) => (
+    foundation?.theme?.[getColorFromColorVariantWithDefaultValue(
+      colorVariant,
+      active ? 'bgtxt-blue-normal' : 'txt-black-dark',
+    )]
+  )};
   }
 
   ${({ active }) => (active && ActiveItemStyle)}

--- a/src/components/ListItem/ListItem.test.tsx
+++ b/src/components/ListItem/ListItem.test.tsx
@@ -1,11 +1,12 @@
 /* External dependencies */
 import React from 'react'
 import { getWindow, getDocument } from 'ssr-window'
+import { LightFoundation } from '../../foundation'
 
 /* Internal dependencies */
 import { render } from '../../utils/testUtils'
 import ListItem, { LIST_ITEM_TEST_ID } from './ListItem'
-import ListItemProps, { ListItemSize } from './ListItem.types'
+import ListItemProps, { ListItemColorVariant, ListItemSize } from './ListItem.types'
 
 describe('ListItem', () => {
   let props: ListItemProps
@@ -21,6 +22,13 @@ describe('ListItem', () => {
   const renderComponent = (optionProps?: Partial<ListItemProps>) => render(
     <ListItem {...props} {...optionProps} />,
   )
+
+  it('Snapshot >', () => {
+    const { getByTestId } = renderComponent()
+    const rendered = getByTestId(LIST_ITEM_TEST_ID)
+
+    expect(rendered).toMatchSnapshot()
+  })
 
   it('should have "optionKey" value on "data-option-key" ', () => {
     const { getByTestId } = renderComponent({ optionKey: 'my-menu-item' })
@@ -48,6 +56,70 @@ describe('ListItem', () => {
     const { queryByTestId } = renderComponent({ hide: true })
     const rendered = queryByTestId(LIST_ITEM_TEST_ID)
     expect(rendered).not.toBeInTheDocument()
+  })
+
+  describe('should have correct style of "colorVariant"', () => {
+    it('red', () => {
+      const { getByTestId } = renderComponent({ colorVariant: ListItemColorVariant.Red })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-red-normal']}`)
+    })
+
+    it('blue', () => {
+      const { getByTestId } = renderComponent({ colorVariant: ListItemColorVariant.Blue })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-blue-normal']}`)
+    })
+
+    it('green', () => {
+      const { getByTestId } = renderComponent({ colorVariant: ListItemColorVariant.Green })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-green-normal']}`)
+    })
+
+    it('cobalt', () => {
+      const { getByTestId } = renderComponent({ colorVariant: ListItemColorVariant.Cobalt })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-cobalt-normal']}`)
+    })
+
+    it('monoChrome', () => {
+      const { getByTestId } = renderComponent({ colorVariant: ListItemColorVariant.Monochrome })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['txt-black-darkest']}`)
+    })
+  })
+
+  describe('should have correct style of "colorVariant" and "active" ', () => {
+    it('red', () => {
+      const { getByTestId } = renderComponent({ colorVariant: ListItemColorVariant.Red, active: true })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-red-normal']}`)
+    })
+
+    it('blue', () => {
+      const { getByTestId } = renderComponent({ colorVariant: ListItemColorVariant.Blue, active: true })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-blue-normal']}`)
+    })
+
+    it('green', () => {
+      const { getByTestId } = renderComponent({ colorVariant: ListItemColorVariant.Green, active: true })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-green-normal']}`)
+    })
+
+    it('cobalt', () => {
+      const { getByTestId } = renderComponent({ colorVariant: ListItemColorVariant.Cobalt, active: true })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-cobalt-normal']}`)
+    })
+
+    it('monoChrome', () => {
+      const { getByTestId } = renderComponent({ colorVariant: ListItemColorVariant.Monochrome, active: true })
+      const rendered = getByTestId(LIST_ITEM_TEST_ID)
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-blue-normal']}`)
+    })
   })
 
   describe('should have correct style of "size"', () => {

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -37,7 +37,7 @@ function ListItem({
   name,
   leftContent,
   leftIcon,
-  leftIconColor,
+  color,
   disableIconActive = false,
   href,
   hide = false,
@@ -47,6 +47,7 @@ function ListItem({
   /* Activable Element Props */
   active,
   activeClassName,
+  disabled = false,
   /* HTMLAttribute Props */
   onClick = noop,
   onMouseDown = noop,
@@ -63,8 +64,11 @@ function ListItem({
   ])
 
   const handleClick = useCallback((e: React.MouseEvent) => {
-    onClick(e, name)
+    if (!disabled) {
+      onClick(e, name)
+    }
   }, [
+    disabled,
     name,
     onClick,
   ])
@@ -108,7 +112,7 @@ function ListItem({
             size={IconSize.S}
             active={active}
             disableIconActive={disableIconActive}
-            color={leftIconColor}
+            color={color}
           />
         </LeftContentWrapper>
       )
@@ -121,7 +125,7 @@ function ListItem({
     iconClassName,
     leftContent,
     leftIcon,
-    leftIconColor,
+    color,
   ])
 
   const titleComponent = useMemo(() => (
@@ -207,6 +211,8 @@ function ListItem({
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         active={false}
+        color={color}
+        disabled={disabled}
         data-active={active}
         data-option-key={optionKey}
         data-testid={testId}
@@ -228,6 +234,8 @@ function ListItem({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       active={active}
+      disabled={disabled}
+      color={color}
       data-active={active}
       data-option-key={optionKey}
       data-testid={testId}

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -8,7 +8,7 @@ import { mergeClassNames } from '../../utils/stringUtils'
 import { Text } from '../Text'
 import { IconSize } from '../Icon'
 import { isIconName } from '../Icon/util'
-import { SemanticNames, Typography } from '../../foundation'
+import { Typography } from '../../foundation'
 import ListItemProps, { ListItemSize, ListItemColorVariant } from './ListItem.types'
 import {
   Wrapper,
@@ -23,14 +23,6 @@ import {
 } from './ListItem.styled'
 
 export const LIST_ITEM_TEST_ID = 'bezier-react-list-menu-item'
-
-const ColorVariantToColor: { [key in ListItemColorVariant]? : SemanticNames } = {
-  [ListItemColorVariant.Blue]: 'bgtxt-blue-normal',
-  [ListItemColorVariant.Red]: 'bgtxt-red-normal',
-  [ListItemColorVariant.Green]: 'bgtxt-green-normal',
-  [ListItemColorVariant.Cobalt]: 'bgtxt-cobalt-normal',
-  [ListItemColorVariant.Monochrome]: undefined,
-}
 
 function ListItem({
   className,
@@ -69,8 +61,6 @@ function ListItem({
     activeClassName,
     active,
   ])
-
-  const color = ColorVariantToColor[colorVariant]
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     if (!disabled) {
@@ -120,7 +110,7 @@ function ListItem({
             name={leftIcon}
             size={IconSize.S}
             active={active}
-            color={color}
+            colorVariant={colorVariant}
           />
         </LeftContentWrapper>
       )
@@ -132,7 +122,7 @@ function ListItem({
     iconClassName,
     leftContent,
     leftIcon,
-    color,
+    colorVariant,
   ])
 
   const titleComponent = useMemo(() => (
@@ -215,7 +205,7 @@ function ListItem({
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         active={false}
-        color={color}
+        colorVariant={colorVariant}
         disabled={disabled}
         data-active={active}
         data-option-key={optionKey}
@@ -239,7 +229,7 @@ function ListItem({
       onMouseLeave={onMouseLeave}
       active={active}
       disabled={disabled}
-      color={color}
+      colorVariant={colorVariant}
       data-active={active}
       data-option-key={optionKey}
       data-testid={testId}

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -8,8 +8,8 @@ import { mergeClassNames } from '../../utils/stringUtils'
 import { Text } from '../Text'
 import { IconSize } from '../Icon'
 import { isIconName } from '../Icon/util'
-import { Typography } from '../../foundation'
-import ListItemProps, { ListItemSize } from './ListItem.types'
+import { SemanticNames, Typography } from '../../foundation'
+import ListItemProps, { ListItemSize, ListItemColorVariant } from './ListItem.types'
 import {
   Wrapper,
   LeftContentWrapper,
@@ -24,6 +24,14 @@ import {
 
 export const LIST_ITEM_TEST_ID = 'bezier-react-list-menu-item'
 
+const ColorVariantToColor: { [key in ListItemColorVariant]? : SemanticNames } = {
+  [ListItemColorVariant.Blue]: 'bgtxt-blue-normal',
+  [ListItemColorVariant.Red]: 'bgtxt-red-normal',
+  [ListItemColorVariant.Green]: 'bgtxt-green-normal',
+  [ListItemColorVariant.Cobalt]: 'bgtxt-cobalt-normal',
+  [ListItemColorVariant.Monochrome]: undefined,
+}
+
 function ListItem({
   className,
   contentClassName,
@@ -37,8 +45,7 @@ function ListItem({
   name,
   leftContent,
   leftIcon,
-  color,
-  disableIconActive = false,
+  colorVariant = ListItemColorVariant.Monochrome,
   href,
   hide = false,
   rightContent = null,
@@ -62,6 +69,8 @@ function ListItem({
     activeClassName,
     active,
   ])
+
+  const color = ColorVariantToColor[colorVariant]
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     if (!disabled) {
@@ -111,7 +120,6 @@ function ListItem({
             name={leftIcon}
             size={IconSize.S}
             active={active}
-            disableIconActive={disableIconActive}
             color={color}
           />
         </LeftContentWrapper>
@@ -121,7 +129,6 @@ function ListItem({
     return null
   }, [
     active,
-    disableIconActive,
     iconClassName,
     leftContent,
     leftIcon,
@@ -151,9 +158,7 @@ function ListItem({
   ])
 
   const descriptionComponent = useMemo(() => (
-    <DescriptionWrapper
-      active={active}
-    >
+    <DescriptionWrapper>
       <Description descriptionMaxLines={descriptionMaxLines}>
         {
           isString(description)
@@ -163,7 +168,6 @@ function ListItem({
       </Description>
     </DescriptionWrapper>
   ), [
-    active,
     description,
     descriptionMaxLines,
     getNewLineComponenet,

--- a/src/components/ListItem/ListItem.types.ts
+++ b/src/components/ListItem/ListItem.types.ts
@@ -23,7 +23,8 @@ export default interface ListItemProps extends ContentComponentProps, ActivableE
   nested?: boolean
   leftContent?: React.ReactNode
   leftIcon?: IconName
-  leftIconColor?: SemanticNames
+  color?: SemanticNames
+  disabled?: boolean
   disableIconActive?: boolean
   descriptionMaxLines?: number
   content?: React.ReactNode

--- a/src/components/ListItem/ListItem.types.ts
+++ b/src/components/ListItem/ListItem.types.ts
@@ -1,6 +1,5 @@
 /* Internal dependencies */
 import React from 'react'
-import { SemanticNames } from '../../foundation/Colors/Theme'
 import ActivableElement from '../../types/ActivatableElement'
 import { ContentComponentProps } from '../../types/ComponentProps'
 import OptionItem from '../../types/OptionItem'
@@ -13,6 +12,14 @@ export enum ListItemSize {
   XL = 'xl',
 }
 
+export enum ListItemColorVariant {
+  Blue = 'blue',
+  Red = 'red',
+  Green = 'green',
+  Cobalt = 'cobalt',
+  Monochrome = 'monochrome',
+}
+
 export default interface ListItemProps extends ContentComponentProps, ActivableElement, OptionItem {
   iconClassName?: string
   contentClassName?: string
@@ -23,7 +30,7 @@ export default interface ListItemProps extends ContentComponentProps, ActivableE
   nested?: boolean
   leftContent?: React.ReactNode
   leftIcon?: IconName
-  color?: SemanticNames
+  colorVariant?: ListItemColorVariant
   disabled?: boolean
   disableIconActive?: boolean
   descriptionMaxLines?: number

--- a/src/components/ListItem/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/ListItem/__snapshots__/ListItem.test.tsx.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListItem Snapshot > 1`] = `
+.c4 {
+  font-size: 14px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: inherit;
+  -webkit-transition-property: color;
+  transition-property: color;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-row: 1;
+  grid-column: 2;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c1 {
+  display: grid;
+  grid-template-columns: fit-content(100%) minmax(0,1fr);
+  width: 100%;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 6px;
+  overflow: hidden;
+  border-radius: 6px;
+  color: #000000D9;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 1;
+  -webkit-transition-property: background-color,color;
+  transition-property: background-color,color;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+}
+
+.c0:hover {
+  background-color: #0000000D;
+}
+
+.c0:hover .sc-iCoGMd {
+  color: #00000066;
+}
+
+<div
+  class="c0"
+  data-active="false"
+  data-option-key="menu-item"
+  data-testid="bezier-react-list-menu-item"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <span
+          class="c4"
+          data-testid="bezier-react-text"
+        >
+          this is content
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/ListItem/index.ts
+++ b/src/components/ListItem/index.ts
@@ -1,4 +1,5 @@
 import ListItem from './ListItem'
+import { ListItemColorVariant } from './ListItem.types'
 import type ListItemProps from './ListItem.types'
 
 export type {
@@ -7,4 +8,5 @@ export type {
 
 export {
   ListItem,
+  ListItemColorVariant,
 }


### PR DESCRIPTION
# Description
ListItem disabled 디자인 및 color props추가
colorVariant props전달시에 icon, text color가 고정이 되도록 했습니다.
**description은 active 여부와 상관없이 'txt-black-darker'로 색상이 고정됩니다.** (jamie와 싱크후 변경됨)
disabled시엔 opacity: 0.4, cursor, hover, onClick 이벤트 블락 처리를 해주었습니다.

![image](https://user-images.githubusercontent.com/24201089/119516793-0293c880-bdb2-11eb-9855-5536ecfa582d.png)
[피그마 링크](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=10663%3A155649
)
## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
