### PR TITLE
refactor(input.type): TextField와 TextArea 타입에서 disabled, readOnly를 명시하고 타입을 중요도 순서로 정리

### DIFF
--- a/src/components/Input/TextArea/TextArea.types.ts
+++ b/src/components/Input/TextArea/TextArea.types.ts
@@ -15,15 +15,16 @@ export enum TextAreaSize {
 
 type TextAreaChangeEventHandler = React.ChangeEventHandler<HTMLTextAreaElement>
 
-export default interface TextAreaProps extends UIComponentProps, React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+export default interface TextAreaProps
+  extends UIComponentProps, Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'readOnly' | 'disabled'> {
+  size?: TextAreaSize
+  autoFocus?: boolean
+  hasError?: boolean
+  readOnly?: boolean
+  disabled?: boolean
   wrapperInterpolation?: InjectedInterpolation
   wrapperStyle?: CSSProperties
   wrapperClassName?: string
-  autoFocus?: boolean
-  value?: string
-  hasError?: boolean
-  size?: TextAreaSize
-  height?: number
   onFocus?: TextAreaChangeEventHandler
   onBlur?: TextAreaChangeEventHandler
   onChange?: TextAreaChangeEventHandler

--- a/src/components/Input/TextField/TextField.types.ts
+++ b/src/components/Input/TextField/TextField.types.ts
@@ -50,15 +50,17 @@ export interface TextFieldRef {
 }
 
 export interface TextFieldProps
-  extends UIComponentProps, Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  extends UIComponentProps, Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'readOnly' | 'disabled'> {
+  leftContent?: TextFieldItemProps
+  rightContent?: TextFieldItemProps | TextFieldItemProps[]
   variant?: TextFieldVariant
   type?: TextFieldType
   hasError?: boolean
+  readOnly?: boolean
+  disabled?: boolean
   allowClear?: boolean
   selectAllOnInit?: boolean
   selectAllOnFocus?: boolean
-  leftContent?: TextFieldItemProps
-  rightContent?: TextFieldItemProps | TextFieldItemProps[]
   withoutLeftContentWrapper?: boolean
   withoutRightContentWrapper?: boolean
   inputClassName?: string


### PR DESCRIPTION
# Description
TextField와 TextArea는 `React.TextareaHTMLAttributes<HTMLTextAreaElement>`, `React.InputHTMLAttributes<HTMLInputElement>` 타입을 extend하고 있습니다.
HTMLInputElement, HTMLTextAreaElement 모두 readOnly와 disabled를 가지고 있지만 해당 타입 파일에 명시되어 있지 않아서 해당 프롭이 있는 것을 잘 인지하지 못하는 문제가 있어서 이를 명시하고 각 프롭의 순서를 정리했습니다

# Tests
- [ ] Jest 테스트 코드 작성 완료
- [ ] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* 이슈 없음.
