### PR TITLE
Avatar의 avatarUrl이 업데이트 되지 않는 문제 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@svgr/cli": "^5.5.0",
         "@testing-library/jest-dom": "^5.11.6",
         "@testing-library/react": "^11.2.6",
+        "@testing-library/react-hooks": "^7.0.0",
         "@testing-library/user-event": "^13.1.9",
         "@types/jest": "^25.2.3",
         "@types/lodash-es": "^4.17.4",
@@ -5402,6 +5403,35 @@
         "react-dom": "*"
       }
     },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.0.tgz",
+      "integrity": "sha512-WFBGH8DWdIGGBHt6PBtQPe2v4Kbj9vQ1sQ9qLBTmwn1PNggngint4MTE/IiWCYhPbyTW3oc/7X62DObMn/AjQQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0",
+        "react-test-renderer": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@testing-library/user-event": {
       "version": "13.1.9",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.9.tgz",
@@ -5920,6 +5950,15 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz",
       "integrity": "sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -24819,6 +24858,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
+      "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
@@ -30911,9 +30966,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -35160,6 +35215,19 @@
         "@testing-library/dom": "^7.28.1"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.0.tgz",
+      "integrity": "sha512-WFBGH8DWdIGGBHt6PBtQPe2v4Kbj9vQ1sQ9qLBTmwn1PNggngint4MTE/IiWCYhPbyTW3oc/7X62DObMn/AjQQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      }
+    },
     "@testing-library/user-event": {
       "version": "13.1.9",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.9.tgz",
@@ -35652,6 +35720,15 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz",
       "integrity": "sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -50257,6 +50334,15 @@
         }
       }
     },
+    "react-error-boundary": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
+      "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "react-error-overlay": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
@@ -55088,9 +55174,9 @@
       }
     },
     "ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@svgr/cli": "^5.5.0",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.6",
+    "@testing-library/react-hooks": "^7.0.0",
     "@testing-library/user-event": "^13.1.9",
     "@types/jest": "^25.2.3",
     "@types/lodash-es": "^4.17.4",

--- a/src/components/Avatars/Avatar/Avatar.test.tsx
+++ b/src/components/Avatars/Avatar/Avatar.test.tsx
@@ -6,6 +6,7 @@ import { render } from '../../../utils/testUtils'
 import Avatar, { AVATAR_TEST_ID } from './Avatar'
 import AvatarProps from './Avatar.types'
 
