### PR TITLE
fix(button): correct Button colors according to its size

### DIFF
--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -70,7 +70,7 @@ function monochromeVariantConverter(styleVariant?: ButtonStyleVariant, disabled?
         `
       case ButtonStyleVariant.Tertiary:
         return css`
-          color: ${({ foundation }) => foundation?.theme?.['txt-black-darker']};
+          color: ${({ foundation }) => foundation?.theme?.['txt-black-darkest']};
           background-color: transparent;
 
           ${!disabled && css`

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -33,15 +33,28 @@ import * as Styled from './Button.styled'
 export const BUTTON_TEST_ID = 'bezier-react-button'
 export const BUTTON_TEXT_TEST_ID = 'bezier-react-button-text'
 
-const monochromeIconAndSpinnerDefaultColors: {
+const monochromeTextDefaultColors: {
   [color in ButtonColorVariant]?: {
-    [style in ButtonStyleVariant]?: SemanticNames
+    [style in ButtonSize]?: SemanticNames
   }
 } = {
   [ButtonColorVariant.Monochrome]: {
-    [ButtonStyleVariant.Secondary]: 'txt-black-darker',
-    [ButtonStyleVariant.Tertiary]: 'txt-black-dark',
-    [ButtonStyleVariant.Floating]: 'txt-black-dark',
+    [ButtonSize.S]: 'txt-black-darker',
+    [ButtonSize.XS]: 'txt-black-darker',
+  },
+}
+
+const monochromeIconAndSpinnerDefaultColors: {
+  [color in ButtonColorVariant]?: {
+    [style in ButtonSize]?: SemanticNames
+  }
+} = {
+  [ButtonColorVariant.Monochrome]: {
+    [ButtonSize.XL]: 'txt-black-darker',
+    [ButtonSize.L]: 'txt-black-darker',
+    [ButtonSize.M]: 'txt-black-darker',
+    [ButtonSize.S]: 'txt-black-dark',
+    [ButtonSize.XS]: 'txt-black-dark',
   },
 }
 
@@ -134,13 +147,24 @@ function Button(
     }
   }, [size])
 
+  const overridedTextColor = useMemo(() => (
+    (active || isHovered)
+      ? undefined
+      : monochromeTextDefaultColors[colorVariant]?.[size]
+  ), [
+    colorVariant,
+    size,
+    active,
+    isHovered,
+  ])
+
   const overridedIconAndSpinnerColor = useMemo(() => (
     (active || isHovered)
       ? undefined
-      : monochromeIconAndSpinnerDefaultColors[colorVariant]?.[styleVariant]
+      : monochromeIconAndSpinnerDefaultColors[colorVariant]?.[size]
   ), [
     colorVariant,
-    styleVariant,
+    size,
     active,
     isHovered,
   ])
@@ -204,6 +228,7 @@ function Button(
             testId={BUTTON_TEXT_TEST_ID}
             typo={typography}
             bold
+            color={overridedTextColor}
             marginRight={textMargin}
             marginLeft={textMargin}
           >


### PR DESCRIPTION
# Description

기존 로직은 monochrome 버튼에 대해 styleVariant에 따라 텍스트와 아이콘 색의 분기가 이루어집니다. 이는 실제 스펙과 다릅니다.

다음과 같이 계산되어야 합니다.

### 텍스트 색

기본: txt-black-darkest
- S 이하 크기 버튼에 대해: 위보다 한 단계 낮음
  - 버튼이 hover되면: 기본 색으로 복원

### 아이콘 색

기본: 계산된 텍스트 색보다 한 단계 낮음

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
