### PR TITLE
revert(foundationstyledcomponent): useFoundation을 revert

### DIFF
--- a/src/foundation/FoundationStyledComponent.tsx
+++ b/src/foundation/FoundationStyledComponent.tsx
@@ -134,13 +134,8 @@ const FoundationCSS: FoundationCSSInterface = function (...args) {
   return baseCSS(...args)
 }
 
-function useFoundation() {
-  return useContext(FoundationContext)
-}
-
 export {
   FoundationStyled as styled,
   FoundationCSS as css,
   FoundationProvider,
-  useFoundation,
 }


### PR DESCRIPTION
# Description
#566 에서 useFoundation 이 사용처가 없어졌기에 이를 revert합니다.
굳이 사용처가 없는데 이를 export 할 필요가 없다는 @jwoo0122 의 커멘트를 반영합니다.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
