### PR TITLE
feat(select): select 컴포넌트에 스타일 관련 속성과 이벤트 핸들러를 주입할 수 있도록 수정

### DIFF
--- a/src/components/Input/Select/Select.styled.ts
+++ b/src/components/Input/Select/Select.styled.ts
@@ -89,10 +89,12 @@ export const MainContentWrapper = styled.div`
   align-items: center;
 `
 
-interface DropdownProps extends WithInterpolation {}
+interface DropdownProps extends WithInterpolation {
+  zIndex: number
+}
 
 export const Dropdown = styled(Overlay)<DropdownProps>`
-  z-index: 10;
+  z-index: ${({ zIndex }) => zIndex};
   min-width: 200px;
   min-height: 42px;
   max-height: 640px;

--- a/src/components/Input/Select/Select.tsx
+++ b/src/components/Input/Select/Select.tsx
@@ -29,6 +29,9 @@ export const SELECT_CONTAINER_TEST_ID = 'bezier-react-select-container'
 export const SELECT_TRIGGER_TEST_ID = 'bezier-react-select-trigger'
 export const SELECT_DROPDOWN_TEST_ID = 'bezier-react-select-dropdown'
 
+const DEFAULT_DROPDOWN_MARGIN_Y = 6
+const DEFAULT_DROPDOWN_Z_INDEX = 10
+
 function Select(
   {
     testId = SELECT_CONTAINER_TEST_ID,
@@ -51,6 +54,9 @@ function Select(
     chevronColor = 'txt-black-darker',
     hasError = false,
     dropdownContainer,
+    dropdownMarginX,
+    dropdownMarginY = DEFAULT_DROPDOWN_MARGIN_Y,
+    dropdownZIndex = DEFAULT_DROPDOWN_Z_INDEX,
     dropdownPosition = OverlayPosition.BottomLeft,
     onClickTrigger = _.noop,
     onHideDropdown = _.noop,
@@ -145,7 +151,9 @@ function Select(
         testId={dropdownTestId}
         withTransition
         show={isDropdownOpened && !disabled}
-        marginY={6}
+        zIndex={dropdownZIndex}
+        marginX={dropdownMarginX}
+        marginY={dropdownMarginY}
         target={triggerRef.current}
         container={dropdownContainer || containerRef.current}
         position={dropdownPosition}

--- a/src/components/Input/Select/Select.tsx
+++ b/src/components/Input/Select/Select.tsx
@@ -8,6 +8,7 @@ import React, {
   Ref,
   useImperativeHandle,
 } from 'react'
+import _ from 'lodash'
 
 /* Internal dependencies */
 import {
@@ -43,11 +44,16 @@ function Select(
     defaultFocus = false,
     placeholder = '',
     iconComponent,
+    iconColor = 'txt-black-dark',
     text,
+    textColor = 'txt-black-darkest',
     withoutChevron = false,
+    chevronColor = 'txt-black-darker',
     hasError = false,
     dropdownContainer,
     dropdownPosition = OverlayPosition.BottomLeft,
+    onClickTrigger = _.noop,
+    onHideDropdown = _.noop,
     children,
   }: SelectProps,
   forwardedRef: Ref<SelectRef>,
@@ -63,23 +69,32 @@ function Select(
         <Icon
           name={iconComponent}
           size={IconSize.XS}
+          color={iconColor}
           marginRight={6}
         />
       )
     }
 
     return iconComponent
-  }, [iconComponent])
+  }, [
+    iconComponent,
+    iconColor,
+  ])
 
-  const handleClickTrigger = useCallback(() => {
+  const handleClickTrigger = useCallback((event: React.MouseEvent) => {
     if (!disabled) {
       setIsDropdownOpened(prevState => !prevState)
+      onClickTrigger(event)
     }
-  }, [disabled])
+  }, [
+    disabled,
+    onClickTrigger,
+  ])
 
   const handleHideDropdown = useCallback(() => {
     setIsDropdownOpened(false)
-  }, [])
+    onHideDropdown()
+  }, [onHideDropdown])
 
   const getDOMNode = useCallback(() => triggerRef.current, [])
 
@@ -109,14 +124,18 @@ function Select(
       >
         <Styled.MainContentWrapper>
           { LeftComponent }
-          <Text typo={Typography.Size14}>
+          <Text
+            typo={Typography.Size14}
+            color={textColor}
+          >
             { text || placeholder }
           </Text>
         </Styled.MainContentWrapper>
         { !withoutChevron && (
           <Icon
-            name={isDropdownOpened ? 'chevron-up' : 'chevron-down'}
+            name={`chevron-${isDropdownOpened ? 'up' : 'down'}` as const}
             size={IconSize.XS}
+            color={chevronColor}
             marginLeft={6}
           />
         ) }

--- a/src/components/Input/Select/Select.types.ts
+++ b/src/components/Input/Select/Select.types.ts
@@ -1,4 +1,5 @@
 /* Internal dependencies */
+import { SemanticNames } from '../../../foundation'
 import { ChildrenComponentProps } from '../../../types/ComponentProps'
 import InjectedInterpolation from '../../../types/InjectedInterpolation'
 import { OverlayProps } from '../../Overlay'
@@ -12,7 +13,7 @@ export enum SelectSize {
 }
 
 export interface SelectRef {
-  handleClickTrigger(): void
+  handleClickTrigger(event: React.MouseEvent): void
   handleHideDropdown(): void
   getDOMNode(): Element | Text | null
 }
@@ -25,12 +26,17 @@ interface SelectProps extends ChildrenComponentProps {
   defaultFocus?: boolean
   placeholder?: string
   iconComponent?: IconName | React.ReactNode
+  iconColor?: SemanticNames
   text?: string
+  textColor?: SemanticNames
   withoutChevron?: boolean
+  chevronColor?: SemanticNames
   dropdownContainer?: HTMLElement | null
   dropdownPosition?: OverlayProps['position']
   dropdownInterpolation?: InjectedInterpolation
   hasError?: boolean
+  onClickTrigger?: (event: React.MouseEvent) => void
+  onHideDropdown?: () => void
 }
 
 export default SelectProps

--- a/src/components/Input/Select/Select.types.ts
+++ b/src/components/Input/Select/Select.types.ts
@@ -32,7 +32,11 @@ interface SelectProps extends ChildrenComponentProps {
   withoutChevron?: boolean
   chevronColor?: SemanticNames
   dropdownContainer?: HTMLElement | null
+  dropdownMarginX?: OverlayProps['marginX']
+  dropdownMarginY?: OverlayProps['marginY']
+  dropdownZIndex?: number
   dropdownPosition?: OverlayProps['position']
+  dropdownStyle?: OverlayProps['containerStyle']
   dropdownInterpolation?: InjectedInterpolation
   hasError?: boolean
   onClickTrigger?: (event: React.MouseEvent) => void

--- a/src/components/Input/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Input/Select/__snapshots__/Select.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin: 0px 0px 0px 6px;
-  color: inherit;
+  color: #00000099;
   -webkit-transition-property: color;
   transition-property: color;
   -webkit-transition-duration: 150ms;
@@ -23,7 +23,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
-  color: inherit;
+  color: #000000D9;
   -webkit-transition-property: color;
   transition-property: color;
   -webkit-transition-duration: 150ms;
@@ -102,11 +102,13 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
     >
       <span
         class="c3"
+        color="txt-black-darkest"
         data-testid="bezier-react-text"
       />
     </div>
     <svg
       class="c4"
+      color="txt-black-darker"
       data-testid="bezier-react-icon"
       fill="none"
       foundation="[object Object]"


### PR DESCRIPTION
# Description

<img width="270" alt="스크린샷 2021-08-17 오후 12 29 03" src="https://user-images.githubusercontent.com/58209009/129660247-c0ab17ed-7c61-4eb6-a8ec-6abacfe70012.png">

디자인 시안에 맞게 Icon과 Text 색상을 최신화하고, 색상과 이벤트 핸들러를 외부에서 주입할 수 있도록 수정합니다

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
