### PR TITLE
foundation 이 tree shakable 하게 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "type": "git",
     "url": "https://github.com/channel-io/bezier-react"
   },
-  "main": "build/index.js",
-  "module": "build/index.es.js",
+  "main": "build/index.cjs.js",
+  "module": "build/src/index.js",
+  "types": "build/src/index.d.ts",
   "sideEffects": false,
-  "types": "build/index.d.ts",
   "files": [
     "build"
   ],
@@ -20,7 +20,7 @@
     "lint": "npm run eslint-all && npm run stylelint-all",
     "eslint-all": "eslint 'src/**/*.+(js|ts)?(x)'",
     "stylelint-all": "stylelint src/**/*.styled.{js,ts}",
-    "typecheck": "ts-prune -e -p tsconfig.prune.json && tsc",
+    "typecheck": "ts-prune -e -p tsconfig.prune.json && tsc --emitDeclarationOnly --declarationDir build/src",
     "test": "npm run lint && npm run typecheck && npm run jest",
     "jest": "cross-env BABEL_ENV=test jest --maxWorkers=2",
     "jest:watch": "cross-env BABEL_ENV=test jest --watch",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -57,8 +57,9 @@ export default [
   // ESModules
   configGenerator({
     output: {
-      file: packageJson.module,
+      dir: 'build',
       format: 'esm',
+      preserveModules: true,
     },
     plugins: [
       nodeResolve({


### PR DESCRIPTION
# Description
Foundation이 Tree Shakable하지 못했던 문제가 있고, 이를 해결합니다.
Limitation이 존재합니다.

## tree shakable이 필요하게 된 이유
- 프론트의 대부분 컴포넌트는 데스크에서 사용해야 함, 미리보기에서 사용됨
- 그렇기 때문에 프론트의 대부분 컴포넌트를 데스크에 복사-붙혀넣기 하여 사용하고 있음
- 심지어 현재 프론트에는 bezier가 적용되어 있지 않음
- 이 뿐만 알림톡 미리보기, 캠페인 미리보기 역시 데스크와 프론트, 레시피까지 동일한 뷰를 공유하고 있음
- 공유되는 컴포넌트를 각 플랫폼에 맞추어서 개발하는 것은 많은 공수가 들어감
-> shared-components 라는 모듈에 이를 보관하자.
-> shared-components 모듈은 bezier-react 를 peer dependency로 가져야 한다.
-> ch-plugin에서 bezier-react의 foundation을 사용해야 한다.

~~아래 문서 참조하여 esm에서 foundation이 tree-shakable하게 변경했습니다.~~
~~Avatar과 같은 컴포넌트의 경우에는 아직까지 tree-shakable하지 않기 때문에 plugin에서 사용할 수 없습니다.~~
~~scalable하게 tree shakable하게 하는 방법에 대해서는 다른 라이브러리들 레퍼런스 조사가 더 필요한 상황입니다.~~
~~https://redd.one/blog/building-a-tree-shakable-library-with-rollupjs~~

## Updated(2021.10.23)
### 해결방향
1. 기존처럼 index.es.js로 하나의 파일으로 번들링 되었을 때, tree-shaking이 잘 되지 않았습니다.
2. 작은 project를 하나 만들어 그곳에 bezier-react를 install 하고 테스트 진행했는데 잘 되지 않았고,([Webpack Tree Shaking문서 참조](https://webpack.js.org/guides/tree-shaking/#root))
3. 그래서 webpack 이 현재 bezier-react의 index.es.js 파일을 tree shaking 하지 못하게 인식하는 문제가 있는 것 같다고 가설을 세웠습니다.
4. 컨슈머 모듈(plugin-web)의 옵션을 수정하려던 기존 생각에서 bezier-react의 번들 옵션을 수정해보기로 했습니다.
5. `preserveModules` 옵션을 사용하면 번들을 project structure를 유지하면서 만들어줍니다.
6. 해당 옵션을 켰을 때 tree shaking이 잘 됩니다!(실행도 잘 됩니다)

| plugin-web | bezier-react |
|:---:|:---:|
<img width="1289" alt="Screen Shot 2021-10-24 at 12 14 33 AM" src="https://user-images.githubusercontent.com/33861398/138562104-e02bce82-7698-4735-bfd7-73abb984dafa.png">|<img width="1194" alt="Screen Shot 2021-10-24 at 12 14 39 AM" src="https://user-images.githubusercontent.com/33861398/138562107-fbc2ff59-23b9-49a2-93be-3e68df2de686.png">


### 문제점
생각해보면 초창기의 bezier-react는 tree shakable했습니다. 기억을 되짚어보면 #431 혹은 #444 이후로 그랬던 것 같습니다.
예전에는 이런 형태의 import가 가능했었습니다. 두가지 문제가 모두 존재했었는데 정확한 시점은 잘 기억나지 않습니다
1. 이런 형태가 의도하지 않은 export를 가져올 수 있었던 문제(entry에서 export하지 않았는데 실제로 사용할 수 있었던 상황임)
2. 그리고 실제로 export 되어 있지 않으나 type definition은 tsc를 통해 생성되어 있어서 import 해올 수 있었던 문제

### **현재 PR의 구현방식대로라면 1번의 문제가 재발합니다😭**
왜냐하면 `preserveModules` 옵션으로 인해 번들이 모듈의 구조를 그대로 따라가게 되면서 export 구문이 생기고 이를 막을 수가 없습니다.
![image](https://user-images.githubusercontent.com/33861398/138561292-d99e24ba-0fa5-4ec6-b83e-542588d1a0c9.png)

### 해결방법에 대한 고민
지금은 bezier-react를 recipe-components, ch-desk-web, plugin-web 세가지 모듈에서 공통적으로 사용하는게 중요한 상황이어서 이대로 진행하는게 좋을 것 같습니다. 하지만 장기적으로 해결되어야 하는 문제이기는 확실하기에 아래와 같은 두가지 전략들을 우선 생각해봅니다
1. #444 에서 언급되었던 https://github.com/wessberg/rollup-plugin-ts/issues/123 문제가 해결된다면 해당 라이브러리를 사용하거나
2. https://github.com/DefinitelyTyped/DefinitelyTyped 처럼 타입 선언을 export 하는 모듈들만 해주는 방식이 있을 것 같습니다
3. root cause를 해결하는 방법입니다. 하나의 파일로 번들링을 진행했을 때 tree shaking이 잘 되지 않는 원인을 찾아서 이를 해결합니다.


# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
