### PR TITLE
Checkbox 컴포넌트 디자인 최신화

### DIFF
--- a/src/components/Checkbox/Checkbox.styled.ts
+++ b/src/components/Checkbox/Checkbox.styled.ts
@@ -39,7 +39,7 @@ const checkerBase = css<StyledCheckerProps>`
     ${({ foundation }) =>
     foundation?.border?.getBorder(
       CHECKER_ICON_THICKNESS,
-      foundation?.theme?.['bgtxt-absolute-white-normal'],
+      foundation?.theme?.['bgtxt-absolute-white-dark'],
       { top: false, left: false },
     )};
     ${({ foundation }) => foundation?.transition?.getTransitionsCSS('border')};
@@ -59,7 +59,7 @@ const partialChecked = css<StyledCheckerProps>`
     ${({ foundation }) =>
     foundation?.border?.getBorder(
       CHECKER_ICON_THICKNESS,
-      foundation?.theme?.['bgtxt-absolute-white-normal'],
+      foundation?.theme?.['bgtxt-absolute-white-dark'],
       { top: false, right: false, left: false },
     )};
   }

--- a/src/components/Checkbox/Checkbox.styled.ts
+++ b/src/components/Checkbox/Checkbox.styled.ts
@@ -78,6 +78,7 @@ export const Checker = styled.div<StyledCheckerProps>`
   min-width: ${CHECKER_BOX_SIZE}px;
   height: ${CHECKER_BOX_SIZE}px;
   min-height: ${CHECKER_BOX_SIZE}px;
+  margin: 1px;
   font-size: 10px;
   color: transparent;
 

--- a/src/components/Checkbox/Checkbox.styled.ts
+++ b/src/components/Checkbox/Checkbox.styled.ts
@@ -1,74 +1,39 @@
 /* Internal dependencies */
 import DisabledOpacity from '../../constants/DisabledOpacity'
 import { styled, css, absoluteCenter } from '../../foundation'
-import { StyledWrapperProps, StyledCheckerProps, StyledContentProps } from './Checkbox.types'
+import { Icon as BaseIcon } from '../Icon'
 import CheckType from './CheckType'
 
 const CHECKER_BOX_SIZE = 18
-const CHECKER_ICON_THICKNESS = 2
 const CHECKER_BORDER_THICKNESS = 2
+
+interface StyledWrapperProps {
+  disabled?: boolean
+}
+
+interface StyledCheckerProps extends StyledWrapperProps {
+  checkStatus?: CheckType
+}
 
 export const Wrapper = styled.div<StyledWrapperProps>`
   display: inline-flex;
   align-items: center;
   cursor: pointer;
 
