### PR TITLE
fix(banner): correct Banner link text style

### DIFF
--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -35,6 +35,7 @@ describe('Banner >', () => {
     expect(bannerLink.tagName).toBe('A')
     expect(bannerLink.children.item(0)).toHaveStyle('text-decoration: underline;')
     expect(bannerLink.children.item(0)).toHaveStyle('font-weight: bold;')
+    expect(bannerLink.children.item(0)).toHaveStyle('font-size: 14px;')
   })
 
   it('does not render dismiss button if dismissible = false', () => {

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -53,6 +53,7 @@ function Link({
   return renderLink({
     content: (
       <Styled.Link
+        typo={Typography.Size14}
         color={TEXT_COLORS[colorVariant]}
         bold
       >


### PR DESCRIPTION
# Description

배너의 링크 텍스트의 typography가 잘못 설정된 부분을 수정합니다. (15 -> 14)

## Changes Detail

| AS-IS | TO-BE |
| -- | -- |
| <img width="331" alt="스크린샷 2021-11-18 오후 1 15 01" src="https://user-images.githubusercontent.com/25701854/142351484-e3301004-236f-4d87-b46c-20f4d7e1cfe8.png"> | <img width="314" alt="스크린샷 2021-11-18 오후 1 15 45" src="https://user-images.githubusercontent.com/25701854/142351506-a210e5e1-eec2-47ff-92d5-ae968af61235.png"> |

# Tests
- [x] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
