### PR TITLE
fix(overlay): 오버레이 ref가 달라져 생긴 사이드이펙트 수정

### DIFF
--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -8,7 +8,6 @@ import React, {
   useEffect,
   Ref,
   forwardRef,
-  useImperativeHandle,
 } from 'react'
 import ReactDOM from 'react-dom'
 import { noop } from 'lodash-es'
@@ -20,6 +19,7 @@ import {
   getRootElement,
 } from '../../utils/domUtils'
 import useEventHandler from '../../hooks/useEventHandler'
+import useMergeRefs from '../../hooks/useMergeRefs'
 import OverlayProps, {
   OverlayPosition,
   ContainerRectAttr,
@@ -68,6 +68,7 @@ function Overlay(
 
   const overlayRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  const mergedRef = useMergeRefs<HTMLDivElement>(overlayRef, forwardedRef)
 
   const handleTransitionEnd = useCallback(() => {
     if (!show) {
@@ -153,11 +154,6 @@ function Overlay(
     children,
   ])
 
-  useImperativeHandle(forwardedRef, () => ({
-    overlayRef,
-    onForceUpdate: handleOverlayForceUpdate,
-  }))
-
   useEventHandler(document, 'click', handleHideOverlay, show, true)
   useEventHandler(document, 'keyup', handleKeydown, show)
   useEventHandler(containerRef.current, 'wheel', handleBlockMouseWheel, show)
@@ -165,7 +161,7 @@ function Overlay(
   const Content = useMemo(() => (
     <Styled.Overlay
       as={as}
-      ref={overlayRef}
+      ref={mergedRef}
       className={className}
       show={shouldShow}
       withTransition={withTransition}
@@ -192,6 +188,7 @@ function Overlay(
     keepInContainer,
     marginX,
     marginY,
+    mergedRef,
     position,
     shouldShow,
     style,


### PR DESCRIPTION
# Description
#552 에서 ref의 접근 인터페이스가 달라져 데스크에서 Overlay에 ref로 접근하여 사용하던곳에서 문제발생함
다시 이전처럼 ref 인터페이스 되돌림

## Changes Detail
* 변경1 세부사항
* 변경2 세부사항

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
