### PR TITLE
KeyValueListItem의 keyContent prop을 확장함

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "prepublishOnly": "npm run build",
     "deploy:storybook": "storybook-to-ghpages --remote=upstream",
     "prepare": "husky install",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "update-snapshot": "jest --updateSnapshot"
   },
   "lint-staged": {
     "src/**/*.styled.{js,ts}": [

--- a/src/components/KeyValueListItem/KeyValueListItem.tsx
+++ b/src/components/KeyValueListItem/KeyValueListItem.tsx
@@ -16,6 +16,7 @@ import { v4 as uuid } from 'uuid'
 
 /* Internal dependencies */
 import { Icon, IconSize } from '../Icon'
+import { isNumberString } from '../../utils/stringUtils'
 import { Typography } from '../../foundation'
 import { isIconName } from '../Icon/util'
 import { KeyValueActionProps, KeyValueListItemProps } from './KeyValueListItem.types'
@@ -133,9 +134,11 @@ function KeyValueListItem(
         <Styled.KeyContentWrapper
           interpolation={keyWrapperInterpolation}
         >
-          <Styled.KeyText bold typo={Typography.Size12}>
-            { keyContent }
-          </Styled.KeyText>
+          { isNumberString() ? (
+            <Styled.KeyText bold typo={Typography.Size12}>
+              { keyContent }
+            </Styled.KeyText>
+          ) : keyContent }
         </Styled.KeyContentWrapper>
 
         { !multiline && ValueComponent }

--- a/src/components/KeyValueListItem/KeyValueListItem.tsx
+++ b/src/components/KeyValueListItem/KeyValueListItem.tsx
@@ -134,7 +134,7 @@ function KeyValueListItem(
         <Styled.KeyContentWrapper
           interpolation={keyWrapperInterpolation}
         >
-          { isNumberString() ? (
+          { isNumberString(keyContent) ? (
             <Styled.KeyText bold typo={Typography.Size12}>
               { keyContent }
             </Styled.KeyText>

--- a/src/components/KeyValueListItem/KeyValueListItem.types.ts
+++ b/src/components/KeyValueListItem/KeyValueListItem.types.ts
@@ -20,7 +20,7 @@ export type KeyValueActionProps = {
 export interface KeyValueListItemProps extends ChildrenComponentProps, React.HTMLAttributes<HTMLDivElement> {
   multiline?: boolean
   keyIcon?: IconName | React.ReactNode
-  keyContent?: string
+  keyContent?: React.ReactNode
   actions?: KeyValueActionProps | KeyValueActionProps[]
   className?: string
   valueWrapperInterpolation?: InjectedInterpolation

--- a/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
+++ b/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
@@ -17,23 +17,6 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   transition-delay: 0ms;
 }
 
-.c5 {
-  font-size: 12px;
-  line-height: 16px;
-  margin: 0px 0px 0px 0px;
-  font-style: normal;
-  font-weight: bold;
-  color: inherit;
-  -webkit-transition-property: color;
-  transition-property: color;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
-  transition-timing-function: cubic-bezier(.3,0,0,1);
-  -webkit-transition-delay: 0ms;
-  transition-delay: 0ms;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -62,13 +45,6 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   background-color: #0000000D;
 }
 
-.c6 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: #00000066;
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -82,11 +58,11 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   padding-left: 8px;
 }
 
-.c8 {
+.c6 {
   min-width: 0;
 }
 
-.c3 ~ .c7 {
+.c3 ~ .c5 {
   margin-left: 8px;
 }
 
@@ -134,15 +110,10 @@ exports[`KeyValueListItem Snapshot > 1`] = `
     <div
       class="c3 c4"
     >
-      <span
-        class="c5 c6"
-        data-testid="bezier-react-text"
-      >
-        key
-      </span>
+      key
     </div>
     <div
-      class="c7 c8"
+      class="c5 c6"
     >
       thisiscontent
     </div>


### PR DESCRIPTION
# Description
아래처럼 사용해야 하는 경우가 있어 string뿐만 아니라 ReactNode도 받을 수 있게끔 prop을 확장했습니다
![image](https://user-images.githubusercontent.com/33861398/123286589-ffbefb80-d548-11eb-82e9-2df243581145.png)
additional: jest snapShot 업데이트 스크립트를 추가

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
