### PR TITLE
feat(listitem): rightContent의 Wrapper에 display:flex 추가

### DIFF
--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -62,6 +62,7 @@ const ActiveItemStyle = css<StyledWrapperProps>`
 `
 
 export const RightContent = styled.div`
+  display: flex;
   margin-left: 8px;
 `
 


### PR DESCRIPTION
# Description

ListItem 컴포넌트의 rightContent Wrapper에 `display:flex` 속성을 추가합니다.

ListItem 컴포넌트 우측에 `Icon` 컴포넌트를 넣는 케이스가 종종 있는데, wrapper에 `display:flex` 가 지정되어 있지 않아, `Icon` 의 `flex: 0 0 auto` 속성이 제대로 동작하지 않았습니다. 사용처에서 불필요하게 `Wrapper` 를 추가로 만들어 해당 엘리먼트에 `display:flex` 속성을 부여했습니다. 이를 피하기 위한 변경사항입니다.

## Changes Detail

없음

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
