### PR TITLE
fix(houdini): remove side effect of enablecsshoudini and move it to foundation provider

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,16 +2,11 @@
 import React from 'react'
 
 /* Internel dependencies */
-import EnableCSSHoudini from '../src/worklets/EnableCSSHoudini'
 import {
   FoundationProvider,
   LightFoundation,
   DarkFoundation,
-  styled,
 } from '../src/foundation'
-
-// CSS Houdini
-EnableCSSHoudini({ smoothCorners: true })
 
 const FoundationKeyword = {
   Light: 'light',

--- a/src/foundation/FoundationStyledComponent.tsx
+++ b/src/foundation/FoundationStyledComponent.tsx
@@ -27,6 +27,7 @@ import styled, {
 } from 'styled-components'
 
 /* Internal dependencies */
+import EnableCSSHoudini from '../worklets/EnableCSSHoudini'
 import domElements from './utils/domElements'
 import { Foundation } from './index'
 
@@ -41,6 +42,7 @@ function FoundationProvider({
   foundation,
   children,
 }: FoundationProviderProps) {
+  EnableCSSHoudini({ smoothCorners: true })
   return <FoundationContext.Provider value={foundation}>{ children }</FoundationContext.Provider>
 }
 

--- a/src/foundation/Mixins.ts
+++ b/src/foundation/Mixins.ts
@@ -1,6 +1,6 @@
 /* External dependencies */
 import type { CSSProperties } from 'react'
-import { isNil } from 'lodash'
+import { isNil } from 'lodash-es'
 
 /* Internal dependencies */
 import { css } from './FoundationStyledComponent'
@@ -96,7 +96,7 @@ export const smoothCorners = ({
     box-shadow: none;
 
     ${hasBackgroundImage && css`
-    border-image-source: var(--background-image);
+      border-image-source: var(--background-image);
     `}
 
     --smooth-corners: ${borderRadius};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,4 @@
-import EnableCSSHoudini from './worklets/EnableCSSHoudini'
-
-EnableCSSHoudini({ smoothCorners: true })
-
 /* Foundation */
-
 export * from './foundation'
 
 /* Components */


### PR DESCRIPTION
# Description
기존에 Smooth Corners 적용을 위해 EnableCSSHoudini를 bezier-react의 entry인 index.ts에서 실행시켜 주고 있었습니다. 
이것은 side effect가 유발되는 행동이기 때문에 트리 쉐이킹하면서 떨어져 나가면 안됩니다.
하지만 트리 쉐이킹을 돕기 위해 package.json의 sideEffect value를 false로 해두었기 때문에 컨슈머 모듈에서는 이 라이브러리가 side effect free 하다고 판단하게 됩니다. 그래서 EnableCSSHoudini가 실행되지 않는 문제가 있었고 이를 수정합니다.

## Changes Detail
이제 bezier-react의 entry가 아니라 FoundationProvider를 사용하게 된다면 EnableCSSHoudini가 실행됩니다.

# Tests
npm pack 하여 데스크에 설치하여 잘 보이는 것 확인

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
https://developer.mozilla.org/en-US/docs/Web/API/PaintWorklet#use_a_paintworklet 
우리는 위 방식처럼 paintworklet을 적용하고 있는데 CSSHoudini를 적용하지 않아도 paint는 support되는 속성이라 fallback 처리가 되지 않음