+// TODO: 테스트 코드 보강
 describe('Avatar test >', () => {
   let props: AvatarProps
 

--- a/src/components/Avatars/Avatar/Avatar.test.tsx
+++ b/src/components/Avatars/Avatar/Avatar.test.tsx
@@ -1,0 +1,34 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { render } from '../../../utils/testUtils'
+import Avatar, { AVATAR_TEST_ID } from './Avatar'
+import AvatarProps from './Avatar.types'
+
+describe('Avatar test >', () => {
+  let props: AvatarProps
+
+  const mockAvatarUrl = 'https://bit.ly/dan-abramov'
+  const mockFallbackUrl = 'https://www.google.com'
+
+  beforeEach(() => {
+    props = {
+      avatarUrl: mockAvatarUrl,
+      fallbackUrl: mockFallbackUrl,
+      name: 'Name',
+    }
+  })
+
+  // NOTE: unavailable smoothCorners
+  const renderAvatar = (optionProps?: AvatarProps) => render(
+    <Avatar {...props} {...optionProps} />,
+  )
+
+  it('Snapshot', () => {
+    const { getByTestId } = renderAvatar()
+    const avatar = getByTestId(AVATAR_TEST_ID)
+
+    expect(avatar).toMatchSnapshot()
+  })
+})

--- a/src/components/Avatars/Avatar/Avatar.tsx
+++ b/src/components/Avatars/Avatar/Avatar.tsx
@@ -11,7 +11,7 @@ import { StyledAvatar, AvatarWrapper, StatusWrapper } from './Avatar.styled'
 
 // TODO: 테스트 코드 작성
 const AVATAR_WRAPPER_TEST_ID = 'bezier-react-avatar-wrapper'
-const AVATAR_TEST_ID = 'bezier-react-avatar'
+export const AVATAR_TEST_ID = 'bezier-react-avatar'
 
 function Avatar({
   avatarUrl = '',

--- a/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Avatar test > Snapshot 1`] = `
+.c0 {
+  position: relative;
+  box-sizing: content-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  outline: none;
+  margin: 0px;
+  background-color: #FFFFFFE6;
+  background-image: url(https://www.google.com);
+  background-size: cover;
+  border-radius: 42%;
+}
+
+@supports (background:paint(smooth-corners)) {
+  .c0 {
+    padding: 0px;
+    margin: 0px;
+    background: paint(smooth-corners);
+    border-radius: 0;
+    border-image-source: url(https://www.google.com);
+    box-shadow: none;
+    --smooth-corners: 42%;
+    --smooth-corners-shadow: 0 0 0 0 transparent;
+    --smooth-corners-bg-color: #FFFFFFE6;
+    --smooth-corners-padding: 0;
+    --smooth-corners-radius-unit: string;
+  }
+}
+
+<div
+  aria-label="Name"
+  class="c0"
+  data-testid="bezier-react-avatar"
+  role="img"
+  size="24"
+/>
+`;

--- a/src/hooks/useProgressiveImage.test.ts
+++ b/src/hooks/useProgressiveImage.test.ts
@@ -1,0 +1,52 @@
+/* External dependencies */
+import { renderHook } from '@testing-library/react-hooks'
+
+/* Internal dependencies */
+import useProgressiveImage, { CachedImage } from './useProgressiveImage'
+
+describe('useProgressiveImage >', () => {
+  const mockValidImageUrlFoo = 'valid_foo'
+  const mockValidImageUrlBar = 'valid_bar'
+  const mockInvalidImageUrl = 'invalid'
+  const mockFallbackImageUrl = 'fallback'
+
+  const mockImageCache = new Map<string, CachedImage>()
+
+  mockImageCache.set(mockValidImageUrlFoo, { src: mockValidImageUrlFoo, isLoaded: true })
+  mockImageCache.set(mockInvalidImageUrl, { src: mockInvalidImageUrl, isLoaded: false })
+
+  it('should return giving url when imageCache.get(givingUrl).isLoaded is "true"', () => {
+    const { result } = renderHook(() => useProgressiveImage(mockValidImageUrlFoo, mockFallbackImageUrl, mockImageCache))
+
+    expect(result.current).toStrictEqual(mockValidImageUrlFoo)
+  })
+
+  it('should return fallback url when imageCache.get(givingUrl).isLoaded is "false"', () => {
+    const { result } = renderHook(() => useProgressiveImage(mockInvalidImageUrl, mockFallbackImageUrl, mockImageCache))
+
+    expect(result.current).toStrictEqual(mockFallbackImageUrl)
+  })
+
+  it('should update url when imageCache.get(url).isLoaded is "true"', () => {
+    const { result, rerender } = renderHook(({ src, defaultSrc, imageCache }) =>
+      useProgressiveImage(src, defaultSrc, imageCache), {
+      initialProps: {
+        src: mockValidImageUrlFoo,
+        defaultSrc: mockFallbackImageUrl,
+        imageCache: mockImageCache,
+      },
+    })
+
+    expect(result.current).toStrictEqual(mockValidImageUrlFoo)
+
+    mockImageCache.set(mockValidImageUrlBar, { src: mockValidImageUrlBar, isLoaded: true })
+
+    rerender({
+      src: mockValidImageUrlBar,
+      defaultSrc: mockFallbackImageUrl,
+      imageCache: mockImageCache,
+    })
+
+    expect(result.current).toStrictEqual(mockValidImageUrlBar)
+  })
+})

--- a/src/hooks/useProgressiveImage.ts
+++ b/src/hooks/useProgressiveImage.ts
@@ -23,7 +23,7 @@ export default function useProgressiveImage(src: string, defaultSrc: string) {
   const [source, setSource] = useState<CacheImage | null>(() => getInitialSource(src))
 
   useEffect(() => {
-    if (source) { return undefined }
+    if (source?.src === src) { return undefined }
 
     const image = new Image()
     image.src = src


### PR DESCRIPTION
# Description

Avatar 컴포넌트의 avatarUrl이 업데이트 되지 않는 문제를 수정합니다.

## Changes Detail

* 잘못된 useEffect 조건 로직을 수정했습니다. 기존 캐시된 이미지의 url과 전달받은 url이 같을 경우에만 effect 훅을 스킵하도록 변경했습니다.

# Tests
- [x] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* fix #497 
