### PR TITLE
fix(keyvaluelistitem): isStringNumber의 의미를 잘못 파악하고 사용하여 isString으로 변경함

### DIFF
--- a/src/components/KeyValueListItem/KeyValueListItem.tsx
+++ b/src/components/KeyValueListItem/KeyValueListItem.tsx
@@ -11,12 +11,12 @@ import {
   isEmpty,
   isArray,
   isBoolean,
+  isString,
 } from 'lodash-es'
 import { v4 as uuid } from 'uuid'
 
 /* Internal dependencies */
 import { Icon, IconSize } from '../Icon'
-import { isNumberString } from '../../utils/stringUtils'
 import { Typography } from '../../foundation'
 import { isIconName } from '../Icon/util'
 import { KeyValueActionProps, KeyValueListItemProps } from './KeyValueListItem.types'
@@ -134,7 +134,7 @@ function KeyValueListItem(
         <Styled.KeyContentWrapper
           interpolation={keyWrapperInterpolation}
         >
-          { isNumberString(keyContent) ? (
+          { isString(keyContent) ? (
             <Styled.KeyText bold typo={Typography.Size12}>
               { keyContent }
             </Styled.KeyText>

--- a/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
+++ b/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
@@ -17,6 +17,23 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   transition-delay: 0ms;
 }
 
+.c5 {
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-property: color;
+  transition-property: color;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -45,6 +62,13 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   background-color: #0000000D;
 }
 
+.c6 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #00000066;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -58,11 +82,11 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   padding-left: 8px;
 }
 
-.c6 {
+.c8 {
   min-width: 0;
 }
 
-.c3 ~ .c5 {
+.c3 ~ .c7 {
   margin-left: 8px;
 }
 
@@ -110,10 +134,15 @@ exports[`KeyValueListItem Snapshot > 1`] = `
     <div
       class="c3 c4"
     >
-      key
+      <span
+        class="c5 c6"
+        data-testid="bezier-react-text"
+      >
+        key
+      </span>
     </div>
     <div
-      class="c5 c6"
+      class="c7 c8"
     >
       thisiscontent
     </div>


### PR DESCRIPTION
# Description
변경사항 개요를 작성해주세요. Github 이슈, Notion 등 연관 문서가 있다면 첨부해주세요.

## Changes Detail
isStringNumber의 의미를 잘못 파악하고 사용하여 isString으로 변경함
string or number인줄 알았는데, number인 string을 찾아내는 것이어서 isString으로 변경합니다.

#553 에서 잘못 작업된 버그 입니다

![image](https://user-images.githubusercontent.com/33861398/123372518-aabdcc80-d5be-11eb-8f0e-b5711e313381.png)
keyContent에 stirng을 넣었을때도 이제 잘 작동합니다
# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
