### PR TITLE
fix(overlay): overlay의 prop이 변하면 children이 remount되는 문제 수정

### DIFF
--- a/src/components/Overlay/Overlay.stories.tsx
+++ b/src/components/Overlay/Overlay.stories.tsx
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React, { useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { base } from 'paths.macro'
 
 /* Internal dependencies */
@@ -134,6 +134,61 @@ const Template = (props) => {
 
 export const Primary = Template.bind({})
 Primary.args = {
+  show: false,
+  position: OverlayPosition.BottomCenter,
+  marginX: 0,
+  marginY: 0,
+  keepInContainer: false,
+  withTransition: false,
+}
+
+const StressTestTemplate = (props) => {
+  const targetRef = useRef<any>()
+  const containerRef = useRef<any>()
+  const [, reload] = useState(0)
+
+  useEffect(() => {
+    setInterval(() => {
+      reload(prev => prev + 1)
+    }, 100)
+  }, [])
+
+  return (
+    <Container ref={containerRef}>
+      <Wrapper>
+        <Target ref={targetRef}>
+          target
+        </Target>
+        <Overlay
+          {...props}
+          // 실제 값은 변하지 않지만, 100ms의 매 렌더링마다 참조가 변하고 있다.
+          containerStyle={{ opacity: 1 }}
+          target={targetRef.current}
+          container={containerRef.current}
+        >
+          <Children>
+            <ScrollContent>
+              {
+                `Lorem Ipsum is simply dummy text of the printing and typesetting
+                industry. Lorem Ipsum has been the industry's standard dummy text
+                ever since the 1500s, when an unknown printer took a galley of type
+                and scrambled it to make a type specimen book. It has survived not
+                only five centuries, but also the leap into electronic typesetting,
+                remaining essentially unchanged. It was popularised in the 1960s
+                with the release of Letraset sheets containing Lorem Ipsum passages,
+                and more recently with desktop publishing software like Aldus PageMaker
+                including versions of Lorem Ipsum.`
+              }
+            </ScrollContent>
+          </Children>
+        </Overlay>
+      </Wrapper>
+    </Container>
+  )
+}
+
+export const StressTest = StressTestTemplate.bind({})
+StressTest.args = {
   show: false,
   position: OverlayPosition.BottomCenter,
   marginX: 0,

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -151,31 +151,47 @@ function Overlay(
   useEventHandler(document, 'keyup', handleKeydown, show)
   useEventHandler(containerRef.current, 'wheel', handleBlockMouseWheel, show)
 
-  const overlay = useMemo(() => {
-    const content = (
-      <Styled.Overlay
-        as={as}
-        ref={mergedRef}
-        className={className}
-        show={shouldShow}
-        withTransition={withTransition}
-        style={style}
-        data-testid={testId}
-        containerRect={containerRect()}
-        targetRect={targetRect()}
-        overlay={overlayRef.current}
-        position={position}
-        marginX={marginX}
-        marginY={marginY}
-        keepInContainer={keepInContainer}
-        onTransitionEnd={handleTransitionEnd}
-      >
-        { children }
-      </Styled.Overlay>
-    )
+  const Content = useMemo(() => (
+    <Styled.Overlay
+      as={as}
+      ref={mergedRef}
+      className={className}
+      show={shouldShow}
+      withTransition={withTransition}
+      style={style}
+      data-testid={testId}
+      containerRect={containerRect()}
+      targetRect={targetRect()}
+      overlay={overlayRef.current}
+      position={position}
+      marginX={marginX}
+      marginY={marginY}
+      keepInContainer={keepInContainer}
+      onTransitionEnd={handleTransitionEnd}
+    >
+      { children }
+    </Styled.Overlay>
+  ), [
+    as,
+    children,
+    className,
+    containerRect,
+    handleTransitionEnd,
+    keepInContainer,
+    marginX,
+    marginY,
+    mergedRef,
+    position,
+    shouldShow,
+    style,
+    targetRect,
+    testId,
+    withTransition,
+  ])
 
+  const overlay = useMemo(() => {
     if (container) {
-      return content
+      return Content
     }
 
     return (
@@ -187,32 +203,18 @@ function Overlay(
         data-testid={containerTestId}
       >
         <Styled.DefaultWrapper data-testid={wrapperTestId}>
-          { content }
+          { Content }
         </Styled.DefaultWrapper>
       </Styled.DefaultContainer>
     )
   }, [
-    as,
-    mergedRef,
-    className,
-    shouldShow,
-    withTransition,
-    style,
-    testId,
-    containerRect,
-    targetRect,
-    position,
-    marginX,
-    marginY,
-    keepInContainer,
-    handleTransitionEnd,
-    children,
     container,
     containerClassName,
     show,
     containerStyle,
     containerTestId,
     wrapperTestId,
+    Content,
   ])
 
   /**

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -151,30 +151,65 @@ function Overlay(
   useEventHandler(document, 'keyup', handleKeydown, show)
   useEventHandler(containerRef.current, 'wheel', handleBlockMouseWheel, show)
 
-  const OverlayContainer = useMemo(() => {
+  const overlay = useMemo(() => {
+    const content = (
+      <Styled.Overlay
+        as={as}
+        ref={mergedRef}
+        className={className}
+        show={shouldShow}
+        withTransition={withTransition}
+        style={style}
+        data-testid={testId}
+        containerRect={containerRect()}
+        targetRect={targetRect()}
+        overlay={overlayRef.current}
+        position={position}
+        marginX={marginX}
+        marginY={marginY}
+        keepInContainer={keepInContainer}
+        onTransitionEnd={handleTransitionEnd}
+      >
+        { children }
+      </Styled.Overlay>
+    )
+
     if (container) {
-      return ({ children: _children }: { children: React.ReactNode }) => (
-        <>{ _children }</>
-      )
+      return content
     }
 
-    return ({ children: _children, show: _show }: { children: React.ReactNode, show: boolean }) => (
+    return (
       <Styled.DefaultContainer
         ref={containerRef}
         className={containerClassName}
-        show={_show}
+        show={show}
         style={containerStyle}
         data-testid={containerTestId}
       >
         <Styled.DefaultWrapper data-testid={wrapperTestId}>
-          { _children }
+          { content }
         </Styled.DefaultWrapper>
       </Styled.DefaultContainer>
     )
   }, [
-    containerRef,
+    as,
+    mergedRef,
+    className,
+    shouldShow,
+    withTransition,
+    style,
+    testId,
+    containerRect,
+    targetRect,
+    position,
+    marginX,
+    marginY,
+    keepInContainer,
+    handleTransitionEnd,
+    children,
     container,
     containerClassName,
+    show,
     containerStyle,
     containerTestId,
     wrapperTestId,
@@ -221,27 +256,7 @@ function Overlay(
   if (!shouldRender) { return null }
 
   return ReactDOM.createPortal(
-    <OverlayContainer show={show}>
-      <Styled.Overlay
-        as={as}
-        ref={mergedRef}
-        className={className}
-        show={shouldShow}
-        withTransition={withTransition}
-        style={style}
-        data-testid={testId}
-        containerRect={containerRect()}
-        targetRect={targetRect()}
-        overlay={overlayRef.current}
-        position={position}
-        marginX={marginX}
-        marginY={marginY}
-        keepInContainer={keepInContainer}
-        onTransitionEnd={handleTransitionEnd}
-      >
-        { children }
-      </Styled.Overlay>
-    </OverlayContainer>,
+    overlay,
     container || getRootElement() as HTMLElement,
   )
 }


### PR DESCRIPTION
# Description
fix #515

## As-is & To-be
### As-is
https://user-images.githubusercontent.com/33291896/122337286-1da0c500-cf79-11eb-8498-7d6099f164da.mp4

### To-be
https://user-images.githubusercontent.com/33291896/122337297-209bb580-cf79-11eb-82b2-b8a952abc892.mp4

## Changes Detail
* OverlayContainer이 현재 React.FunctionalComponent 형식인데, 이러면 OverlayContainer가 변경되어도 react에도 제대로 포착하지 못하는 것으로 보임. 따라서 unmount 후 mount가 일어나서 부작용이 발생함.
중복 코드를 최소화하는 코드였기에 기본적인 React.ReactNode를 사용하도록 변경해도 문제는 없음.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [x] Storybook 작성 완료
- [x] **desk-web에 적용하여 테스트 완료**

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
