### PR TITLE
TextArea의 minRow, maxRow prop을 부활하고 size option 삭제, disabled 옵션 & 스타일 추가

### DIFF
--- a/src/components/Input/TextArea/TextArea.stories.tsx
+++ b/src/components/Input/TextArea/TextArea.stories.tsx
@@ -8,11 +8,25 @@ import base from 'paths.macro'
 /* Internal dependencies */
 import { getObjectFromEnum, getTitle } from '../../../utils/storyUtils'
 import TextArea from './TextArea'
-import { TextAreaSize } from './TextArea.types'
+import { TextAreaHeight } from './TextArea.types'
 
 export default {
   title: getTitle(base),
   component: TextArea,
+  argTypes: {
+    minRows: {
+      control: {
+        type: 'radio',
+        options: getObjectFromEnum(TextAreaHeight),
+      },
+    },
+    maxRows: {
+      control: {
+        type: 'radio',
+        options: getObjectFromEnum(TextAreaHeight),
+      },
+    },
+  },
 }
 
 const Template = ({ ...otherProps }) => {
@@ -41,15 +55,7 @@ Primary.args = {
   autoFocus: true,
   readOnly: false,
   hasError: false,
-  size: TextAreaSize.S,
+  minRows: TextAreaHeight.Row6,
+  maxRows: TextAreaHeight.Row10,
   placeholder: 'say hi to autoResizable textarea!',
-}
-
-Primary.argTypes = {
-  size: {
-    control: {
-      type: 'radio',
-      options: getObjectFromEnum(TextAreaSize),
-    },
-  },
 }

--- a/src/components/Input/TextArea/TextArea.stories.tsx
+++ b/src/components/Input/TextArea/TextArea.stories.tsx
@@ -54,6 +54,7 @@ export const Primary = Template.bind({})
 Primary.args = {
   autoFocus: true,
   readOnly: false,
+  disabled: false,
   hasError: false,
   minRows: TextAreaHeight.Row6,
   maxRows: TextAreaHeight.Row10,

--- a/src/components/Input/TextArea/TextArea.styled.ts
+++ b/src/components/Input/TextArea/TextArea.styled.ts
@@ -44,6 +44,7 @@ const Wrapper = styled.div<WrapperProps>`
 `
 
 interface TextAreaAutoSizeBaseProps extends WithInterpolation{
+  disabled: boolean
   readOnly: boolean
 }
 
@@ -58,6 +59,7 @@ const TextAreaAutoSizeBase = styled(TextareaAutosize.default ?? TextareaAutosize
   width: 100%;
   padding: 8px 12px;
   margin: 0;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'auto')};
   resize: none;
   background: none;
   border: none;

--- a/src/components/Input/TextArea/TextArea.styled.ts
+++ b/src/components/Input/TextArea/TextArea.styled.ts
@@ -8,6 +8,7 @@ import {
   styled,
   Typography,
 } from '../../../foundation'
+import DisabledOpacity from '../../../constants/DisabledOpacity'
 import { WithInterpolation } from '../../../types/InjectedInterpolation'
 import {
   erroredInputWrapperStyle,
@@ -19,6 +20,7 @@ interface WrapperProps extends WithInterpolation {
   focused: boolean
   hasError?: boolean
   bgColor: SemanticNames
+  disabled: boolean
 }
 
 const Wrapper = styled.div<WrapperProps>`
@@ -28,6 +30,7 @@ const Wrapper = styled.div<WrapperProps>`
   display: flex;
   align-items: center;
   background-color: ${({ foundation, bgColor }) => foundation?.theme?.[bgColor]};
+  opacity: ${({ disabled }) => disabled && DisabledOpacity};
 
   ${({ focused }) => focused && focusedInputWrapperStyle}
 

--- a/src/components/Input/TextArea/TextArea.test.tsx
+++ b/src/components/Input/TextArea/TextArea.test.tsx
@@ -1,6 +1,8 @@
 /* External dependencies */
 import { fireEvent } from '@testing-library/dom'
 import React from 'react'
+import disabledOpacity from '../../../constants/DisabledOpacity'
+import { Palette } from '../../../foundation/Colors/Palette'
 
 /* Internal dependencies */
 import { render } from '../../../utils/testUtils'
@@ -13,6 +15,7 @@ describe('TextArea 테스트 >', () => {
   let props: TextAreaProps
 
   beforeEach(() => {
+    jest.useFakeTimers()
     props = {}
   })
 
@@ -30,9 +33,11 @@ describe('TextArea 테스트 >', () => {
     const rendered = getByTestId(TEXT_AREA_TEST_ID)
     const textareaElement = rendered.getElementsByTagName('textarea')[0]
 
+    expect(textareaElement).not.toHaveAttribute('readOnly')
     expect(textareaElement).not.toHaveAttribute('disabled')
     expect(textareaElement).not.toHaveAttribute('placeholder')
     expect(textareaElement).not.toHaveAttribute('maxRows')
+    expect(textareaElement).not.toHaveAttribute('minRows')
   })
 
   it('placeholder가 주입되었을 때 주입되는 값과 동일한 "placeholder"를 가져야 한다', () => {
@@ -44,8 +49,42 @@ describe('TextArea 테스트 >', () => {
     expect(textareaElement).toHaveAttribute('placeholder', PLACEHOLDER_TEXT)
   })
 
+  it('disabled 나 readOnly prop이 주입되었을 때 주입되는 attribute를 가져야 한다', () => {
+    const { getByTestId } = renderComponent({ disabled: true, readOnly: true })
+    const rendered = getByTestId(TEXT_AREA_TEST_ID)
+    const textareaElement = rendered.getElementsByTagName('textarea')[0]
+    expect(textareaElement).toHaveAttribute('readOnly')
+    expect(textareaElement).toHaveAttribute('disabled')
+  })
+
+  it('disabled prop이 주입되었을 때는 root wrapper의 opacity가 0.4이어야 한다', () => {
+    const { getByTestId } = renderComponent({ disabled: true })
+    const rendered = getByTestId(TEXT_AREA_TEST_ID)
+    expect(rendered).toHaveStyle(`opacity: ${disabledOpacity}`)
+  })
+
+  it('focus 상태일 때는 그에 맞는 shadow 스타일을 가져야 한다', () => {
+    const onFocus = jest.fn()
+    const { getByTestId } = renderComponent({ onFocus })
+    const rendered = getByTestId(TEXT_AREA_TEST_ID)
+    const textareaElement = rendered.getElementsByTagName('textarea')[0]
+    textareaElement.focus()
+
+    jest.advanceTimersByTime(1000)
+    expect(rendered).toHaveStyle(`box-shadow: 0 0 0 3px ${Palette.blue400_20}, inset 0 0 0 1px ${Palette.blue400}`)
+  })
+
+  it('error 상태일 때는 그에 맞는 shadow 스타일을 가져야 한다', () => {
+    const onFocus = jest.fn()
+    const { getByTestId } = renderComponent({ onFocus, hasError: true })
+    const rendered = getByTestId(TEXT_AREA_TEST_ID)
+
+    jest.advanceTimersByTime(1000)
+    expect(rendered).toHaveStyle(`box-shadow: 0 0 0 3px ${Palette.orange400_20}, inset 0 0 0 1px ${Palette.orange400}`)
+  })
+
   describe('onFocus 테스트 >', () => {
-    it('readOnly 이면 onFocus 가 안 불려야 한다', () => {
+    it('readOnly가 주입됐다면 onFocus 가 안 불려야 한다', () => {
       const onFocus = jest.fn()
       const { getByTestId } = renderComponent({ onFocus, readOnly: true })
       const rendered = getByTestId(TEXT_AREA_TEST_ID)
@@ -55,7 +94,27 @@ describe('TextArea 테스트 >', () => {
       expect(onFocus).not.toBeCalled()
     })
 
-    it('readOnly 가 주입되지 않았다면 onFocus는 불려야 한다', () => {
+    it('disabled가 주입됐다면 onFocus 가 안 불려야 한다', () => {
+      const onFocus = jest.fn()
+      const { getByTestId } = renderComponent({ onFocus, disabled: true })
+      const rendered = getByTestId(TEXT_AREA_TEST_ID)
+      const textareaElement = rendered.getElementsByTagName('textarea')[0]
+      textareaElement.focus()
+
+      expect(onFocus).not.toBeCalled()
+    })
+
+    it('disabled, readOnly가 주입됐다면 onFocus 가 안 불려야 한다', () => {
+      const onFocus = jest.fn()
+      const { getByTestId } = renderComponent({ onFocus, disabled: true, readOnly: true })
+      const rendered = getByTestId(TEXT_AREA_TEST_ID)
+      const textareaElement = rendered.getElementsByTagName('textarea')[0]
+      textareaElement.focus()
+
+      expect(onFocus).not.toBeCalled()
+    })
+
+    it('readOnly, disabled 가 주입되지 않았다면 onFocus는 불려야 한다', () => {
       const onFocus = jest.fn()
       const { getByTestId } = renderComponent({ onFocus })
       const rendered = getByTestId(TEXT_AREA_TEST_ID)

--- a/src/components/Input/TextArea/TextArea.tsx
+++ b/src/components/Input/TextArea/TextArea.tsx
@@ -27,6 +27,7 @@ function TextArea(
     wrapperStyle,
     testId = TEXT_AREA_TEST_ID,
     autoFocus = false,
+    disabled = false,
     readOnly = false,
     value = '',
     hasError = false,
@@ -41,6 +42,8 @@ function TextArea(
 ) {
   const inputRef = useRef<HTMLTextAreaElement | null>(null)
   const mergedInputRef = useMergeRefs<HTMLTextAreaElement>(inputRef, forwardedRef)
+
+  const activeInput = !disabled && !readOnly
 
   const [focused, setFocused] = useState(false)
 
@@ -57,12 +60,12 @@ function TextArea(
   ])
 
   const handleFocus = useCallback((event: React.FocusEvent<HTMLTextAreaElement>) => {
-    if (readOnly) { return }
+    if (!activeInput) { return }
     setFocused(true)
     onFocus?.(event)
   }, [
     onFocus,
-    readOnly,
+    activeInput,
   ])
 
   const handleBlur = useCallback((event: React.FocusEvent<HTMLTextAreaElement>) => {
@@ -89,12 +92,14 @@ function TextArea(
       interpolation={interpolation}
       focused={focused}
       hasError={hasError}
+      disabled={disabled}
       bgColor={bgColorSemanticName}
       data-testid={testId}
     >
       <Styled.TextAreaAutoSizeBase
         ref={mergedInputRef}
         value={value}
+        disabled={disabled}
         readOnly={readOnly}
         maxRows={maxRows}
         minRows={minRows}

--- a/src/components/Input/TextArea/TextArea.tsx
+++ b/src/components/Input/TextArea/TextArea.tsx
@@ -13,7 +13,7 @@ import React, {
 import useMergeRefs from '../../../hooks/useMergeRefs'
 import Styled from './TextArea.styled'
 import { getTextAreaBgColorSemanticName } from './utils'
-import TextAreaProps, { TextAreaSize, MIN_ROWS } from './TextArea.types'
+import TextAreaProps, { TextAreaHeight } from './TextArea.types'
 
 export const TEXT_AREA_TEST_ID = 'bezier-react-text-area'
 
@@ -30,7 +30,8 @@ function TextArea(
     readOnly = false,
     value = '',
     hasError = false,
-    size = TextAreaSize.S,
+    minRows = TextAreaHeight.Row6,
+    maxRows = TextAreaHeight.Row6,
     onFocus,
     onBlur,
     onChange,
@@ -95,8 +96,8 @@ function TextArea(
         ref={mergedInputRef}
         value={value}
         readOnly={readOnly}
-        maxRows={size}
-        minRows={MIN_ROWS}
+        maxRows={maxRows}
+        minRows={minRows}
         onChange={onChange}
         onFocus={handleFocus}
         onBlur={handleBlur}

--- a/src/components/Input/TextArea/TextArea.types.ts
+++ b/src/components/Input/TextArea/TextArea.types.ts
@@ -5,12 +5,13 @@ import React, { CSSProperties } from 'react'
 import { UIComponentProps } from '../../../types/ComponentProps'
 import InjectedInterpolation from '../../../types/InjectedInterpolation'
 
-export const MIN_ROWS = 5
-
-export enum TextAreaSize {
-  S = 10,
-  M = 17,
-  L = 29,
+export enum TextAreaHeight {
+  Row3 = 3,
+  Row6 = 6,
+  Row10 = 10,
+  Row16 = 16,
+  Row24 = 24,
+  Row36 = 36,
 }
 
 type TextAreaChangeEventHandler = React.ChangeEventHandler<HTMLTextAreaElement>
@@ -22,7 +23,8 @@ export default interface TextAreaProps extends UIComponentProps, React.TextareaH
   autoFocus?: boolean
   value?: string
   hasError?: boolean
-  size?: TextAreaSize
+  minRows?: TextAreaHeight
+  maxRows?: TextAreaHeight
   height?: number
   onFocus?: TextAreaChangeEventHandler
   onBlur?: TextAreaChangeEventHandler

--- a/src/components/Input/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/Input/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`TextArea 테스트 > SnapShot 테스트 > 1`] = `
   width: 100%;
   padding: 8px 12px;
   margin: 0;
+  cursor: auto;
   resize: none;
   background: none;
   border: none;

--- a/src/components/Input/TextArea/index.ts
+++ b/src/components/Input/TextArea/index.ts
@@ -1,5 +1,5 @@
 /* Internal dependencies */
-import TextAreaProps, { TextAreaSize } from './TextArea.types'
+import TextAreaProps, { TextAreaHeight } from './TextArea.types'
 import TextArea from './TextArea'
 
 export type {
@@ -8,5 +8,5 @@ export type {
 
 export {
   TextArea,
-  TextAreaSize,
+  TextAreaHeight,
 }

--- a/src/components/Input/TextField/TextField.styled.ts
+++ b/src/components/Input/TextField/TextField.styled.ts
@@ -30,6 +30,8 @@ const Input = styled.input<WithInterpolation>`
 
   color: ${({ foundation }) => foundation?.theme?.['txt-black-darkest']};
 
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'auto')};
+
   background-color: transparent;
   border: none;
   outline: none;


### PR DESCRIPTION
# Description
- https://desk.channel.io/root/groups/Bezier-62019/618cee9cba2ca222938a 의 논의에 따라서 minRows와 maxRows 옵션을 TextArea에 추가합니다.
  - 이에 따라 size option을 삭제합니다
- TextField에는 있었고 TextArea에는 없었던 disabled 옵션을 추가합니다

## Changes Detail
- minRows, maxRows 추가
- TextAreaHeight enum 추가
- size prop 삭제
- disabled 옵션 추가

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [x] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
