### PR TITLE
TextField 스타일을 올바르게 수정

### DIFF
--- a/src/components/Input/TextField/TextField.styled.ts
+++ b/src/components/Input/TextField/TextField.styled.ts
@@ -102,7 +102,7 @@ const Wrapper = styled.div<WrapperProps & WithInterpolation>`
   display: flex;
   align-items: center;
   height: ${({ size }) => size}px;
-  padding: 0 10px;
+  padding: 0 12px;
   background-color: ${({ foundation, bgColor }) => foundation?.theme?.[bgColor]};
 
   ${({ foundation }) => foundation?.rounding.round8}


### PR DESCRIPTION
# Description

~~좌측 컴포넌트(`leftComponent`) 가 없을 땐~~ 양옆 패딩이 12px 이 되도록 수정합니다.

## Changes Detail

- 패딩 수정

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
