### PR TITLE
OutlineItem 컴포넌트에 "focused" prop 추가

### DIFF
--- a/src/components/OutlineItem/OutlineItem.styled.ts
+++ b/src/components/OutlineItem/OutlineItem.styled.ts
@@ -10,9 +10,14 @@ import OutlineItemProps from './OutlineItem.types'
 
 interface WrapperProps extends WithInterpolation {
   active: boolean
+  focused: boolean
   paddingLeft: number
   currentOutlineItemIndex?: number | null
 }
+
+const FocusedItemStyle = css<WrapperProps>`
+  background-color: ${props => (isNil(props.currentOutlineItemIndex) && props.foundation?.theme?.['bg-black-lighter'])};
+`
 
 const ActiveItemStyle = css`
   color: ${({ foundation }) => foundation?.theme?.['bgtxt-blue-normal']};
@@ -20,8 +25,10 @@ const ActiveItemStyle = css`
 `
 
 const NonActiveItemStyle = css<WrapperProps>`
+  ${({ focused }) => focused && FocusedItemStyle}
+
   &:hover {
-    background-color: ${props => (isNil(props.currentOutlineItemIndex) && props.foundation?.theme?.['bg-black-lighter'])};
+    ${FocusedItemStyle}
   }
 `
 

--- a/src/components/OutlineItem/OutlineItem.test.tsx
+++ b/src/components/OutlineItem/OutlineItem.test.tsx
@@ -6,7 +6,10 @@ import { range } from 'lodash-es'
 /* Internal dependencies */
 import { LightFoundation } from '../../foundation'
 import { render } from '../../utils/testUtils'
-import OutlineItem, { OUTLINE_ITEM_TEST_ID } from './OutlineItem'
+import OutlineItem, {
+  OUTLINE_ITEM_LEFT_ICON_TEST_ID,
+  OUTLINE_ITEM_TEST_ID,
+} from './OutlineItem'
 import OutlineItemProps from './OutlineItem.types'
 
 describe('OutlineItem', () => {
@@ -48,35 +51,79 @@ describe('OutlineItem', () => {
     expect(rendered[0]).toHaveAttribute('data-active-index', '2')
   })
 
-  it('should have focused style when given "focused = true"', () => {
-    const { getAllByTestId } = renderComponent({ focused: true })
-    const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
+  describe('should have correct background style', () => {
+    it('should have no background style when not given focused or active prop', () => {
+      const { getAllByTestId } = renderComponent()
+      const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
 
-    expect(rendered[0]).toHaveStyle(`background-color: ${LightFoundation.theme['bg-black-lighter']};`)
-  })
-
-  it('should have active style when given "active = true"', () => {
-    const { getAllByTestId } = renderComponent({ active: true })
-    const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
-
-    expect(rendered[0]).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-lightest']};`)
-  })
-
-  it('should have active style when given both "focused = true" and "active = true"', () => {
-    const { getAllByTestId } = renderComponent({ active: true, focused: true })
-    const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
-
-    expect(rendered[0]).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-lightest']};`)
-  })
-
-  it('cannot have focused style when "selectedOutlineItemIndex" prop is not null', () => {
-    const { getAllByTestId } = renderComponent({
-      focused: true,
-      selectedOutlineItemIndex: 0,
-      children: renderComponent(),
+      expect(rendered[0]).not.toHaveStyle(`background-color: ${LightFoundation.theme['bg-black-lighter']};`)
+      expect(rendered[0]).not.toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-lightest']};`)
     })
-    const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
 
-    expect(rendered[0]).not.toHaveStyle(`background-color: ${LightFoundation.theme['bg-black-lighter']};`)
+    it('should have focused style when given "focused = true"', () => {
+      const { getAllByTestId } = renderComponent({ focused: true })
+      const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
+
+      expect(rendered[0]).toHaveStyle(`background-color: ${LightFoundation.theme['bg-black-lighter']};`)
+    })
+
+    it('should have active style when given "active = true"', () => {
+      const { getAllByTestId } = renderComponent({ active: true })
+      const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
+
+      expect(rendered[0]).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-lightest']};`)
+    })
+
+    it('should have active style when given both "focused = true" and "active = true"', () => {
+      const { getAllByTestId } = renderComponent({ active: true, focused: true })
+      const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
+
+      expect(rendered[0]).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-lightest']};`)
+    })
+
+    it('cannot have focused style when "selectedOutlineItemIndex" prop is not null', () => {
+      const { getAllByTestId } = renderComponent({
+        focused: true,
+        selectedOutlineItemIndex: 0,
+      })
+      const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
+
+      expect(rendered[0]).not.toHaveStyle(`background-color: ${LightFoundation.theme['bg-black-lighter']};`)
+    })
+  })
+
+  describe('should have correct left icon style', () => {
+    it('shows default left icon color', () => {
+      const { getByTestId } = renderComponent({ leftIcon: 'info' })
+      const rendered = getByTestId(OUTLINE_ITEM_LEFT_ICON_TEST_ID)
+
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']};`)
+    })
+
+    it('shows given leftIconColor if exists', () => {
+      const { getByTestId } = renderComponent({ leftIcon: 'info', leftIconColor: 'bgtxt-green-normal' })
+      const rendered = getByTestId(OUTLINE_ITEM_LEFT_ICON_TEST_ID)
+
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-green-normal']};`)
+    })
+
+    it('shows active icon color, ignoring given leftIconColor', () => {
+      const { getByTestId } = renderComponent({ leftIcon: 'info', leftIconColor: 'bgtxt-green-normal', active: true })
+      const rendered = getByTestId(OUTLINE_ITEM_LEFT_ICON_TEST_ID)
+
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-blue-normal']};`)
+    })
+
+    it('shows given leftIconColor even if "active = true", if "disableIconActive = true"', () => {
+      const { getByTestId } = renderComponent({
+        leftIcon: 'info',
+        leftIconColor: 'bgtxt-purple-normal',
+        active: true,
+        disableIconActive: true,
+      })
+      const rendered = getByTestId(OUTLINE_ITEM_LEFT_ICON_TEST_ID)
+
+      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-purple-normal']};`)
+    })
   })
 })

