### PR TITLE
Add Divider Component

### DIFF
--- a/src/components/Divider/Divider.stories.tsx
+++ b/src/components/Divider/Divider.stories.tsx
@@ -6,6 +6,7 @@ import type { Story, Meta } from '@storybook/react'
 /* Internal dependencies */
 import { styled } from '../../foundation'
 import { getTitle } from '../../utils/storyUtils'
+import { ListItem } from '../ListItem'
 import Divider from './Divider'
 import DividerProps from './Divider.types'
 
@@ -22,7 +23,14 @@ export default {
   },
 } as Meta
 
-const Wrapper = styled.div`
+interface WrapperProps {
+  direction?: 'column' | 'row'
+}
+
+const Wrapper = styled.div<WrapperProps>`
+  display: flex;
+  justify-content: center;
+  flex-direction: ${({ direction = 'column' }) => direction};
   width: 200px;
   height: 200px;
 `
@@ -35,6 +43,23 @@ const Template: Story<DividerProps> = props => (
 
 export const Primary: Story<DividerProps> = Template.bind({})
 Primary.args = {
+  orientation: 'horizontal',
+  withoutSideIndent: false,
+}
+
+const CompositionTemplate: Story<DividerProps> = ({ orientation, ...rest }) => (
+  <Wrapper direction={orientation === 'horizontal' ? 'column' : 'row'}>
+    <ListItem content="Channel" />
+    <Divider
+      orientation={orientation}
+      {...rest}
+    />
+    <ListItem content="Bezier" />
+  </Wrapper>
+)
+
+export const Composition: Story<DividerProps> = CompositionTemplate.bind({})
+Composition.args = {
   orientation: 'horizontal',
   withoutSideIndent: false,
 }

--- a/src/components/Divider/Divider.stories.tsx
+++ b/src/components/Divider/Divider.stories.tsx
@@ -1,0 +1,40 @@
+/* External dependencies */
+import React from 'react'
+import base from 'paths.macro'
+import type { Story, Meta } from '@storybook/react'
+
+/* Internal dependencies */
+import { styled } from '../../foundation'
+import { getTitle } from '../../utils/storyUtils'
+import Divider from './Divider'
+import DividerProps from './Divider.types'
+
+export default {
+  title: getTitle(base),
+  component: Divider,
+  argTypes: {
+    orientation: {
+      control: {
+        type: 'radio',
+        options: ['horizontal', 'vertical'],
+      },
+    },
+  },
+} as Meta
+
+const Wrapper = styled.div`
+  width: 200px;
+  height: 200px;
+`
+
+const Template: Story<DividerProps> = props => (
+  <Wrapper>
+    <Divider {...props} />
+  </Wrapper>
+)
+
+export const Primary: Story<DividerProps> = Template.bind({})
+Primary.args = {
+  orientation: 'horizontal',
+  withoutSideIndent: false,
+}

--- a/src/components/Divider/Divider.styled.ts
+++ b/src/components/Divider/Divider.styled.ts
@@ -1,0 +1,37 @@
+/* Internal dependencies */
+import { styled, css } from '../../foundation'
+import { StyledDividerProps } from './Divider.types'
+
+const DIVIDER_THICKNESS = 1
+const DIVIDER_INDENT_SIZE = 6
+const DIVIDER_LENGTH_WITH_SIDE_INDENT = `calc(100% - ${DIVIDER_INDENT_SIZE * 2}px)`
+
+const BaseDivider = styled.hr<StyledDividerProps>`
+  box-sizing: content-box;
+  margin: ${DIVIDER_INDENT_SIZE}px;
+  border: 0;
+  border-color: ${({ foundation }) => foundation?.theme?.['bdr-black-light']};
+  border-style: solid;
+`
+
+export const HorizontalDivider = styled(BaseDivider)`
+  width: ${DIVIDER_LENGTH_WITH_SIDE_INDENT};
+  border-bottom-width: ${DIVIDER_THICKNESS}px;
+
+  ${({ withoutSideIndent }) => withoutSideIndent && css`
+      width: 100%;
+      margin-right: 0px;
+      margin-left: 0px;
+  `}
+`
+
+export const VerticalDivider = styled(BaseDivider)`
+  height: ${DIVIDER_LENGTH_WITH_SIDE_INDENT};
+  border-left-width: ${DIVIDER_THICKNESS}px;
+
+  ${({ withoutSideIndent }) => withoutSideIndent && css`
+      height: 100%;
+      margin-top: 0px;
+      margin-bottom: 0px;
+  `}
+`

--- a/src/components/Divider/Divider.styled.ts
+++ b/src/components/Divider/Divider.styled.ts
@@ -12,6 +12,8 @@ const BaseDivider = styled.hr<StyledDividerProps>`
   border: 0;
   border-color: ${({ foundation }) => foundation?.theme?.['bdr-black-light']};
   border-style: solid;
