### PR TITLE
Select에 placeholder style 추가

### DIFF
--- a/src/components/Input/Select/Select.test.tsx
+++ b/src/components/Input/Select/Select.test.tsx
@@ -3,11 +3,13 @@ import React from 'react'
 import userEvent from '@testing-library/user-event'
 
 /* Internal dependencies */
+import { LightFoundation } from '../../../foundation'
 import { render } from '../../../utils/testUtils'
 import Select, {
   SELECT_CONTAINER_TEST_ID,
   SELECT_TRIGGER_TEST_ID,
   SELECT_DROPDOWN_TEST_ID,
+  SELECT_TRIGGER_TEXT_TEST_ID,
 } from './Select'
 import SelectProps, { SelectSize } from './Select.types'
 
@@ -28,7 +30,7 @@ describe('Select Test >', () => {
 
   describe('Default Style >', () => {
     it('Snapshot >', () => {
-      const { container } = renderSelect()
+      const { container } = renderSelect({ text: 'foo' })
       expect(container.firstChild).toMatchSnapshot()
     })
 
@@ -145,6 +147,29 @@ describe('Select Test >', () => {
       const defaultSelectDropdown = getByTestId(SELECT_TRIGGER_TEST_ID)
 
       expect(defaultSelectDropdown).toHaveStyle('height: 54px;')
+    })
+  })
+
+  describe('Trigger text style >', () => {
+    it('shows default text color', () => {
+      const { getByTestId } = renderSelect({ text: 'lorem ipsum' })
+      const triggerText = getByTestId(SELECT_TRIGGER_TEXT_TEST_ID)
+
+      expect(triggerText).toHaveStyle(`color: ${LightFoundation.theme['txt-black-darkest']};`)
+    })
+
+    it('shows given text color', () => {
+      const { getByTestId } = renderSelect({ text: 'lorem ipsum', textColor: 'bgtxt-green-normal' })
+      const triggerText = getByTestId(SELECT_TRIGGER_TEXT_TEST_ID)
+
+      expect(triggerText).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-green-normal']};`)
+    })
+
+    it('shows placeholder text color if content is empty', () => {
+      const { getByTestId } = renderSelect({ text: '', textColor: 'bgtxt-blue-normal' })
+      const triggerText = getByTestId(SELECT_TRIGGER_TEXT_TEST_ID)
+
+      expect(triggerText).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']};`)
     })
   })
 })

--- a/src/components/Input/Select/Select.tsx
+++ b/src/components/Input/Select/Select.tsx
@@ -8,7 +8,10 @@ import React, {
   Ref,
   useImperativeHandle,
 } from 'react'
-import _ from 'lodash'
+import {
+  isEmpty,
+  noop,
+} from 'lodash-es'
 
 /* Internal dependencies */
 import {
@@ -27,6 +30,7 @@ import * as Styled from './Select.styled'
 
 export const SELECT_CONTAINER_TEST_ID = 'bezier-react-select-container'
 export const SELECT_TRIGGER_TEST_ID = 'bezier-react-select-trigger'
+export const SELECT_TRIGGER_TEXT_TEST_ID = 'bezier-react-select-trigger-text'
 export const SELECT_DROPDOWN_TEST_ID = 'bezier-react-select-dropdown'
 
 const DEFAULT_DROPDOWN_MARGIN_Y = 6
@@ -36,6 +40,7 @@ function Select(
   {
     testId = SELECT_CONTAINER_TEST_ID,
     triggerTestId = SELECT_TRIGGER_TEST_ID,
+    triggerTextTestId = SELECT_TRIGGER_TEXT_TEST_ID,
     dropdownTestId = SELECT_DROPDOWN_TEST_ID,
     as,
     style,
@@ -58,8 +63,8 @@ function Select(
     dropdownMarginY = DEFAULT_DROPDOWN_MARGIN_Y,
     dropdownZIndex = DEFAULT_DROPDOWN_Z_INDEX,
     dropdownPosition = OverlayPosition.BottomLeft,
-    onClickTrigger = _.noop,
-    onHideDropdown = _.noop,
+    onClickTrigger = noop,
+    onHideDropdown = noop,
     children,
   }: SelectProps,
   forwardedRef: Ref<SelectRef>,
@@ -112,6 +117,8 @@ function Select(
 
   useImperativeHandle(forwardedRef, () => handle)
 
+  const hasContent = !isEmpty(text)
+
   return (
     <Styled.Container
       data-testid={testId}
@@ -133,10 +140,11 @@ function Select(
         <Styled.MainContentWrapper>
           { LeftComponent }
           <Text
+            testId={triggerTextTestId}
             typo={Typography.Size14}
-            color={textColor}
+            color={hasContent ? textColor : 'txt-black-dark'}
           >
-            { text || placeholder }
+            { hasContent ? text : placeholder }
           </Text>
         </Styled.MainContentWrapper>
         { !withoutChevron && (

--- a/src/components/Input/Select/Select.types.ts
+++ b/src/components/Input/Select/Select.types.ts
@@ -20,6 +20,7 @@ export interface SelectRef {
 
 interface SelectProps extends ChildrenComponentProps {
   triggerTestId?: string
+  triggerTextTestId?: string
   dropdownTestId?: string
   size?: SelectSize
   disabled?: boolean

--- a/src/components/Input/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Input/Select/__snapshots__/Select.test.tsx.snap
@@ -103,8 +103,10 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
       <span
         class="c3"
         color="txt-black-darkest"
-        data-testid="bezier-react-text"
-      />
+        data-testid="bezier-react-select-trigger-text"
+      >
+        foo
+      </span>
     </div>
     <svg
       class="c4"


### PR DESCRIPTION
# Description

<img width="838" alt="스크린샷 2021-09-29 오후 5 32 11" src="https://user-images.githubusercontent.com/25701854/135232522-7fda5bb5-44ca-4bee-9d13-6f6087c4694c.png">

위 사진과 같은 스펙 추가.

## Changes Detail

* 원래 Select.tsx 에서 lodash-es 가 아니라 lodash를 쓰고 있던 점도 함께 수정.

# Tests
- [x] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
