### PR TITLE
fix(overlay): 오버레이가 뿌옇게 보이는 현상 수정

### DIFF
--- a/src/components/Overlay/utils/positionUtils.ts
+++ b/src/components/Overlay/utils/positionUtils.ts
@@ -190,7 +190,7 @@ export function getOverlayStyle({
     return css`
       top: ${top}px;
       left: ${left}px;
-      transform: translateX(${translateX}px) translateY(${translateY}px);
+      transform: translateX(${Math.round(translateX)}px) translateY(${Math.round(translateY)}px);
     `
   }
   return css``


### PR DESCRIPTION
# Description

가끔 오버레이가 뿌옇게 보이는 현상을 수정합니다.

## Changes Detail

* 오버레이 포지션을 계산할 때, translateX, Y에 정수를 넣어주도록 변경합니다.
* [참고 링크](https://stackoverflow.com/questions/18257132/is-it-possible-to-snap-to-pixel-after-a-css-translate)

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
