### PR TITLE
fix(rollup): commonjs bundle 방식 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "regenerator-runtime": "^0.13.7",
-        "rollup": "^2.37.1",
+        "rollup": "^2.50.5",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-visualizer": "^5.5.0",
         "semantic-release": "^17.4.3",
@@ -25784,9 +25784,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.49.0.tgz",
-      "integrity": "sha512-UnrCjMXICx9q0jF8L7OYs7LPk95dW0U5UYp/VANnWqfuhyr66FWi/YVlI34Oy8Tp4ZGLcaUDt4APJm80b9oPWQ==",
+      "version": "2.50.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.5.tgz",
+      "integrity": "sha512-Ztz4NurU2LbS3Jn5rlhnYv35z6pkjBUmYKr94fOBIKINKRO6kug9NTFHArT7jqwMP2kqEZ39jJuEtkk91NBltQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -51013,9 +51013,9 @@
       }
     },
     "rollup": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.49.0.tgz",
-      "integrity": "sha512-UnrCjMXICx9q0jF8L7OYs7LPk95dW0U5UYp/VANnWqfuhyr66FWi/YVlI34Oy8Tp4ZGLcaUDt4APJm80b9oPWQ==",
+      "version": "2.50.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.5.tgz",
+      "integrity": "sha512-Ztz4NurU2LbS3Jn5rlhnYv35z6pkjBUmYKr94fOBIKINKRO6kug9NTFHArT7jqwMP2kqEZ39jJuEtkk91NBltQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.1"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "regenerator-runtime": "^0.13.7",
-    "rollup": "^2.37.1",
+    "rollup": "^2.50.5",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-visualizer": "^5.5.0",
     "semantic-release": "^17.4.3",

--- a/src/components/Input/TextArea/TextArea.styled.ts
+++ b/src/components/Input/TextArea/TextArea.styled.ts
@@ -38,7 +38,13 @@ interface TextAreaAutoSizeBaseProps extends WithInterpolation{
   readOnly: boolean
 }
 
-const TextAreaAutoSizeBase = styled(TextareaAutosize)<TextAreaAutoSizeBaseProps>`
+/**
+ * FIXME: https://github.com/rollup/plugins/issues/872
+ * @rollup/plugin-commonjs 의 버그로 인해 default export 가 namespace 그 자체로 계산됨.
+ * commonjs 상황을 위해 '.default' 를 추가함.
+ */
+// @ts-ignore
+const TextAreaAutoSizeBase = styled(TextareaAutosize.default ?? TextareaAutosize)<TextAreaAutoSizeBaseProps>`
   box-sizing: border-box;
   width: 100%;
   resize: none;


### PR DESCRIPTION
# Description
commonjs 의 경우 module package 대신 main package 를 우선하도록 수정합니다.

## Changes Detail
1. `react-textarea-autosize` 는 cjs, esm 빌드를 각각 제공하고 있음.
2. 두 빌드 모두 babel helper 를 포함하고 있는데, esm 은 특히 esm 버전의 helper 를 가리킴 (external deps)
3. 이때 rollup 은 esm 을 우선해서 가져오므로, `react-textarea-autosize` 또한 esm 빌드를 가져오게 됨.
4. 그러나 cjs 번들링 시 구문 자체는 cjs 형식으로 잘 감싸지만, babel helper import 문 자체까지 cjs helper import 문으로 변경하지는 않음.
5. 따라서 cjs 번들에 esm babel helper 가 들어가 있는 상황이 발생함.
6. 이것은 추후에 jest 등 esm 을 사용할 수 없는 환경에서 bezier-react 를 사용할 때 문제가 됨.

### 해결 방식
두 가지가 있습니다.
1. 사용처에서 알아서 esm 사용가능하도록 수정, 해결하는 것. 예를 들면 jest 에서 transformIgnorePatterns 옵션을 통해 babel helper 를 transpile 하도록 설정할 수 있습니다. 이는 간단하지만 실질적으로 패키지가 가지고 있는 문제점은 해결하지 않습니다.
2. cjs 빌드 시에는 cjs 로 컴파일 된 패키지를 가져오기. 이는 정확한 해결 방식이지만, `@rollup/plugin-commonjs` 의 문제로 인해 default export 를 가져올 때 버그가 발생합니다. 자세한 내용은 아래 Issues 에 적어두었습니다.

근본적으로 언젠가는 2번 방향으로 가야 한다고 생각했고, https://github.com/rollup/plugins/issues/872 버그는 추후 해결될 것이므로 (적어도 workaround 는 만들어질 예정이므로) 적절한 우회코드를 삽입한 채로 2번 방식을 채택하여 문제를 해결합니다.

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
- https://github.com/rollup/plugins/issues/872
