### PR TITLE
fix(outlineitem): active인 OutlineItem을 hover하면 background가 덮어씌워지는 문제 수정

### DIFF
--- a/src/components/OutlineItem/OutlineItem.styled.ts
+++ b/src/components/OutlineItem/OutlineItem.styled.ts
@@ -13,6 +13,12 @@ const ActiveItemStyle = css<StyledWrapperProps>`
   background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-blue-lightest']};
 `
 
+const NonActiveItemStyle = css<StyledWrapperProps>`
+  &:hover {
+    background-color: ${props => (isNil(props.currentOutlineItemIndex) && props.foundation?.theme?.['bg-black-lighter'])};
+  }
+`
+
 export const GroupItemWrapper = styled.div<StyledWrapperProps & OutlineItemProps>`
   display: flex;
   align-items: center;
@@ -26,13 +32,9 @@ export const GroupItemWrapper = styled.div<StyledWrapperProps & OutlineItemProps
   cursor: pointer;
   border-radius: 6px;
 
-  &:hover {
-    background-color: ${props => (isNil(props.currentOutlineItemIndex) && props.foundation?.theme?.['bg-black-lighter'])};
-  }
-
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'color'])};
 
-  ${props => (props.active && ActiveItemStyle)}
+  ${({ active }) => (active ? ActiveItemStyle : NonActiveItemStyle)}
 
   ${({ interpolation }) => interpolation}
 `


### PR DESCRIPTION
# Description

## As-is & To-be

| AS-IS | TO-BE |
| -- | -- |
| <img width="285" alt="스크린샷 2021-06-10 오후 6 55 08" src="https://user-images.githubusercontent.com/33291896/121506603-d36e8f80-ca1e-11eb-84d4-57dc547a50ee.png"> | <img width="290" alt="스크린샷 2021-06-10 오후 6 57 36" src="https://user-images.githubusercontent.com/33291896/121506636-da959d80-ca1e-11eb-8dd6-19e8da8101d6.png"> |

(active인 `푸시 메시지 설정` 을 hover중인 상태)

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)
