### PR TITLE
TextArea의 rows설정을 TextAreaSize를 통해서 하도록 변경

### DIFF
--- a/src/components/Input/TextArea/TextArea.stories.tsx
+++ b/src/components/Input/TextArea/TextArea.stories.tsx
@@ -6,8 +6,9 @@ import React, {
 import base from 'paths.macro'
 
 /* Internal dependencies */
-import { getTitle } from '../../../utils/storyUtils'
+import { getObjectFromEnum, getTitle } from '../../../utils/storyUtils'
 import TextArea from './TextArea'
+import { TextAreaSize } from './TextArea.types'
 
 export default {
   title: getTitle(base),
@@ -40,6 +41,15 @@ Primary.args = {
   autoFocus: true,
   readOnly: false,
   hasError: false,
-  maxRows: 5,
+  size: TextAreaSize.S,
   placeholder: 'say hi to autoResizable textarea!',
+}
+
+Primary.argTypes = {
+  size: {
+    control: {
+      type: 'radio',
+      options: getObjectFromEnum(TextAreaSize),
+    },
+  },
 }

--- a/src/components/Input/TextArea/TextArea.test.tsx
+++ b/src/components/Input/TextArea/TextArea.test.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 /* Internal dependencies */
 import { render } from '../../../utils/testUtils'
 import TextArea, { TEXT_AREA_TEST_ID } from './TextArea'
-import { TextAreaProps } from './TextArea.types'
+import TextAreaProps from './TextArea.types'
 import { getTextAreaBgColorSemanticName } from './utils'
 
 // SEE ALSO: https://github.com/Andarist/react-textarea-autosize#how-to-test-it-with-jest-and-react-test-renderer-if-you-need-ref

--- a/src/components/Input/TextArea/TextArea.tsx
+++ b/src/components/Input/TextArea/TextArea.tsx
@@ -13,7 +13,7 @@ import React, {
 import useMergeRefs from '../../../hooks/useMergeRefs'
 import Styled from './TextArea.styled'
 import { getTextAreaBgColorSemanticName } from './utils'
-import type { TextAreaProps } from './TextArea.types'
+import TextAreaProps, { TextAreaSize } from './TextArea.types'
 
 export const TEXT_AREA_TEST_ID = 'bezier-react-text-area'
 
@@ -30,8 +30,7 @@ function TextArea(
     readOnly = false,
     value = '',
     hasError = false,
-    maxRows,
-    minRows,
+    size = TextAreaSize.S,
     onFocus,
     onBlur,
     onChange,
@@ -96,8 +95,8 @@ function TextArea(
         ref={mergedInputRef}
         value={value}
         readOnly={readOnly}
-        maxRows={maxRows}
-        minRows={minRows}
+        maxRows={size}
+        minRows={5}
         onChange={onChange}
         onFocus={handleFocus}
         onBlur={handleBlur}

--- a/src/components/Input/TextArea/TextArea.tsx
+++ b/src/components/Input/TextArea/TextArea.tsx
@@ -13,7 +13,7 @@ import React, {
 import useMergeRefs from '../../../hooks/useMergeRefs'
 import Styled from './TextArea.styled'
 import { getTextAreaBgColorSemanticName } from './utils'
-import TextAreaProps, { TextAreaSize } from './TextArea.types'
+import TextAreaProps, { TextAreaSize, MIN_ROWS } from './TextArea.types'
 
 export const TEXT_AREA_TEST_ID = 'bezier-react-text-area'
 
@@ -96,7 +96,7 @@ function TextArea(
         value={value}
         readOnly={readOnly}
         maxRows={size}
-        minRows={5}
+        minRows={MIN_ROWS}
         onChange={onChange}
         onFocus={handleFocus}
         onBlur={handleBlur}

--- a/src/components/Input/TextArea/TextArea.types.ts
+++ b/src/components/Input/TextArea/TextArea.types.ts
@@ -1,22 +1,26 @@
 /* External dependencies */
 import React, { CSSProperties } from 'react'
-import { TextareaAutosizeProps } from 'react-textarea-autosize'
 
 /* Internal dependencies */
 import { UIComponentProps } from '../../../types/ComponentProps'
 import InjectedInterpolation from '../../../types/InjectedInterpolation'
 
+export enum TextAreaSize {
+  S = 10,
+  M = 17,
+  L = 29,
+}
+
 type TextAreaChangeEventHandler = React.ChangeEventHandler<HTMLTextAreaElement>
 
-export interface TextAreaProps extends UIComponentProps, React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+export default interface TextAreaProps extends UIComponentProps, React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   wrapperInterpolation?: InjectedInterpolation
   wrapperStyle?: CSSProperties
   wrapperClassName?: string
   autoFocus?: boolean
   value?: string
   hasError?: boolean
-  maxRows?: TextareaAutosizeProps['maxRows']
-  minRows?: TextareaAutosizeProps['minRows']
+  size?: TextAreaSize
   height?: number
   onFocus?: TextAreaChangeEventHandler
   onBlur?: TextAreaChangeEventHandler

--- a/src/components/Input/TextArea/TextArea.types.ts
+++ b/src/components/Input/TextArea/TextArea.types.ts
@@ -5,6 +5,8 @@ import React, { CSSProperties } from 'react'
 import { UIComponentProps } from '../../../types/ComponentProps'
 import InjectedInterpolation from '../../../types/InjectedInterpolation'
 
+export const MIN_ROWS = 5
+
 export enum TextAreaSize {
   S = 10,
   M = 17,

--- a/src/components/Input/TextArea/index.ts
+++ b/src/components/Input/TextArea/index.ts
@@ -1,5 +1,5 @@
 /* Internal dependencies */
-import type TextAreaProps from './TextArea.types'
+import TextAreaProps, { TextAreaSize } from './TextArea.types'
 import TextArea from './TextArea'
 
 export type {
@@ -8,4 +8,5 @@ export type {
 
 export {
   TextArea,
+  TextAreaSize,
 }

--- a/src/components/Input/TextArea/index.ts
+++ b/src/components/Input/TextArea/index.ts
@@ -1,5 +1,5 @@
 /* Internal dependencies */
-import type { TextAreaProps } from './TextArea.types'
+import type TextAreaProps from './TextArea.types'
 import TextArea from './TextArea'
 
 export type {


### PR DESCRIPTION
# Description

TextArea의 rows설정을 기존에 숫자를 prop으로 넣어 변경해 주던 것을 TextAreaSize를 통해서 하도록 변경하였습니다.

## Changes Detail
* TextArea.tsx의 maxRows, minRows prop을 삭제, 대신 size prop을 받도록 변경
* size prop은 TextAreaSize enum만을 받아들이도록 제한
* size prop은 mapping되어 maxRow로 설정됨
* minRow는 5로 고정됨

# Tests
- [x] Jest 테스트 코드 작성 완료
- [x] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
