### PR TITLE
TextField에서 size가 XL일때, border-radius가 12px로 적용되도록 수정

### DIFF
--- a/src/components/Input/TextField/TextField.styled.ts
+++ b/src/components/Input/TextField/TextField.styled.ts
@@ -112,11 +112,11 @@ const Wrapper = styled.div<WrapperProps & WithInterpolation>`
   ${({ borderRadius }) => borderRadius}
   opacity: ${({ disabled }) => disabled && DisabledOpacity};
 
-  ${({ variant }) => variant === TextFieldVariant.Primary && inputWrapperStyle};
-  ${({ focused }) => focused && focusedInputWrapperStyle};
-  ${({ hasError }) => hasError && erroredInputWrapperStyle};
+  ${({ variant }) => variant === TextFieldVariant.Primary && inputWrapperStyle}
+  ${({ focused }) => focused && focusedInputWrapperStyle}
+  ${({ hasError }) => hasError && erroredInputWrapperStyle}
 
-  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['border-color', 'box-shadow'])};
+  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['border-color', 'box-shadow'])}
 
   ${({ interpolation }) => interpolation}
 `

--- a/src/components/Input/TextField/TextField.styled.ts
+++ b/src/components/Input/TextField/TextField.styled.ts
@@ -1,3 +1,6 @@
+/* External dependencies */
+import { FlattenSimpleInterpolation } from 'styled-components'
+
 /* Internal dependencies */
 import { css, styled, Typography } from '../../../foundation'
 import DisabledOpacity from '../../../constants/DisabledOpacity'
@@ -91,6 +94,7 @@ interface WrapperProps {
   variant?: TextFieldVariant
   bgColor: SemanticNames
   size?: TextFieldSize
+  borderRadius?: FlattenSimpleInterpolation
   hasError?: boolean
   focused?: boolean
   disabled?: boolean
@@ -105,12 +109,12 @@ const Wrapper = styled.div<WrapperProps & WithInterpolation>`
   padding: 0 12px;
   background-color: ${({ foundation, bgColor }) => foundation?.theme?.[bgColor]};
 
-  ${({ foundation }) => foundation?.rounding.round8}
+  ${({ borderRadius }) => borderRadius}
   opacity: ${({ disabled }) => disabled && DisabledOpacity};
 
   ${({ variant }) => variant === TextFieldVariant.Primary && inputWrapperStyle};
-  ${({ focused }) => focused && focusedInputWrapperStyle}
-  ${({ hasError }) => hasError && erroredInputWrapperStyle}
+  ${({ focused }) => focused && focusedInputWrapperStyle};
+  ${({ hasError }) => hasError && erroredInputWrapperStyle};
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['border-color', 'box-shadow'])};
 

--- a/src/components/Input/TextField/TextField.tsx
+++ b/src/components/Input/TextField/TextField.tsx
@@ -24,7 +24,7 @@ import {
   TextFieldSize,
   TextFieldVariant,
 } from './TextField.types'
-import { getProperTextFieldBgColor } from './TextFieldUtils'
+import { getProperTextFieldBgColor, getProperTextFieldBorderRadius } from './TextFieldUtils'
 import type { TextFieldProps } from './TextField.types'
 
 export const TEXT_INPUT_TEST_ID = 'bezier-react-text-input'
@@ -81,6 +81,12 @@ function TextFieldComponent({
     hasError,
     readOnly,
   ])
+
+  const wrapperBorderRadius = useMemo(() => (
+    getProperTextFieldBorderRadius({
+      size,
+    })
+  ), [size])
 
   const focusTimeout = useRef<ReturnType<Window['setTimeout']>>()
   const blurTimeout = useRef<ReturnType<Window['setTimeout']>>()
@@ -342,6 +348,7 @@ function TextFieldComponent({
       variant={variant}
       size={size}
       bgColor={wrapperBgColorSemanticName}
+      borderRadius={wrapperBorderRadius}
       hasError={hasError}
       disabled={disabled}
       focused={focused}

--- a/src/components/Input/TextField/TextFieldUtils.ts
+++ b/src/components/Input/TextField/TextFieldUtils.ts
@@ -1,6 +1,10 @@
+/* External dependencies */
+import { FlattenSimpleInterpolation } from 'styled-components'
+
 /* Internal dependencies */
 import { SemanticNames } from '../../../foundation/Colors/Theme'
-import { TextFieldVariant } from './TextField.types'
+import { Rounding } from '../../../foundation/Rounding'
+import { TextFieldVariant, TextFieldSize } from './TextField.types'
 
 interface BackgroundColorProps {
   variant: TextFieldVariant
@@ -19,4 +23,18 @@ export function getProperTextFieldBgColor({
   if (variant === TextFieldVariant.Primary && readOnly) { return 'bg-grey-lighter' }
   if (variant === TextFieldVariant.Primary && (focused || hasError)) { return 'bg-white-normal' }
   return 'bg-grey-lightest'
+}
+
+interface BorderRadiusProps {
+  size: TextFieldSize
+}
+
+export function getProperTextFieldBorderRadius({
+  size,
+}: BorderRadiusProps): FlattenSimpleInterpolation {
+  if (size > TextFieldSize.L) {
+    return Rounding.round12
+  }
+
+  return Rounding.round8
 }

--- a/src/components/Input/TextField/TextFieldUtils.ts
+++ b/src/components/Input/TextField/TextFieldUtils.ts
@@ -32,9 +32,10 @@ interface BorderRadiusProps {
 export function getProperTextFieldBorderRadius({
   size,
 }: BorderRadiusProps): FlattenSimpleInterpolation {
-  if (size > TextFieldSize.L) {
-    return Rounding.round12
+  switch (size) {
+    case TextFieldSize.XL:
+      return Rounding.round12
+    default:
+      return Rounding.round8
   }
-
-  return Rounding.round8
 }


### PR DESCRIPTION
# Description

기존에 8px로 고정되어있던 border-radius값을 size가 XL일땐, border-radius가 12px가 될 수 있도록 변경했습니다.

## Changes Detail
* size에 따른 border-radius를 변경하기 쉽도록 util function을 만들어 추가했습니다.
* 해당 util function을 통해 border-radius css가 주입됩니다.
* border-radius는 foundation의 Rounding을 사용했습니다.

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
