### PR TITLE
ListItem에 focused 추가 및 개선

### DIFF
--- a/src/components/ListItem/ListItem.stories.tsx
+++ b/src/components/ListItem/ListItem.stories.tsx
@@ -59,6 +59,8 @@ Primary.args = {
   rightContent: '',
   leftIcon: 'inbox',
   active: false,
+  focused: false,
   disableIconActive: false,
   descriptionMaxLines: 0,
+  href: '',
 }

--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -17,6 +17,7 @@ import { getStyleOfSize } from './utils'
 interface StyledWrapperProps {
   size?: ListItemSize
   active?: boolean
+  focused?: boolean
   disabled?: boolean
   colorVariant: ListItemColorVariant
 }
@@ -38,6 +39,19 @@ const getColorFromColorVariantWithDefaultValue = (
       return defaultValue
   }
 }
+
+const FocusedItemStyle = css<StyledWrapperProps>`
+  background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
+`
+
+const FocusedIconStyle = css<StyledWrapperProps>`
+  color: ${({ foundation, active, colorVariant }) => (
+    foundation?.theme?.[getColorFromColorVariantWithDefaultValue(
+      colorVariant,
+      active ? 'bgtxt-blue-normal' : 'txt-black-dark',
+    )]
+  )};
+`
 
 const ActiveItemStyle = css<StyledWrapperProps>`
   color: ${({ foundation, colorVariant }) => (
@@ -118,20 +132,23 @@ export const Wrapper = styled.div<StyledWrapperProps>`
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'color'])};
 
-  &:hover {
-    ${({ foundation, disabled, active }) => (!disabled && !active && `
-      background-color: ${foundation?.theme?.['bg-black-lighter']};
-    `)}
-  }
+  ${({ disabled, active, focused }) => !disabled && !active && css`
+    ${focused && css`
+      ${FocusedItemStyle}
 
-  &:hover ${StyledIcon} {
-    color: ${({ foundation, active, colorVariant }) => (
-    foundation?.theme?.[getColorFromColorVariantWithDefaultValue(
-      colorVariant,
-      active ? 'bgtxt-blue-normal' : 'txt-black-dark',
-    )]
-  )};
-  }
+      ${StyledIcon} {
+        ${FocusedIconStyle}
+      }
+    `}
+
+    &:hover {
+      ${FocusedItemStyle}
+    }
+
+    &:hover ${StyledIcon} {
+      ${FocusedIconStyle}
+    }
+`};
 
   ${({ active }) => (active && ActiveItemStyle)}
 `

--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -5,6 +5,7 @@ import {
   ellipsis,
   LineHeightAbsoluteNumber,
   styled,
+  TransitionDuration,
 } from '../../foundation'
 import { SemanticNames } from '../../foundation/Colors/Theme'
 import { Icon } from '../Icon'
@@ -69,6 +70,10 @@ export const TitleWrapper = styled.div`
   grid-row: 1;
   grid-column: 2;
   align-items: center;
+
+  & span {
+    ${({ foundation }) => foundation?.transition?.getTransitionsCSS('color')};
+  }
 `
 
 export const DescriptionWrapper = styled.div`
@@ -103,6 +108,8 @@ export const StyledIcon = styled(Icon)<IconWrapperProps>`
   color: ${({ foundation, colorVariant, active }) => (
     foundation?.theme?.[getColorFromColorVariantWithDefaultValue(colorVariant, active ? 'bgtxt-blue-normal' : 'txt-black-dark')]
   )};
+  
+  ${({ foundation }) => foundation?.transition?.getTransitionsCSS('color', TransitionDuration.M)};
 `
 
 export const LeftContentWrapper = styled.div`
@@ -123,14 +130,16 @@ export const Wrapper = styled.div<StyledWrapperProps>`
   display: flex;
   align-items: center;
   ${({ size }) => getStyleOfSize(size)}
+
   color: ${({ foundation, colorVariant }) => (
     foundation?.theme?.[getColorFromColorVariantWithDefaultValue(colorVariant, 'txt-black-darkest')]
   )};
+  
   text-decoration: none;
   cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
   opacity: ${({ disabled }) => (disabled ? disabledOpacity : 1)};
 
