### PR TITLE
Tag, Badge 컴포넌트의 ClassName생성을 줄이는 작업

### DIFF
--- a/src/components/TagBadge/Badge/Badge.tsx
+++ b/src/components/TagBadge/Badge/Badge.tsx
@@ -2,6 +2,7 @@
 import React, { useMemo } from 'react'
 
 /* Internal dependencies */
+import { useFoundation } from '../../../foundation'
 import { Icon } from '../../Icon'
 import {
   TagBadgeText,
@@ -14,7 +15,7 @@ import {
   getProperTagBadgePadding,
   getProperTagBadgeRounding,
   getProperTagBadgeTypo,
-  TagBadgeStyled as Styled,
+  TagBadgeStyled,
 } from '../TagBadgeCommon'
 import BadgeProps from './Badge.types'
 
@@ -31,6 +32,8 @@ function Badge({
   testId = BADGE_TEST_ID,
   ...props
 }: BadgeProps) {
+  const foundation = useFoundation()
+
   const bgSemanticName = useMemo(() => (getProperTagBadgeBgColor(variant)), [variant])
   const textSemanticName = useMemo(() => (getProperBadgeTextColor(variant)), [variant])
 
@@ -46,15 +49,17 @@ function Badge({
   ])
 
   return (
-    <Styled.Wrapper
+    <TagBadgeStyled.Wrapper
       {...props}
       className={className}
       interpolation={interpolation}
       data-testid={testId}
       horizontalPadding={getProperTagBadgePadding(size)}
       rounding={getProperTagBadgeRounding(size)}
-      bgColor={bgSemanticName}
       color={textSemanticName}
+      style={{
+        '--bgColor': foundation?.theme[bgSemanticName],
+      }}
     >
       { IconComponent }
 
@@ -64,8 +69,8 @@ function Badge({
       >
         { children }
       </TagBadgeText>
-    </Styled.Wrapper>
+    </TagBadgeStyled.Wrapper>
   )
 }
 
-export default Badge
+export default React.memo(Badge)

--- a/src/components/TagBadge/Badge/Badge.tsx
+++ b/src/components/TagBadge/Badge/Badge.tsx
@@ -2,7 +2,6 @@
 import React, { useMemo } from 'react'
 
 /* Internal dependencies */
-import { useFoundation } from '../../../foundation'
 import { Icon } from '../../Icon'
 import {
   TagBadgeText,
@@ -32,8 +31,6 @@ function Badge({
   testId = BADGE_TEST_ID,
   ...props
 }: BadgeProps) {
-  const foundation = useFoundation()
-
   const bgSemanticName = useMemo(() => (getProperTagBadgeBgColor(variant)), [variant])
   const textSemanticName = useMemo(() => (getProperBadgeTextColor(variant)), [variant])
 
@@ -57,9 +54,7 @@ function Badge({
       horizontalPadding={getProperTagBadgePadding(size)}
       rounding={getProperTagBadgeRounding(size)}
       color={textSemanticName}
-      style={{
-        '--bgColor': foundation?.theme[bgSemanticName],
-      }}
+      bgColor={bgSemanticName}
     >
       { IconComponent }
 

--- a/src/components/TagBadge/Tag/Tag.tsx
+++ b/src/components/TagBadge/Tag/Tag.tsx
@@ -3,7 +3,6 @@ import React, { useMemo } from 'react'
 import { isNil } from 'lodash-es'
 
 /* Internal dependencies */
-import { useFoundation } from '../../../foundation'
 import {
   TagBadgeStyled,
   TagBadgeSize,
@@ -34,8 +33,6 @@ function Tag({
   testId = TAG_TEST_ID,
   ...props
 }: TagProps) {
-  const foundation = useFoundation()
-
   const bgSemanticName = useMemo(() => (
     givenColor || getProperTagBadgeBgColor(variant)
   ), [
@@ -60,9 +57,7 @@ function Tag({
       data-testid={testId}
       horizontalPadding={getProperTagBadgePadding(size)}
       rounding={getProperTagBadgeRounding(size)}
-      style={{
-        '--bgColor': foundation?.theme[bgSemanticName],
-      }}
+      bgColor={bgSemanticName}
     >
       <TagBadgeText
         horizontalPadding={TAG_TEXT_HORIZONTAL_PADDING}

--- a/src/components/TagBadge/Tag/Tag.tsx
+++ b/src/components/TagBadge/Tag/Tag.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react'
 import { isNil } from 'lodash-es'
 
 /* Internal dependencies */
+import { useFoundation } from '../../../foundation'
 import {
   TagBadgeStyled,
   TagBadgeSize,
@@ -33,7 +34,9 @@ function Tag({
   testId = TAG_TEST_ID,
   ...props
 }: TagProps) {
-  const bgColor = useMemo(() => (
+  const foundation = useFoundation()
+
+  const bgSemanticName = useMemo(() => (
     givenColor || getProperTagBadgeBgColor(variant)
   ), [
     givenColor,
@@ -57,7 +60,9 @@ function Tag({
       data-testid={testId}
       horizontalPadding={getProperTagBadgePadding(size)}
       rounding={getProperTagBadgeRounding(size)}
-      bgColor={bgColor}
+      style={{
+        '--bgColor': foundation?.theme[bgSemanticName],
+      }}
     >
       <TagBadgeText
         horizontalPadding={TAG_TEXT_HORIZONTAL_PADDING}
@@ -71,4 +76,4 @@ function Tag({
   )
 }
 
-export default Tag
+export default React.memo(Tag)

--- a/src/components/TagBadge/TagBadgeCommon/TagBadge.styled.ts
+++ b/src/components/TagBadge/TagBadgeCommon/TagBadge.styled.ts
@@ -8,7 +8,6 @@ interface CommonTagBadgeStyleProps extends WithInterpolation {
   rounding: ReturnType<typeof css>
   horizontalPadding: number
   color?: SemanticNames
-  bgColor: SemanticNames
 }
 
 const Wrapper = styled.div<CommonTagBadgeStyleProps>`
@@ -16,7 +15,7 @@ const Wrapper = styled.div<CommonTagBadgeStyleProps>`
   align-items: center;
   padding: ${TAGBADGE_VERTICAL_PADDING}px ${({ horizontalPadding }) => horizontalPadding}px;
   color: ${({ foundation, color = 'txt-black-darkest' }) => foundation?.theme?.[color]};
-  background-color: ${({ foundation, bgColor }) => foundation?.theme?.[bgColor]};
+  background-color: var(--bgColor);
 
   ${({ rounding }) => rounding};
 

--- a/src/components/TagBadge/TagBadgeCommon/TagBadge.styled.ts
+++ b/src/components/TagBadge/TagBadgeCommon/TagBadge.styled.ts
@@ -1,6 +1,7 @@
 /* Internal dependencies */
 import { styled, css } from '../../../foundation'
 import { SemanticNames } from '../../../foundation/Colors/Theme'
+import { WithFoundation } from '../../../types/InjectedFoundation'
 import { WithInterpolation } from '../../../types/InjectedInterpolation'
 import { TAGBADGE_VERTICAL_PADDING } from './constants/TagBadgeStyle'
 
@@ -8,14 +9,23 @@ interface CommonTagBadgeStyleProps extends WithInterpolation {
   rounding: ReturnType<typeof css>
   horizontalPadding: number
   color?: SemanticNames
+  bgColor: SemanticNames
 }
 
-const Wrapper = styled.div<CommonTagBadgeStyleProps>`
+const Wrapper = styled.div.attrs(({
+  foundation,
+  bgColor,
+  color = 'txt-black-darkest',
+  horizontalPadding,
+}: CommonTagBadgeStyleProps & WithFoundation) => ({
+  style: {
+    padding: `${TAGBADGE_VERTICAL_PADDING}px ${horizontalPadding}px`,
+    color: foundation?.theme?.[color],
+    backgroundColor: foundation?.theme?.[bgColor],
+  },
+}))<CommonTagBadgeStyleProps>`
   display: flex;
   align-items: center;
-  padding: ${TAGBADGE_VERTICAL_PADDING}px ${({ horizontalPadding }) => horizontalPadding}px;
-  color: ${({ foundation, color = 'txt-black-darkest' }) => foundation?.theme?.[color]};
-  background-color: var(--bgColor);
 
   ${({ rounding }) => rounding};
 

--- a/src/foundation/FoundationStyledComponent.tsx
+++ b/src/foundation/FoundationStyledComponent.tsx
@@ -134,8 +134,13 @@ const FoundationCSS: FoundationCSSInterface = function (...args) {
   return baseCSS(...args)
 }
 
+function useFoundation() {
+  return useContext(FoundationContext)
+}
+
 export {
   FoundationStyled as styled,
   FoundationCSS as css,
   FoundationProvider,
+  useFoundation,
 }

--- a/src/types/InjectedFoundation.ts
+++ b/src/types/InjectedFoundation.ts
@@ -1,0 +1,6 @@
+/* Internal dependencies */
+import { Foundation } from '../foundation'
+
+export interface WithFoundation {
+  foundation?: Foundation
+}


### PR DESCRIPTION
# Description
 | as-is | to-be |
|:---:|:---:|
<img width="1008" alt="스크린샷 2021-07-14 오후 5 55 51" src="https://user-images.githubusercontent.com/33861398/125594019-b905a265-0a21-441f-89ec-076342c3ee2c.png">|<img width="967" alt="스크린샷 2021-07-14 오후 5 42 18" src="https://user-images.githubusercontent.com/33861398/125593930-10382df2-dfb7-4367-a8ba-788dd0e5c2fd.png">
다른 색상에 대해 다른 className을 generate|다른 색상도 같은 className을 generate
- foundation을 react component 내부에서 사용하기 위한 useFoundation을 작성했습니다.
    styled component의 useTheme과 동일한 역할을 합니다.
- Tag
# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
