### PR TITLE
Tooltip에 줄 수 제한 및 ellipsis 적용

### DIFF
--- a/src/components/Tooltip/Tooltip.styled.ts
+++ b/src/components/Tooltip/Tooltip.styled.ts
@@ -1,5 +1,5 @@
 /* Internal dependencies */
-import { styled, css } from '../../foundation'
+import { styled, css, ellipsis, LineHeightAbsoluteNumber } from '../../foundation'
 
 interface ContentWrapperProps {
   disabled: boolean
@@ -34,4 +34,8 @@ export const Content = styled.div`
   word-break: break-all;
   ${({ foundation }) => foundation?.elevation?.ev2(true)};
   ${({ foundation }) => foundation?.rounding?.round8};
+`
+
+export const EllipsisableContent = styled.div`
+  ${ellipsis(10, LineHeightAbsoluteNumber.Lh18)}
 `

--- a/src/components/Tooltip/Tooltip.styled.ts
+++ b/src/components/Tooltip/Tooltip.styled.ts
@@ -37,5 +37,5 @@ export const Content = styled.div`
 `
 
 export const EllipsisableContent = styled.div`
-  ${ellipsis(10, LineHeightAbsoluteNumber.Lh18)}
+  ${ellipsis(20, LineHeightAbsoluteNumber.Lh18)}
 `

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -14,7 +14,7 @@ import { Typography } from '../../foundation'
 import { Text } from '../Text'
 import TooltipProps, { TooltipPosition } from './Tooltip.types'
 import { getReplacement, getTooltipStyle } from './utils/positionUtils'
-import { Container, ContentWrapper, Content } from './Tooltip.styled'
+import { Container, ContentWrapper, Content, EllipsisableContent } from './Tooltip.styled'
 
 // TODO: 테스트 코드 작성
 const TOOLTIP_TEST_ID = 'bezier-react-tooltip'
@@ -164,7 +164,9 @@ function Tooltip(
         className={contentClassName}
         ref={mergedRef}
       >
-        { ContentComponent }
+        <EllipsisableContent>
+          { ContentComponent }
+        </EllipsisableContent>
       </Content>
     </ContentWrapper>
   ), [

--- a/src/foundation/Mixin.test.tsx
+++ b/src/foundation/Mixin.test.tsx
@@ -1,0 +1,54 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal Dependencies */
+import { render } from '../utils/testUtils'
+import { css, styled } from './FoundationStyledComponent'
+import { ellipsis } from './Mixins'
+
+const ELLIPSIS_TEST_ID = 'bezier-react-ellipsis'
+
+describe('Mixin test >', () => {
+  describe('ellipsis test >', () => {
+    it('return 1 line ellipsis without parameter', () => {
+      const style = ellipsis()
+      expect(style).toEqual(css`
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      `)
+    })
+
+    it('return 1 line ellipsis when line is 1', () => {
+      const style = ellipsis(1)
+      expect(style).toEqual(css`
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      `)
+    })
+
+    it('If lineHeight does not exist when line is more than 1, console.warn called and return empty style', () => {
+      const spyConsole = jest.spyOn(console, 'warn').mockImplementation()
+      // @ts-ignore
+      const style = ellipsis(5)
+      expect(spyConsole).toBeCalled()
+      expect(style).toEqual(css``)
+    })
+
+    it('return multiline style when line is more than 1 and lineHeight exist', () => {
+      const Element = styled.div`
+        ${ellipsis(5, 10)}
+      `
+      const { getByTestId } = render(<Element data-testid={ELLIPSIS_TEST_ID} />)
+      const renderedComponent = getByTestId(ELLIPSIS_TEST_ID)
+      expect(renderedComponent).toHaveStyle(`
+        display: -webkit-box;
+        max-height: 50px;
+        overflow: hidden;
+        line-height: 10px;
+        text-overflow: ellipsis;
+      `)
+    })
+  })
+})

--- a/src/foundation/Mixins.ts
+++ b/src/foundation/Mixins.ts
@@ -1,4 +1,5 @@
 /* Internal dependencies */
+import { isNil } from 'lodash'
 import { css } from './FoundationStyledComponent'
 
 export const absoluteCenter = (otherTransforms: any) => `
@@ -21,20 +22,32 @@ export const hideScrollbars = () => css`
   }
 `
 
-export const ellipsis = (line = 1, lineHeight = 22, unit = 'px') => {
-  if (line <= 1) {
+/* line이  1이거나 undefined일때는 lineheight가 optional이지만, 1보다 큰 숫자일 경우 lineHeight를 명시하도록 합니다. */
+type One = 1
+export function ellipsis(line?: undefined, lineHeight?: undefined): ReturnType<typeof css>
+export function ellipsis(line?: One, lineHeight?: undefined): ReturnType<typeof css>
+export function ellipsis(line: number, lineHeight: number): ReturnType<typeof css>
+export function ellipsis(line?: number, lineHeight?: number): ReturnType<typeof css> {
+  if (isNil(line) || line <= 1) {
     return css`
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
       `
   }
+
+  if (isNil(lineHeight)) {
+    // eslint-disable-next-line no-console
+    console.warn('lineHeight required')
+    return css``
+  }
+
   /* stylelint-disable value-no-vendor-prefix, property-no-vendor-prefix */
   return css`
       display: -webkit-box;
-      max-height: ${(line * lineHeight) + unit};
+      max-height: ${(line * lineHeight)}px;
       overflow: hidden;
-      line-height: ${lineHeight + unit};
+      line-height: ${lineHeight}px;
       text-overflow: ellipsis;
       -webkit-box-orient: vertical;
       -webkit-line-clamp: ${line};


### PR DESCRIPTION
# Description
[Notion issue](https://www.notion.so/channelio/51466cfb272440e993448228cad3ff2a)
[관련 논의 스레드](https://desk.channel.io/root/groups/Bezier-62019/60c8574eb94d851ca4aa)

## Changes Detail
* Tooltip에 20줄 제한 ellipsis를 적용합니다.
* ellipsis 함수 타입을 재정의합니다.
  * 불필요한 파라미터 unit 삭제
  * 두번째 파라미터(lineHeight)를 첫 번째 파라미터(line 수)에 따라 conditional하게 받도록 수정.

| as-is | to-be |
|:---:|:---:|
|<img width="450" alt="스크린샷 2021-06-15 오후 5 24 45" src="https://user-images.githubusercontent.com/16368822/122021299-8153b280-ce00-11eb-9d0e-4f9dc6802d0e.png">|<img width="450" alt="스크린샷 2021-06-15 오후 5 25 01" src="https://user-images.githubusercontent.com/16368822/122021284-7dc02b80-ce00-11eb-88db-8ad44efd1ca6.png">|

# Tests
- [x] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
