### PR TITLE
fix(useresizinghandler.ts): onChangeWidth가 인접 column 을 움직일 때에도 불리던 문제를 수정

### DIFF
--- a/src/hooks/useResizingHandlers.ts
+++ b/src/hooks/useResizingHandlers.ts
@@ -45,10 +45,14 @@ export default function useResizingHandlers() {
       if (resultWidth <= maxWidth) {
         const widthChangeTarget = columnRefs[currentKey.current].target
 
+        const isMovingInitial = initialKey.current === currentKey.current
+
         window.requestAnimationFrame!(() => {
           widthChangeTarget.style.width = `${resultWidth}px`
 
-          onChangeWidth(resultWidth)
+          if (isMovingInitial) {
+            onChangeWidth(resultWidth)
+          }
         })
       }
 
@@ -71,10 +75,14 @@ export default function useResizingHandlers() {
       if (resultWidth <= maxWidth) {
         const widthChangeTarget = target
 
+        const isMovingInitial = initialKey.current === currentKey.current
+
         window.requestAnimationFrame!(() => {
           widthChangeTarget.style.width = `${resultWidth}px`
 
-          onChangeWidth(resultWidth)
+          if (isMovingInitial) {
+            onChangeWidth(resultWidth)
+          }
         })
       }
 

--- a/src/hooks/useResizingHandlers.ts
+++ b/src/hooks/useResizingHandlers.ts
@@ -31,7 +31,7 @@ export default function useResizingHandlers() {
     initialPosition.current = event.clientX
   }, [columnRefs])
 
-  const handleResizing = useCallback((event: HTMLElementEventMap['mousemove'], onChangeWidth: (width: number) => void = noop) => {
+  const handleResizing = useCallback((event: HTMLElementEventMap['mousemove']) => {
     let movedPosition = event.clientX - initialPosition.current
     currentKey.current = initialKey.current
 
@@ -44,15 +44,12 @@ export default function useResizingHandlers() {
 
       if (resultWidth <= maxWidth) {
         const widthChangeTarget = columnRefs[currentKey.current].target
-
-        const isMovingInitial = initialKey.current === currentKey.current
+        const onChangeWidth = columnStates[currentKey.current]?.onChangeWidth ?? noop
 
         window.requestAnimationFrame!(() => {
           widthChangeTarget.style.width = `${resultWidth}px`
 
-          if (isMovingInitial) {
-            onChangeWidth(resultWidth)
-          }
+          onChangeWidth(resultWidth)
         })
       }
 
@@ -74,15 +71,12 @@ export default function useResizingHandlers() {
 
       if (resultWidth <= maxWidth) {
         const widthChangeTarget = target
-
-        const isMovingInitial = initialKey.current === currentKey.current
+        const onChangeWidth = columnStates[currentKey.current]?.onChangeWidth ?? noop
 
         window.requestAnimationFrame!(() => {
           widthChangeTarget.style.width = `${resultWidth}px`
 
-          if (isMovingInitial) {
-            onChangeWidth(resultWidth)
-          }
+          onChangeWidth(resultWidth)
         })
       }
 

--- a/src/layout/Navigations/NavigationArea/NavigationArea.tsx
+++ b/src/layout/Navigations/NavigationArea/NavigationArea.tsx
@@ -46,7 +46,6 @@ function NavigationArea(
     setShowChevron,
     isHoveringOnPresenter,
     setIsHoveringOnPresenter,
-    onChangeWidth,
     children,
   }: NavigationProps,
   forwardedRef: React.Ref<HTMLDivElement>,
@@ -103,13 +102,12 @@ function NavigationArea(
 
     window.requestAnimationFrame!(() => {
       if (!allowMouseMove) { return }
-      handleResizing(event, onChangeWidth)
+      handleResizing(event)
     })
   }, [
     disableResize,
     allowMouseMove,
     handleResizing,
-    onChangeWidth,
   ])
 
   useEventHandler(resizeBarRef, 'mousedown', handleMouseDown)

--- a/src/layout/Navigations/NavigationArea/NavigationArea.types.ts
+++ b/src/layout/Navigations/NavigationArea/NavigationArea.types.ts
@@ -10,5 +10,4 @@ export default interface NavigationProps extends Omit<ChildrenComponentProps, 'a
   setShowChevron?: any
   isHoveringOnPresenter?: any
   setIsHoveringOnPresenter?: any
-  onChangeWidth: (width: number) => void
 }

--- a/src/layout/Navigations/NavigationContent/NavigationContent.tsx
+++ b/src/layout/Navigations/NavigationContent/NavigationContent.tsx
@@ -67,7 +67,13 @@ function NavigationContent({
 
   // NOTE: LAYOUTEFFECT를 사용하지 않으면 initial 값이 없을때 순간 깜빡임이 발생한다
   useLayoutEffect(() => {
-    dispatch(LayoutActions.addNavOption({ key: currentKey, option: layoutOption }))
+    dispatch(LayoutActions.addNavOption({
+      key: currentKey,
+      option: {
+        ...layoutOption,
+        onChangeWidth,
+      },
+    }))
 
     if (!isNil(showNavigation)) {
       dispatch(LayoutActions.setShowNavigation(showNavigation))
@@ -81,6 +87,7 @@ function NavigationContent({
     layoutOption,
     showNavigation,
     dispatch,
+    onChangeWidth,
   ])
 
   const clazzName = useMemo(() => (
@@ -149,7 +156,6 @@ function NavigationContent({
       setAllowMouseMove={setAllowMouseMove}
       isHoveringOnPresenter={isHoveringOnPresenter}
       setIsHoveringOnPresenter={setIsHoveringOnPresenter}
-      onChangeWidth={onChangeWidth}
     >
       { (header && fixedHeader) && (
         HeaderElement

--- a/src/layout/redux/LayoutActions.ts
+++ b/src/layout/redux/LayoutActions.ts
@@ -18,6 +18,7 @@ export interface ColumnState {
   minWidth: number
   hidable?: boolean
   disableResize?: boolean
+  onChangeWidth?: (width: number) => void
 }
 
 type SetShowSideActionPayload = {

--- a/src/layout/stories/LayoutPlayground/LayoutPlayGround.stories.tsx
+++ b/src/layout/stories/LayoutPlayground/LayoutPlayGround.stories.tsx
@@ -176,9 +176,9 @@ const Template = ({ onChangeWidth }) => {
             /* LayoutState Prop */
             showNavigation
             layoutOption={{
-              initialWidth: 200,
+              initialWidth: 400,
               maxWidth: 600,
-              minWidth: 180,
+              minWidth: 300,
               hidable: true,
               // disableResize: true,
             }}


### PR DESCRIPTION


# Description
변경사항 개요를 작성해주세요. Github 이슈, Notion 등 연관 문서가 있다면 첨부해주세요.

## Changes Detail
initialKey일때만 onChangeWidth를 불리게 수정합니다.
해당 이슈를 해결합니다  - [유저챗 리스트의 최소너비 버그](https://www.notion.so/channelio/e6adaac5429b4a2ea4b0d2bf4d6eaf7a)

as-is|to-be
---|---
![Jun-18-2021 04-46-57](https://user-images.githubusercontent.com/33861398/122463202-47e19980-cff0-11eb-8241-0c4382c72da9.gif)|![Jun-18-2021 04-47-05](https://user-images.githubusercontent.com/33861398/122463212-4b752080-cff0-11eb-9fe4-4fccb1430095.gif)



# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
