### PR TITLE
ci(jest): maxWorkers 를 제한하여 CI 메모리 부족 현상을 해결 (시도)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "stylelint-all": "stylelint src/**/*.styled.{js,ts}",
     "typecheck": "ts-prune -e -p tsconfig.prune.json && tsc",
     "test": "npm run lint && npm run typecheck && npm run jest",
-    "jest": "cross-env BABEL_ENV=test jest",
+    "jest": "cross-env BABEL_ENV=test jest --maxWorkers=2",
     "jest:watch": "cross-env BABEL_ENV=test jest --watch",
     "build": "npm run build:icon && npm run build:rollup",
     "build:rollup": "cross-env BABEL_ENV=build rollup -c",


### PR DESCRIPTION
# Description
CircleCI 에서 jest 가 메모리 부족으로 실패하는 경우를 해결합니다.

## Changes Detail
* maxWorkers 를 2로 제한합니다.

# References
https://support.circleci.com/hc/en-us/articles/360038192673-NodeJS-Builds-or-Test-Suites-Fail-With-ENOMEM-or-a-Timeout
