### PR TITLE
ci(circle): change coverage report file to lcov.info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       - *attach_workspace
       - run: npm run jest
       - codecov/upload:
-          file: './coverage/clover.xml'
+          file: './coverage/lcov.info'
           token: $CODECOV_TOKEN
 
   release:


### PR DESCRIPTION
# Description

code coverage 관리를 위해 사용하는 codecov integration에 관한 수정입니다.

현재 codecov에서는 clover.xml 파일을 coverage report로 보고 있는데요, 이 report에서는 branch에 따라 coverage가 잘 판정되지 않아 fully covered line이 partially covered line으로 판정되는 오류가 있습니다. 관련 사례는 Changes Detail 섹션을 참조해주세요.

관련하여 조사해본 결과 facebook/jest#10262 에서 논의된 내용을 보면 clover가 자기쪽 진영의 라이브러리가 아니라서 잘 모르고, maintaining되지 않는 것 같다며 lcov를 사용할 것을 권장하고 있었습니다.

## Changes Detail

[관련 스레드](https://desk.channel.io/root/groups/Web-18500/6154091867fe3e9f17fe) 요약입니다.

#587 의 케이스

### clover.xml

(테스트 추가 전 - L68의 브랜치)

truecount = 3, falsecount = 1 → fully covered로 판정됨

(테스트 추가 후 - L75의 브랜치)

truecount = 4, falsecount = 0 → partially covered로 판정됨

![image](https://user-images.githubusercontent.com/25701854/142820884-6f26e610-5800-4fd7-aa98-f1cd3065a9db.png)
![image](https://user-images.githubusercontent.com/25701854/142820897-b254770b-ede7-4f15-89b0-61163161c5da.png)


### lcov.info

(테스트 추가 전 - L68 의 브랜치)

```
BRDA: 68,2,0,0 // L68의 2번 분기, if가 0번 실행
BRDA: 68,2,1,2 // L68의 2번 분기, else가 2번 실행
BRDA: 68,3,0,2 // L68의 3번 분기, if가 2번 실행
BRDA: 68,3,1,2 // L68의 3번 분기, else가 2번 실행
```

(테스트 추가 후 - L75 의 브랜치 **같은 브랜치임)

```
BRDA: 75,3,0,1  // L75의 3번 분기, if가 1번 실행
BRDA: 75,3,1,14 // L75의 3번 분기, else가 14번 실행
BRDA: 75,4,0,15 // L75의 4번 분기, if가 15번 실행
BRDA: 75,4,1,14 // L75의 4번 분기, else가 14번 실행
```

![image](https://user-images.githubusercontent.com/25701854/142820909-470eb2be-fbad-4b10-8d6c-3a2e1f31353c.png)
![image](https://user-images.githubusercontent.com/25701854/142820916-0fbad196-f9ff-44ca-b66e-759aef15c01b.png)


# Tests

해당사항 없음.

## Browser Compatibility

해당사항 없음.

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
- https://github.com/facebook/jest/issues/10262