### PR TITLE
fix(avatar): 아바타의 background, border 색상을 투명도 없는 색상으로 변경

### DIFF
--- a/src/components/Avatars/Avatar/Avatar.styled.ts
+++ b/src/components/Avatars/Avatar/Avatar.styled.ts
@@ -28,7 +28,7 @@ const disabledStyle = css`
 
 const smoothCornersFallbackBorderStyle = css`
   &::after {
-    ${({ foundation }) => foundation?.border?.getBorder(AVATAR_BORDER_WIDTH, foundation?.theme?.['bgtxt-absolute-white-normal'])};
+    ${({ foundation }) => foundation?.border?.getBorder(AVATAR_BORDER_WIDTH, foundation?.theme?.['bgtxt-absolute-white-dark'])};
 
     position: absolute;
     top: -${AVATAR_BORDER_WIDTH}px;
@@ -39,7 +39,7 @@ const smoothCornersFallbackBorderStyle = css`
     width: 100%;
     height: 100%;
     content: '';
-    background-color: ${({ foundation }) => `${foundation?.theme?.['bgtxt-absolute-white-normal']}`};
+    background-color: ${({ foundation }) => `${foundation?.theme?.['bgtxt-absolute-white-dark']}`};
     border-radius: ${AVATAR_BORDER_RADIUS_PERCENTAGE}%;
   }
 `
@@ -58,9 +58,9 @@ export const AvatarImage = styled.div<AvatarProps>`
   ${({ showBorder }) => (!enableSmoothCorners.current && showBorder) && smoothCornersFallbackBorderStyle}
 
   ${({ foundation, avatarUrl, showBorder }) => smoothCorners({
-    shadow: showBorder ? `0 0 0 ${AVATAR_BORDER_WIDTH}px ${foundation?.theme?.['bgtxt-absolute-white-normal']}` : undefined,
+    shadow: showBorder ? `0 0 0 ${AVATAR_BORDER_WIDTH}px ${foundation?.theme?.['bgtxt-absolute-white-dark']}` : undefined,
     shadowBlur: showBorder ? AVATAR_BORDER_WIDTH : 0,
-    backgroundColor: foundation?.theme?.['bgtxt-absolute-white-normal'],
+    backgroundColor: foundation?.theme?.['bgtxt-absolute-white-dark'],
     borderRadius: `${AVATAR_BORDER_RADIUS_PERCENTAGE}%`,
     backgroundImage: avatarUrl,
   })};

--- a/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Avatar test > Snapshot 1`] = `
   height: 24px;
   outline: none;
   margin: 0px;
-  background-color: #FFFFFFE6;
+  background-color: #FFFFFF;
   background-image: url(https://www.google.com);
   background-size: cover;
   border-radius: 42%;
@@ -39,7 +39,7 @@ exports[`Avatar test > Snapshot 1`] = `
     box-shadow: none;
     --smooth-corners: 42%;
     --smooth-corners-shadow: 0 0 0 0 transparent;
-    --smooth-corners-bg-color: #FFFFFFE6;
+    --smooth-corners-bg-color: #FFFFFF;
     --smooth-corners-padding: 0;
     --smooth-corners-radius-unit: string;
   }


### PR DESCRIPTION
# Description

기존에 컬러 시스템 업데이트하며 아바타 기본 배경, 보더에 투명도 있는 흰색이 지정되어서 아래 색상이 투과되어 보였습니다.
투명도가 없는 #FFF 흰색으로 변경합니다.

## Changes Detail

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
