### PR TITLE
fix(textarea): TextArea 스타일 수정

### DIFF
--- a/src/components/Input/TextArea/TextArea.styled.ts
+++ b/src/components/Input/TextArea/TextArea.styled.ts
@@ -2,7 +2,7 @@
 import TextareaAutosize from 'react-textarea-autosize'
 
 /* Internal dependencies */
-import { SemanticNames, styled, Typography } from '../../../foundation'
+import { hideScrollbars, SemanticNames, styled, Typography } from '../../../foundation'
 import { WithInterpolation } from '../../../types/InjectedInterpolation'
 import {
   erroredInputWrapperStyle,
@@ -20,7 +20,8 @@ const Wrapper = styled.div<WrapperProps>`
   ${inputWrapperStyle};
 
   box-sizing: border-box;
-  padding: 8px 12px;
+  display: flex;
+  align-items: center;
   background-color: ${({ foundation, bgColor }) => foundation?.theme?.[bgColor]};
 
   ${({ focused }) => focused && focusedInputWrapperStyle}
@@ -47,12 +48,14 @@ interface TextAreaAutoSizeBaseProps extends WithInterpolation{
 const TextAreaAutoSizeBase = styled(TextareaAutosize.default ?? TextareaAutosize)<TextAreaAutoSizeBaseProps>`
   box-sizing: border-box;
   width: 100%;
-  padding: 0;
+  padding: 8px 12px;
   margin: 0;
   resize: none;
   background: none;
   border: none;
   outline: none;
+
+  ${hideScrollbars()}
 
   ${Typography.Size14}
 

--- a/src/components/Input/TextArea/TextArea.styled.ts
+++ b/src/components/Input/TextArea/TextArea.styled.ts
@@ -2,7 +2,12 @@
 import TextareaAutosize from 'react-textarea-autosize'
 
 /* Internal dependencies */
-import { hideScrollbars, SemanticNames, styled, Typography } from '../../../foundation'
+import {
+  hideScrollbars,
+  SemanticNames,
+  styled,
+  Typography,
+} from '../../../foundation'
 import { WithInterpolation } from '../../../types/InjectedInterpolation'
 import {
   erroredInputWrapperStyle,

--- a/src/components/Input/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/Input/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -4,7 +4,14 @@ exports[`TextArea 테스트 > SnapShot 테스트 > 1`] = `
 .c0 {
   box-shadow: 0 1px 2px #00000008, inset 0 0 0 1px #0000000D;
   box-sizing: border-box;
-  padding: 8px 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   background-color: #FCFCFC;
   overflow: hidden;
   border-radius: 8px;
@@ -21,14 +28,19 @@ exports[`TextArea 테스트 > SnapShot 테스트 > 1`] = `
 .c1 {
   box-sizing: border-box;
   width: 100%;
-  padding: 0;
+  padding: 8px 12px;
   margin: 0;
   resize: none;
   background: none;
   border: none;
   outline: none;
+  -ms-overflow-style: none;
   font-size: 14px;
   line-height: 18px;
+}
+
+.c1::-webkit-scrollbar {
+  display: none;
 }
 
 .c1::-webkit-input-placeholder {


### PR DESCRIPTION
# Description

TextArea 스타일이 Figma와 일치하도록 수정합니다.

<img width="782" alt="스크린샷 2021-06-04 오후 3 20 16" src="https://user-images.githubusercontent.com/16368822/120755007-5fc51200-c548-11eb-897a-6caf909040f2.png">


## Changes Detail
* overflow시 콘테이너 꽉 차게 텍스트가 자리잡음
* 스크롤바 제거

# Tests
- [x] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
### [FireFox Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=748518)
overflow: scroll 시 padding-bottom이 무시되어 firefox에선 스타일이 깨집니다.
