### PR TITLE
AvatarGroup 컴포넌트 최신화

### DIFF
--- a/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
@@ -5,12 +5,30 @@ import { AVATAR_BORDER_RADIUS_PERCENTAGE, AVATAR_GROUP_DEFAULT_SPACING } from '.
 import { Text, TextProps } from '../../Text'
 import { AvatarSize } from '../Avatar/Avatar.types'
 
+interface AvatarSizeProps {
+  size: AvatarSize
+}
+
 interface AvatarGroupProps {
   spacing: number
 }
 
-interface AvatarEllipsisCountProps extends TextProps, WithInterpolation {
-  size: AvatarSize
+interface AvatarEllipsisCountWrapperProps extends AvatarSizeProps, AvatarGroupProps { }
+
+interface AvatarEllipsisCountProps extends AvatarSizeProps, TextProps, WithInterpolation { }
+
+// TODO: 올바른 페어의 패딩 사이즈를 지정해줘야함
+function getProperEllipsisCountPaddingRight(avatarSize: AvatarSize) {
+  return {
+    [AvatarSize.Size20]: 4,
+    [AvatarSize.Size24]: 5,
+    [AvatarSize.Size30]: 6,
+    [AvatarSize.Size36]: 6,
+    [AvatarSize.Size42]: 6,
+    [AvatarSize.Size48]: 6,
+    [AvatarSize.Size90]: 6,
+    [AvatarSize.Size120]: 6,
+  }[avatarSize]
 }
 
 export const AvatarEllipsisCount = styled(Text)<AvatarEllipsisCountProps>`
@@ -37,8 +55,10 @@ export const AvatarEllipsisWrapper = styled.div<WithInterpolation>`
   ${({ interpolation }) => interpolation}
 `
 
-export const AvatarEllipsisCountWrapper = styled(AvatarEllipsisWrapper)<AvatarGroupProps>`
-  ${({ spacing }) => css`
+export const AvatarEllipsisCountWrapper = styled.div<AvatarEllipsisCountWrapperProps>`
+  ${({ spacing, size }) => css`
+    padding-right: ${getProperEllipsisCountPaddingRight(size)}px;
+
     && {
       margin-left: ${spacing > AVATAR_GROUP_DEFAULT_SPACING ? spacing : AVATAR_GROUP_DEFAULT_SPACING}px;
     }

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
@@ -49,7 +49,7 @@ export const StyledAvatarGroup = styled.div<AvatarGroupProps>`
   }
 `
 
-export const AvatarEllipsisWrapper = styled.div<WithInterpolation>`
+export const AvatarEllipsisIconWrapper = styled.div<WithInterpolation>`
   position: relative;
 
   ${({ interpolation }) => interpolation}

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
@@ -17,7 +17,6 @@ export const AvatarEllipsisCount = styled(Text)<AvatarEllipsisCountProps>`
   position: relative;
   display: flex;
   align-items: center;
-  width: ${({ size }) => size}px;
   height: ${({ size }) => size}px;
   color: ${({ foundation }) => foundation?.theme?.['txt-black-dark']};
 

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -70,7 +70,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
 ) {
   const renderAvatarElement = useCallback((avatar: React.ReactElement<AvatarProps>) => (
     React.cloneElement(avatar, {
-      key: `${avatar.props.name}-${avatar.props.avatarUrl}`,
+      key: avatar.key ?? `${avatar.props.name}-${avatar.props.avatarUrl}`,
       size,
       showBorder: avatar.props.showBorder || spacing < 0,
     })

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -63,6 +63,7 @@ function AvatarGroup({
   onMouseEnterEllipsis = noop,
   onMouseLeaveEllipsis = noop,
   ellipsisInterpolation,
+  className,
   children,
 }: AvatarGroupProps,
 forwardedRef: React.Ref<HTMLDivElement>,
@@ -159,6 +160,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
 
   return (
     <StyledAvatarGroup
+      className={className}
       data-testid={AVATAR_GROUP_TEST_ID}
       ref={forwardedRef}
       spacing={spacing}

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -124,6 +124,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
           >
             { renderAvatarElement(avatar) }
             <AvatarEllipsisCountWrapper
+              size={size}
               spacing={spacing}
               onMouseEnter={onMouseEnterEllipsis}
               onMouseLeave={onMouseLeaveEllipsis}

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -11,7 +11,7 @@ import { AVATAR_GROUP_DEFAULT_SPACING } from '../constants/AvatarStyle'
 import AvatarGroupProps, { AvatarGroupEllipsisType } from './AvatarGroup.types'
 import {
   StyledAvatarGroup,
-  AvatarEllipsisWrapper,
+  AvatarEllipsisIconWrapper,
   AvatarEllipsisCountWrapper,
   AvatarEllipsisIcon,
   AvatarEllipsisCount,
@@ -99,7 +99,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
 
       if (ellipsisType === AvatarGroupEllipsisType.Icon) {
         return (
-          <AvatarEllipsisWrapper
+          <AvatarEllipsisIconWrapper
             key="ellipsis"
             interpolation={ellipsisInterpolation}
             onMouseEnter={onMouseEnterEllipsis}
@@ -113,7 +113,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
               />
             </AvatarEllipsisIcon>
             { renderAvatarElement(avatar) }
-          </AvatarEllipsisWrapper>
+          </AvatarEllipsisIconWrapper>
         )
       }
 

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -110,7 +110,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
               <Icon
                 size={getProperIconSize(size)}
                 name="more"
-                color="bgtxt-absolute-white-normal"
+                color="bgtxt-absolute-white-dark"
               />
             </AvatarEllipsisIcon>
             { renderAvatarElement(avatar) }


### PR DESCRIPTION
# Description

AvatarGroup 컴포넌트를 시안에 맞게 최신화하고, 수정/리팩토링을 진행합니다.

## Changes Detail

- 기존 아바타 사이즈로 고정된 width의 Count를 글자의 크기만큼 가변너비를 가지되, 사이즈별 다른 우측 패딩을 가지도록 변경
- className을 받을 수 있도록 변경
- ellipsisIcon의 색상을 투명도 없는 흰색으로 변경
- children으로 넘긴 Avatar의 key가 없을 경우에만 AvatarGroup에서 key를 지정해주도록 변경

# Tests

없음

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