--- a/src/components/OutlineItem/OutlineItem.test.tsx
+++ b/src/components/OutlineItem/OutlineItem.test.tsx
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid'
 import { range } from 'lodash-es'
 
 /* Internal dependencies */
+import { LightFoundation } from '../../foundation'
 import { render } from '../../utils/testUtils'
 import OutlineItem, { OUTLINE_ITEM_TEST_ID } from './OutlineItem'
 import OutlineItemProps from './OutlineItem.types'
@@ -45,5 +46,26 @@ describe('OutlineItem', () => {
     const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
 
     expect(rendered[0]).toHaveAttribute('data-active-index', '2')
+  })
+
+  it('should have focused style when given "focused = true"', () => {
+    const { getAllByTestId } = renderComponent({ focused: true })
+    const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
+
+    expect(rendered[0]).toHaveStyle(`background-color: ${LightFoundation.theme['bg-black-lighter']};`)
+  })
+
+  it('should have active style when given "active = true"', () => {
+    const { getAllByTestId } = renderComponent({ active: true })
+    const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
+
+    expect(rendered[0]).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-lightest']};`)
+  })
+
+  it('should have active style when given both "focused = true" and "active = true"', () => {
+    const { getAllByTestId } = renderComponent({ active: true, focused: true })
+    const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
+
+    expect(rendered[0]).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-lightest']};`)
   })
 })

--- a/src/components/OutlineItem/OutlineItem.test.tsx
+++ b/src/components/OutlineItem/OutlineItem.test.tsx
@@ -68,4 +68,15 @@ describe('OutlineItem', () => {
 
     expect(rendered[0]).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-lightest']};`)
   })
