### PR TITLE
Add FormHelperText Component

### DIFF
--- a/src/components/FormHelperText/FormHelperText.stories.tsx
+++ b/src/components/FormHelperText/FormHelperText.stories.tsx
@@ -1,0 +1,23 @@
+/* External dependencies */
+import React from 'react'
+import base from 'paths.macro'
+import type { Story, Meta } from '@storybook/react'
+
+/* Internal dependencies */
+import { getTitle } from '../../utils/storyUtils'
+import FormHelperText from './FormHelperText'
+import FormHelperTextProps from './FormHelperText.types'
+
+export default {
+  title: getTitle(base),
+  component: FormHelperText,
+} as Meta
+
+const Template: Story<FormHelperTextProps> = props => <FormHelperText {...props} />
+
+export const Primary: Story<FormHelperTextProps> = Template.bind({})
+Primary.args = {
+  id: 'test',
+  description: 'Description',
+  errorMessage: '',
+}

--- a/src/components/FormHelperText/FormHelperText.stories.tsx
+++ b/src/components/FormHelperText/FormHelperText.stories.tsx
@@ -18,6 +18,6 @@ const Template: Story<FormHelperTextProps> = props => <FormHelperText {...props}
 export const Primary: Story<FormHelperTextProps> = Template.bind({})
 Primary.args = {
   id: 'test',
-  description: 'Description',
   errorMessage: '',
+  children: 'Description',
 }

--- a/src/components/FormHelperText/FormHelperText.stories.tsx
+++ b/src/components/FormHelperText/FormHelperText.stories.tsx
@@ -18,6 +18,6 @@ const Template: Story<FormHelperTextProps> = props => <FormHelperText {...props}
 export const Primary: Story<FormHelperTextProps> = Template.bind({})
 Primary.args = {
   id: 'test',
-  errorMessage: '',
+  hasError: false,
   children: 'Description',
 }

--- a/src/components/FormHelperText/FormHelperText.styled.ts
+++ b/src/components/FormHelperText/FormHelperText.styled.ts
@@ -1,0 +1,9 @@
+/* Internal dependencies */
+import { styled } from '../../foundation'
+
+/* Internal dependencies */
+import { Text } from '../Text'
+
+export const HelperText = styled(Text)`
+  padding: 0 2px;
+`

--- a/src/components/FormHelperText/FormHelperText.styled.ts
+++ b/src/components/FormHelperText/FormHelperText.styled.ts
@@ -1,7 +1,5 @@
 /* Internal dependencies */
 import { styled } from '../../foundation'
-
-/* Internal dependencies */
 import { Text } from '../Text'
 
 export const HelperText = styled(Text)`

--- a/src/components/FormHelperText/FormHelperText.test.tsx
+++ b/src/components/FormHelperText/FormHelperText.test.tsx
@@ -16,7 +16,7 @@ describe('FormHelperText >', () => {
   beforeEach(() => {
     props = {
       id: 'test',
-      description,
+      children: description,
       errorMessage: '',
     }
   })
@@ -69,7 +69,7 @@ describe('FormHelperText >', () => {
   })
 
   it('renders nothing when description and errorMessage prop is empty', () => {
-    const { queryByTestId } = renderFormHelperText({ description: '', errorMessage: '' })
+    const { queryByTestId } = renderFormHelperText({ children: '', errorMessage: '' })
     const helperText = queryByTestId(FORM_HELPER_TEXT_TEST_ID)
 
     expect(helperText).toBeNull()

--- a/src/components/FormHelperText/FormHelperText.test.tsx
+++ b/src/components/FormHelperText/FormHelperText.test.tsx
@@ -1,6 +1,5 @@
 /* External dependencies */
 import React from 'react'
-import { within } from '@testing-library/dom'
 
 /* Internal dependencies */
 import { LightFoundation } from '../../foundation'
@@ -10,14 +9,13 @@ import type FormHelperTextProps from './FormHelperText.types'
 
 describe('FormHelperText >', () => {
   let props: FormHelperTextProps
-  const description = 'Description'
-  const errorMessage = 'Error'
+  const text = 'Lorem ipsum'
 
   beforeEach(() => {
     props = {
       id: 'test',
-      children: description,
-      errorMessage: '',
+      hasError: false,
+      children: text,
     }
   })
 
@@ -45,31 +43,22 @@ describe('FormHelperText >', () => {
     expect(helperText).toHaveStyle('margin-top: 4px')
   })
 
-  it('renders description with correct style when description prop is not empty and errorMessage prop is empty', () => {
+  it('renders text with correct style when children prop is not empty', () => {
     const { getByTestId } = renderFormHelperText()
     const helperText = getByTestId(FORM_HELPER_TEXT_TEST_ID)
 
     expect(helperText).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']}`)
