### PR TITLE
Avatar가 사용처에서 의도치않게 위에 쌓이는 문제 수정

### DIFF
--- a/src/components/Avatars/Avatar/Avatar.styled.ts
+++ b/src/components/Avatars/Avatar/Avatar.styled.ts
@@ -44,7 +44,7 @@ const smoothCornersFallbackBorderStyle = css`
   }
 `
 
-export const StyledAvatar = styled.div<AvatarProps>`
+export const AvatarImage = styled.div<AvatarProps>`
   position: relative;
   box-sizing: content-box;
   display: flex;
@@ -68,11 +68,16 @@ export const StyledAvatar = styled.div<AvatarProps>`
   ${({ interpolation }) => interpolation}
 `
 
-export const AvatarWrapper = styled.div<AvatarWrapperProps>`
+export const AvatarImageWrapper = styled.div`
   position: relative;
   z-index: 1;
+`
 
-  ${({ disabled }) => disabled && disabledStyle};
+export const AvatarWrapper = styled.div<AvatarWrapperProps>`
+  position: relative;
+  z-index: 0;
+
+  ${({ disabled }) => disabled && disabledStyle}
 
   ${({ interpolation }) => interpolation}
 `

--- a/src/components/Avatars/Avatar/Avatar.tsx
+++ b/src/components/Avatars/Avatar/Avatar.tsx
@@ -7,7 +7,7 @@ import useProgressiveImage from '../../../hooks/useProgressiveImage'
 import defaultAvatarUrl from '../assets/defaultAvatar.svg'
 import { Status } from '../../Status'
 import AvatarProps, { AvatarSize } from './Avatar.types'
-import { StyledAvatar, AvatarWrapper, StatusWrapper } from './Avatar.styled'
+import { AvatarImage, AvatarImageWrapper, AvatarWrapper, StatusWrapper } from './Avatar.styled'
 
 // TODO: 테스트 코드 작성
 const AVATAR_WRAPPER_TEST_ID = 'bezier-react-avatar-wrapper'
@@ -73,22 +73,24 @@ forwardedRef: React.Ref<HTMLDivElement>,
       disabled={disabled}
       data-testid={AVATAR_WRAPPER_TEST_ID}
     >
-      <StyledAvatar
-        interpolation={interpolation}
-        className={className}
-        ref={forwardedRef}
-        data-testid={testId}
-        avatarUrl={loadedAvatarUrl}
-        size={size}
-        role="img"
-        aria-label={name}
-        showBorder={showBorder}
-        onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-      >
-        { StatusComponent }
-      </StyledAvatar>
+      <AvatarImageWrapper>
+        <AvatarImage
+          className={className}
+          interpolation={interpolation}
+          ref={forwardedRef}
+          data-testid={testId}
+          avatarUrl={loadedAvatarUrl}
+          size={size}
+          role="img"
+          aria-label={name}
+          showBorder={showBorder}
+          onClick={onClick}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+        >
+          { StatusComponent }
+        </AvatarImage>
+      </AvatarImageWrapper>
     </AvatarWrapper>
   )
 }

--- a/src/components/Avatars/CheckableAvatar/CheckableAvatar.styled.ts
+++ b/src/components/Avatars/CheckableAvatar/CheckableAvatar.styled.ts
@@ -4,7 +4,7 @@ import { enableSmoothCorners } from '../../../worklets/EnableCSSHoudini'
 import { Icon, IconSize } from '../../Icon'
 import { AVATAR_BORDER_RADIUS_PERCENTAGE } from '../constants/AvatarStyle'
 import { AvatarSize } from '../Avatar/Avatar.types'
-import { StyledAvatar } from '../Avatar/Avatar.styled'
+import { AvatarImage } from '../Avatar/Avatar.styled'
 import { WithInterpolation } from '../../../types/InjectedInterpolation'
 
 const BASE_ICON_SIZE = IconSize.S
@@ -44,7 +44,7 @@ const getCheckableStyle = (isChecked: boolean, isCheckable: boolean) =>
       ${({ foundation }) => foundation?.transition.getTransitionsCSS('opacity')}
     }
 
-    ${StyledAvatar}::before {
+    ${AvatarImage}::before {
       display: block;
       width: 100%;
       height: 100%;
@@ -66,7 +66,7 @@ const getCheckableStyle = (isChecked: boolean, isCheckable: boolean) =>
     }
 
     &:hover ${CheckIcon},
-    &:hover ${StyledAvatar}::before {
+    &:hover ${AvatarImage}::before {
       opacity: 1;
     }
   `)


### PR DESCRIPTION
# Description

smooth corner 관련해서 스타일링을 위해 `z-index: 1` 이 AvatarWrapper 컴포넌트에 들어가 있었습니다. 이 부분 때문에 사용처에서 의도치않게 Avatar 컴포넌트가 위로 뜨는 현상이 발생해서 `z-index: 0` 으로 수정합니다.

`z-index: 1` 은 내부 `Wrapper` 컴포넌트를 추가로 만들고 스타일링해서, 내부에서 쌓임 맥락을 추가로 생성하는 방식으로 해결했습니다.

## Changes Detail

* 일부 스타일 컴포넌트 변수명을 변경합니다
  * StyledAvatar -> AvatarImage 

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
