### PR TITLE
Select 컴포넌트를 제어하는 메서드를 외부에서도 사용할 수 있도록 변경

### DIFF
--- a/src/components/Input/Select/Select.tsx
+++ b/src/components/Input/Select/Select.tsx
@@ -8,7 +8,6 @@ import React, {
   Ref,
   useImperativeHandle,
 } from 'react'
-import ReactDOM from 'react-dom'
 
 /* Internal dependencies */
 import {
@@ -81,7 +80,7 @@ function Select(
     setIsDropdownOpened(false)
   }, [])
 
-  const getDOMNode = useCallback(() => ReactDOM.findDOMNode(triggerRef.current), [])
+  const getDOMNode = useCallback(() => triggerRef.current, [])
 
   useImperativeHandle(forwardedRef, () => ({
     handleClickTrigger,

--- a/src/components/Input/Select/Select.types.ts
+++ b/src/components/Input/Select/Select.types.ts
@@ -10,6 +10,12 @@ export enum SelectSize {
   S = 'S',
 }
 
+export interface SelectRef {
+  handleClickTrigger(): void
+  handleHideDropdown(): void
+  getDOMNode(): Element | Text | null
+}
+
 interface SelectProps extends ChildrenComponentProps {
   triggerTestId?: string
   dropdownTestId?: string

--- a/src/components/Input/Select/index.ts
+++ b/src/components/Input/Select/index.ts
@@ -1,9 +1,13 @@
 import Select from './Select'
-import { SelectSize } from './Select.types'
+import {
+  SelectSize,
+  SelectRef,
+} from './Select.types'
 import type SelectProps from './Select.types'
 
 export type {
   SelectProps,
+  SelectRef,
 }
 
 export {

--- a/src/components/Input/TextField/TextField.tsx
+++ b/src/components/Input/TextField/TextField.tsx
@@ -9,7 +9,6 @@ import React, {
   useCallback,
   useMemo,
 } from 'react'
-import ReactDOM from 'react-dom'
 import { size as getSize, isNil, isEmpty, isArray, toString, includes } from 'lodash-es'
 import { v4 as uuid } from 'uuid'
 
@@ -143,7 +142,7 @@ function TextFieldComponent({
     return { top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0 }
   }, [])
 
-  const getDOMNode = useCallback(() => ReactDOM.findDOMNode(inputRef.current), [])
+  const getDOMNode = useCallback(() => inputRef.current, [])
 
   useImperativeHandle(forwardedRef, () => ({
     focus,


### PR DESCRIPTION
# Description

현재 드롭다운을 닫기 위해선 트리거를 클릭하거나, 드롭다운이 열렸을 때 외부를 클릭하는 방법 두 가지 방법이 있습니다. 

라디오 버튼의 동작처럼 여러가지 선택을 하는 케이스라면 문제가 없지만, 체크박스 버튼의 동작처럼 한 번의 선택만을 하는 케이스에선 UX가 그다지 좋지 않습니다. **아이템 클릭 -> 드롭다운 닫힘** 이 아니라, **아이템 클릭 -> 드롭다운 외부 클릭 -> 드롭다운 닫힘** 이 되기 때문입니다.

Select 컴포넌트에선 드롭다운 안에 들어가는 내용물에 대해선 알고 있지 않기 때문에, 사용처에서 Select 컴포넌트를 제어할 수 있도록 내부 메서드들을 `useImperativeHandle` 을 사용해서 외부로 노출했습니다.

- 참고: #511

## Changes Detail

* `useImperativeHandle` 로 `handleClickTrigger`, `handleHideDropdown`, `getDOMNode` 메서드를 외부로 노출합니다
  * 사용처에서 `ref` 를 통해 DOM node를 가져올 수 없게 되었으므로, `getDOMNode` 메서드를 외부로 함께 노출하여 사용처에서 DOM node를 가져올 수 있도록 합니다
*  `SelectRef` 타입을 추가합니다
* 사용할 수 없게 된 `useMergeRef` 를 제거합니다. `useMergeRef` 의 정확한 타입 추론을 위해 사용되었던 콜백 ref 또한 `useRef` 로 변경합니다

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
