### PR TITLE
TransitionDuration enum을 string 대신 number로 정의

### DIFF
--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -65,7 +65,7 @@ export const Element = styled.div<StyledToastProps>`
   transition: ${({ foundation, transitionDuration }) =>
     foundation?.transition.getTransitionsCSS('transform', transitionDuration)};
   animation: ${({ transitionDuration, placement }) => `
-    ${transitionDuration}
+    ${transitionDuration}ms
     ${Transition.TransitionEasing}
     0s
     1

--- a/src/components/Toast/ToastController.tsx
+++ b/src/components/Toast/ToastController.tsx
@@ -8,21 +8,8 @@ import React, {
 
 /* Internal dependencies */
 import { window } from '../../utils/domUtils'
-import { TransitionDuration } from '../../foundation'
 import { ToastControllerProps } from './Toast.types'
 import { showedToastTranslateXStyle, initPosition } from './utils'
-
-function parseDuration(transitionDuration: TransitionDuration) {
-  switch (transitionDuration) {
-    case TransitionDuration.L:
-      return 500
-    case TransitionDuration.M:
-      return 300
-    case TransitionDuration.S:
-    default:
-      return 150
-  }
-}
 
 function ToastController({
   autoDismissTimeout,
@@ -38,7 +25,7 @@ function ToastController({
 
   const handleDismiss = useCallback(() => {
     setTransform(initPosition(placement))
-    timer.current = window.setTimeout(onDismiss, parseDuration(transitionDuration))
+    timer.current = window.setTimeout(onDismiss, transitionDuration)
   }, [
     onDismiss,
     placement,
@@ -60,7 +47,7 @@ function ToastController({
 
   useEffect(() => {
     if (autoDismiss) {
-      timer.current = window.setTimeout(startTimer, parseDuration(transitionDuration))
+      timer.current = window.setTimeout(startTimer, transitionDuration)
     }
     return clearTimer
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/foundation/Transition/index.ts
+++ b/src/foundation/Transition/index.ts
@@ -2,9 +2,9 @@
 import { css } from '../FoundationStyledComponent'
 
 export enum TransitionDuration {
-  S = '150ms',
-  M = '300ms',
-  L = '500ms',
+  S = 150,
+  M = 300,
+  L = 500,
 }
 
 const TransitionEasing = 'cubic-bezier(.3,0,0,1)'
@@ -22,7 +22,7 @@ function getTransitionsCSS(
 
   return css`
     transition-property: ${properties};
-    transition-duration: ${duration};
+    transition-duration: ${duration}ms;
     transition-timing-function: ${TransitionEasing};
     transition-delay: ${delay}ms;
   `


### PR DESCRIPTION
# Description
setTimeout 등에서 TransitionDuration의 값을 사용할 때 용이하게 하기 위해서 string 대신 number로 정의합니다.

## Changes Detail
* `TransitionDuration` 수정 `"300ms"` -> `300`
* `ToastController`에서 `TransitionDuration`에 따라 parsing 하던 로직 제거

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues

close #554 