### PR TITLE
fix(outlineitem): height, color를 디자인에 맞게 수정

### DIFF
--- a/src/components/OutlineItem/OutlineItem.styled.ts
+++ b/src/components/OutlineItem/OutlineItem.styled.ts
@@ -16,12 +16,12 @@ const ActiveItemStyle = css<StyledWrapperProps>`
 export const GroupItemWrapper = styled.div<StyledWrapperProps & OutlineItemProps>`
   display: flex;
   align-items: center;
-  height: 32px;
+  height: 28px;
   padding: 0 6px;
   padding-left: ${({ paddingLeft }) => `${paddingLeft}px`};
   font-size: 14px;
   font-weight: normal;
-  color: ${({ foundation }) => foundation?.theme?.['txt-black-darker']};
+  color: ${({ foundation }) => foundation?.theme?.['txt-black-darkest']};
   text-decoration: none;
   cursor: pointer;
   border-radius: 6px;

--- a/src/components/OutlineItem/OutlineItem.test.tsx
+++ b/src/components/OutlineItem/OutlineItem.test.tsx
@@ -37,7 +37,7 @@ describe('OutlineItem', () => {
 
     expect(rendered[0]).toHaveStyle('display: flex;')
     expect(rendered[0]).toHaveStyle('align-items: center;')
-    expect(rendered[0]).toHaveStyle('height: 32px;')
+    expect(rendered[0]).toHaveStyle('height: 28px;')
   })
 
   it('should have index on "data-active-index" attr when "selectedOptionIndex" given', () => {


### PR DESCRIPTION
# Description
OutlineItem의 height, color를 기본 디자인에 맞게 수정합니다.
1. 현재 모든 Navigations 내부에서 쓰이는 OutlineItem는 height가 28px이어야 합니다. 32px을 쓰는 경우는 28px보다 적기에 28px이 기본 적용되도록 합니다.
2. OutlineItem에서 쓰이는 color는 txt-black-darker가 아닌 txt-black-darkest여야 합니다.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)
