### PR TITLE
fix(select): dropdown width 100% 제거

### DIFF
--- a/src/components/Input/Select/Select.styled.ts
+++ b/src/components/Input/Select/Select.styled.ts
@@ -90,7 +90,6 @@ export const MainContentWrapper = styled.div`
 `
 
 export const Dropdown = styled(Overlay)`
-  width: 100%;
   min-width: 200px;
   min-height: 42px;
   max-height: 640px;

--- a/src/components/Input/Select/Select.test.tsx
+++ b/src/components/Input/Select/Select.test.tsx
@@ -58,7 +58,6 @@ describe('Select Test >', () => {
 
       const defaultSelectDropdown = getByTestId(SELECT_DROPDOWN_TEST_ID)
 
-      expect(defaultSelectDropdown).toHaveStyle('width: 100%;')
       expect(defaultSelectDropdown).toHaveStyle('min-width: 200px;')
       expect(defaultSelectDropdown).toHaveStyle('min-height: 42px;')
       expect(defaultSelectDropdown).toHaveStyle('max-height: 640px;')


### PR DESCRIPTION
# Description
width 100% 로 인해 children 의 너비를 존중하지 않고 있었음.

# Tests
- [X] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)