### PR TITLE
fix(listitem): content가 string이 아닐 때, TitleWrapper 영역 모두 차지하도록 수정

### DIFF
--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -167,8 +167,8 @@ forwardedRef: React.Ref<ListItemRef>,
 
   const titleComponent = useMemo(() => (
     <TitleWrapper className={contentClassName}>
-      <Title>
-        { isString(content) ? (
+      { isString(content) ? (
+        <Title>
           <Text
             typo={size === ListItemSize.XL
               ? Typography.Size18
@@ -176,8 +176,8 @@ forwardedRef: React.Ref<ListItemRef>,
           >
             { content }
           </Text>
-        ) : content }
-      </Title>
+        </Title>
+      ) : content }
     </TitleWrapper>
   ), [
     content,


### PR DESCRIPTION
# Description
content가 `<Title>` 안에 갇혀 TitleWrapper 영역을 모두 사용하지 못하고 있었습니다.
사용처에서 좀 더 자유로운 스타일링 가능하도록 수정합니다.

## Changes Detail
* content가 String일 때만 Title 안에 렌더링하게 수정

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