+
+  it('cannot have focused style when "selectedOutlineItemIndex" prop is not null', () => {
+    const { getAllByTestId } = renderComponent({
+      focused: true,
+      selectedOutlineItemIndex: 0,
+      children: renderComponent(),
+    })
+    const rendered = getAllByTestId(OUTLINE_ITEM_TEST_ID)
+
+    expect(rendered[0]).not.toHaveStyle(`background-color: ${LightFoundation.theme['bg-black-lighter']};`)
+  })
 })

--- a/src/components/OutlineItem/OutlineItem.tsx
+++ b/src/components/OutlineItem/OutlineItem.tsx
@@ -38,6 +38,7 @@ function OutlineItem(
     paddingLeft: givenPaddingLeft,
     open = false,
     active: givenActive,
+    focused = false,
     chevronIconType = ChevronIconType.Small,
     chevronIconSize = IconSize.XS,
     leftContent,
@@ -252,6 +253,7 @@ function OutlineItem(
           className={className}
           interpolation={interpolation}
           active={false}
+          focused={focused}
           currentOutlineItemIndex={currentOutlineItemIndex}
           paddingLeft={paddingLeft}
           onClick={handleClickGroup}
@@ -276,6 +278,7 @@ function OutlineItem(
         className={className}
         interpolation={interpolation}
         active={active}
+        focused={focused}
         currentOutlineItemIndex={currentOutlineItemIndex}
         paddingLeft={paddingLeft}
         onClick={handleClickGroup}

--- a/src/components/OutlineItem/OutlineItem.tsx
+++ b/src/components/OutlineItem/OutlineItem.tsx
@@ -21,11 +21,13 @@ import {
 const LIST_GROUP_PADDING_LEFT = 16
 
 export const OUTLINE_ITEM_TEST_ID = 'bezier-react-outline-item'
+export const OUTLINE_ITEM_LEFT_ICON_TEST_ID = 'bezier-react-outline-item-left-icon'
 
 function OutlineItem(
   {
     as,
     testId = OUTLINE_ITEM_TEST_ID,
+    leftIconTestId = OUTLINE_ITEM_LEFT_ICON_TEST_ID,
     style,
     className,
     interpolation,
@@ -168,6 +170,7 @@ function OutlineItem(
       return (
         <LeftContentWrapper>
           <StyledIcon
+            testId={leftIconTestId}
             className={iconClassName}
             interpolation={iconInterpolation}
             name={leftIcon}
@@ -189,6 +192,7 @@ function OutlineItem(
     leftContent,
     leftIcon,
     leftIconColor,
+    leftIconTestId,
   ])
 
   const ContentComponent = useMemo(() => (

--- a/src/components/OutlineItem/OutlineItem.types.ts
+++ b/src/components/OutlineItem/OutlineItem.types.ts
@@ -25,6 +25,7 @@ export default interface OutlineItemProps extends ContentComponentProps, Childre
   iconInterpolation?: InjectedInterpolation
   open?: boolean
   active?: boolean
+  focused?: boolean
   content?: React.ReactNode
   leftContent?: React.ReactNode
   leftIcon?: IconName

--- a/src/components/OutlineItem/OutlineItem.types.ts
+++ b/src/components/OutlineItem/OutlineItem.types.ts
@@ -17,6 +17,7 @@ export enum ChevronIconType {
 }
 
 export default interface OutlineItemProps extends ContentComponentProps, ChildrenComponentProps, OptionItem {
+  leftIconTestId?: string
   chevronClassName?: string
   chevronInterpolation?: InjectedInterpolation
   contentClassName?: string


### PR DESCRIPTION
# Description

ListItem과 마찬가지로, 키보드 동작 관련 a11y를 보강하기 위해 focused prop을 추가합니다.

## Changes Detail

- `focused = true`로 주어진 경우, 기존의 mouse hover와 동일한 스타일이 적용됩니다.
- `focused = false`로 주어진 경우, 변화 없음

# Tests
- [x] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
