### PR TITLE
feat(header): header 크기가 70px을 넘을 수 있도록 변경

### DIFF
--- a/src/layout/Main/Main.styled.ts
+++ b/src/layout/Main/Main.styled.ts
@@ -16,7 +16,7 @@ export const MainWrapper = styled.div.attrs(({ hasSide, sideWidth }: MainWrapper
   },
 }))<MainWrapperProps>`
   display: grid;
-  grid-template-rows: ${({ hasHeader }) => (hasHeader ? `${HEADER_HEIGHT}px 1fr` : '0 1fr')};
+  grid-template-rows: ${({ hasHeader }) => (hasHeader ? `minmax(${HEADER_HEIGHT}px, auto) 1fr` : '0 1fr')};
   width: 100%;
   height: 100%;
 


### PR DESCRIPTION
# Description
현재는 70px을 넘는 header가 없습니다.
하지만 더 넓은 header를 사용하는 디자인이 아래와 같이 추가되어, 70px 이상인 header를 적용할 수 있도록 수정합니다.

<img width="926" alt="스크린샷 2021-10-28 오후 5 20 34" src="https://user-images.githubusercontent.com/33291896/139216326-629d5d87-97e7-4f6b-8f60-7461eb09d577.png">

As-is | To-be
----- | -----
 <img width="873" alt="스크린샷 2021-10-28 오후 5 20 03" src="https://user-images.githubusercontent.com/33291896/139216223-af1bbf13-7f85-4d57-a5c6-d1f2e6ace4f4.png"> | <img width="873" alt="after" src="https://user-images.githubusercontent.com/33291896/139216093-6f5cf4c8-7471-4e15-946f-bb48049eb280.png">

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [x] Safari - WebKit
- [ ] Firefox - Gecko (Option)
