### PR TITLE
OutlineItem의 chevron 영역을 제거할 수 있도록 prop 추가

### DIFF
--- a/src/components/OutlineItem/OutlineItem.styled.ts
+++ b/src/components/OutlineItem/OutlineItem.styled.ts
@@ -6,14 +6,20 @@ import { css, ellipsis, styled } from '../../foundation'
 import { WithInterpolation } from '../../types/InjectedInterpolation'
 import { SemanticNames } from '../../foundation/Colors/Theme'
 import { Icon } from '../Icon'
-import OutlineItemProps, { StyledWrapperProps } from './OutlineItem.types'
+import OutlineItemProps from './OutlineItem.types'
 
-const ActiveItemStyle = css<StyledWrapperProps>`
+interface WrapperProps extends WithInterpolation {
+  active: boolean
+  paddingLeft: number
+  currentOutlineItemIndex?: number | null
+}
+
+const ActiveItemStyle = css`
   color: ${({ foundation }) => foundation?.theme?.['bgtxt-blue-normal']};
   background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-blue-lightest']};
 `
 
-export const GroupItemWrapper = styled.div<StyledWrapperProps & OutlineItemProps>`
+export const GroupItemWrapper = styled.div<WrapperProps>`
   display: flex;
   align-items: center;
   height: 28px;

--- a/src/components/OutlineItem/OutlineItem.tsx
+++ b/src/components/OutlineItem/OutlineItem.tsx
@@ -26,6 +26,7 @@ function OutlineItem(
   {
     as,
     testId = OUTLINE_ITEM_TEST_ID,
+    style,
     className,
     interpolation,
     chevronClassName,
@@ -56,7 +57,6 @@ function OutlineItem(
     /* HTMLAttribute props */
     onClick: givenOnClick = noop,
     children,
-    ...otherProps
   }: OutlineItemProps,
   forwardedRef: React.Ref<HTMLElement>,
 ) {
@@ -235,17 +235,15 @@ function OutlineItem(
           href={href}
           target="_blank"
           rel="noopener noreferrer"
-          name={name}
+          style={style}
           className={className}
           interpolation={interpolation}
-          open={open}
           active={false}
           currentOutlineItemIndex={currentOutlineItemIndex}
+          paddingLeft={paddingLeft}
           onClick={handleClickGroup}
           data-testid={testId}
           data-active-index={currentOutlineItemIndex}
-          paddingLeft={paddingLeft}
-          {...otherProps}
         >
           { ContentComponent }
         </GroupItemWrapper>
@@ -261,17 +259,15 @@ function OutlineItem(
       <GroupItemWrapper
         as={as}
         ref={forwardedRef}
-        name={name}
+        style={style}
         className={className}
         interpolation={interpolation}
-        open={open}
         active={active}
         currentOutlineItemIndex={currentOutlineItemIndex}
+        paddingLeft={paddingLeft}
         onClick={handleClickGroup}
         data-testid={testId}
         data-active-index={currentOutlineItemIndex}
-        paddingLeft={paddingLeft}
-        {...otherProps}
       >
         { ContentComponent }
       </GroupItemWrapper>

--- a/src/components/OutlineItem/OutlineItem.tsx
+++ b/src/components/OutlineItem/OutlineItem.tsx
@@ -43,6 +43,7 @@ function OutlineItem(
     leftContent,
     leftIcon,
     leftIconColor,
+    disableChevron = false,
     disableIconActive = false,
     name,
     href,
@@ -121,6 +122,39 @@ function OutlineItem(
     onClick,
   ])
 
+  const chevronComponent = useMemo(() => {
+    if (disableChevron) {
+      return null
+    }
+
+    const chevronIcon = `${chevronIconType}-${open ? 'down' : 'right'}` as const
+    const showChevron = !isNil(children)
+
+    return (
+      <ChevronWrapper>
+        { showChevron && (
+          <StyledIcon
+            className={chevronClassName}
+            interpolation={chevronInterpolation}
+            name={chevronIcon}
+            size={chevronIconSize}
+            onClick={handleClickIcon}
+            color="txt-black-darker"
+          />
+        ) }
+      </ChevronWrapper>
+    )
+  }, [
+    disableChevron,
+    open,
+    chevronIconType,
+    chevronIconSize,
+    chevronClassName,
+    chevronInterpolation,
+    children,
+    handleClickIcon,
+  ])
+
   const leftComponent = useMemo(() => {
     if (!isNil(leftContent)) {
       return (
@@ -156,42 +190,21 @@ function OutlineItem(
     leftIconColor,
   ])
 
-  const ContentComponent = useMemo(() => {
-    const chevronIcon = `${chevronIconType}-${open ? 'down' : 'right'}` as const
-
-    return (
-      <>
-        <ChevronWrapper>
-          { !isNil(children) && (
-            <StyledIcon
-              className={chevronClassName}
-              interpolation={chevronInterpolation}
-              name={chevronIcon}
-              size={chevronIconSize}
-              onClick={handleClickIcon}
-              color="txt-black-darker"
-            />
-          ) }
-        </ChevronWrapper>
-        { leftComponent }
-        <ContentWrapper
-          className={contentClassName}
-          interpolation={contentInterpolation}
-        >
-          { content }
-        </ContentWrapper>
-        { rightContent }
-      </>
-    )
-  },
+  const ContentComponent = useMemo(() => (
+    <>
+      { chevronComponent }
+      { leftComponent }
+      <ContentWrapper
+        className={contentClassName}
+        interpolation={contentInterpolation}
+      >
+        { content }
+      </ContentWrapper>
+      { rightContent }
+    </>
+  ),
   [
-    chevronIconType,
-    open,
-    children,
-    chevronClassName,
-    chevronInterpolation,
-    chevronIconSize,
-    handleClickIcon,
+    chevronComponent,
     leftComponent,
     contentClassName,
     contentInterpolation,

--- a/src/components/OutlineItem/OutlineItem.types.ts
+++ b/src/components/OutlineItem/OutlineItem.types.ts
@@ -31,7 +31,6 @@ export default interface OutlineItemProps extends ContentComponentProps, Childre
   leftIconColor?: SemanticNames
   rightContent?: React.ReactNode
   hide?: boolean
-  disableGroupSelect?: boolean
   disableIconActive?: boolean
   chevronIconType?: ChevronIconType
   chevronIconSize?: IconSize
@@ -44,14 +43,4 @@ export default interface OutlineItemProps extends ContentComponentProps, Childre
   /* OptionItemHost for Sidebar Menu - nullable selectedOutlineItemIndex */
   selectedOutlineItemIndex?: number | null
   onChangeOption?: (name?: string, optionKey?: string, optionIndex?: number) => void
-}
-
-export interface StyledWrapperProps extends ContentComponentProps {
-  open?: boolean
-  rightContent?: React.ReactNode
-  currentOutlineItemIndex?: number | null
-  chevronClassName?: string
-  selectedOptionIndex?: number
-  selected?: boolean
-  onChangeOption?: (optionKey?: string, optionIndex?: number) => void
 }

--- a/src/components/OutlineItem/OutlineItem.types.ts
+++ b/src/components/OutlineItem/OutlineItem.types.ts
@@ -32,6 +32,7 @@ export default interface OutlineItemProps extends ContentComponentProps, Childre
   rightContent?: React.ReactNode
   hide?: boolean
   disableIconActive?: boolean
+  disableChevron?: boolean
   chevronIconType?: ChevronIconType
   chevronIconSize?: IconSize
   paddingLeft?: number


### PR DESCRIPTION
# Description

OutlineItem의 기존 사용처에는 두 가지 종류가 있었습니다.

| chevron과 아이콘이 동시에 사용되는 경우 | chevron과 아이콘이 서로 배타적인 경우 |
| -- | -- |
| <img width="275" alt="스크린샷 2021-06-09 오후 1 48 28" src="https://user-images.githubusercontent.com/25701854/121295121-7c3ac300-c929-11eb-96cb-ed9c24007b7f.png"> | <img width="234" alt="스크린샷 2021-06-09 오후 1 48 22" src="https://user-images.githubusercontent.com/25701854/121295113-79d86900-c929-11eb-962b-61fb750e8c99.png"> |

기존 구현에는 chevron 영역을 reserve 해 놓기 때문에 2번째 케이스의 경우 올바른 스타일이 나타나지 않습니다. 기존 prop인 `chevronClassName`, `chevronInterpolation`은 reserve한 영역 안쪽의 chevron icon 자체에 적용되기 때문에 이것을 사용해서는 구현할 수 없습니다. 따라서 새로운 prop을 추가합니다.

+) prop 추가에 관한 고민: chevron은 nested될 수 있다는 특징과 이어지는, OutlineItem의 정체성을 나타내는 feature 중 하나인데 이것을 disable하는 케이스는 사실 다른 컴포넌트로 작성되어야 하는 것이 아닌가? 라는 고민입니다.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
