### PR TITLE
fix(status): Status Enum 값 중 Private을 Lock으로 변경

### DIFF
--- a/src/components/Status/Status.styled.ts
+++ b/src/components/Status/Status.styled.ts
@@ -33,7 +33,7 @@ export const StatusCircle = styled.div<StatusCircleProps>`
   }
 `
 
-export const PrivateIcon = styled(Icon)`
+export const LockIcon = styled(Icon)`
   ${absoluteCenter('')}
   z-index: 1;
 `

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -2,8 +2,9 @@
 import React from 'react'
 
 /* Internal denpendencies */
+import { IconSize } from '../Icon'
 import { StatusType, StatusProps } from './Status.types'
-import { StatusCircle, PrivateIcon } from './Status.styled'
+import { StatusCircle, LockIcon } from './Status.styled'
 
 // TODO: 테스트 코드 작성
 const STATUS_TEST_ID = 'bezier-react-status'
@@ -11,15 +12,15 @@ const STATUS_TEST_ID = 'bezier-react-status'
 function Status({
   type,
 }: StatusProps) {
-  if (type === StatusType.Private) {
+  if (type === StatusType.Lock) {
     return (
       <StatusCircle
         data-testid={STATUS_TEST_ID}
         color="bg-white-normal"
       >
-        <PrivateIcon
+        <LockIcon
           name="lock"
-          size={10 /* NOTE: IconSize에 없는 예외 케이스 */}
+          size={IconSize.XXS}
           color="txt-black-darker"
         />
       </StatusCircle>

--- a/src/components/Status/Status.types.ts
+++ b/src/components/Status/Status.types.ts
@@ -1,7 +1,7 @@
 export enum StatusType {
   Online = 'Online',
   Offline = 'Offline',
-  Private = 'Private',
+  Lock = 'Lock',
 }
 
 export interface StatusProps {


### PR DESCRIPTION


# Description
- #571에 따라서 Private enum을 Lock으로 변경합니다.
- 피그마 시안에 따라 Lock Icon의 Size를 12로 변경했습니다.

fix #571

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
