### PR TITLE
Overlay에서 발생되는 reflow 개선

### DIFF
--- a/src/components/Overlay/Overlay.stories.tsx
+++ b/src/components/Overlay/Overlay.stories.tsx
@@ -119,14 +119,19 @@ const ScrollContent = styled.div`
   color: white;
 `
 
-const Template: Story<OverlayProps & ContainerProps> = ({ width, height, ...overlayProps }) => {
-  const targetRef = useRef<any>()
-  const containerRef = useRef<any>()
+const OverlayTemplate: React.FC<OverlayProps & ContainerProps> = ({
+  children,
+  width: containerWidth,
+  height: containerHeight,
+  ...rests
+}) => {
+  const containerRef = useRef<any>(null)
+  const targetRef = useRef<any>(null)
 
   return (
     <Container
-      width={width}
-      height={height}
+      width={containerWidth}
+      height={containerHeight}
       ref={containerRef}
     >
       <Wrapper>
@@ -134,30 +139,36 @@ const Template: Story<OverlayProps & ContainerProps> = ({ width, height, ...over
           target
         </Target>
         <Overlay
-          {...overlayProps}
+          {...rests}
           target={targetRef.current}
           container={containerRef.current}
         >
-          <Children>
-            <ScrollContent>
-              {
-                `Lorem Ipsum is simply dummy text of the printing and typesetting
-                industry. Lorem Ipsum has been the industry's standard dummy text
-                ever since the 1500s, when an unknown printer took a galley of type
-                and scrambled it to make a type specimen book. It has survived not
-                only five centuries, but also the leap into electronic typesetting,
-                remaining essentially unchanged. It was popularised in the 1960s
-                with the release of Letraset sheets containing Lorem Ipsum passages,
-                and more recently with desktop publishing software like Aldus PageMaker
-                including versions of Lorem Ipsum.`
-              }
-            </ScrollContent>
-          </Children>
+          { children }
         </Overlay>
       </Wrapper>
     </Container>
   )
 }
+
+const Template: Story = (props) => (
+  <OverlayTemplate {...props}>
+    <Children>
+      <ScrollContent>
+        {
+          `Lorem Ipsum is simply dummy text of the printing and typesetting
+          industry. Lorem Ipsum has been the industry's standard dummy text
+          ever since the 1500s, when an unknown printer took a galley of type
+          and scrambled it to make a type specimen book. It has survived not
+          only five centuries, but also the leap into electronic typesetting,
+          remaining essentially unchanged. It was popularised in the 1960s
+          with the release of Letraset sheets containing Lorem Ipsum passages,
+          and more recently with desktop publishing software like Aldus PageMaker
+          including versions of Lorem Ipsum.`
+        }
+      </ScrollContent>
+    </Children>
+  </OverlayTemplate>
+)
 
 export const Primary = Template.bind({})
 Primary.args = {
@@ -181,45 +192,69 @@ const StressTestTemplate: Story<OverlayProps> = (props) => {
   }, [])
 
   return (
-    <Container ref={containerRef}>
-      <Wrapper>
-        <Target ref={targetRef}>
-          target
-        </Target>
-        <Overlay
-          {...props}
-          // 실제 값은 변하지 않지만, 100ms의 매 렌더링마다 참조가 변하고 있다.
-          containerStyle={{ opacity: 1 }}
-          target={targetRef.current}
-          container={containerRef.current}
-        >
-          <Children>
-            <ScrollContent>
-              {
-                `Lorem Ipsum is simply dummy text of the printing and typesetting
-                industry. Lorem Ipsum has been the industry's standard dummy text
-                ever since the 1500s, when an unknown printer took a galley of type
-                and scrambled it to make a type specimen book. It has survived not
-                only five centuries, but also the leap into electronic typesetting,
-                remaining essentially unchanged. It was popularised in the 1960s
-                with the release of Letraset sheets containing Lorem Ipsum passages,
-                and more recently with desktop publishing software like Aldus PageMaker
-                including versions of Lorem Ipsum.`
-              }
-            </ScrollContent>
-          </Children>
-        </Overlay>
-      </Wrapper>
-    </Container>
+    <OverlayTemplate
+      {...props}
+      // 실제 값은 변하지 않지만, 100ms의 매 렌더링마다 참조가 변하고 있다.
+      containerStyle={{ opacity: 1 }}
+      target={targetRef.current}
+      container={containerRef.current}
+    >
+      <Children>
+        <ScrollContent>
+          {
+            `Lorem Ipsum is simply dummy text of the printing and typesetting
+            industry. Lorem Ipsum has been the industry's standard dummy text
+            ever since the 1500s, when an unknown printer took a galley of type
+            and scrambled it to make a type specimen book. It has survived not
+            only five centuries, but also the leap into electronic typesetting,
+            remaining essentially unchanged. It was popularised in the 1960s
+            with the release of Letraset sheets containing Lorem Ipsum passages,
+            and more recently with desktop publishing software like Aldus PageMaker
+            including versions of Lorem Ipsum.`
+          }
+        </ScrollContent>
+      </Children>
+    </OverlayTemplate>
   )
 }
 
 export const StressTest = StressTestTemplate.bind({})
 StressTest.args = {
+  enableClickOutside: false,
+}
+
+const ChangeableChildrenTemplate: Story<OverlayProps> = (props) => {
+  const [items, setItems] = useState<number[]>([])
+
+  const addItem = React.useCallback(() => {
+    setItems([...items, Math.random()])
+  }, [items])
+
+  return (
+    <>
+      <button type="button" onClick={addItem}>Add</button>
+      <div>
+        <OverlayTemplate {...props}>
+          <Children>
+            { items.map((item) => (
+              <div key={item}>
+                { item }
+              </div>
+            )) }
+          </Children>
+        </OverlayTemplate>
+      </div>
+    </>
+  )
+}
+
+export const ChangeableChildren = ChangeableChildrenTemplate.bind({})
+ChangeableChildren.args = {
   show: false,
   position: OverlayPosition.BottomCenter,
   marginX: 0,
   marginY: 0,
   keepInContainer: false,
   withTransition: false,
+  enableClickOutside: true,
 }

--- a/src/components/Overlay/Overlay.test.tsx
+++ b/src/components/Overlay/Overlay.test.tsx
@@ -318,7 +318,7 @@ describe('Overlay test >', () => {
     })
 
     describe('Event', () => {
-      describe('keyup', () => {
+      describe('keydown', () => {
         document.onkeydown = jest.fn()
         const onHide = jest.fn()
 

--- a/src/components/Overlay/Overlay.test.tsx
+++ b/src/components/Overlay/Overlay.test.tsx
@@ -1,12 +1,22 @@
 /* External dependencies */
 import React from 'react'
 import { getWindow } from 'ssr-window'
+import { fireEvent } from '@testing-library/dom'
 
 /* Internal dependencies */
+import { TransitionDuration } from 'Foundation'
 import { render } from 'Utils/testUtils'
 import OverlayProps, { ContainerRectAttr, TargetRectAttr, OverlayPosition } from './Overlay.types'
-import Overlay, { OVERLAY_TEST_ID } from './Overlay'
+import Overlay, { CONTAINER_TEST_ID, ESCAPE_KEY, OVERLAY_TEST_ID, WRAPPER_TEST_ID } from './Overlay'
 import { getOverlayTranslation } from './utils'
+
+const RootOverlay: React.FC<OverlayProps> = ({ children, ...rests }) => (
+  <div id="main">
+    <Overlay {...rests}>
+      { children }
+    </Overlay>
+  </div>
+)
 
 describe('Overlay test >', () => {
   let props: OverlayProps
@@ -143,7 +153,6 @@ describe('Overlay test >', () => {
           containerHeight: 600,
           targetHeight: 100에
           targetTop: 200이므로,
-
           target의 아래쪽 공간은 300이다.
           300이 200보다 크므로, overlay는 아래쪽에 나타나야 함.
         */
@@ -161,6 +170,183 @@ describe('Overlay test >', () => {
         expect(result).toEqual({
           translateX: 0,
           translateY: 100,
+        })
+      })
+    })
+  })
+
+  describe('Props and Event', () => {
+    const renderRootOverlay = (optionProps?: OverlayProps) => render(<RootOverlay {...props} {...optionProps} />)
+
+    beforeEach(() => {
+      props = {
+        show: true,
+        className: '',
+        containerClassName: '',
+        position: OverlayPosition.LeftCenter,
+        marginX: 0,
+        marginY: 0,
+        keepInContainer: false,
+        withTransition: false,
+        enableClickOutside: false,
+        children: 'Test Overlay',
+      }
+    })
+
+    describe('Props', () => {
+      describe('show', () => {
+        describe('is True', () => {
+          it('container style', () => {
+            const { getByTestId } = renderRootOverlay()
+            const overlay = getByTestId(CONTAINER_TEST_ID)
+            expect(overlay).toHaveStyle('position: fixed')
+            expect(overlay).toHaveStyle('top: 0')
+            expect(overlay).toHaveStyle('right: 0')
+            expect(overlay).toHaveStyle('bottom: 0')
+            expect(overlay).toHaveStyle('left: 0')
+            expect(overlay).toHaveStyle('width: 100%')
+            expect(overlay).toHaveStyle('height: 100%')
+            expect(overlay).toHaveStyle('pointer-events: all')
+          })
+
+          it('wrapper style', () => {
+            const { getByTestId } = renderRootOverlay()
+            const overlay = getByTestId(WRAPPER_TEST_ID)
+            expect(overlay).toHaveStyle('position: relative')
+            expect(overlay).toHaveStyle('width: 100%')
+            expect(overlay).toHaveStyle('height: 100%')
+          })
+
+          it('overlay style', () => {
+            const { getByTestId } = renderRootOverlay()
+            const overlay = getByTestId(OVERLAY_TEST_ID)
+            expect(overlay).toHaveStyle('position: absolute')
+          })
+        })
+
+        describe('is False', () => {
+          it('container style', () => {
+            const { container } = renderRootOverlay()
+            // <main id="main" />
+            expect(container.children.length).toBe(1)
+          })
+        })
+      })
+
+      describe('className', () => {
+        it('is transferred', () => {
+          const CLASSNAME = 'Test__Overlay'
+          const { getByTestId } = renderRootOverlay({ className: CLASSNAME })
+          const overlay = getByTestId(OVERLAY_TEST_ID)
+          expect(overlay).toHaveClass(CLASSNAME)
+        })
+      })
+
+      describe('style', () => {
+        it('is transferred', () => {
+          const STYLE: React.CSSProperties = {
+            width: '100px',
+          }
+          const { getByTestId } = renderRootOverlay({ style: STYLE })
+          const overlay = getByTestId(OVERLAY_TEST_ID)
+          expect(overlay).toHaveStyle('width: 100px')
+        })
+      })
+
+      describe('containerClassName', () => {
+        it('is transferred', () => {
+          const CLASSNAME = 'Test__Container'
+          const { getByTestId } = renderRootOverlay({ containerClassName: CLASSNAME })
+          const overlay = getByTestId(CONTAINER_TEST_ID)
+          expect(overlay).toHaveClass(CLASSNAME)
+        })
+      })
+
+      describe('containerStyle', () => {
+        it('is transferred', () => {
+          const STYLE: React.CSSProperties = {
+            width: '100px',
+          }
+          const { getByTestId } = renderRootOverlay({ containerStyle: STYLE })
+          const overlay = getByTestId(CONTAINER_TEST_ID)
+          expect(overlay).toHaveStyle('width: 100px')
+        })
+      })
+
+      describe('enableClickOutside', () => {
+        document.onclick = jest.fn()
+        const onHide = jest.fn()
+
+        afterEach(jest.clearAllMocks)
+
+        it('is True', () => {
+          const { getByTestId } = renderRootOverlay({ enableClickOutside: true, onHide })
+          const overlay = getByTestId(CONTAINER_TEST_ID)
+
+          overlay.click()
+          expect(document.onclick).toHaveBeenCalledTimes(1)
+          expect(onHide).toHaveBeenCalledTimes(1)
+          overlay.click()
+          expect(document.onclick).toHaveBeenCalledTimes(2)
+          expect(onHide).toHaveBeenCalledTimes(2)
+        })
+
+        it('is False - click is stopPropagation ', () => {
+          const { getByTestId } = renderRootOverlay()
+          const overlay = getByTestId(CONTAINER_TEST_ID)
+
+          overlay.click()
+          expect(document.onclick).toHaveBeenCalledTimes(0)
+          expect(onHide).toHaveBeenCalledTimes(0)
+          overlay.click()
+          expect(document.onclick).toHaveBeenCalledTimes(0)
+          expect(onHide).toHaveBeenCalledTimes(0)
+        })
+      })
+
+      describe('withTransition', () => {
+        it('is True', () => {
+          const { getByTestId } = renderRootOverlay({ withTransition: true })
+          const overlay = getByTestId(OVERLAY_TEST_ID)
+
+          expect(overlay).toHaveStyle(`transition-property: ${['top', 'opacity'].join(',')}`)
+          expect(overlay).toHaveStyle(`transition-duration: ${TransitionDuration.S}ms`)
+          expect(overlay).toHaveStyle('transition-timing-function: cubic-bezier(.3,0,0,1)')
+          expect(overlay).toHaveStyle('transition-delay: 0ms')
+        })
+      })
+    })
+
+    describe('Event', () => {
+      describe('keyup', () => {
+        document.onkeydown = jest.fn()
+        const onHide = jest.fn()
+
+        afterEach(jest.clearAllMocks)
+
+        it('is Triggered By Escape', () => {
+          const { getByTestId } = renderRootOverlay({ withTransition: true, onHide })
+          const overlay = getByTestId(OVERLAY_TEST_ID)
+          fireEvent.keyDown(overlay, { key: ESCAPE_KEY })
+          expect(document.onkeydown).toHaveBeenCalledTimes(1)
+          expect(onHide).toHaveBeenCalledTimes(1)
+          fireEvent.keyDown(overlay, { key: ESCAPE_KEY })
+          expect(document.onkeydown).toHaveBeenCalledTimes(2)
+          expect(onHide).toHaveBeenCalledTimes(2)
+        })
+
+        it('is not Triggered By All keys except Escape', () => {
+          const { getByTestId } = renderRootOverlay({ withTransition: true, onHide })
+          const overlay = getByTestId(OVERLAY_TEST_ID)
+          fireEvent.keyDown(overlay, { key: 'Enter' })
+          expect(document.onkeydown).toHaveBeenCalledTimes(1)
+          expect(onHide).toHaveBeenCalledTimes(0)
+          fireEvent.keyDown(overlay, { key: 'ArrowRight' })
+          expect(document.onkeydown).toHaveBeenCalledTimes(2)
+          expect(onHide).toHaveBeenCalledTimes(0)
+          fireEvent.keyDown(overlay, { key: 'Z' })
+          expect(document.onkeydown).toHaveBeenCalledTimes(3)
+          expect(onHide).toHaveBeenCalledTimes(0)
         })
       })
     })

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -67,6 +67,10 @@ function Overlay(
   }, [])
 
   const handleContainerRect = useCallback(() => {
+    if (!show) {
+      return
+    }
+
     const containerElement = container || getRootElement() as HTMLElement
 
     const {
@@ -84,14 +88,17 @@ function Overlay(
       scrollTop: container ? container.scrollTop : 0,
       scrollLeft: container ? container.scrollLeft : 0,
     }
-  }, [container])
+  }, [
+    container,
+    show,
+  ])
 
   useLayoutEffect(function initContainerRect() {
     handleContainerRect()
   }, [handleContainerRect])
 
   const handleTargetRect = useCallback(() => {
-    if (!target) {
+    if (!target || !show) {
       return
     }
     const {
@@ -110,7 +117,10 @@ function Overlay(
       clientTop,
       clientLeft,
     }
-  }, [target])
+  }, [
+    target,
+    show,
+  ])
 
   useLayoutEffect(function initTargetRect() {
     handleTargetRect()

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -19,12 +19,10 @@ import { window, document, getRootElement } from 'Utils/domUtils'
 import OverlayProps, { OverlayPosition, ContainerRectAttr, TargetRectAttr } from './Overlay.types'
 import * as Styled from './Overlay.styled'
 
-// TODO: 테스트 코드 작성
-const CONTAINER_TEST_ID = 'bezier-react-container'
-const WRAPPER_TEST_ID = 'bezier-react-wrapper'
+export const CONTAINER_TEST_ID = 'bezier-react-container'
+export const WRAPPER_TEST_ID = 'bezier-react-wrapper'
 export const OVERLAY_TEST_ID = 'bezier-react-overlay'
-
-const ESCAPE_KEY = 'Escape'
+export const ESCAPE_KEY = 'Escape'
 
 function Overlay(
   {
@@ -147,7 +145,7 @@ function Overlay(
   }, [onHide])
 
   useEventHandler(document, 'click', handleHideOverlay, show, true)
-  useEventHandler(document, 'keyup', handleKeydown, show)
+  useEventHandler(document, 'keydown', handleKeydown, show)
   useEventHandler(containerRef.current, 'wheel', handleBlockMouseWheel, show)
 
   const Content = useMemo(() => (

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useRef,
   useCallback,
+  useLayoutEffect,
   useEffect,
   Ref,
   forwardRef,
@@ -85,7 +86,7 @@ function Overlay(
     }
   }, [container])
 
-  React.useLayoutEffect(function initContainerRect() {
+  useLayoutEffect(function initContainerRect() {
     handleContainerRect()
   }, [handleContainerRect])
 
@@ -111,7 +112,7 @@ function Overlay(
     }
   }, [target])
 
-  React.useLayoutEffect(function initTargetRect() {
+  useLayoutEffect(function initTargetRect() {
     handleTargetRect()
   }, [handleTargetRect])
 

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -67,10 +67,6 @@ function Overlay(
   }, [])
 
   const handleContainerRect = useCallback(() => {
-    if (!show) {
-      return
-    }
-
     const containerElement = container || getRootElement() as HTMLElement
 
     const {
@@ -88,17 +84,19 @@ function Overlay(
       scrollTop: container ? container.scrollTop : 0,
       scrollLeft: container ? container.scrollLeft : 0,
     }
-  }, [
-    container,
-    show,
-  ])
+  }, [container])
 
   useLayoutEffect(function initContainerRect() {
-    handleContainerRect()
-  }, [handleContainerRect])
+    if (show) {
+      handleContainerRect()
+    }
+  }, [
+    show,
+    handleContainerRect,
+  ])
 
   const handleTargetRect = useCallback(() => {
-    if (!target || !show) {
+    if (!target) {
       return
     }
     const {
@@ -117,14 +115,16 @@ function Overlay(
       clientTop,
       clientLeft,
     }
-  }, [
-    target,
-    show,
-  ])
+  }, [target])
 
   useLayoutEffect(function initTargetRect() {
-    handleTargetRect()
-  }, [handleTargetRect])
+    if (show) {
+      handleTargetRect()
+    }
+  }, [
+    show,
+    handleTargetRect,
+  ])
 
   const handleTransitionEnd = useCallback(() => {
     if (!show) {


### PR DESCRIPTION
# Summary
- rect를 계산하는 함수가 새로운 객체를 계속 리턴하여 re-render가 되는 문제 개선

# Details
- rect를 계산하는 함수의 return Object를 ref에 할당하여 객체 주소 변경 안되게 변경
- DOM에 영향을 받는 함수로서 useLayoutEffect로 변경하여 ref에 할당
- keyup과 keydown 함수이름이 혼동되어 keydown으로 변경 (리뷰에 확인바람)
- 스토리북에 overlay children이 바뀌는 스펙 추가

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References

https://www.notion.so/channelio/Reflow-e32b87347d07496999b0fa5fe2b691ec

# Additional Context
- `enableClickOutside`는 Click에 대한 SideEffect가 존재합니다. 코드자체로는 의도를 하신것 같은데요, outside를 눌렀을 경우 overlay가 꺼지는게 UX적으로 괜찮아보입니다. overlay가 떠있는 동안 다른 Click event를 막는것은 버그에 가깝게 느껴집니다. 
- forceReducer가 안에 존재하던데, 이 부분은 한번 더 확인이 필요해보입니다. (#552)

# Additional Action Item
- Props의 container, target의 영역을 ref로 감쌀 수 있는가? (e.g. Overlay로 Dropdown을 사용하는데 Dropdown의 ref값을 알 수 있어야 함)
  - 초기 설계되었던 Overlay의 기능과 Portal의 기능이 분리되는 방법도 있을것 같습니다. 현재 두가지가 혼용되어있는것 같습니다.
- forceRender를 사용하지 않고 ref를 다시 계산할 수 있는 방법 리서치