### PR TITLE
perf(smoothcorners): cache smoothcorner path computation result

### DIFF
--- a/src/worklets/smoothCorners/smoothCorners.ts
+++ b/src/worklets/smoothCorners/smoothCorners.ts
@@ -22,7 +22,7 @@ class SmoothCorners {
   superellipse(...args) {
     const sanitizedArgs = this.sanitizeSuperellipseArgs(...args)
 
-    const cacheKey = this.getSuperellipseCacheKey(...sanitizedArgs)
+    const cacheKey = this.getSuperellipseCacheKey(sanitizedArgs)
 
     if (this.superellipseCache.has(cacheKey)) {
       return [...this.superellipseCache.get(cacheKey)]
@@ -61,8 +61,8 @@ class SmoothCorners {
     return Array.from({ length: steps + 1 }, (_, i) => points(i * step))
   }
 
-  getSuperellipseCacheKey(a, b, nX, nY) {
-    return [a, b, nX, nY].join(':')
+  getSuperellipseCacheKey(args) {
+    return args.join(':')
   }
 
   paint(ctx, geom, properties) {

--- a/src/worklets/smoothCorners/smoothCorners.ts
+++ b/src/worklets/smoothCorners/smoothCorners.ts
@@ -11,16 +11,40 @@ class SmoothCorners {
     ]
   }
 
+  constructor() {
+    this.superellipseCache = new Map()
+  }
+
   trimPX(pixel) {
     return parseInt(pixel.replace('px', ''), 10)
   }
 
-  superellipse(a, b, nX, nY) {
+  superellipse(...args) {
+    const sanitizedArgs = this.sanitizeSuperellipseArgs(...args)
+
+    const cacheKey = this.getSuperellipseCacheKey(...sanitizedArgs)
+
+    if (this.superellipseCache.has(cacheKey)) {
+      return [...this.superellipseCache.get(cacheKey)]
+    }
+
+    const result = this.computeSuperellipse(...sanitizedArgs)
+
+    this.superellipseCache.set(cacheKey, result);
+
+    return result;
+  }
+
+  sanitizeSuperellipseArgs(a, b, nX, nY) {
     if (nX > 100) nX = 100
     if (nY > 100) nY = 100
     if (nX < 0.00000000001) nX = 0.00000000001
     if (nY < 0.00000000001) nY = 0.00000000001
 
+    return [a, b, nX, nY]
+  }
+
+  computeSuperellipse(a, b, nX, nY) {
     const nX2 = 2 / nX
     const nY2 = 2 / nY
     const steps = 360
@@ -33,7 +57,12 @@ class SmoothCorners {
         y: Math.abs(sinT) ** nY2 * b * Math.sign(sinT)
       }
     }
+
     return Array.from({ length: steps + 1 }, (_, i) => points(i * step))
+  }
+
+  getSuperellipseCacheKey(a, b, nX, nY) {
+    return [a, b, nX, nY].join(':')
   }
 
   paint(ctx, geom, properties) {

--- a/src/worklets/smoothCorners/smoothCorners.ts
+++ b/src/worklets/smoothCorners/smoothCorners.ts
@@ -32,7 +32,7 @@ class SmoothCorners {
 
     this.superellipseCache.set(cacheKey, result);
 
-    return result;
+    return [...result];
   }
 
   sanitizeSuperellipseArgs(a, b, nX, nY) {


### PR DESCRIPTION
# Description

화면에 그려야 하는 smooth corner가 많아지면, path를 계산하는 superellipse 함수의 실행시간이 부담이 됩니다!

![image](https://user-images.githubusercontent.com/25701854/125404902-22c72780-e3f2-11eb-8129-9dc62a1f3c2d.png)

(위 사진에서 "points" 함수)

주어진 argument에 따라 결과를 캐싱해두어 같은 크기의 smooth corner를 paint한다면 중복 계산이 이루어지지 않도록 합니다.

## Changes Detail

- superellipse 함수 실행 결과를 argument에 따라 캐싱

<img width="981" alt="스크린샷 2021-07-13 오후 3 53 51" src="https://user-images.githubusercontent.com/25701854/125405298-8b160900-e3f2-11eb-8e5b-75f76fd33aea.png">

위 사진은 캐싱 후.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
