### PR TITLE
perf(smoothcorners): do not generate new classname per image url

### DIFF
--- a/src/components/Avatars/Avatar/Avatar.styled.ts
+++ b/src/components/Avatars/Avatar/Avatar.styled.ts
@@ -11,7 +11,6 @@ interface AvatarWrapperProps extends WithInterpolation {
 }
 
 interface AvatarProps extends WithInterpolation {
-  avatarUrl: string
   size: AvatarSize
   showBorder: boolean
 }
@@ -57,12 +56,12 @@ export const AvatarImage = styled.div<AvatarProps>`
 
   ${({ showBorder }) => (!enableSmoothCorners.current && showBorder) && smoothCornersFallbackBorderStyle}
 
-  ${({ foundation, avatarUrl, showBorder }) => smoothCorners({
+  ${({ foundation, showBorder }) => smoothCorners({
     shadow: showBorder ? `0 0 0 ${AVATAR_BORDER_WIDTH}px ${foundation?.theme?.['bgtxt-absolute-white-dark']}` : undefined,
     shadowBlur: showBorder ? AVATAR_BORDER_WIDTH : 0,
     backgroundColor: foundation?.theme?.['bgtxt-absolute-white-dark'],
     borderRadius: `${AVATAR_BORDER_RADIUS_PERCENTAGE}%`,
-    backgroundImage: avatarUrl,
+    hasBackgroundImage: true,
   })};
 
   ${({ interpolation }) => interpolation}

--- a/src/components/Avatars/Avatar/Avatar.tsx
+++ b/src/components/Avatars/Avatar/Avatar.tsx
@@ -6,6 +6,7 @@ import { noop, isEmpty } from 'lodash-es'
 import useProgressiveImage from '../../../hooks/useProgressiveImage'
 import defaultAvatarUrl from '../assets/defaultAvatar.svg'
 import { Status } from '../../Status'
+import { smoothCornersStyle } from '../../../foundation'
 import AvatarProps, { AvatarSize } from './Avatar.types'
 import { AvatarImage, AvatarImageWrapper, AvatarWrapper, StatusWrapper } from './Avatar.styled'
 
@@ -75,11 +76,11 @@ forwardedRef: React.Ref<HTMLDivElement>,
     >
       <AvatarImageWrapper>
         <AvatarImage
+          style={smoothCornersStyle({ imageUrl: loadedAvatarUrl })}
           className={className}
           interpolation={interpolation}
           ref={forwardedRef}
           data-testid={testId}
-          avatarUrl={loadedAvatarUrl}
           size={size}
           role="img"
           aria-label={name}

--- a/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Avatar test > Snapshot 1`] = `
   outline: none;
   margin: 0px;
   background-color: #FFFFFF;
-  background-image: url(https://www.google.com);
+  background-image: var(--background-image);
   background-size: cover;
   border-radius: 42%;
 }
@@ -35,7 +35,7 @@ exports[`Avatar test > Snapshot 1`] = `
     margin: 0px;
     background: paint(smooth-corners);
     border-radius: 0;
