### PR TITLE
배너 컴포넌트에 text prop을 string과 ReactNode를 받을 수 있도록 확장

### DIFF
--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -54,7 +54,7 @@ export const Primary: Story<BannerProps> = Template.bind({})
 Primary.args = {
   colorVariant: BannerColorVariant.Default,
   icon: 'lightbulb',
-  text: 'Information here.',
+  content: 'Information here.',
   dismissible: true,
   onDismiss: noop,
 }

--- a/src/components/Banner/Banner.styled.ts
+++ b/src/components/Banner/Banner.styled.ts
@@ -10,7 +10,7 @@ import {
 import type { BannerColorVariant } from './Banner.types'
 
 const BannerIcon = styled(Icon)``
-const Content = styled(Text)``
+const ContentWrapper = styled.div``
 const Dismiss = styled.div`
   display: flex;
   width: 20px;
@@ -42,11 +42,11 @@ const Wrapper = styled.div<{
 
   ${({ interpolation }) => interpolation}
 
-  > ${Content} {
+  > ${ContentWrapper} {
     flex: 1;
   }
 
-  > ${BannerIcon} + ${Content} {
+  > ${BannerIcon} + ${ContentWrapper} {
     margin-left: 6px;
   }
 
@@ -61,7 +61,7 @@ const Wrapper = styled.div<{
 
 export default {
   BannerIcon,
-  Content,
+  ContentWrapper,
   Dismiss,
   Link,
   Wrapper,

--- a/src/components/Banner/Banner.styled.ts
+++ b/src/components/Banner/Banner.styled.ts
@@ -5,12 +5,17 @@ import { Icon } from '../Icon'
 import { Text } from '../Text'
 import {
   BACKGROUND_COLORS,
+  TEXT_COLORS,
   ELEVATIONS,
 } from './Banner.const'
 import type { BannerColorVariant } from './Banner.types'
 
 const BannerIcon = styled(Icon)``
-const ContentWrapper = styled.div``
+const ContentWrapper = styled.div<{
+  colorVariant: BannerColorVariant
+}>`
+  color: ${({ foundation, colorVariant }) => foundation?.theme?.[TEXT_COLORS[colorVariant]]};
+`
 const Dismiss = styled.div`
   display: flex;
   width: 20px;

--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -15,7 +15,7 @@ describe('Banner >', () => {
   beforeEach(() => {
     props = {
       icon: 'info',
-      text: 'Lorem ipsum dolor amet.',
+      content: 'Lorem ipsum dolor amet.',
       hasLink: false,
       dismissible: false,
     }

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -115,7 +115,7 @@ function Banner(
         />
       ) }
 
-      <Styled.ContentWrapper>
+      <Styled.ContentWrapper colorVariant={colorVariant}>
         { isString(content) ? (
           <Text
             typo={Typography.Size14}

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,9 +1,13 @@
 /* External dependencies */
 import React, { forwardRef } from 'react'
-import { isNil } from 'lodash-es'
+import {
+  isNil,
+  isString,
+} from 'lodash-es'
 
 /* Internal dependencies */
 import { Typography } from '../../foundation'
+import { Text } from '../Text'
 import {
   Icon,
   IconSize,
@@ -111,13 +115,17 @@ function Banner(
         />
       ) }
 
-      <Styled.Content
-        typo={Typography.Size14}
-        color={TEXT_COLORS[colorVariant]}
-      >
-        { text }
-        <Link {...props} />
-      </Styled.Content>
+      <Styled.ContentWrapper>
+        { isString(text) ? (
+          <Text
+            typo={Typography.Size14}
+            color={TEXT_COLORS[colorVariant]}
+          >
+            { text }
+            <Link {...props} />
+          </Text>
+        ) : text }
+      </Styled.ContentWrapper>
 
       <DismissButton {...props} />
     </Styled.Wrapper>

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -95,7 +95,7 @@ function Banner(
     colorVariant = BannerColorVariant.Default,
     icon,
     iconColor,
-    text,
+    content,
     testId = BANNER_TEST_ID,
   } = props
 
@@ -116,15 +116,15 @@ function Banner(
       ) }
 
       <Styled.ContentWrapper>
-        { isString(text) ? (
+        { isString(content) ? (
           <Text
             typo={Typography.Size14}
             color={TEXT_COLORS[colorVariant]}
           >
-            { text }
+            { content }
             <Link {...props} />
           </Text>
-        ) : text }
+        ) : content }
       </Styled.ContentWrapper>
 
       <DismissButton {...props} />

--- a/src/components/Banner/Banner.types.ts
+++ b/src/components/Banner/Banner.types.ts
@@ -25,7 +25,7 @@ export interface BannerProps extends UIComponentProps {
   colorVariant?: BannerColorVariant
   icon: IconName | null
   iconColor?: SemanticNames
-  text: string
+  text: string | ReactNode
 
   hasLink?: boolean
   linkText?: string

--- a/src/components/Banner/Banner.types.ts
+++ b/src/components/Banner/Banner.types.ts
@@ -25,7 +25,7 @@ export interface BannerProps extends UIComponentProps {
   colorVariant?: BannerColorVariant
   icon: IconName | null
   iconColor?: SemanticNames
-  text: string | ReactNode
+  content: string | ReactNode
 
   hasLink?: boolean
   linkText?: string


### PR DESCRIPTION
# Description
배너 컴포넌트에 데스크의 translateWithInnerHtml를 사용한 번역을 넘겨야하는 상황이 생기게 되었습니다. (번역 값에 bold태그와 같이 html을 사용하는 경우)
text prop은 string만을 받으므로 text prop을 ReactNode까지 받을 수 있도록 확장했습니다. 

@제이미 께 추후 배너 컴포넌트에 아이콘이나 텍스트외 다른 컴포넌트가 들어 갈 수 있는 상황에 대해 여쭈어보고 현재로선 딱히 생각나는 케이스가 없다고 답변주셔서 children으로 넘기지 않고 text prop을 확장시켰습니다.

## Changes Detail
* 변경1 세부사항
* 변경2 세부사항

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
#600