### PR TITLE
TextArea 스타일을 올바르게 수정

### DIFF
--- a/src/components/Input/TextArea/TextArea.styled.ts
+++ b/src/components/Input/TextArea/TextArea.styled.ts
@@ -47,6 +47,8 @@ interface TextAreaAutoSizeBaseProps extends WithInterpolation{
 const TextAreaAutoSizeBase = styled(TextareaAutosize.default ?? TextareaAutosize)<TextAreaAutoSizeBaseProps>`
   box-sizing: border-box;
   width: 100%;
+  padding: 0;
+  margin: 0;
   resize: none;
   background: none;
   border: none;

--- a/src/components/Input/TextArea/TextArea.styled.ts
+++ b/src/components/Input/TextArea/TextArea.styled.ts
@@ -54,6 +54,10 @@ const TextAreaAutoSizeBase = styled(TextareaAutosize.default ?? TextareaAutosize
 
   ${Typography.Size14}
 
+  &::placeholder {
+    ${Typography.Size14}
+  }
+
   ${({ interpolation }) => interpolation}
 `
 

--- a/src/components/Input/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/Input/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -29,6 +29,26 @@ exports[`TextArea 테스트 > SnapShot 테스트 > 1`] = `
   line-height: 18px;
 }
 
+.c1::-webkit-input-placeholder {
+  font-size: 14px;
+  line-height: 18px;
+}
+
+.c1::-moz-placeholder {
+  font-size: 14px;
+  line-height: 18px;
+}
+
+.c1:-ms-input-placeholder {
+  font-size: 14px;
+  line-height: 18px;
+}
+
+.c1::placeholder {
+  font-size: 14px;
+  line-height: 18px;
+}
+
 <div
   class="c0"
   data-testid="bezier-react-text-area"

--- a/src/components/Input/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/Input/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -21,6 +21,8 @@ exports[`TextArea 테스트 > SnapShot 테스트 > 1`] = `
 .c1 {
   box-sizing: border-box;
   width: 100%;
+  padding: 0;
+  margin: 0;
   resize: none;
   background: none;
   border: none;


### PR DESCRIPTION
# Description

TextArea 스타일을 올바르게 수정합니다.

## Changes Detail

* placeholder 텍스트 사이즈 적용
* 브라우저 기본 textarea의 margin, padding을 오버라이드
  * 엣지(Mac) 기준 margin은 없지만 예외 케이스를 방지하기 위해 함께 오버라이드합니다

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
