### PR TITLE
Toast line break 관련 버그 수정

### DIFF
--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -104,6 +104,7 @@ export const EllipsisableContent = styled.div`
   ${ellipsis(5, 18)};
 
   overflow: visible;
+  word-break: break-word;
 `
 
 export const NormalContent = styled.span`

--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -95,18 +95,22 @@ const getEllipsisColor = (
 )
 
 export const Content = styled.div<Pick<ToastElementProps, 'actionContent' | 'onClick'>>`
-  ${ellipsis(5, 18)};
   margin: 3px 6px;
+  overflow: hidden;
   color: ${({ actionContent, onClick, foundation }) => getEllipsisColor(actionContent, onClick, foundation)};
 `
 
-export const NormalContent = styled.div`
-  display: inline;
+export const EllipsisableContent = styled.div`
+  ${ellipsis(5, 18)};
+
+  overflow: visible;
+`
+
+export const NormalContent = styled.span`
   color: ${({ foundation }) => foundation?.subTheme?.['txt-black-darkest']};
 `
 
-export const ActionContent = styled.div`
-  display: inline;
+export const ActionContent = styled.span`
   color: ${({ foundation }) => foundation?.subTheme?.['bgtxt-cobalt-normal']};
   cursor: pointer;
 

--- a/src/components/Toast/ToastElement.tsx
+++ b/src/components/Toast/ToastElement.tsx
@@ -14,6 +14,7 @@ import {
   ActionContent,
   NormalContent,
   Content,
+  EllipsisableContent,
 } from './Toast.styled'
 import { getToastPreset } from './utils'
 
@@ -80,22 +81,24 @@ const ToastElement = (
         actionContent={actionContent}
         onClick={onClick}
       >
-        <Text
-          typo={Typography.Size14}
-          style={{
-            height: '18px',
-          }}
-        >
-          <NormalContent>
-            { newLineComponent }
-          </NormalContent>
-          { ' ' }
-          { actionContent && onClick && (
-            <ActionContent onClick={() => onClick()}>
-              { actionContent }
-            </ActionContent>
-          ) }
-        </Text>
+        <EllipsisableContent>
+          <Text
+            typo={Typography.Size14}
+            style={{
+              height: '18px',
+            }}
+          >
+            <NormalContent>
+              { newLineComponent }
+            </NormalContent>
+            { ' ' }
+            { actionContent && onClick && (
+              <ActionContent onClick={() => onClick()}>
+                { actionContent }
+              </ActionContent>
+            ) }
+          </Text>
+        </EllipsisableContent>
       </Content>
       <Close onClick={onDismiss}>
         <Icon


### PR DESCRIPTION
# Description
Electron에서만 Toast의 각 line에서 말줄임표가 나타나는 현상이 있습니다.
텍스트가 overflow 되면 말줄임표가 나타나는 것인데, 일반적인 상황이라면 텍스트가 overflow 되기 전에 개행이 되기 때문에 이런 현상은 없어야 합니다.

정확하진 않지만 일렉트론에서 텍스트 element 범위를 정확히 잡지 못하는 것이 아닌가 하는 의심을 하고 있습니다.

이 수정에서는 약간의 트릭을 써서 해당 문제를 해결합니다.
Mixin의 ellipsis에서 주는 `overflow: hidden을` 무시하게 하고, 한 단계 위 부모에서 `overflow: hidden`을 줍니다.
이렇게 하면 5 줄 이상은 보이지 않으면서 (_아마_)일렉트론 버그로 인한 텍스트 오버플로우는 사라집니다.

|as-is|to-be|
|:---:|:---:|
|<img width="313" alt="스크린샷 2021-06-26 오후 2 28 42" src="https://user-images.githubusercontent.com/16368822/123503131-e07cb700-d68b-11eb-9b47-82774bb0f546.png">|<img width="313" alt="스크린샷 2021-06-26 오후 2 28 03" src="https://user-images.githubusercontent.com/16368822/123503133-e2df1100-d68b-11eb-8606-60d0ace6e09c.png">|

# Tests
직접 build해서 desk `node_modules`에 넣고, `npm run dev:app:prod` 실행하고, 일렉트론 켜서 테스트 함.


## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
