### PR TITLE
feat(tag): 태그, 뱃지 프리셋의 타입을 정확하게 수정

### DIFF
--- a/src/components/TagBadge/TagBadgeCommon/constants/TagBadgeVariant.ts
+++ b/src/components/TagBadge/TagBadgeCommon/constants/TagBadgeVariant.ts
@@ -1,6 +1,3 @@
-/* Internal dependneices */
-import { SemanticNames } from '../../../../foundation/Colors/Theme'
-
 enum TagBadgeVariant {
   Default = 'Default',
   MonochromeLight = 'MonochromeLight',
@@ -18,7 +15,7 @@ enum TagBadgeVariant {
   Purple = 'Purple',
 }
 
-export const TagBadgeBgColorPreset: { [T in TagBadgeVariant]: SemanticNames } = {
+export const TagBadgeBgColorPreset = {
   [TagBadgeVariant.Default]: 'bg-black-lighter',
   [TagBadgeVariant.MonochromeLight]: 'bg-black-lighter',
   [TagBadgeVariant.MonochromeDark]: 'bg-black-darkest',
@@ -33,9 +30,9 @@ export const TagBadgeBgColorPreset: { [T in TagBadgeVariant]: SemanticNames } = 
   [TagBadgeVariant.Orange]: 'bgtxt-orange-lighter',
   [TagBadgeVariant.Red]: 'bgtxt-red-lighter',
   [TagBadgeVariant.Purple]: 'bgtxt-purple-lighter',
-}
+} as const
 
-export const BadgeColorPreset: { [T in TagBadgeVariant]: SemanticNames } = {
+export const BadgeColorPreset = {
   [TagBadgeVariant.Default]: 'txt-black-darkest',
   [TagBadgeVariant.MonochromeLight]: 'txt-black-dark',
   [TagBadgeVariant.MonochromeDark]: 'bgtxt-absolute-white-dark',
@@ -50,6 +47,6 @@ export const BadgeColorPreset: { [T in TagBadgeVariant]: SemanticNames } = {
   [TagBadgeVariant.Orange]: 'bgtxt-orange-normal',
   [TagBadgeVariant.Red]: 'bgtxt-red-normal',
   [TagBadgeVariant.Purple]: 'bgtxt-purple-normal',
-}
+} as const
 
 export default TagBadgeVariant


### PR DESCRIPTION
# Description

사용처에서 정확한 타입을 사용할 수 있도록 태그, 뱃지 컬러 프리셋의 타입을 `SemanticNames` 에서 리터럴 타입으로 변경합니다.

## Changes Detail

없음

# Tests

없음

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* **See also**: https://github.com/channel-io/ch-desk-web/pull/7292#discussion_r639641315
