### PR TITLE
fix(segmentedcontrol): correct disabled style

### DIFF
--- a/src/components/SegmentedControl/SegmentedControl.styled.ts
+++ b/src/components/SegmentedControl/SegmentedControl.styled.ts
@@ -1,10 +1,12 @@
 /* Internal dependencies */
 import { styled, Transition } from '../../foundation'
+import disabledOpacity from '../../constants/DisabledOpacity'
 import { UIComponentProps } from '../../types/ComponentProps'
 import { toLength } from '../../utils/styleUtils'
 import { SegmentedControlItemProps } from './SegmentedControl.types'
 
 interface StyledWrapperProps extends UIComponentProps {
+  disabled?: boolean
   wrapperWidth: number | string
   wrapperHeight: number | string
 }
@@ -25,6 +27,9 @@ export const Wrapper = styled.div<StyledWrapperProps>`
   line-height: 18px;
   background-color: ${props => props.foundation?.theme?.['bg-black-lighter']};
   border-radius: 8px;
+  ${({ disabled }) => disabled && `
+    opacity: ${disabledOpacity};
+  `}
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS('background-color')};
 `
 
@@ -40,14 +45,11 @@ export const OptionItemWrapper = styled.div<StyledOptionItemWrapperProps>`
   font-size: inherit;
   font-weight: inherit;
   line-height: inherit;
-  color: ${props => {
-    if (props.disabled) {
-      return props.foundation?.theme?.['txt-black-light']
-    }
-    return props.active
+  color: ${props => (
+    props.active
       ? props.foundation?.theme?.['txt-black-darkest']
       : props.foundation?.theme?.['txt-black-dark']
-  }};
+  )};
   cursor: ${props => {
     if (props.disabled) { return 'not-allowed' }
     if (props.active) { return 'auto' }

--- a/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -4,6 +4,7 @@ import { range } from 'lodash-es'
 
 /* Internal dependencies */
 import ResizeObserver from '../../__mocks__/ResizeObserver'
+import disabledOpacity from '../../constants/DisabledOpacity'
 import { render } from '../../utils/testUtils'
 import { Text } from '../Text'
 import SegmentedControl, { SEGMENTED_CONTROL_TEST_ID } from './SegmentedControl'
@@ -36,5 +37,12 @@ describe('SegmentedControl', () => {
     const rendered = getByTestId(SEGMENTED_CONTROL_TEST_ID)
 
     expect(rendered).toMatchSnapshot()
+  })
+
+  it('should have correct disabled style', () => {
+    const { getByTestId } = renderComponent({ disabled: true })
+    const rendered = getByTestId(SEGMENTED_CONTROL_TEST_ID)
+
+    expect(rendered).toHaveStyle(`opacity: ${disabledOpacity};`)
   })
 })

--- a/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -5,9 +5,13 @@ import { range } from 'lodash-es'
 /* Internal dependencies */
 import ResizeObserver from '../../__mocks__/ResizeObserver'
 import disabledOpacity from '../../constants/DisabledOpacity'
+import { LightFoundation } from '../../foundation'
 import { render } from '../../utils/testUtils'
 import { Text } from '../Text'
-import SegmentedControl, { SEGMENTED_CONTROL_TEST_ID } from './SegmentedControl'
+import SegmentedControl, {
+  SEGMENTED_CONTROL_TEST_ID,
+  segmentedControlOptionItemTestId,
+} from './SegmentedControl'
 import type SegmentedControlProps from './SegmentedControl.types'
 
 describe('SegmentedControl', () => {
@@ -39,10 +43,30 @@ describe('SegmentedControl', () => {
     expect(rendered).toMatchSnapshot()
   })
 
+  it('has active and non-active items with correct style', () => {
+    const { getByTestId } = renderComponent({ selectedOptionIndex: 1 })
+
+    const firstItem = getByTestId(segmentedControlOptionItemTestId(0))
+    const secondItem = getByTestId(segmentedControlOptionItemTestId(1))
+
+    expect(firstItem).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']};`)
+    expect(secondItem).toHaveStyle(`color: ${LightFoundation.theme['txt-black-darkest']};`)
+  })
+
   it('should have correct disabled style', () => {
     const { getByTestId } = renderComponent({ disabled: true })
     const rendered = getByTestId(SEGMENTED_CONTROL_TEST_ID)
 
     expect(rendered).toHaveStyle(`opacity: ${disabledOpacity};`)
+  })
+
+  it('has active and non-active items with correct style, even if disabled', () => {
+    const { getByTestId } = renderComponent({ disabled: true, selectedOptionIndex: 1 })
+
+    const firstItem = getByTestId(segmentedControlOptionItemTestId(0))
+    const secondItem = getByTestId(segmentedControlOptionItemTestId(1))
+
+    expect(firstItem).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']};`)
+    expect(secondItem).toHaveStyle(`color: ${LightFoundation.theme['txt-black-darkest']};`)
   })
 })

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -10,6 +10,9 @@ import SegmentedControlProps from './SegmentedControl.types'
 import { Wrapper, OptionItemWrapper, Indicator, IndicatorBox } from './SegmentedControl.styled'
 
 export const SEGMENTED_CONTROL_TEST_ID = 'bezier-react-segmented-control'
