### PR TITLE
fix(checkableavatar): checkableAvatar가 체크된 상태일때 background color를 커스텀 가능하도록 변경

### DIFF
--- a/src/components/Avatars/CheckableAvatar/CheckableAvatar.stories.tsx
+++ b/src/components/Avatars/CheckableAvatar/CheckableAvatar.stories.tsx
@@ -64,6 +64,15 @@ export default {
         options: avatarSizeList,
       },
     },
+    checkedBackgroundColor: {
+      control: {
+        type: 'radio',
+        options: [
+          'bgtxt-green-normal',
+          'bgtxt-cobalt-normal',
+        ],
+      },
+    },
   },
 } as Meta
 
@@ -104,6 +113,7 @@ Primary.args = {
   disabled: false,
   isChecked: false,
   isCheckable: true,
+  checkedBackgroundColor: undefined,
 }
 
 const List = styled.li`
@@ -121,7 +131,7 @@ const Name = styled.span`
   margin-left: 4px;
 `
 
-const TemplateCheckableAvatarList: Story<CheckableAvatarProps> = () => {
+const TemplateCheckableAvatarList: Story<CheckableAvatarProps> = (args) => {
   const [checkedList, setCheckedList] = useState<{ [id: number]: boolean }>({})
 
   const handleClickList = useCallback((id: number) => {
@@ -138,6 +148,7 @@ const TemplateCheckableAvatarList: Story<CheckableAvatarProps> = () => {
           key={id}
         >
           <CheckableAvatar
+            {...args}
             avatarUrl={avatarUrl}
             name={name}
             isChecked={checkedList[id]}
@@ -168,5 +179,6 @@ CheckableAvatarList.args = {
   disabled: false,
   isChecked: false,
   isCheckable: true,
+  checkedBackgroundColor: undefined,
 }
 

--- a/src/components/Avatars/CheckableAvatar/CheckableAvatar.styled.ts
+++ b/src/components/Avatars/CheckableAvatar/CheckableAvatar.styled.ts
@@ -1,5 +1,5 @@
 /* Internal denpendencies */
-import { styled, css, smoothCorners, Foundation } from '../../../foundation'
+import { styled, css, smoothCorners, Foundation, SemanticNames } from '../../../foundation'
 import { enableSmoothCorners } from '../../../worklets/EnableCSSHoudini'
 import { Icon, IconSize } from '../../Icon'
 import { AVATAR_BORDER_RADIUS_PERCENTAGE } from '../constants/AvatarStyle'
@@ -14,6 +14,7 @@ const CHECK_ICON_SIZE_PERCENTAGE = (BASE_ICON_SIZE / BASE_WRAPPER_SIZE) * 100
 interface CheckableAvatarWrapperProps extends WithInterpolation {
   isChecked: boolean
   isCheckable: boolean
+  checkedBackgroundColor: SemanticNames
 }
 
 export const CheckIcon = styled(Icon)`
@@ -25,11 +26,11 @@ export const CheckIcon = styled(Icon)`
   opacity: 0;
 `
 
-const getBackgroundColor = (isChecked: boolean, foundation?: Foundation) =>
-  foundation?.theme?.[isChecked ? 'bgtxt-green-dark' : 'bg-grey-dark']
+const getBackgroundColor = (isChecked: boolean, checkedBackgroundColor: SemanticNames, foundation?: Foundation) =>
+  foundation?.theme?.[isChecked ? checkedBackgroundColor : 'bg-grey-dark']
 
 /* eslint-disable @typescript-eslint/indent */
-const getCheckableStyle = (isChecked: boolean, isCheckable: boolean) =>
+const getCheckableStyle = (isChecked: boolean, isCheckable: boolean, checkedBackgroundColor: SemanticNames) =>
   (!isCheckable
   ? css`
     cursor: not-allowed;
@@ -60,7 +61,7 @@ const getCheckableStyle = (isChecked: boolean, isCheckable: boolean) =>
       ${({ foundation }) => foundation?.transition.getTransitionsCSS(['opacity', 'background-color'])}
 
       ${({ foundation }) => smoothCorners({
-        backgroundColor: getBackgroundColor(isChecked, foundation),
+        backgroundColor: getBackgroundColor(isChecked, checkedBackgroundColor, foundation),
         borderRadius: `${AVATAR_BORDER_RADIUS_PERCENTAGE}%`,
       })};
     }
@@ -79,7 +80,7 @@ export const CheckableAvatarWrapper = styled.div<CheckableAvatarWrapperProps>`
   justify-content: center;
   user-select: none;
 
-  ${({ isChecked, isCheckable }) => getCheckableStyle(isChecked, isCheckable)}
+  ${({ isChecked, isCheckable, checkedBackgroundColor }) => getCheckableStyle(isChecked, isCheckable, checkedBackgroundColor)}
 
   ${({ interpolation }) => interpolation}
 `

--- a/src/components/Avatars/CheckableAvatar/CheckableAvatar.tsx
+++ b/src/components/Avatars/CheckableAvatar/CheckableAvatar.tsx
@@ -12,6 +12,7 @@ const CHECKABLE_AVATAR_TEST_ID = 'bezier-react-checkable-avatar'
 function CheckableAvatar({
   isChecked = false,
   isCheckable = true,
+  checkedBackgroundColor = 'bgtxt-green-dark',
   checkableWrapperClassName,
   checkableWrapperInterpolation,
   children,
@@ -22,6 +23,7 @@ function CheckableAvatar({
       data-testid={CHECKABLE_AVATAR_TEST_ID}
       isChecked={isChecked}
       isCheckable={isCheckable}
+      checkedBackgroundColor={checkedBackgroundColor}
       className={checkableWrapperClassName}
       interpolation={checkableWrapperInterpolation}
     >

--- a/src/components/Avatars/CheckableAvatar/CheckableAvatar.types.ts
+++ b/src/components/Avatars/CheckableAvatar/CheckableAvatar.types.ts
@@ -1,10 +1,12 @@
 /* Internal dependencies */
+import { SemanticNames } from '../../../foundation'
 import InjectedInterpolation from '../../../types/InjectedInterpolation'
 import { AvatarProps } from '../Avatar'
 
 export default interface CheckableAvatarProps extends AvatarProps {
   isChecked?: boolean
   isCheckable?: boolean
+  checkedBackgroundColor?: SemanticNames
   checkableWrapperClassName?: string
   checkableWrapperInterpolation?: InjectedInterpolation
 }


### PR DESCRIPTION
# Description
prev pr: #527
CheckableAvatar는 체크된 상태의 background color가 일반적으로 bgtxt-green-dark로 지정되지만, 일부 경우에는 다르게 지정되어야 하기에 커스텀 가능하도록 변경합니다.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [x] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)
