### PR TITLE
Main Nav를 숨기는 chevron-double의 아이콘 색상을 darkest -> darker으로 변경

### DIFF
--- a/src/layout/Navigations/NavigationContent/NavigationContent.tsx
+++ b/src/layout/Navigations/NavigationContent/NavigationContent.tsx
@@ -98,7 +98,7 @@ function NavigationContent({
     >
       <Icon
         name={`chevron-${isShowingNavigation ? 'left' : 'right'}-double` as const}
-        color="txt-black-darkest"
+        color="txt-black-darker"
         size={IconSize.S}
       />
     </ChevronIconWrapper>


### PR DESCRIPTION
## Changes Detail
Main Nav를 숨기는 chevron-double의 아이콘 색상을 darkest -> darker으로 변경

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)

https://www.notion.so/channelio/e508731aa79f48aeb0ebfa16d3fd74e7