### PR TITLE
CheckableAvatar 등, background image가 없는 smooth corners가 잘 작동하지 않는 문제 수정

### DIFF
--- a/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -35,8 +35,8 @@ exports[`Avatar test > Snapshot 1`] = `
     margin: 0px;
     background: paint(smooth-corners);
     border-radius: 0;
-    border-image-source: var(--background-image);
     box-shadow: none;
+    border-image-source: var(--background-image);
     --smooth-corners: 42%;
     --smooth-corners-shadow: 0 0 0 0 transparent;
     --smooth-corners-bg-color: #FFFFFF;

--- a/src/foundation/Mixins.ts
+++ b/src/foundation/Mixins.ts
@@ -93,8 +93,11 @@ export const smoothCorners = ({
     background: paint(smooth-corners);
     border-radius: 0;
     /* Custom property 는 CSSUnparsedValue 로만 잡혀서 사용하는 임시 속성 */
-    border-image-source: var(--background-image);
     box-shadow: none;
+
+    ${hasBackgroundImage && css`
+    border-image-source: var(--background-image);
+    `}
 
     --smooth-corners: ${borderRadius};
     --smooth-corners-shadow: ${shadow};

--- a/src/worklets/smoothCorners/smoothCorners.ts
+++ b/src/worklets/smoothCorners/smoothCorners.ts
@@ -140,7 +140,7 @@ class SmoothCorners {
       ctx.fill()
     }
 
-    if (backgroundImage) {
+    if (backgroundImage instanceof CSSImageValue) {
       smooth.forEach(({ x, y }, index) => {
         if (index === 0) {
           ctx.moveTo(x, y)


### PR DESCRIPTION
# Description

원래 아래 사진처럼 어정쩡하게 작동하고 있었습니다 😢 

<img width="290" alt="스크린샷 2021-07-08 오후 3 48 25" src="https://user-images.githubusercontent.com/25701854/124875689-26c70400-e004-11eb-95bc-1006a12251a9.png">

#561 에서 수정되면서 어정쩡함이 해소되었습니다. 그러면서 pseudo element의 background image가 제대로 적용되지 않았습니다.

## Changes Detail

1. smoothCorners mixin에서, `hasBackgroundImage` prop이 smooth corners가 적용되었을 때 잘 존중되도록 수정
2. paint worklet에서, border-image-source attribute가 주어지지 않았을 때를 올바르게 구별하도록 수정
  - 기본값이 falsy한 value가 아니라, 'none' 값을 가지는 CSSKeywordValue 이기 때문에 guard를 통과합니다. 따라서 drawImage에서 에러가 발생합니다.
  - 올바른 값이 주어진다면 CSSImageValue의 instance 여야 하므로 그 조건으로 수정합니다.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* #561
