### PR TITLE
AvatarGroup의 EllipsisCount 잘못된 스타일 수정

### DIFF
--- a/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
@@ -1,5 +1,5 @@
 /* Internal denpendencies */
-import { styled, smoothCorners } from '../../../foundation'
+import { styled, smoothCorners, css } from '../../../foundation'
 import { WithInterpolation } from '../../../types/InjectedInterpolation'
 import { AVATAR_BORDER_RADIUS_PERCENTAGE, AVATAR_GROUP_DEFAULT_SPACING } from '../constants/AvatarStyle'
 import { Text, TextProps } from '../../Text'
@@ -11,6 +11,10 @@ interface AvatarGroupProps {
 
 interface AvatarEllipsisCountProps extends TextProps, WithInterpolation {
   size: AvatarSize
+}
+
+interface AvatarEllipsisWrapperProps extends WithInterpolation {
+  isCountEllipsisType?: boolean
 }
 
 export const AvatarEllipsisCount = styled(Text)<AvatarEllipsisCountProps>`
@@ -30,14 +34,16 @@ export const StyledAvatarGroup = styled.div<AvatarGroupProps>`
   & > * + * {
     margin-left: ${({ spacing }) => spacing}px;
   }
-
-  & ${AvatarEllipsisCount} {
-    margin-left: ${({ spacing }) => (spacing > AVATAR_GROUP_DEFAULT_SPACING ? spacing : AVATAR_GROUP_DEFAULT_SPACING)}px;
-  }
 `
 
-export const AvatarEllipsisWrapper = styled.div<Pick<AvatarEllipsisCountProps, 'interpolation'>>`
+export const AvatarEllipsisWrapper = styled.div<AvatarEllipsisWrapperProps>`
   position: relative;
+
+  ${({ isCountEllipsisType }) => isCountEllipsisType && css`
+    && {
+      margin-left: ${AVATAR_GROUP_DEFAULT_SPACING}px;
+    }
+  `}
 
   ${({ interpolation }) => interpolation}
 `

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
@@ -13,10 +13,6 @@ interface AvatarEllipsisCountProps extends TextProps, WithInterpolation {
   size: AvatarSize
 }
 
-interface AvatarEllipsisWrapperProps extends Partial<AvatarGroupProps>, WithInterpolation {
-  isCountEllipsisType?: boolean
-}
-
 export const AvatarEllipsisCount = styled(Text)<AvatarEllipsisCountProps>`
   position: relative;
   display: flex;
@@ -36,16 +32,18 @@ export const StyledAvatarGroup = styled.div<AvatarGroupProps>`
   }
 `
 
-export const AvatarEllipsisWrapper = styled.div<AvatarEllipsisWrapperProps>`
+export const AvatarEllipsisWrapper = styled.div<WithInterpolation>`
   position: relative;
 
-  ${({ isCountEllipsisType, spacing = 0 }) => isCountEllipsisType && css`
+  ${({ interpolation }) => interpolation}
+`
+
+export const AvatarEllipsisCountWrapper = styled(AvatarEllipsisWrapper)<AvatarGroupProps>`
+  ${({ spacing }) => css`
     && {
       margin-left: ${spacing > AVATAR_GROUP_DEFAULT_SPACING ? spacing : AVATAR_GROUP_DEFAULT_SPACING}px;
     }
   `}
-
-  ${({ interpolation }) => interpolation}
 `
 
 export const AvatarEllipsisIcon = styled.div`

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
@@ -13,7 +13,7 @@ interface AvatarEllipsisCountProps extends TextProps, WithInterpolation {
   size: AvatarSize
 }
 
-interface AvatarEllipsisWrapperProps extends WithInterpolation {
+interface AvatarEllipsisWrapperProps extends Partial<AvatarGroupProps>, WithInterpolation {
   isCountEllipsisType?: boolean
 }
 
@@ -39,9 +39,9 @@ export const StyledAvatarGroup = styled.div<AvatarGroupProps>`
 export const AvatarEllipsisWrapper = styled.div<AvatarEllipsisWrapperProps>`
   position: relative;
 
-  ${({ isCountEllipsisType }) => isCountEllipsisType && css`
+  ${({ isCountEllipsisType, spacing = 0 }) => isCountEllipsisType && css`
     && {
-      margin-left: ${AVATAR_GROUP_DEFAULT_SPACING}px;
+      margin-left: ${spacing > AVATAR_GROUP_DEFAULT_SPACING ? spacing : AVATAR_GROUP_DEFAULT_SPACING}px;
     }
   `}
 

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -118,6 +118,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
           >
             { renderAvatarElement(avatar) }
             <AvatarEllipsisWrapper
+              isCountEllipsisType
               onMouseEnter={onMouseEnterEllipsis}
               onMouseLeave={onMouseLeaveEllipsis}
             >

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -118,6 +118,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
           >
             { renderAvatarElement(avatar) }
             <AvatarEllipsisWrapper
+              spacing={spacing}
               isCountEllipsisType
               onMouseEnter={onMouseEnterEllipsis}
               onMouseLeave={onMouseLeaveEllipsis}
@@ -141,6 +142,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
     max,
     size,
     children,
+    spacing,
     ellipsisType,
     ellipsisInterpolation,
     avatarListCount,

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -9,7 +9,13 @@ import { AvatarProps, AvatarSize } from '../Avatar'
 import { isLastIndex } from '../../../utils/arrayUtils'
 import { AVATAR_GROUP_DEFAULT_SPACING } from '../constants/AvatarStyle'
 import AvatarGroupProps, { AvatarGroupEllipsisType } from './AvatarGroup.types'
-import { StyledAvatarGroup, AvatarEllipsisWrapper, AvatarEllipsisIcon, AvatarEllipsisCount } from './AvatarGroup.styled'
+import {
+  StyledAvatarGroup,
+  AvatarEllipsisWrapper,
+  AvatarEllipsisCountWrapper,
+  AvatarEllipsisIcon,
+  AvatarEllipsisCount,
+} from './AvatarGroup.styled'
 
 // TODO: 테스트 코드 작성
 const AVATAR_GROUP_TEST_ID = 'bezier-react-avatar-group'
@@ -117,9 +123,8 @@ forwardedRef: React.Ref<HTMLDivElement>,
             key="ellipsis"
           >
             { renderAvatarElement(avatar) }
-            <AvatarEllipsisWrapper
+            <AvatarEllipsisCountWrapper
               spacing={spacing}
-              isCountEllipsisType
               onMouseEnter={onMouseEnterEllipsis}
               onMouseLeave={onMouseLeaveEllipsis}
             >
@@ -131,7 +136,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
               >
                 { getRestAvatarListCountText(avatarListCount, max) }
               </AvatarEllipsisCount>
-            </AvatarEllipsisWrapper>
+            </AvatarEllipsisCountWrapper>
           </React.Fragment>
         )
       }


### PR DESCRIPTION
# Description

EllipsisCount의 좌측 마진이 제대로 적용되도록 변경합니다.

## AS-IS

<img width="210" alt="스크린샷 2021-06-11 오후 4 45 56" src="https://user-images.githubusercontent.com/58209009/121653278-7aaefd80-cad7-11eb-9963-6a40c07085ca.png">

## TO-BE

<img width="200" alt="스크린샷 2021-06-11 오후 4 45 34" src="https://user-images.githubusercontent.com/58209009/121653273-78e53a00-cad7-11eb-851b-da65ae809c36.png">

## Changes Detail

- 잘못된 스타일 변경

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