-  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'color'])};
+  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color'])};
 
   ${({ disabled, active, focused }) => !disabled && !active && css`
     ${focused && css`

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -34,6 +34,8 @@ import {
   ContentWrapper,
 } from './ListItem.styled'
 
+const LINE_BREAK_CHAR = '\n'
+
 export const LIST_ITEM_TEST_ID = 'bezier-react-list-menu-item'
 
 type ListItemRefType = React.Ref<HTMLDivElement & HTMLAnchorElement>
@@ -91,7 +93,7 @@ function ListItem({
   ])
 
   const getNewLineComponenet = useCallback((desc: string) => (
-    desc.split('\n').map((str, index) => {
+    desc.split(LINE_BREAK_CHAR).map((str, index) => {
       if (index === 0) {
         return (
           <Text key={uuid()} typo={Typography.Size12}>

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -1,6 +1,15 @@
 /* External dependencies */
-import React, { Ref, forwardRef, useCallback, useMemo, Fragment } from 'react'
-import { noop, isNil, isString } from 'lodash-es'
+import React, {
+  forwardRef,
+  useCallback,
+  useMemo,
+} from 'react'
+import {
+  noop,
+  isNil,
+  isEmpty,
+  isString,
+} from 'lodash-es'
 import { v4 as uuid } from 'uuid'
 
 /* Internal dependencies */
@@ -9,7 +18,10 @@ import { Text } from '../Text'
 import { IconSize } from '../Icon'
 import { isIconName } from '../Icon/util'
 import { Typography } from '../../foundation'
-import ListItemProps, { ListItemSize, ListItemColorVariant } from './ListItem.types'
+import ListItemProps, {
+  ListItemSize,
+  ListItemColorVariant,
+} from './ListItem.types'
 import {
   Wrapper,
   LeftContentWrapper,
@@ -23,6 +35,8 @@ import {
 } from './ListItem.styled'
 
 export const LIST_ITEM_TEST_ID = 'bezier-react-list-menu-item'
+
+type ListItemRefType = React.Ref<HTMLDivElement & HTMLAnchorElement>
 
 function ListItem({
   className,
@@ -38,7 +52,7 @@ function ListItem({
   leftContent,
   leftIcon,
   colorVariant = ListItemColorVariant.Monochrome,
-  href,
+  href = '',
   hide = false,
   rightContent = null,
   /* OptionItem Props */
@@ -46,20 +60,24 @@ function ListItem({
   /* Activable Element Props */
   active,
   activeClassName,
+  focused = false,
   disabled = false,
   /* HTMLAttribute Props */
   onClick = noop,
   onMouseDown = noop,
   onMouseEnter = noop,
   onMouseLeave = noop,
-  ...othreProps
-}: ListItemProps, forwardedRef: Ref<any>) {
-  const clazzName = useMemo(() => (
-    mergeClassNames(className, ((active && activeClassName) || undefined))
+  ...otherProps
+}: ListItemProps, forwardedRef: ListItemRefType) {
+  const isHyperLink = !isEmpty(href)
+  const isActive = isHyperLink ? false : active
+
+  const mergedClassName = useMemo(() => (
+    mergeClassNames(className, ((isActive && activeClassName) || undefined))
   ), [
     className,
     activeClassName,
-    active,
+    isActive,
   ])
 
   const handleClick = useCallback((e: React.MouseEvent) => {
@@ -83,12 +101,12 @@ function ListItem({
       }
 
       return (
-        <Fragment key={uuid()}>
+        <React.Fragment key={uuid()}>
           <br />
           <Text typo={Typography.Size12}>
             { str }
           </Text>
-        </Fragment>
+        </React.Fragment>
       )
     })
   ), [])
@@ -109,7 +127,7 @@ function ListItem({
             className={iconClassName}
             name={leftIcon}
             size={IconSize.S}
-            active={active}
+            active={isActive}
             colorVariant={colorVariant}
           />
         </LeftContentWrapper>
@@ -118,7 +136,7 @@ function ListItem({
 
     return null
   }, [
-    active,
+    isActive,
     iconClassName,
     leftContent,
     leftIcon,
@@ -128,17 +146,15 @@ function ListItem({
   const titleComponent = useMemo(() => (
     <TitleWrapper className={contentClassName}>
       <Title>
-        {
-          isString(content) ? (
-            <Text
-              typo={size === ListItemSize.XL
-                ? Typography.Size18
-                : Typography.Size14}
-            >
-              { content }
-            </Text>
-          ) : content
-        }
+        { isString(content) ? (
+          <Text
+            typo={size === ListItemSize.XL
+              ? Typography.Size18
+              : Typography.Size14}
+          >
+            { content }
+          </Text>
+        ) : content }
       </Title>
     </TitleWrapper>
   ), [
@@ -187,57 +203,69 @@ function ListItem({
     rightComponent,
   ])
 
+  const commonDataAttr = useMemo(() => ({
+    'data-active': isActive,
+    'data-option-key': optionKey,
+    'data-testid': testId,
+  }), [
+    isActive,
+    optionKey,
+    testId,
+  ])
+
+  const commonListItemProps = useMemo((): ListItemProps & { ref: ListItemRefType } => ({
+    ref: forwardedRef,
+    className: mergedClassName,
+    size,
+    onClick: handleClick,
+    onMouseDown,
+    onMouseEnter,
+    onMouseLeave,
+    active: isActive,
+    focused,
+    disabled,
+    colorVariant,
+    ...otherProps,
+  }), [
+    forwardedRef,
+    mergedClassName,
+    size,
+    handleClick,
+    onMouseDown,
+    onMouseEnter,
+    onMouseLeave,
+    isActive,
+    focused,
+    disabled,
+    colorVariant,
+    otherProps,
+  ])
+
   if (hide) { return null }
 
-  if (!isNil(href)) {
-    return (
+  return isHyperLink
+    ? (
       <Wrapper
-        ref={forwardedRef}
-        as="a"
-        className={clazzName}
-        size={size}
-        draggable={false}
+        {...commonDataAttr}
+        {...commonListItemProps}
+        as={'a' as React.ElementType<any>}
         href={href}
+        draggable={false}
         target="_blank"
         rel="noopener noreferrer"
-        onClick={handleClick}
-        onMouseDown={onMouseDown}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        active={false}
-        colorVariant={colorVariant}
-        disabled={disabled}
-        data-active={active}
-        data-option-key={optionKey}
-        data-testid={testId}
-        {...othreProps}
       >
         { ContentComponent }
       </Wrapper>
     )
-  }
-
-  return (
-    <Wrapper
-      ref={forwardedRef}
-      as={as}
-      className={clazzName}
-      size={size}
-      onClick={handleClick}
-      onMouseDown={onMouseDown}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      active={active}
-      disabled={disabled}
-      colorVariant={colorVariant}
-      data-active={active}
-      data-option-key={optionKey}
-      data-testid={testId}
-      {...othreProps}
-    >
-      { ContentComponent }
-    </Wrapper>
-  )
+    : (
+      <Wrapper
+        {...commonDataAttr}
+        {...commonListItemProps}
+        as={as}
+      >
+        { ContentComponent }
+      </Wrapper>
+    )
 }
 
 export default forwardRef(ListItem)

--- a/src/components/ListItem/ListItem.types.ts
+++ b/src/components/ListItem/ListItem.types.ts
@@ -31,6 +31,7 @@ export default interface ListItemProps extends ContentComponentProps, ActivableE
   leftContent?: React.ReactNode
   leftIcon?: IconName
   colorVariant?: ListItemColorVariant
+  focused?: boolean
   disabled?: boolean
   disableIconActive?: boolean
   descriptionMaxLines?: number

--- a/src/components/ListItem/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/ListItem/__snapshots__/ListItem.test.tsx.snap
@@ -31,6 +31,17 @@ exports[`ListItem Snapshot > 1`] = `
   align-items: center;
 }
 
+.c2 span {
+  -webkit-transition-property: color;
+  transition-property: color;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+}
+
 .c3 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -60,8 +71,8 @@ exports[`ListItem Snapshot > 1`] = `
   text-decoration: none;
   cursor: pointer;
   opacity: 1;
-  -webkit-transition-property: background-color,color;
-  transition-property: background-color,color;
+  -webkit-transition-property: background-color;
+  transition-property: background-color;
   -webkit-transition-duration: 150ms;
   transition-duration: 150ms;
   -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);


### PR DESCRIPTION
# Description

hover 됐을 때 뿐만 아니라, ListItem에 직접 focused 스타일을 줘야 할 필요성(키보드로 이동)이 생겨 해당 prop을 추가합니다. 

## Changes Detail

* `focused` prop 추가
  * `focused={true}` 이고 포커스 가능한 상태일 경우, hover 됐을 때와 동일한 스타일을 지정
* 제대로 동작하지 않던 `href` 관련 로직을 수정
  * `href` 가 빈 문자열이 아닌 문자열일 경우에만 하이퍼링크라고 판단하도록 변경 (기존엔 nil 체크)
  * 하이퍼링크일 경우, active 스타일이 아이콘에만 지정되던걸 지정되지 않도록 변경
* 아이콘과 텍스트 사이의 어색한 트랜지션을 수정
  * 동일한 트랜지션 옵션으로 지정하면 아이콘과 텍스트의 color가 변하는 타이밍이 약간 다르기때문에, 빠르게 변하는 아이콘의 트랜지션 duration을 한단계 높임(느리게)
* 링크로 동작하는 ListItem과 일반적인 ListItem의 공통 속성 분리 등 리팩토링 진행

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [x] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