-
-    const { getByText } = within(helperText)
-
-    expect(getByText(description)).toBeInTheDocument()
   })
 
-  it('renders errorMessage with correct style when errorMessage prop is not empty', () => {
-    const { getByTestId } = renderFormHelperText({ errorMessage })
+  it('renders error style text with correct style when hasError prop is true', () => {
+    const { getByTestId } = renderFormHelperText({ hasError: true })
     const helperText = getByTestId(FORM_HELPER_TEXT_TEST_ID)
 
     expect(helperText).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-orange-normal']}`)
-
-    const { queryByText } = within(helperText)
-
-    expect(queryByText(description)).not.toBeInTheDocument()
-    expect(queryByText(errorMessage)).toBeInTheDocument()
   })
 
-  it('renders nothing when description and errorMessage prop is empty', () => {
-    const { queryByTestId } = renderFormHelperText({ children: '', errorMessage: '' })
+  it('renders nothing when children prop is empty', () => {
+    const { queryByTestId } = renderFormHelperText({ children: '' })
     const helperText = queryByTestId(FORM_HELPER_TEXT_TEST_ID)
 
     expect(helperText).toBeNull()

--- a/src/components/FormHelperText/FormHelperText.test.tsx
+++ b/src/components/FormHelperText/FormHelperText.test.tsx
@@ -8,7 +8,7 @@ import { render } from '../../utils/testUtils'
 import FormHelperText, { FORM_HELPER_TEXT_TEST_ID } from './FormHelperText'
 import type FormHelperTextProps from './FormHelperText.types'
 
-describe('Divider >', () => {
+describe('FormHelperText >', () => {
   let props: FormHelperTextProps
   const description = 'Description'
   const errorMessage = 'Error'

--- a/src/components/FormHelperText/FormHelperText.test.tsx
+++ b/src/components/FormHelperText/FormHelperText.test.tsx
@@ -1,0 +1,77 @@
+/* External dependencies */
+import React from 'react'
+import { within } from '@testing-library/dom'
+
+/* Internal dependencies */
+import { LightFoundation } from '../../foundation'
+import { render } from '../../utils/testUtils'
+import FormHelperText, { FORM_HELPER_TEXT_TEST_ID } from './FormHelperText'
+import type FormHelperTextProps from './FormHelperText.types'
+
+describe('Divider >', () => {
+  let props: FormHelperTextProps
+  const description = 'Description'
+  const errorMessage = 'Error'
+
+  beforeEach(() => {
+    props = {
+      id: 'test',
+      description,
+      errorMessage: '',
+    }
+  })
+
+  const renderFormHelperText = (otherProps?: Partial<FormHelperTextProps>) =>
+    render(<FormHelperText {...props} {...otherProps} />)
+
+  it('Snapshot >', () => {
+    const { getByTestId } = renderFormHelperText()
+    const helperText = getByTestId(FORM_HELPER_TEXT_TEST_ID)
+
+    expect(helperText).toMatchSnapshot()
+  })
+
+  it('has vertical padding', () => {
+    const { getByTestId } = renderFormHelperText()
+    const helperText = getByTestId(FORM_HELPER_TEXT_TEST_ID)
+
+    expect(helperText).toHaveStyle('padding: 0 2px')
+  })
+
+  it('has top margin', () => {
+    const { getByTestId } = renderFormHelperText()
+    const helperText = getByTestId(FORM_HELPER_TEXT_TEST_ID)
+
+    expect(helperText).toHaveStyle('margin-top: 4px')
+  })
+
+  it('renders description with correct style when description prop is not empty and errorMessage prop is empty', () => {
+    const { getByTestId } = renderFormHelperText()
+    const helperText = getByTestId(FORM_HELPER_TEXT_TEST_ID)
+
+    expect(helperText).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']}`)
+
+    const { getByText } = within(helperText)
+
+    expect(getByText(description)).toBeInTheDocument()
+  })
+
+  it('renders errorMessage with correct style when errorMessage prop is not empty', () => {
+    const { getByTestId } = renderFormHelperText({ errorMessage })
+    const helperText = getByTestId(FORM_HELPER_TEXT_TEST_ID)
+
+    expect(helperText).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-orange-normal']}`)
+
+    const { queryByText } = within(helperText)
+
+    expect(queryByText(description)).not.toBeInTheDocument()
+    expect(queryByText(errorMessage)).toBeInTheDocument()
+  })
+
+  it('renders nothing when description and errorMessage prop is empty', () => {
+    const { queryByTestId } = renderFormHelperText({ description: '', errorMessage: '' })
+    const helperText = queryByTestId(FORM_HELPER_TEXT_TEST_ID)
+
+    expect(helperText).toBeNull()
+  })
+})

--- a/src/components/FormHelperText/FormHelperText.tsx
+++ b/src/components/FormHelperText/FormHelperText.tsx
@@ -22,7 +22,7 @@ forwardedRef: React.Ref<HTMLParamElement>,
     color: SemanticNames
     content: React.ReactNode
   } | null>(() => {
-    if (!isNil(errorMessage) && !isEmpty(errorMessage)) {
+    if (!isEmpty(errorMessage)) {
       return {
         color: 'bgtxt-orange-normal',
         content: errorMessage,

--- a/src/components/FormHelperText/FormHelperText.tsx
+++ b/src/components/FormHelperText/FormHelperText.tsx
@@ -1,10 +1,9 @@
 /* External dependencies */
 import React, { forwardRef, useMemo } from 'react'
-import { isNil } from 'lodash-es'
+import { isNil, isEmpty } from 'lodash-es'
 
 /* Internal dependencies */
 import { Typography, SemanticNames } from '../../foundation'
-import { isNotEmptyString } from '../../utils/stringUtils'
 import type FormHelperTextProps from './FormHelperText.types'
 import * as Styled from './FormHelperText.styled'
 
@@ -13,32 +12,32 @@ export const FORM_HELPER_TEXT_TEST_ID = 'bezier-react-form-helper-text'
 function FormHelperText({
   id,
   testId = FORM_HELPER_TEXT_TEST_ID,
-  description,
   errorMessage,
+  children,
   ...rest
 }: FormHelperTextProps,
 forwardedRef: React.Ref<HTMLParamElement>,
 ) {
   const helperTextProps = useMemo<{
     color: SemanticNames
-    content: string
+    content: React.ReactNode
   } | null>(() => {
-    if (isNotEmptyString(errorMessage)) {
+    if (!isNil(errorMessage) && !isEmpty(errorMessage)) {
       return {
         color: 'bgtxt-orange-normal',
         content: errorMessage,
       }
     }
-    if (isNotEmptyString(description)) {
+    if (!isEmpty(children)) {
       return {
         color: 'txt-black-dark',
-        content: description,
+        content: children,
       }
     }
     return null
   }, [
     errorMessage,
-    description,
+    children,
   ])
 
   if (isNil(helperTextProps)) { return null }

--- a/src/components/FormHelperText/FormHelperText.tsx
+++ b/src/components/FormHelperText/FormHelperText.tsx
@@ -1,9 +1,10 @@
 /* External dependencies */
-import React, { forwardRef } from 'react'
-import { isEmpty } from 'lodash-es'
+import React, { forwardRef, useMemo } from 'react'
+import { isNil } from 'lodash-es'
 
 /* Internal dependencies */
-import { Typography } from '../../foundation'
+import { Typography, SemanticNames } from '../../foundation'
+import { isNotEmptyString } from '../../utils/stringUtils'
 import type FormHelperTextProps from './FormHelperText.types'
 import * as Styled from './FormHelperText.styled'
 
@@ -15,10 +16,31 @@ function FormHelperText({
 }: FormHelperTextProps,
 forwardedRef: React.Ref<HTMLParamElement>,
 ) {
-  const hasDescription = !isEmpty(description)
-  const hasError = !isEmpty(errorMessage)
+  const helperTextProps = useMemo<{
+    color: SemanticNames
+    content: string
+  } | null>(() => {
+    if (isNotEmptyString(errorMessage)) {
+      return {
+        color: 'bgtxt-orange-normal',
+        content: errorMessage,
+      }
+    }
+    if (isNotEmptyString(description)) {
+      return {
+        color: 'txt-black-dark',
+        content: description,
+      }
+    }
+    return null
+  }, [
+    errorMessage,
+    description,
+  ])
 
-  if (!hasDescription && !hasError) { return null }
+  if (isNil(helperTextProps)) { return null }
+
+  const { color, content } = helperTextProps
 
   return (
     <Styled.HelperText
@@ -28,9 +50,9 @@ forwardedRef: React.Ref<HTMLParamElement>,
       forwardedAs="p"
       marginTop={4}
       typo={Typography.Size13}
-      color={hasError ? 'bgtxt-orange-normal' : 'txt-black-dark'}
+      color={color}
     >
-      { hasError ? errorMessage : description }
+      { content }
     </Styled.HelperText>
   )
 }

--- a/src/components/FormHelperText/FormHelperText.tsx
+++ b/src/components/FormHelperText/FormHelperText.tsx
@@ -8,8 +8,11 @@ import { isNotEmptyString } from '../../utils/stringUtils'
 import type FormHelperTextProps from './FormHelperText.types'
 import * as Styled from './FormHelperText.styled'
 
+export const FORM_HELPER_TEXT_TEST_ID = 'bezier-react-form-helper-text'
+
 function FormHelperText({
   id,
+  testId = FORM_HELPER_TEXT_TEST_ID,
   description,
   errorMessage,
   ...rest
@@ -46,6 +49,7 @@ forwardedRef: React.Ref<HTMLParamElement>,
     <Styled.HelperText
       {...rest}
       id={id}
+      testId={testId}
       ref={forwardedRef}
       forwardedAs="p"
       marginTop={4}

--- a/src/components/FormHelperText/FormHelperText.tsx
+++ b/src/components/FormHelperText/FormHelperText.tsx
@@ -1,0 +1,38 @@
+/* External dependencies */
+import React, { forwardRef } from 'react'
+import { isEmpty } from 'lodash-es'
+
+/* Internal dependencies */
+import { Typography } from '../../foundation'
+import type FormHelperTextProps from './FormHelperText.types'
+import * as Styled from './FormHelperText.styled'
+
+function FormHelperText({
+  id,
+  description,
+  errorMessage,
+  ...rest
+}: FormHelperTextProps,
+forwardedRef: React.Ref<HTMLParamElement>,
+) {
+  const hasDescription = !isEmpty(description)
+  const hasError = !isEmpty(errorMessage)
+
+  if (!hasDescription && !hasError) { return null }
+
+  return (
+    <Styled.HelperText
+      {...rest}
+      id={id}
+      ref={forwardedRef}
+      forwardedAs="p"
+      marginTop={4}
+      typo={Typography.Size13}
+      color={hasError ? 'bgtxt-orange-normal' : 'txt-black-dark'}
+    >
+      { hasError ? errorMessage : description }
+    </Styled.HelperText>
+  )
+}
+
+export default forwardRef(FormHelperText)

--- a/src/components/FormHelperText/FormHelperText.tsx
+++ b/src/components/FormHelperText/FormHelperText.tsx
@@ -1,6 +1,6 @@
 /* External dependencies */
 import React, { forwardRef, useMemo } from 'react'
-import { isNil, isEmpty } from 'lodash-es'
+import { isEmpty } from 'lodash-es'
 
 /* Internal dependencies */
 import { Typography, SemanticNames } from '../../foundation'
@@ -12,37 +12,20 @@ export const FORM_HELPER_TEXT_TEST_ID = 'bezier-react-form-helper-text'
 function FormHelperText({
   id,
   testId = FORM_HELPER_TEXT_TEST_ID,
-  errorMessage,
+  hasError,
   children,
   ...rest
 }: FormHelperTextProps,
 forwardedRef: React.Ref<HTMLParamElement>,
 ) {
-  const helperTextProps = useMemo<{
-    color: SemanticNames
-    content: React.ReactNode
-  } | null>(() => {
-    if (!isEmpty(errorMessage)) {
-      return {
-        color: 'bgtxt-orange-normal',
-        content: errorMessage,
-      }
+  const color = useMemo<SemanticNames>(() => {
+    if (hasError) {
+      return 'bgtxt-orange-normal'
     }
-    if (!isEmpty(children)) {
-      return {
-        color: 'txt-black-dark',
-        content: children,
-      }
-    }
-    return null
-  }, [
-    errorMessage,
-    children,
-  ])
+    return 'txt-black-dark'
+  }, [hasError])
 
-  if (isNil(helperTextProps)) { return null }
-
-  const { color, content } = helperTextProps
+  if (isEmpty(children)) { return null }
 
   return (
     <Styled.HelperText
@@ -55,7 +38,7 @@ forwardedRef: React.Ref<HTMLParamElement>,
       typo={Typography.Size13}
       color={color}
     >
-      { content }
+      { children }
     </Styled.HelperText>
   )
 }

--- a/src/components/FormHelperText/FormHelperText.tsx
+++ b/src/components/FormHelperText/FormHelperText.tsx
@@ -12,6 +12,7 @@ export const FORM_HELPER_TEXT_TEST_ID = 'bezier-react-form-helper-text'
 function FormHelperText({
   id,
   testId = FORM_HELPER_TEXT_TEST_ID,
+  as = 'p',
   hasError,
   children,
   ...rest
@@ -33,7 +34,7 @@ forwardedRef: React.Ref<HTMLParamElement>,
       id={id}
       testId={testId}
       ref={forwardedRef}
-      forwardedAs="p"
+      forwardedAs={as}
       marginTop={4}
       typo={Typography.Size13}
       color={color}

--- a/src/components/FormHelperText/FormHelperText.types.ts
+++ b/src/components/FormHelperText/FormHelperText.types.ts
@@ -2,5 +2,5 @@
 import { IdentifierProps, ChildrenComponentProps } from '../../types/ComponentProps'
 
 export default interface FormHelperTextProps extends Omit<ChildrenComponentProps, 'as'>, IdentifierProps {
-  errorMessage?: React.ReactNode
+  hasError?: boolean
 }

--- a/src/components/FormHelperText/FormHelperText.types.ts
+++ b/src/components/FormHelperText/FormHelperText.types.ts
@@ -3,5 +3,5 @@ import { ChildrenComponentProps } from '../../types/ComponentProps'
 
 export default interface FormHelperTextProps extends Omit<ChildrenComponentProps, 'as'> {
   id: string
-  errorMessage?: string
+  errorMessage?: React.ReactNode
 }

--- a/src/components/FormHelperText/FormHelperText.types.ts
+++ b/src/components/FormHelperText/FormHelperText.types.ts
@@ -1,8 +1,7 @@
 /* Internal dependencies */
-import { UIComponentProps } from '../../types/ComponentProps'
+import { ChildrenComponentProps } from '../../types/ComponentProps'
 
-export default interface FormHelperTextProps extends Omit<UIComponentProps, 'as'> {
+export default interface FormHelperTextProps extends Omit<ChildrenComponentProps, 'as'> {
   id: string
-  description?: string
   errorMessage?: string
 }

--- a/src/components/FormHelperText/FormHelperText.types.ts
+++ b/src/components/FormHelperText/FormHelperText.types.ts
@@ -1,6 +1,6 @@
 /* Internal dependencies */
 import { IdentifierProps, ChildrenComponentProps } from '../../types/ComponentProps'
 
-export default interface FormHelperTextProps extends Omit<ChildrenComponentProps, 'as'>, Required<IdentifierProps> {
+export default interface FormHelperTextProps extends Omit<ChildrenComponentProps, 'as'>, IdentifierProps {
   errorMessage?: React.ReactNode
 }

--- a/src/components/FormHelperText/FormHelperText.types.ts
+++ b/src/components/FormHelperText/FormHelperText.types.ts
@@ -1,7 +1,6 @@
 /* Internal dependencies */
-import { ChildrenComponentProps } from '../../types/ComponentProps'
+import { IdentifierProps, ChildrenComponentProps } from '../../types/ComponentProps'
 
-export default interface FormHelperTextProps extends Omit<ChildrenComponentProps, 'as'> {
-  id: string
+export default interface FormHelperTextProps extends Omit<ChildrenComponentProps, 'as'>, Required<IdentifierProps> {
   errorMessage?: React.ReactNode
 }

--- a/src/components/FormHelperText/FormHelperText.types.ts
+++ b/src/components/FormHelperText/FormHelperText.types.ts
@@ -1,6 +1,6 @@
 /* Internal dependencies */
 import { IdentifierProps, ChildrenComponentProps } from '../../types/ComponentProps'
 
-export default interface FormHelperTextProps extends Omit<ChildrenComponentProps, 'as'>, IdentifierProps {
+export default interface FormHelperTextProps extends ChildrenComponentProps, IdentifierProps {
   hasError?: boolean
 }

--- a/src/components/FormHelperText/FormHelperText.types.ts
+++ b/src/components/FormHelperText/FormHelperText.types.ts
@@ -1,0 +1,8 @@
+/* Internal dependencies */
+import { UIComponentProps } from '../../types/ComponentProps'
+
+export default interface FormHelperTextProps extends Omit<UIComponentProps, 'as'> {
+  id: string
+  description?: string
+  errorMessage?: string
+}

--- a/src/components/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
+++ b/src/components/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
@@ -28,6 +28,6 @@ exports[`FormHelperText > Snapshot > 1`] = `
   data-testid="bezier-react-form-helper-text"
   id="test"
 >
-  Description
+  Lorem ipsum
 </p>
 `;

--- a/src/components/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
+++ b/src/components/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Divider > Snapshot > 1`] = `
+.c0 {
+  font-size: 13px;
+  line-height: 18px;
+  margin: 4px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: #00000066;
+  -webkit-transition-property: color;
+  transition-property: color;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+}
+
+.c1 {
+  padding: 0 2px;
+}
+
+<p
+  class="c0 c1"
+  color="txt-black-dark"
+  data-testid="bezier-react-form-helper-text"
+  id="test"
+>
+  Description
+</p>
+`;

--- a/src/components/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
+++ b/src/components/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Divider > Snapshot > 1`] = `
+exports[`FormHelperText > Snapshot > 1`] = `
 .c0 {
   font-size: 13px;
   line-height: 18px;

--- a/src/components/FormHelperText/index.ts
+++ b/src/components/FormHelperText/index.ts
@@ -1,0 +1,2 @@
+export { default as FormHelperText } from './FormHelperText'
+export type { default as FormHelperTextProps } from './FormHelperText.types'

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -25,6 +25,7 @@ function Text(
     marginHorizontal = 0,
     marginAll = 0,
     style,
+    id,
     className,
     children,
     onClick = noop,
@@ -34,6 +35,7 @@ function Text(
   return (
     <TextView
       as={as}
+      id={id}
       style={style}
       ref={forwardedRef}
       className={className}

--- a/src/components/Text/Text.types.ts
+++ b/src/components/Text/Text.types.ts
@@ -5,7 +5,7 @@ import { css } from 'styled-components'
 import { SemanticNames } from '../../foundation'
 import { IdentifierProps, ChildrenComponentProps } from '../../types/ComponentProps'
 
-export default interface TextProps extends ChildrenComponentProps, IdentifierProps {
+export default interface TextProps extends ChildrenComponentProps, Partial<IdentifierProps> {
   bold?: boolean
   italic?: boolean
   color?: SemanticNames

--- a/src/components/Text/Text.types.ts
+++ b/src/components/Text/Text.types.ts
@@ -3,9 +3,9 @@ import { css } from 'styled-components'
 
 /* Internal dependencies */
 import { SemanticNames } from '../../foundation'
-import { ChildrenComponentProps } from '../../types/ComponentProps'
+import { IdentifierProps, ChildrenComponentProps } from '../../types/ComponentProps'
 
-export default interface TextProps extends ChildrenComponentProps {
+export default interface TextProps extends ChildrenComponentProps, IdentifierProps {
   bold?: boolean
   italic?: boolean
   color?: SemanticNames

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export * from './components/Input/Select'
 export * from './components/Input/TextField'
 export * from './components/Input/TextArea'
 export * from './components/Input/constants/InputWrapperStyle'
+export * from './components/FormHelperText'
 export * from './components/KeyValueListItem'
 
 /* Layout */

--- a/src/types/ComponentProps.ts
+++ b/src/types/ComponentProps.ts
@@ -5,7 +5,7 @@ import React, { CSSProperties } from 'react'
 import type InjectedInterpolation from './InjectedInterpolation'
 
 export interface IdentifierProps {
-  id?: string
+  id: string
 }
 
 interface RenderConfigProps {

--- a/src/types/ComponentProps.ts
+++ b/src/types/ComponentProps.ts
@@ -4,6 +4,10 @@ import React, { CSSProperties } from 'react'
 /* Internal dependencies */
 import type InjectedInterpolation from './InjectedInterpolation'
 
+interface IdentifierProps {
+  id?: string
+}
+
 interface RenderConfigProps {
   as?: React.ElementType
   testId?: string
@@ -15,7 +19,7 @@ interface StylableComponentProps {
   interpolation?: InjectedInterpolation
 }
 
-export type UIComponentProps = RenderConfigProps & StylableComponentProps
+export type UIComponentProps = RenderConfigProps & StylableComponentProps & IdentifierProps
 
 export interface ContentComponentProps<Content = React.ReactNode> extends UIComponentProps {
   content?: Content

--- a/src/types/ComponentProps.ts
+++ b/src/types/ComponentProps.ts
@@ -4,7 +4,7 @@ import React, { CSSProperties } from 'react'
 /* Internal dependencies */
 import type InjectedInterpolation from './InjectedInterpolation'
 
-interface IdentifierProps {
+export interface IdentifierProps {
   id?: string
 }
 
@@ -19,7 +19,7 @@ interface StylableComponentProps {
   interpolation?: InjectedInterpolation
 }
 
-export type UIComponentProps = RenderConfigProps & StylableComponentProps & IdentifierProps
+export type UIComponentProps = RenderConfigProps & StylableComponentProps
 
 export interface ContentComponentProps<Content = React.ReactNode> extends UIComponentProps {
   content?: Content

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -64,3 +64,7 @@ export function isNumberString(value?: any) {
   if (isString(value)) { return /^(?:-|\+|)?\d+(?:,\d{3})*(?:\.\d+)?$/.test(value) }
   return false
 }
+
+export function isNotEmptyString(value?: string): value is string {
+  return !isEmpty(value)
+}

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -64,7 +64,3 @@ export function isNumberString(value?: any) {
   if (isString(value)) { return /^(?:-|\+|)?\d+(?:,\d{3})*(?:\.\d+)?$/.test(value) }
   return false
 }
-
-export function isNotEmptyString(value?: string): value is string {
-  return !isEmpty(value)
-}


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

여러가지 폼 아래에 들어가게 되는 `FormHelperText` 컴포넌트를 만들었습니다. 

## TODO

- 이어지는 PR에서 `TextField`, `TextArea` 등과 함께 손쉽게 사용처에서 사용할 수 있도록 작업할 예정입니다.
- `FormLabel` 컴포넌트 추가도 예정되어 있습니다.

## Usage

### Primary

|Description|Error|
|---|---|
|<img width="278" alt="스크린샷 2021-11-29 오후 8 12 17" src="https://user-images.githubusercontent.com/58209009/143858477-b3db549e-08f9-4537-b90e-8d21873690b8.png">|<img width="278" alt="스크린샷 2021-11-29 오후 8 12 13" src="https://user-images.githubusercontent.com/58209009/143858485-a3e3a3b4-ef82-41a3-a51e-1cd4dbc8aff7.png">|

### Composition (Figma)

<img width="385" alt="스크린샷 2021-11-29 오후 8 17 35" src="https://user-images.githubusercontent.com/58209009/143858606-08d921bc-1861-476e-bf11-150d4d79dc74.png">

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
- `aria-describedby` 속성을 사용하기 위해서, `FormHelperText` 는 `id` prop을 필수로 가집니다. Form과 함께 사용되어야 하는 속성이라 후속 PR에서 함께 잘 사용되도록 만들 예정입니다.
- `margin-top: 4px` 과 `padding: 0 2px` 을 가집니다.
- ~~아래와 같은 정책을 가집니다. **description, errorMessage 둘 중 하나만 존재할 수 있다는 내용이 핵심입니다.**~~
  1. ~~description, errorMessage 둘 다 없으면 아무것도 반환하지 않습니다.~~
  2. ~~errorMeesage가 있으면 errorMessage를 반환합니다.~~
  3. ~~description이 있고, errorMessage가 없으면 description을 반환합니다.~~
- errorMessage 같은 string을 전달해주는 대신, FormHelperText 컴포넌트는 `children` , `hasError` 속성만 받는 방식으로 변경했습니다. 'Form과 함께 사용되는 컨텍스트 안에서' 만 비로소 description, errorMessage 둘 중 하나만 존재할 수 있다는 정책이 유효하다고 생각했습니다. 개별로 사용했을 경우엔 Text의 preset 정도로 사용할 수 있도록 했습니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