-  ${props => (props.disabled && css`
+  ${({ disabled }) => disabled && css`
     cursor: not-allowed;
-  `)}
+  `};
 `
 
 function isTrueOrPartial(checkStatus: CheckType = CheckType.False) {
   return checkStatus === CheckType.True || checkStatus === CheckType.Partial
 }
 
-const checkerBase = css<StyledCheckerProps>`
-  background-color:
-    ${({ foundation, checkStatus }) => (isTrueOrPartial(checkStatus)
-    ? foundation?.theme?.['bgtxt-green-normal']
-    : foundation?.theme?.['bg-white-normal'])};
-  border-color: ${({ checkStatus }) => (isTrueOrPartial(checkStatus) && 'transparent')};
-
-  &::after {
-    ${absoluteCenter`translateY(-13%) rotate(42deg)`}
-    display: ${({ checkStatus }) => (isTrueOrPartial(checkStatus) ? 'initial' : 'none')};
-    width: 6px;
-    height: 10px;
-    content: '';
-    ${({ foundation }) =>
-    foundation?.border?.getBorder(
-      CHECKER_ICON_THICKNESS,
-      foundation?.theme?.['bgtxt-absolute-white-dark'],
-      { top: false, left: false },
-    )};
-    ${({ foundation }) => foundation?.transition?.getTransitionsCSS('border')};
-  }
-
-  &:hover {
-    background-color:
-      ${({ foundation, disabled, checkStatus }) =>
-    ((!disabled && isTrueOrPartial(checkStatus)) && foundation?.theme?.['bgtxt-green-dark'])};
-  }
-`
-
-const partialChecked = css<StyledCheckerProps>`
-  &::after {
-    ${absoluteCenter`translateY(-36%) rotate(0)`}
-    width: 10px;
-    ${({ foundation }) =>
-    foundation?.border?.getBorder(
-      CHECKER_ICON_THICKNESS,
-      foundation?.theme?.['bgtxt-absolute-white-dark'],
-      { top: false, right: false, left: false },
-    )};
-  }
-`
-
-const disabledStyle = css<StyledCheckerProps>`
+const disabledStyle = css`
   opacity: ${DisabledOpacity};
 `
 
-export const Checker = styled.div<StyledCheckerProps>`
+const checkerBaseStyle = css<StyledCheckerProps>`
   position: relative;
   box-sizing: border-box !important;
   display: flex;
@@ -79,36 +44,42 @@ export const Checker = styled.div<StyledCheckerProps>`
   height: ${CHECKER_BOX_SIZE}px;
   min-height: ${CHECKER_BOX_SIZE}px;
   margin: 1px;
-  font-size: 10px;
-  color: transparent;
-
-  ${({ foundation }) =>
-    foundation
-      ?.border
-      ?.getBorder(CHECKER_BORDER_THICKNESS, foundation?.theme?.['bdr-black-light'])};
-
-  border-radius: ${({ foundation }) => foundation?.rounding.round4};
+  border-radius: ${({ foundation }) => foundation?.rounding.round6};
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'opacity'])};
 
-  ${({ foundation, disabled }) => (!disabled && css`
-    &:hover {
-      &::after {
-        border-color: ${foundation?.theme?.['bdr-black-light']};
-      }
-    }
-  `)};
-
-  ${checkerBase};
-
-  ${({ checkStatus }) => (checkStatus === CheckType.Partial && partialChecked)};
-
-  ${({ disabled }) => (disabled && disabledStyle)};
+  ${({ disabled }) => disabled && disabledStyle};
 `
 
-export const Content = styled.div<StyledContentProps>`
+const checkerDynamicStyle = css<StyledCheckerProps>`
+  ${({ foundation, checkStatus, disabled }) => (isTrueOrPartial(checkStatus)
+    ? css`
+        border-color: transparent;
+        background-color: ${foundation?.theme?.['bgtxt-green-normal']};
+
+        &:hover {
+          background-color: ${!disabled && foundation?.theme?.['bgtxt-green-dark']};
+        }
+      `
+    : css`
+        ${foundation?.border?.getBorder(CHECKER_BORDER_THICKNESS, foundation?.theme?.['bg-black-dark'])};
+        background-color: ${foundation?.theme?.['bg-white-normal']};
+      `
+  )}
+`
+
+export const Icon = styled(BaseIcon)`
+  ${absoluteCenter('')}
+`
+
+export const Checker = styled.div`
+  ${checkerBaseStyle};
+  ${checkerDynamicStyle};
+`
+
+export const Content = styled.div`
   box-sizing: border-box;
   padding: ${CHECKER_BORDER_THICKNESS}px 0;
-  margin-left: 9px;
+  margin-left: 8px;
   user-select: none;
 `

--- a/src/components/Checkbox/Checkbox.styled.ts
+++ b/src/components/Checkbox/Checkbox.styled.ts
@@ -85,7 +85,8 @@ export const Checker = styled.div<StyledCheckerProps>`
     foundation
       ?.border
       ?.getBorder(CHECKER_BORDER_THICKNESS, foundation?.theme?.['bdr-black-light'])};
-  border-radius: 4px;
+
+  border-radius: ${({ foundation }) => foundation?.rounding.round4};
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'opacity'])};
 

--- a/src/components/Checkbox/Checkbox.styled.ts
+++ b/src/components/Checkbox/Checkbox.styled.ts
@@ -13,10 +13,9 @@ export const Wrapper = styled.div<StyledWrapperProps>`
   align-items: center;
   cursor: pointer;
 
-  ${props => (props.disabled
-    ? 'cursor: not-allowed;'
-    : ''
-  )}
+  ${props => (props.disabled && css`
+    cursor: not-allowed;
+  `)}
 `
 
 function isTrueOrPartial(checkStatus: CheckType = CheckType.False) {
@@ -28,7 +27,7 @@ const checkerBase = css<StyledCheckerProps>`
     ${({ foundation, checkStatus }) => (isTrueOrPartial(checkStatus)
     ? foundation?.theme?.['bgtxt-green-normal']
     : foundation?.theme?.['bg-white-normal'])};
-  border-color: ${({ checkStatus }) => (isTrueOrPartial(checkStatus) ? 'transparent' : '')};
+  border-color: ${({ checkStatus }) => (isTrueOrPartial(checkStatus) && 'transparent')};
 
   &::after {
     ${absoluteCenter`translateY(-13%) rotate(42deg)`}
@@ -48,7 +47,7 @@ const checkerBase = css<StyledCheckerProps>`
   &:hover {
     background-color:
       ${({ foundation, disabled, checkStatus }) =>
-    ((!disabled && isTrueOrPartial(checkStatus)) ? foundation?.theme?.['bgtxt-green-dark'] : '')};
+    ((!disabled && isTrueOrPartial(checkStatus)) && foundation?.theme?.['bgtxt-green-dark'])};
   }
 `
 
@@ -81,6 +80,7 @@ export const Checker = styled.div<StyledCheckerProps>`
   min-height: ${CHECKER_BOX_SIZE}px;
   font-size: 10px;
   color: transparent;
