### PR TITLE
semantic name 추가(bdr-black-dark), Dark Theme에서  bdr-white 색상 변경

### DIFF
--- a/src/foundation/Colors/Theme/presets/DarkTheme.ts
+++ b/src/foundation/Colors/Theme/presets/DarkTheme.ts
@@ -113,9 +113,10 @@ const DarkTheme: ThemeType = {
   'bgtxt-absolute-white-lightest': Palette.white_20,
 
   // Border
+  'bdr-black-dark': Palette.white_20,
   'bdr-black-light': Palette.white_12,
   'bdr-grey-light': Palette.grey700,
-  'bdr-white': Palette.grey900,
+  'bdr-white': Palette.grey700,
 
   // Shadow
   'shdw-xlarge': Palette.black_60,

--- a/src/foundation/Colors/Theme/presets/LightTheme.ts
+++ b/src/foundation/Colors/Theme/presets/LightTheme.ts
@@ -114,6 +114,7 @@ const LightTheme: ThemeType = {
   'bgtxt-absolute-white-lightest': Palette.white_20,
 
   // Border
+  'bdr-black-dark': Palette.black_15,
   'bdr-black-light': Palette.black_8,
   'bdr-grey-light': Palette.grey200,
   'bdr-white': Palette.white,

--- a/src/foundation/Colors/Theme/types/SemanticNames.ts
+++ b/src/foundation/Colors/Theme/types/SemanticNames.ts
@@ -44,6 +44,7 @@ type MonoAbsoluteTextAndBackgroundColor =
   | `bgtxt-absolute-${BaseMonoPaletteKey}-lightest`
 
 type BorderColor =
+  | 'bdr-black-dark'
   | 'bdr-black-light'
   | 'bdr-grey-light'
   | 'bdr-white'


### PR DESCRIPTION

# Description
변경사항 개요를 작성해주세요. Github 이슈, Notion 등 연관 문서가 있다면 첨부해주세요.
아래 이슈를 해결합니다
#574 

## Changes Detail
bdr-white 의 DarkTheme Palette를 grey700으로 변경
bdr-black-dark Semantic Name 추가

