### PR TITLE
fix(toast): toast z-index 수정 및 관리 방식 추가

### DIFF
--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { noop } from 'lodash-es'
 import { base } from 'paths.macro'
 
@@ -12,7 +12,7 @@ import {
 import useToast from '../../hooks/useToast'
 import ToastProvider from './ToastProvider'
 import ToastElement from './ToastElement'
-import ToastProps, { ToastAppearance, ToastPreset } from './Toast.types'
+import { ToastAppearance, ToastPreset } from './Toast.types'
 
 export default {
   title: getTitle(base),
@@ -72,7 +72,7 @@ const Template = (args) => (
   />
 )
 
-export const Primary: ToastProps = Template.bind({})
+export const Primary = Template.bind({})
 
 Primary.args = {
   content: '안내문구입니다.\nnewLine',
@@ -168,3 +168,43 @@ WithAction.args = {
   iconName: undefined,
   actionContent: '액션 함수 테스트',
 }
+
+function ZIndexController() {
+  const { addToast } = useToast()
+
+  const handleClick = useCallback((zIndex?: number) => {
+    addToast(`z-index: ${zIndex}`, {
+      preset: ToastPreset.Default,
+      zIndex,
+    })
+  }, [addToast])
+
+  return (
+    <div>
+      <button type="button" onClick={() => handleClick()}>default</button>
+      <button type="button" onClick={() => handleClick(1000)}>z-index: 1000</button>
+      <button type="button" onClick={() => handleClick(3000)}>z-index: 3000</button>
+    </div>
+  )
+}
+
+const Box = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 2000;
+  width: 100vw;
+  height: 200px;
+  background-color: ${({ foundation }) => foundation.theme['bgtxt-orange-lighter']};
+`
+
+export const WithZIndex = () => (
+  <Container id="story-wrapper">
+    <ToastProvider>
+      <ZIndexController />
+      <Box>
+        z-index: 2000
+      </Box>
+    </ToastProvider>
+  </Container>
+)

--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -3,6 +3,9 @@ import { ellipsis, Foundation, styled, Transition } from '../../foundation'
 import ToastElementProps, { ToastAppearance, ToastContainerProps, ToastPlacement } from './Toast.types'
 import { getIconColor, getPlacement, initPosition, showedToastTranslateXStyle } from './utils'
 
+// z-index 최대 크기
+const TOAST_DEFAULT_ZINDEX = 2147483647
+
 interface IconProps {
   appearance: ToastAppearance
 }
@@ -21,7 +24,13 @@ export const Container = styled.div<ToastContainerProps>`
   ${({ placement }) => getPlacement(placement)}
 `
 
-export const Element = styled.div<Pick<ToastElementProps, 'transform' | 'transitionDuration' | 'placement'>>`
+interface StyledToastProps extends Pick<ToastElementProps,
+| 'transform'
+| 'transitionDuration'
+| 'placement'
+| 'zIndex'>{}
+
+export const Element = styled.div<StyledToastProps>`
   @keyframes ToastAnimationLeft {
     from {
       ${initPosition(ToastPlacement.BottomLeft)}
@@ -43,7 +52,7 @@ export const Element = styled.div<Pick<ToastElementProps, 'transform' | 'transit
   }
 
   position: relative;
-  z-index: 10000000;
+  z-index: ${({ zIndex }) => zIndex ?? TOAST_DEFAULT_ZINDEX};
   display: flex;
   align-items: flex-start;
   width: 288px;

--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -3,8 +3,7 @@ import { ellipsis, Foundation, styled, Transition } from '../../foundation'
 import ToastElementProps, { ToastAppearance, ToastContainerProps, ToastPlacement } from './Toast.types'
 import { getIconColor, getPlacement, initPosition, showedToastTranslateXStyle } from './utils'
 
-// z-index 최대 크기
-const TOAST_DEFAULT_ZINDEX = 2147483647
+const TOAST_DEFAULT_ZINDEX = Number.MAX_SAFE_INTEGER
 
 interface IconProps {
   appearance: ToastAppearance
@@ -28,7 +27,8 @@ interface StyledToastProps extends Pick<ToastElementProps,
 | 'transform'
 | 'transitionDuration'
 | 'placement'
-| 'zIndex'>{}
+| 'zIndex'
+>{}
 
 export const Element = styled.div<StyledToastProps>`
   @keyframes ToastAnimationLeft {

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -1,0 +1,114 @@
+/* External dependencies */
+import React from 'react'
+import _ from 'lodash'
+
+/* Internal dependencies */
+import { css, TransitionDuration } from '../../foundation'
+import { DarkTheme } from '../../foundation/Colors/Theme'
+import { render } from '../../utils/testUtils'
+import ToastElementProps, { ToastAppearance, ToastPlacement, ToastPreset } from './Toast.types'
+import ToastElement, { TOAST_TEST_ID } from './ToastElement'
+
+describe('Toast test >', () => {
+  let props: ToastElementProps
+
+  beforeEach(() => {
+    props = {
+      content: 'Test Toast',
+      transitionDuration: TransitionDuration.M,
+      onDismiss: _.noop,
+      transform: css``,
+      placement: ToastPlacement.BottomLeft,
+    }
+  })
+
+  const renderToast = (optionProps?: Omit<ToastElementProps,
+  | 'content'
+  | 'onDismiss'
+  | 'transitionDuration'
+  | 'transform'
+  | 'placement'
+  >) => render(<ToastElement {...props} {...optionProps} />)
+
+  it('Reset CSS', () => {
+    const { getByTestId } = renderToast()
+    const defaultToast = getByTestId(TOAST_TEST_ID)
+
+    expect(defaultToast).toHaveStyle('position: relative')
+    expect(defaultToast).toHaveStyle('display: flex')
+    expect(defaultToast).toHaveStyle('width: 288px')
+    expect(defaultToast).toHaveStyle('padding: 16px')
+    expect(defaultToast).toHaveStyle(`z-index: ${Number.MAX_SAFE_INTEGER}`)
+  })
+
+  describe('Apearance Variant Test > ', () => {
+    it('info color', () => {
+      const { getByTestId } = renderToast({ appearance: ToastAppearance.Info })
+      const infoToast = getByTestId(TOAST_TEST_ID)
+
+      expect(infoToast.firstChild).toHaveStyle(`color: ${DarkTheme['txt-black-darkest']}`)
+    })
+    it('success color', () => {
+      const { getByTestId } = renderToast({ appearance: ToastAppearance.Success })
+      const successToast = getByTestId(TOAST_TEST_ID)
+
+      expect(successToast.firstChild).toHaveStyle(`color: ${DarkTheme['bgtxt-green-normal']}`)
+    })
+    it('success color', () => {
+      const { getByTestId } = renderToast({ appearance: ToastAppearance.Warning })
+      const warningToast = getByTestId(TOAST_TEST_ID)
+
+      expect(warningToast.firstChild).toHaveStyle(`color: ${DarkTheme['bgtxt-orange-normal']}`)
+    })
+    it('success color', () => {
+      const { getByTestId } = renderToast({ appearance: ToastAppearance.Error })
+      const errorToast = getByTestId(TOAST_TEST_ID)
+
+      expect(errorToast.firstChild).toHaveStyle(`color: ${DarkTheme['bgtxt-red-normal']}`)
+    })
+  })
+
+  describe('Preset Variant Test > ', () => {
+    it('default preset', () => {
+      const { getByTestId } = renderToast({ preset: ToastPreset.Default })
+      const defaultToast = getByTestId(TOAST_TEST_ID)
+
+      expect(defaultToast.firstChild).toHaveStyle(`color: ${DarkTheme['txt-black-darkest']}`)
+    })
+
+    it('default preset', () => {
+      const { getByTestId } = renderToast({ preset: ToastPreset.Success })
+      const successToast = getByTestId(TOAST_TEST_ID)
+
+      expect(successToast.firstChild).toHaveStyle(`color: ${DarkTheme['bgtxt-green-normal']}`)
+    })
+
+    it('default preset', () => {
+      const { getByTestId } = renderToast({ preset: ToastPreset.Error })
+      const errorToast = getByTestId(TOAST_TEST_ID)
+
+      expect(errorToast.firstChild).toHaveStyle(`color: ${DarkTheme['bgtxt-red-normal']}`)
+    })
+
+    it('default preset', () => {
+      const { getByTestId } = renderToast({ preset: ToastPreset.Offline })
+      const offlineToast = getByTestId(TOAST_TEST_ID)
+
+      expect(offlineToast.firstChild).toHaveStyle(`color: ${DarkTheme['bgtxt-orange-normal']}`)
+    })
+
+    it('default preset', () => {
+      const { getByTestId } = renderToast({ preset: ToastPreset.Online })
+      const onlineToast = getByTestId(TOAST_TEST_ID)
+
+      expect(onlineToast.firstChild).toHaveStyle(`color: ${DarkTheme['bgtxt-green-normal']}`)
+    })
+  })
+
+  it('z-index Test > ', () => {
+    const { getByTestId } = renderToast({ zIndex: 317 })
+    const toast = getByTestId(TOAST_TEST_ID)
+
+    expect(toast).toHaveStyle('z-index: 317')
+  })
+})

--- a/src/components/Toast/Toast.types.ts
+++ b/src/components/Toast/Toast.types.ts
@@ -51,6 +51,7 @@ export default interface ToastElementProps extends UIComponentProps {
   transitionDuration: TransitionDuration
   transform: ReturnType<typeof css>
   placement: ToastPlacement
+  zIndex?: number
 }
 
 export interface ToastProviderProps {
@@ -71,6 +72,7 @@ export type ToastOptions = {
   autoDismiss?: boolean
   onDismiss?: OnDismissCallback
   rightSide?: boolean
+  zIndex?: number
 }
 
 export const defaultOptions: ToastOptions = {

--- a/src/components/Toast/ToastElement.tsx
+++ b/src/components/Toast/ToastElement.tsx
@@ -17,9 +17,12 @@ import {
 } from './Toast.styled'
 import { getToastPreset } from './utils'
 
+export const TOAST_TEST_ID = 'bezier-react-toast'
+
 const ToastElement = (
   {
     as,
+    testId = TOAST_TEST_ID,
     preset = ToastPreset.Default,
     content = '',
     appearance,
@@ -62,6 +65,7 @@ const ToastElement = (
   return (
     <Element
       ref={forwardedRef}
+      data-testid={testId}
       {...props}
     >
       <IconWrapper

--- a/src/components/Toast/ToastProvider.tsx
+++ b/src/components/Toast/ToastProvider.tsx
@@ -111,6 +111,7 @@ function ToastProvider({
         onClick,
         id,
         onDismiss,
+        zIndex,
       }) => (
         <ToastController
           key={id}
@@ -127,6 +128,7 @@ function ToastProvider({
           component={ToastElement}
           onDismiss={() => handleDismiss(id, onDismiss)}
           transform={css``}
+          zIndex={zIndex}
         />
       )) }
     </ToastContainer>


### PR DESCRIPTION


# Description
Toast가 Modal dim에 가리는 등의 문제가 있어 해결합니다.

## Changes Detail
* Toast z-index를 가능한 최대 값으로 설정
* addToast에 zIndex를 실어 표현할 수 있게 수정
* storybook에 zIndex 테스트를 할 수 있는 코드 추가

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