+
   ${({ foundation }) =>
     foundation
       ?.border
@@ -89,19 +89,19 @@ export const Checker = styled.div<StyledCheckerProps>`
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'opacity'])};
 
-  ${({ foundation, disabled }) => (!disabled ? `
+  ${({ foundation, disabled }) => (!disabled && css`
     &:hover {
       &::after {
         border-color: ${foundation?.theme?.['bdr-black-light']};
       }
     }
-  ` : '')}
+  `)};
 
-  ${checkerBase}
+  ${checkerBase};
 
-  ${({ checkStatus }) => (checkStatus === CheckType.Partial ? partialChecked : '')}
+  ${({ checkStatus }) => (checkStatus === CheckType.Partial && partialChecked)};
 
-  ${({ disabled }) => (disabled ? disabledStyle : '')}
+  ${({ disabled }) => (disabled && disabledStyle)};
 `
 
 export const Content = styled.div<StyledContentProps>`

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -53,7 +53,7 @@ describe('Checkbox test >', () => {
 
     const renderedCheckboxChecker = getByTestId(CHECKBOX_CHECKER_TEST_ID)
 
-    expect(renderedCheckboxChecker).toHaveStyle(`border-color: ${Themes.LightTheme['bdr-black-light']};`)
+    expect(renderedCheckboxChecker).toHaveStyle(`border-color: ${Themes.LightTheme['bg-black-dark']};`)
   })
 
   it('Checker of Checkbox has green background when check status is truthy', () => {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -7,7 +7,8 @@ import React, {
 import { values, isBoolean, isEmpty, includes, noop } from 'lodash-es'
 
 /* Internal dependencies */
-import { Wrapper, Checker, Content } from './Checkbox.styled'
+import { IconSize, IconProps } from '../Icon'
+import { Wrapper, Checker, Icon, Content } from './Checkbox.styled'
 import CheckType from './CheckType'
 import type CheckboxProps from './Checkbox.types'
 
@@ -15,6 +16,11 @@ export const CHECKBOX_TEST_ID = 'bezier-react-checkbox'
 export const CHECKBOX_CHECKER_TEST_ID = 'bezier-react-checkbox-checker'
 
 const checkTypeValues = values(CheckType)
+
+const checkIconCommonProps: Pick<IconProps, 'size' | 'color'> = {
+  size: IconSize.XS,
+  color: 'bgtxt-absolute-white-dark',
+}
 
 function Checkbox(
   {
@@ -36,6 +42,28 @@ function Checkbox(
     return CheckType.False
   }, [checked])
 
+  const CheckIcon = useMemo(() => {
+    switch (checkStatus) {
+      case CheckType.True:
+        return (
+          <Icon
+            name="check-bold"
+            {...checkIconCommonProps}
+          />
+        )
+      case CheckType.Partial:
+        return (
+          <Icon
+            name="hyphen-bold"
+            {...checkIconCommonProps}
+
+          />
+        )
+      default:
+        return null
+    }
+  }, [checkStatus])
+
   return (
     <Wrapper
       ref={forwardedRef}
@@ -49,8 +77,9 @@ function Checkbox(
         disabled={disabled}
         checkStatus={checkStatus}
         data-testid={checkerTestId}
-      />
-
+      >
+        { CheckIcon }
+      </Checker>
       { !isEmpty(children) ? (
         <Content className={contentClassName}>
           { children }

--- a/src/components/Checkbox/Checkbox.types.ts
+++ b/src/components/Checkbox/Checkbox.types.ts
@@ -1,8 +1,5 @@
 /* Internal dependencies */
-import {
-  UIComponentProps,
-  ChildrenComponentProps,
-} from '../../types/ComponentProps'
+import { ChildrenComponentProps } from '../../types/ComponentProps'
 import CheckType from './CheckType'
 
 export default interface CheckboxProps extends ChildrenComponentProps {
@@ -11,17 +8,4 @@ export default interface CheckboxProps extends ChildrenComponentProps {
   disabled?: boolean
   checked?: boolean | CheckType
   onClick?: () => void
-}
-
-export interface StyledWrapperProps extends UIComponentProps {
-  disabled?: boolean
-}
-
-export interface StyledCheckerProps extends UIComponentProps {
-  disabled?: boolean
-  checkStatus?: CheckType
-}
-
-export interface StyledContentProps extends UIComponentProps {
-  className?: string
 }


### PR DESCRIPTION
# Description

<img width="801" alt="스크린샷 2021-06-25 오후 5 01 27" src="https://user-images.githubusercontent.com/58209009/123391427-fda37e00-d5d6-11eb-9930-7844cbd66d95.png">

Checkbox 컴포넌트를 디자인 시안에 맞게 최신화합니다.

## Changes Detail

### Fix

- 마우스 호버 시 체크 아이콘의 색상은 변하지 않도록 수정합니다.

### Change

- 수도 엘리먼트로 구현한 체크 아이콘을, Icon 컴포넌트로 구현하도록 변경합니다.
  - 보더의 끝에 Radius가 있는 아이콘이라, 수도 엘리먼트의 Border로는 표현하기가 어렵습니다. 디자인 시안과 오차 없이 동일하게 만들고자 했습니다.
- border-radius를 4-> 6px 로 변경합니다.
- border의 색상을 시안과 동일하게 변경합니다.
- `*실제 크기는 18이나, margin을 1로 잡아 전체 크기가 20이 되게 합니다.` 를 적용합니다. 
  - margin: 1px 을 추가합니다.
  - Content와의 간격은 9 -> 8px로 변경합니다.
- 불필요한 코드 제거 & 리팩토링

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
