### PR TITLE
fix(keyvaluelistitem): multiline일때의 padding 미세 조정

### DIFF
--- a/src/components/KeyValueListItem/KeyValueListItem.styled.ts
+++ b/src/components/KeyValueListItem/KeyValueListItem.styled.ts
@@ -20,16 +20,14 @@ const Wrapper = styled.div<WrapperProps>`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  min-height: 28px;
-  padding: 4px 6px;
-
-  ${({ multiline }) => multiline && css`
-    padding-bottom: 6px;
-  `}
 
   &:hover {
     background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
   }
+
+  ${({ multiline }) => multiline && css`
+    padding-bottom: 6px;
+  `}
 
   ${({ foundation }) => foundation?.rounding?.round6}
 
@@ -67,17 +65,16 @@ const ValueWrapper = styled.div<ValueWrapperProps>`
   ${({ interpolation }) => interpolation}
 `
 
-interface RowProps {
-  multiline?: boolean
-}
-
-const Row = styled.div<RowProps>`
+const Row = styled.div`
   display: flex;
   align-items: center;
+  padding: 4px 6px;
+`
 
-  ${({ multiline }) => multiline && css`
-    padding-bottom: 6px;
-  `}
+const MultiValueRow = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 0 6px;
 `
 
 const ActionIcon = styled(Icon)``
@@ -123,6 +120,7 @@ export default {
   KeyContentWrapper,
   ValueWrapper,
   Row,
+  MultiValueRow,
   ActionIcon,
   ActionIconWrapper,
   ActionIconTooltip,

--- a/src/components/KeyValueListItem/KeyValueListItem.styled.ts
+++ b/src/components/KeyValueListItem/KeyValueListItem.styled.ts
@@ -12,7 +12,9 @@ const alignRight = css`
   margin-left: auto;
 `
 
-interface WrapperProps extends WithInterpolation {}
+interface WrapperProps extends WithInterpolation {
+  multiline: boolean
+}
 
 const Wrapper = styled.div<WrapperProps>`
   display: flex;
@@ -20,6 +22,10 @@ const Wrapper = styled.div<WrapperProps>`
   justify-content: center;
   min-height: 28px;
   padding: 4px 6px;
+
+  ${({ multiline }) => multiline && css`
+    padding-bottom: 6px;
+  `}
 
   &:hover {
     background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
@@ -61,9 +67,17 @@ const ValueWrapper = styled.div<ValueWrapperProps>`
   ${({ interpolation }) => interpolation}
 `
 
-const Row = styled.div`
+interface RowProps {
+  multiline?: boolean
+}
+
+const Row = styled.div<RowProps>`
   display: flex;
   align-items: center;
+
+  ${({ multiline }) => multiline && css`
+    padding-bottom: 6px;
+  `}
 `
 
 const ActionIcon = styled(Icon)``