+const SEGMENTED_CONTROL_OPTION_ITEM_TEST_ID_PREFIX = 'bezier-react-segmented-control-option-item'
+export const segmentedControlOptionItemTestId = (index: number) =>
+  [SEGMENTED_CONTROL_OPTION_ITEM_TEST_ID_PREFIX, index.toString()].join('-')
 
 function SegmentedControl(
   {
@@ -56,6 +59,7 @@ function SegmentedControl(
   const renderOption = useCallback((Element: React.ReactNode, index: number) => (
     <OptionItemWrapper
       key={uuid()}
+      data-testid={segmentedControlOptionItemTestId(index)}
       disabled={disabled}
       active={index === currentIndex}
       style={{

--- a/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -191,6 +191,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   </div>
   <div
     class="c3"
+    data-testid="bezier-react-segmented-control-option-item-0"
     style="width: 0px; height: 0px; left: 0px;"
   >
     <span
@@ -202,6 +203,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   </div>
   <div
     class="c5"
+    data-testid="bezier-react-segmented-control-option-item-1"
     style="width: 0px; height: 0px; left: 0px;"
   >
     <span
@@ -213,6 +215,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   </div>
   <div
     class="c3"
+    data-testid="bezier-react-segmented-control-option-item-2"
     style="width: 0px; height: 0px; left: 0px;"
   >
     <span
@@ -224,6 +227,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   </div>
   <div
     class="c3"
+    data-testid="bezier-react-segmented-control-option-item-3"
     style="width: 0px; height: 0px; left: 0px;"
   >
     <span


### PR DESCRIPTION
# Description

SegmentedControl 컴포넌트가 disable = true prop을 받았을 때 잘못된 스타일을 수정합니다.

## Changes Detail

| AS-IS | TO-BE |
| -- | -- |
| <img width="430" alt="스크린샷 2021-11-18 오후 1 43 57" src="https://user-images.githubusercontent.com/25701854/142353304-308606af-42f3-4855-9936-a51bda63a115.png"> | <img width="433" alt="스크린샷 2021-11-18 오후 1 43 46" src="https://user-images.githubusercontent.com/25701854/142353303-9a951977-7902-4489-893f-70df838db0ea.png"> |

- 기존 구현에서 disable = true일 때 텍스트 색상을 txt-black-light로 했는데, 해당 색상이 LightTheme에 정의가 되어있지 않아 default color로 표시됨
- disable일 때 텍스트 색상만 바꾸는 것은 스펙에 맞지 않아, opacity를 조정하도록 올바르게 변경

# Tests
- [x] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
