### PR TITLE
fix(sectionlabel.types.ts): sectionLabelHelpProps['tooltipContent']의 타입을 Tooltip Content 타입과 맞춤

### DIFF
--- a/src/components/SectionLabel/SectionLabel.types.ts
+++ b/src/components/SectionLabel/SectionLabel.types.ts
@@ -11,7 +11,7 @@ type SectionLabelHelpProps = {
   icon?: IconName
   iconSize?: IconSize
   iconColor?: SemanticNames
-  tooltipContent: string
+  tooltipContent: React.ReactNode
 }
 
 export type SectionLabelItemProps = {


### PR DESCRIPTION
# Description
SectionLabelHelpProps에 커스텀한 tooltipContent를 넣어야 할 필요가 있습니다
하지만 이 prop의 type이 Tooltip의 content prop과 달라서, 동작에 문제는 없지만 타입이 맞지 않기에 이를 수정합니다
![image](https://user-images.githubusercontent.com/33861398/121136916-23a7ef00-c871-11eb-8adf-f5adf1940801.png)

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