--- a/src/components/KeyValueListItem/KeyValueListItem.test.tsx
+++ b/src/components/KeyValueListItem/KeyValueListItem.test.tsx
@@ -1,0 +1,43 @@
+/* External dependencies */
+import React from 'react'
+import { render } from '../../utils/testUtils'
+import { KeyValueListItemProps } from './KeyValueListItem.types'
+import KeyValueListItem, { KEY_VALUE_LIST_ITEM_TEST_ID } from './KeyValueListItem'
+
+describe('KeyValueListItem', () => {
+  let props: KeyValueListItemProps
+
+  beforeEach(() => {
+    props = {
+      keyContent: 'key',
+      keyIcon: 'apple',
+    }
+  })
+
+  const renderedComponent = (optionProps?: Partial<KeyValueListItemProps>) => render(
+    <KeyValueListItem {...props} {...optionProps}>
+      thisiscontent
+    </KeyValueListItem>,
+  )
+
+  it('Snapshot >', () => {
+    const { getByTestId } = renderedComponent()
+    const rendered = getByTestId(KEY_VALUE_LIST_ITEM_TEST_ID)
+
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('multiline이 아니면 하나의 div를 가진다', () => {
+    const { getByTestId } = renderedComponent()
+    const rendered = getByTestId(KEY_VALUE_LIST_ITEM_TEST_ID)
+
+    expect(rendered.childElementCount).toBe(1)
+  })
+
+  it('multiline이라면 key 와 value가 다른 dom에 존재한다', () => {
+    const { getByTestId } = renderedComponent({ multiline: true })
+    const rendered = getByTestId(KEY_VALUE_LIST_ITEM_TEST_ID)
+
+    expect(rendered.childElementCount).toBe(2)
+  })
+})

--- a/src/components/KeyValueListItem/KeyValueListItem.tsx
+++ b/src/components/KeyValueListItem/KeyValueListItem.tsx
@@ -21,8 +21,7 @@ import { isIconName } from '../Icon/util'
 import { KeyValueActionProps, KeyValueListItemProps } from './KeyValueListItem.types'
 import Styled from './KeyValueListItem.styled'
 
-// TODO: 테스트 코드 작성
-const KEY_VALUE_LIST_ITEM_TEST_ID = 'bezier-react-key-value-list-item'
+export const KEY_VALUE_LIST_ITEM_TEST_ID = 'bezier-react-key-value-list-item'
 
 function KeyValueListItem(
   {

--- a/src/components/KeyValueListItem/KeyValueListItem.tsx
+++ b/src/components/KeyValueListItem/KeyValueListItem.tsx
@@ -125,10 +125,13 @@ function KeyValueListItem(
       interpolation={interpolation}
       className={className}
       data-testid={testId}
+      multiline={multiline}
       // eslint-disable-next-line react/jsx-props-no-multi-spaces
       {...props}
     >
-      <Styled.Row>
+      <Styled.Row
+        multiline={multiline}
+      >
         { KeyIconComponent }
         <Styled.KeyContentWrapper
           interpolation={keyWrapperInterpolation}

--- a/src/components/KeyValueListItem/KeyValueListItem.tsx
+++ b/src/components/KeyValueListItem/KeyValueListItem.tsx
@@ -129,9 +129,7 @@ function KeyValueListItem(
       // eslint-disable-next-line react/jsx-props-no-multi-spaces
       {...props}
     >
-      <Styled.Row
-        multiline={multiline}
-      >
+      <Styled.Row>
         { KeyIconComponent }
         <Styled.KeyContentWrapper
           interpolation={keyWrapperInterpolation}
@@ -147,9 +145,9 @@ function KeyValueListItem(
       </Styled.Row>
 
       { multiline && (
-        <Styled.Row>
+        <Styled.MultiValueRow>
           { ValueComponent }
-        </Styled.Row>
+        </Styled.MultiValueRow>
       ) }
     </Styled.Wrapper>
   )

--- a/src/components/KeyValueListItem/KeyValueListItem.types.ts
+++ b/src/components/KeyValueListItem/KeyValueListItem.types.ts
@@ -19,7 +19,7 @@ export type KeyValueActionProps = {
 
 export interface KeyValueListItemProps extends ChildrenComponentProps, React.HTMLAttributes<HTMLDivElement> {
   multiline?: boolean
-  keyIcon?: IconName
+  keyIcon?: IconName | React.ReactNode
   keyContent?: string
   actions?: KeyValueActionProps | KeyValueActionProps[]
   className?: string

--- a/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
+++ b/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
@@ -1,0 +1,151 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KeyValueListItem Snapshot > 1`] = `
+.c2 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0px 0px 0px 0px;
+  color: #00000066;
+  -webkit-transition-property: color;
+  transition-property: color;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+}
+
+.c5 {
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-property: color;
+  transition-property: color;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 6px;
+  -webkit-transition-property: background-color,color;
+  transition-property: background-color,color;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+}
+
+.c0:hover {
+  background-color: #0000000D;
+}
+
+.c6 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #00000066;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  max-width: 118px;
+  padding-left: 8px;
+}
+
+.c8 {
+  min-width: 0;
+}
+
+.c3 ~ .c7 {
+  margin-left: 8px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 6px;
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-key-value-list-item"
+>
+  <div
+    class="c1"
+  >
+    <svg
+      class="c2"
+      color="txt-black-dark"
+      data-testid="bezier-react-icon"
+      fill="none"
+      foundation="[object Object]"
+      height="20"
+      marginbottom="0"
+      marginleft="0"
+      marginright="0"
+      margintop="0"
+      viewBox="0 0 24 24"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clip-rule="evenodd"
+        d="M15.832 1s.272 1.628-1.033 3.197c-1.394 1.675-2.979 1.4-2.979 1.4s-.297-1.317.872-2.857C14.006 1.01 15.832 1 15.832 1zm3.637 6.81s-2.163 1.105-2.163 3.789c0 3.027 2.694 4.07 2.694 4.07s-1.883 5.302-4.427 5.302c-.577 0-1.09-.192-1.611-.387-.534-.2-1.075-.401-1.698-.401-.695 0-1.388.25-2.005.475-.497.18-.945.342-1.306.342-2.322 0-5.257-5.03-5.257-9.071 0-3.977 2.484-6.063 4.814-6.063.88 0 1.646.295 2.288.542.462.178.86.33 1.19.33.264 0 .618-.142 1.047-.315.669-.27 1.522-.613 2.517-.613 2.81 0 3.917 2 3.917 2z"
+        fill="currentColor"
+        fill-rule="evenodd"
+      />
+    </svg>
+    <div
+      class="c3 c4"
+    >
+      <span
+        class="c5 c6"
+        data-testid="bezier-react-text"
+      >
+        key
+      </span>
+    </div>
+    <div
+      class="c7 c8"
+    >
+      thisiscontent
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
# Description
변경사항 개요를 작성해주세요. Github 이슈, Notion 등 연관 문서가 있다면 첨부해주세요.
KeyValueItem의 multine 속성은 Key와 Value를 뉴라인으로 두는 옵션입니다.

multiline일 경우에는 Value Row의 Padding bottom이 6px이어야 합니다.
multiline일 경우에는 Key Row는 multiline이 아닐때와 동일해야 합니다
이를 위해 최상단에 걸려 있던 padding을 한 단계씩 내렸습니다

## Changes Detail
* 변경1 세부사항
* 변경2 세부사항

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