+
+  ${({ interpolation }) => interpolation}
 `
 
 export const HorizontalDivider = styled(BaseDivider)`

--- a/src/components/Divider/Divider.test.tsx
+++ b/src/components/Divider/Divider.test.tsx
@@ -1,0 +1,75 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { render } from '../../utils/testUtils'
+import Divider, { DIVIDER_TEST_ID } from './Divider'
+import type DividerProps from './Divider.types'
+
+describe('Divider >', () => {
+  let props: DividerProps
+
+  beforeEach(() => {
+    props = {
+      orientation: 'horizontal',
+      withoutSideIndent: false,
+    }
+  })
+
+  const renderDivider = (otherProps?: Partial<DividerProps>) => render(<Divider {...props} {...otherProps} />)
+
+  it('Snapshot >', () => {
+    const { getByTestId } = renderDivider()
+    const divider = getByTestId(DIVIDER_TEST_ID)
+
+    expect(divider).toMatchSnapshot()
+  })
+
+  it('has reset css', () => {
+    const { getByTestId } = renderDivider()
+    const divider = getByTestId(DIVIDER_TEST_ID)
+
+    expect(divider).toHaveStyle('box-sizing: content-box')
+    expect(divider).toHaveStyle('border: 0')
+    expect(divider).toHaveStyle('border-style: solid')
+  })
+
+  it('has margin', () => {
+    const { getByTestId } = renderDivider()
+    const divider = getByTestId(DIVIDER_TEST_ID)
+
+    expect(divider).toHaveStyle('margin: 6px')
+  })
+
+  it('renders horizontal divider with correct style', () => {
+    const { getByTestId } = renderDivider()
+    const divider = getByTestId(DIVIDER_TEST_ID)
+
+    expect(divider).toHaveStyle('width: calc(100% - 12px)')
+    expect(divider).toHaveStyle('border-bottom-width: 1px')
+  })
+
+  it('renders vertical divider with correct style', () => {
+    const { getByTestId } = renderDivider({ orientation: 'vertical' })
+    const divider = getByTestId(DIVIDER_TEST_ID)
+
+    expect(divider).toHaveStyle('height: calc(100% - 12px)')
+    expect(divider).toHaveStyle('border-left-width: 1px')
+  })
+
+  it('renders horizontal divider has not side indent when withoutSideIndent option is true', () => {
+    const { getByTestId } = renderDivider({ withoutSideIndent: true })
+    const divider = getByTestId(DIVIDER_TEST_ID)
+
+    expect(divider).toHaveStyle('margin-right: 0px')
+    expect(divider).toHaveStyle('margin-left: 0px')
+  })
+
+  it('renders vertical divider has not side indent when withoutSideIndent option is true', () => {
+    const { getByTestId } = renderDivider({ orientation: 'vertical', withoutSideIndent: true })
+    const divider = getByTestId(DIVIDER_TEST_ID)
+
+    expect(divider).toHaveStyle('margin-top: 0px')
+    expect(divider).toHaveStyle('margin-bottom: 0px')
+  })
+})

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React from 'react'
+import React, { forwardRef } from 'react'
 
 /* Internal dependencies */
 import DividerProps from './Divider.types'