-    border-image-source: url(https://www.google.com);
+    border-image-source: var(--background-image);
     box-shadow: none;
     --smooth-corners: 42%;
     --smooth-corners-shadow: 0 0 0 0 transparent;
@@ -51,5 +51,6 @@ exports[`Avatar test > Snapshot 1`] = `
   data-testid="bezier-react-avatar"
   role="img"
   size="24"
+  style="--background-image: url(https://www.google.com);"
 />
 `;

--- a/src/components/Header/Header.styled.ts
+++ b/src/components/Header/Header.styled.ts
@@ -34,7 +34,6 @@ export const ActionWrapper = styled.div`
 
 interface TitleImageProps {
   imageSize: number
-  imageUrl: string
 }
 
 export const TitleImage = styled.div<TitleImageProps>`
@@ -45,15 +44,14 @@ export const TitleImage = styled.div<TitleImageProps>`
   width: ${props => props.imageSize}px;
   height: ${props => props.imageSize}px;
   background-color: white;
-  background-image: ${props => `url(${props.imageUrl})`};
   border-radius: 36%;
   outline: none;
   box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.1), 0 5px 15px 0 rgba(0, 0, 0, 0.5);
 
-  ${props => smoothCorners({
+  ${smoothCorners({
     shadow: '0 0 0px 3px rgba(0, 0, 0, 0.1), 0 5px 15px 0 rgba(0, 0, 0, 0.5)',
     backgroundColor: 'white',
-    backgroundImage: props.imageUrl,
     shadowBlur: 15,
+    hasBackgroundImage: true,
   })};
 `

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,7 +2,7 @@
 import React, { forwardRef, useMemo } from 'react'
 
 /* Internal dependencies */
-import { Typography } from '../../foundation'
+import { smoothCornersStyle, Typography } from '../../foundation'
 import { Text } from '../Text'
 import { ActionWrapper, Container, ImageWrapper, TitleImage, TitleWrapper } from './Header.styled'
 import HeaderProps from './Header.types'
@@ -31,7 +31,10 @@ function Header(
     <TitleWrapper className={titleClassName}>
       { titleImageUrl && (
         <ImageWrapper>
-          <TitleImage imageUrl={titleImageUrl} imageSize={titleImageSize} />
+          <TitleImage
+            style={smoothCornersStyle({ imageUrl: titleImageUrl })}
+            imageSize={titleImageSize}
+          />
         </ImageWrapper>
       ) }
       <Text

--- a/src/foundation/Mixins.ts
+++ b/src/foundation/Mixins.ts
@@ -1,5 +1,8 @@
-/* Internal dependencies */
+/* External dependencies */
+import type { CSSProperties } from 'react'
 import { isNil } from 'lodash'
+
+/* Internal dependencies */
 import { css } from './FoundationStyledComponent'
 
 export const absoluteCenter = (otherTransforms: any) => `
@@ -59,7 +62,7 @@ interface SmoothCornersOptions {
   borderRadius?: number | string
   shadow?: string
   backgroundColor?: string
-  backgroundImage?: string
+  hasBackgroundImage?: boolean
   shadowBlur?: number
   margin?: number
 }
@@ -68,15 +71,15 @@ export const smoothCorners = ({
   borderRadius = 0,
   shadow = '0 0 0 0 transparent',
   backgroundColor = 'white',
-  backgroundImage = '',
+  hasBackgroundImage = false,
   shadowBlur = 0,
   margin = 0,
 }: SmoothCornersOptions) => css`
   margin: ${margin}px;
   background-color: ${backgroundColor};
 
-  ${backgroundImage && css`
-    background-image: url(${backgroundImage});
+  ${hasBackgroundImage && css`
+    background-image: var(--background-image);
     background-size: cover;
   `}
 
@@ -90,7 +93,7 @@ export const smoothCorners = ({
     background: paint(smooth-corners);
     border-radius: 0;
     /* Custom property 는 CSSUnparsedValue 로만 잡혀서 사용하는 임시 속성 */
-    border-image-source: url(${backgroundImage});
+    border-image-source: var(--background-image);
     box-shadow: none;
 
     --smooth-corners: ${borderRadius};
@@ -100,3 +103,12 @@ export const smoothCorners = ({
     --smooth-corners-radius-unit: ${typeof borderRadius === 'string' ? 'string' : 'number'};
   }
 `
+
+interface SmoothCornersElementOptions {
+  imageUrl: string
+}
+
+export const smoothCornersStyle = ({ imageUrl }: SmoothCornersElementOptions): CSSProperties => ({
+  // @ts-ignore
+  '--background-image': `url(${imageUrl})`,
+})


### PR DESCRIPTION
# Description

### Overview

기존 `smoothCorners` interpolation을 보면, prop에 backgroundImageUrl을 포함하고 있습니다. 이는, 사용처에서 서로 다른 avatarUrl 하나마다 classname 하나가 만들어진다는 것을 의미합니다. 실제로 profiler를 통해 유저챗 화면에서 fetch more를 할 때 측정해 보면, 새로운 유저의 아바타가 필요할 때마다 classname을 하나 만들고, CSSOM에 추가한 후 (`insertRules`), css가 업데이트되었으므로 전체 스타일을 재계산하는 연산이 실행됩니다. 매번 새로운 avatarUrl이 추가될 때마다 비싼 computation이 실행됩니다.

<img width="658" alt="스크린샷 2021-07-05 오후 4 22 41" src="https://user-images.githubusercontent.com/25701854/124433367-a0b18000-ddad-11eb-8221-741994d57700.png">

### Solution

이를 개선하여, avatarUrl은 styled component의 prop으로 전달하지 않도록 합니다. 대신, element에 attribute로 전달하고 `var()` 함수를 통해 읽도록 합니다. (`attr()`는 대부분의 브라우저에서 지원하지 않아 동작하지 않더라구요)

### Analysis

**측정 1**
- 측정 방법: 유저챗 전체, 열림 목록에서 idle 상태 될 때까지 기다렸다가 측정 시작, 아래로 스크롤 하면서 fetch more 5번 수행
- 측정 조건: production server, build

| AS-IS (production) | TO-BE |
| -- | -- |
| <img width="969" alt="스크린샷 2021-07-05 오후 4 05 23" src="https://user-images.githubusercontent.com/25701854/124433784-17e71400-ddae-11eb-8a91-f775d161e524.png"> | <img width="969" alt="스크린샷 2021-07-05 오후 4 06 34" src="https://user-images.githubusercontent.com/25701854/124433833-233a3f80-ddae-11eb-8b2e-df06320f117b.png"> |

| | AS-IS (production) | TO-BE | diff |
| -- | -- | -- | -- |
| Scripting | 8503 ms | 7207 ms | **-15.2%** |
| Rendering | 1855 ms | 987 ms | **-46.8%** |

**측정 2**
- 측정 방법: 팀챗 화면에서 idle 상태 될 때까지 기다렸다가 측정 시작, 유저챗 탭으로 전환
- 측정 조건: production server, build

| AS-IS (production) | TO-BE |
| -- | -- |
| <img width="969" alt="스크린샷 2021-07-05 오후 4 08 56" src="https://user-images.githubusercontent.com/25701854/124433938-4238d180-ddae-11eb-870e-4bc47063fbb5.png"> | <img width="971" alt="스크린샷 2021-07-05 오후 4 07 33" src="https://user-images.githubusercontent.com/25701854/124433977-4b29a300-ddae-11eb-86ec-ec292636da6c.png"> |

| | AS-IS (production) | TO-BE | diff |
| -- | -- | -- | -- |
| Scripting | 3845 ms | 3041 ms | **-20.9%** |
| Rendering | 942 ms | 962 ms | **+2.12%** |

### Conclusion

- 생각보다 탭 전환 시에는 드라마틱한 감소가 없었습니다. (매니저 아바타 url이 많은데 이미 팀챗 화면에서 가져와서 그런듯)
- 위의 overhead는 새로운 아바타 url이 많을수록 크기 때문에, 유저챗 fetch more를 하면서 측정을 했을 때는 예상대로 큰 실행 시간 감소가 있었습니다.

## Changes Detail
생략.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
