### PR TITLE
fix(main): 윈도우 환경에서 메인뷰 가로스크롤을 항상 표시하지 않도록 수정

### DIFF
--- a/src/layout/Main/Main.styled.ts
+++ b/src/layout/Main/Main.styled.ts
@@ -21,5 +21,5 @@ export const MainWrapper = styled.div.attrs(({ hasSide, sideWidth }: MainWrapper
   height: 100%;
 
   /* TODO: 레이아웃 동작 다듬기, 스크롤은 좋지 않은 UX */
-  overflow-x: scroll;
+  overflow-x: auto;
 `


### PR DESCRIPTION
# Description

Main 컴포넌트의 `overflow-x: scroll` 속성을 `auto` 로 변경합니다. 
윈도우 환경의 대부분의 브라우저에서 불필요하게 가로 스크롤 바를 만드는 문제를 해결합니다.

## Changes Detail

없음

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
