### PR TITLE
chore(rollup-visualizer): update rollup-plugin-visualizer 5.5.0 to 5.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "regenerator-runtime": "^0.13.7",
         "rollup": "^2.50.5",
         "rollup-plugin-peer-deps-external": "^2.2.4",
-        "rollup-plugin-visualizer": "^5.5.0",
+        "rollup-plugin-visualizer": "^5.5.2",
         "semantic-release": "^17.4.3",
         "styled-components": "^5.2.1",
         "stylelint": "^13.8.0",
@@ -27016,9 +27016,9 @@
       }
     },
     "node_modules/rollup-plugin-visualizer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.5.0.tgz",
-      "integrity": "sha512-QUd0ZHGYn6rgogS+yzG08AvMk9J4kR1lO1cpLJCIAQhbyIGSBdqCddKWtxDsdmsxhkY/GCGw8CvoSB3MwMQOIQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.5.2.tgz",
+      "integrity": "sha512-sh+P9KhuWTzeStyRA5yNZpoEFGuj5Ph34JLMa9+muhU8CneFf9L0XE4fmAwAojJLWp//uLUEyytBPSCdZEg5AA==",
       "dev": true,
       "dependencies": {
         "nanoid": "^3.1.22",
@@ -53035,9 +53035,9 @@
       "requires": {}
     },
     "rollup-plugin-visualizer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.5.0.tgz",
-      "integrity": "sha512-QUd0ZHGYn6rgogS+yzG08AvMk9J4kR1lO1cpLJCIAQhbyIGSBdqCddKWtxDsdmsxhkY/GCGw8CvoSB3MwMQOIQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.5.2.tgz",
+      "integrity": "sha512-sh+P9KhuWTzeStyRA5yNZpoEFGuj5Ph34JLMa9+muhU8CneFf9L0XE4fmAwAojJLWp//uLUEyytBPSCdZEg5AA==",
       "dev": true,
       "requires": {
         "nanoid": "^3.1.22",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "regenerator-runtime": "^0.13.7",
     "rollup": "^2.50.5",
     "rollup-plugin-peer-deps-external": "^2.2.4",
-    "rollup-plugin-visualizer": "^5.5.0",
+    "rollup-plugin-visualizer": "^5.5.2",
     "semantic-release": "^17.4.3",
     "styled-components": "^5.2.1",
     "stylelint": "^13.8.0",


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
rollup plugin visualizer 버전 업데이트
# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
생략

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
생략
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