@@ -8,16 +8,23 @@ import * as Styled from './Divider.styled'
 export const DIVIDER_TEST_ID = 'bezier-react-divider'
 
 function Divider({
+  as,
+  testId = DIVIDER_TEST_ID,
   orientation = 'horizontal',
   withoutSideIndent = false,
-  testId = DIVIDER_TEST_ID,
-}: DividerProps) {
+  ...rest
+}: DividerProps,
+forwardedRef: React.Ref<HTMLHRElement>,
+) {
   const DividerComponent = orientation === 'horizontal'
     ? Styled.HorizontalDivider
     : Styled.VerticalDivider
 
   return (
     <DividerComponent
+      {...rest}
+      forwardedAs={as}
+      ref={forwardedRef}
       data-testid={testId}
       aria-orientation={orientation}
       withoutSideIndent={withoutSideIndent}
@@ -25,4 +32,4 @@ function Divider({
   )
 }
 
-export default Divider
+export default forwardRef(Divider)

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,0 +1,28 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import DividerProps from './Divider.types'
+import * as Styled from './Divider.styled'
+
+const DIVIDER_TEST_ID = 'bezier-react-divider'
+
+function Divider({
+  orientation = 'horizontal',
+  withoutSideIndent = false,
+  testId = DIVIDER_TEST_ID,
+}: DividerProps) {
+  const DividerComponent = orientation === 'horizontal'
+    ? Styled.HorizontalDivider
+    : Styled.VerticalDivider
+
+  return (
+    <DividerComponent
+      data-testid={testId}
+      aria-orientation={orientation}
+      withoutSideIndent={withoutSideIndent}
+    />
+  )
+}
+
+export default Divider

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import DividerProps from './Divider.types'
 import * as Styled from './Divider.styled'
 
-const DIVIDER_TEST_ID = 'bezier-react-divider'
+export const DIVIDER_TEST_ID = 'bezier-react-divider'
 
 function Divider({
   orientation = 'horizontal',

--- a/src/components/Divider/Divider.types.ts
+++ b/src/components/Divider/Divider.types.ts
@@ -1,0 +1,9 @@
+/* Internal dependencies */
+import { UIComponentProps } from '../../types/ComponentProps'
+
+export default interface DividerProps extends UIComponentProps {
+  orientation: 'horizontal' | 'vertical'
+  withoutSideIndent?: boolean
+}
+
+export interface StyledDividerProps extends Pick<DividerProps, 'withoutSideIndent'> {}

--- a/src/components/Divider/Divider.types.ts
+++ b/src/components/Divider/Divider.types.ts
@@ -6,4 +6,4 @@ export default interface DividerProps extends UIComponentProps {
   withoutSideIndent?: boolean
 }
 
-export interface StyledDividerProps extends Pick<DividerProps, 'withoutSideIndent'> {}
+export interface StyledDividerProps extends Pick<DividerProps, 'withoutSideIndent' | 'interpolation'> {}

--- a/src/components/Divider/__snapshots__/Divider.test.tsx.snap
+++ b/src/components/Divider/__snapshots__/Divider.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Divider > Snapshot > 1`] = `
+.c0 {
+  box-sizing: content-box;
+  margin: 6px;
+  border: 0;
+  border-color: #00000014;
+  border-style: solid;
+}
+
+.c1 {
+  width: calc(100% - 12px);
+  border-bottom-width: 1px;
+}
+
+<hr
+  aria-orientation="horizontal"
+  class="c0 c1"
+  data-testid="bezier-react-divider"
+/>
+`;

--- a/src/components/Divider/index.ts
+++ b/src/components/Divider/index.ts
@@ -1,0 +1,2 @@
+export { default as Divider } from './Divider'
+export type { default as DividerProps } from './Divider.types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from './foundation'
 /* Components */
 export * from './components/Banner'
 export * from './components/Button'
+export * from './components/Divider'
 export * from './components/Icon'
 export * from './components/Switch'
 export * from './components/Text'


### PR DESCRIPTION
# Description

[Divider 컴포넌트](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=3263%3A0)를 추가합니다. 
Divider는 가로 혹은 세로로 그려질 수 있습니다. 기본적으로 사방에 마진을 가지나, 축 양쪽에 마진이 없을 수 있습니다.

## Changes Detail

- 스토리북 추가
- 테스트코드 추가

# Tests
- [x] Jest 테스트 코드 작성 완료
- [x] Storybook 작성 완료

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# (Option) Issues
(연관된 PR이나 Task / 특정 시점까지 머지하면 안됨 / 번역 추가 필요 / ...)
* Close #126 
