### PR TITLE
Typography를 Rem 단위로 바꾸는 작업(BezierProvider, Typography, GlobalStyle)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,11 @@ module.exports = {
             position: 'before',
           },
           {
+            pattern: 'Providers/**',
+            group: 'internal',
+            position: 'before',
+          },
+          {
             pattern: 'Hooks/**',
             group: 'internal',
             position: 'before',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,7 +2,11 @@
 import React from 'react'
 
 /* Internal dependencies */
-import { FoundationProvider, LightFoundation, DarkFoundation } from 'Foundation'
+import {
+  LightFoundation,
+  DarkFoundation,
+} from 'Foundation'
+import BezierProvider from 'Providers/BezierProvider'
 
 const FoundationKeyword = {
   Light: 'light',
@@ -49,6 +53,16 @@ function withFoundationProvider(Story, context) {
     ? DarkFoundation.theme['bg-white-normal']
     : LightFoundation.theme['bg-white-normal']
 
+  const foundation = {
+    ...Foundation,
+    // You can inject custom global CSS
+    // global: {
+    //   html: {
+    //     fontSize: '20px',
+    //   }
+    // }
+  }
+
   return (
     <div
       style={{
@@ -57,9 +71,9 @@ function withFoundationProvider(Story, context) {
         fontFamily: 'Inter',
       }}
     >
-      <FoundationProvider foundation={Foundation}>
+      <BezierProvider foundation={foundation}>
         { Story(context) }
-      </FoundationProvider>
+      </BezierProvider>
     </div>
   )
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
     'Foundation/(.*)$': '<rootDir>/src/foundation/$1',
     'Hooks/(.*)$': '<rootDir>/src/hooks/$1',
     'Layout/(.*)$': '<rootDir>/src/layout/$1',
+    'Providers/(.*)$': '<rootDir>/src/providers/$1',
     'Types/(.*)$': '<rootDir>/src/types/$1',
     'Utils/(.*)$': '<rootDir>/src/utils/$1',
     'Worklets/(.*)$': '<rootDir>/src/worklets/$1',

--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -32,7 +32,7 @@ describe('Banner >', () => {
     expect(bannerLink.tagName).toBe('A')
     expect(bannerLink.children.item(0)).toHaveStyle('text-decoration: underline;')
     expect(bannerLink.children.item(0)).toHaveStyle('font-weight: bold;')
-    expect(bannerLink.children.item(0)).toHaveStyle('font-size: 14px;')
+    expect(bannerLink.children.item(0)).toHaveStyle('font-size: 1.4rem;')
   })
 
   it('does not render dismiss button if dismissible = false', () => {

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -109,8 +109,8 @@ describe('Button Test >', () => {
         expect(xsButton).toHaveStyle('padding: 2px;')
 
         // Typograpy.Size13
-        expect(xsButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}px;`)
-        expect(xsButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}px;`)
+        expect(xsButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}rem;`)
+        expect(xsButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}rem;`)
       })
 
       it('Size S', () => {
@@ -123,8 +123,8 @@ describe('Button Test >', () => {
         expect(sButton).toHaveStyle('padding: 3px 4px;')
 
         // Typograpy.Size13
-        expect(sButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}px;`)
-        expect(sButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}px;`)
+        expect(sButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}rem;`)
+        expect(sButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}rem;`)
       })
 
       it('Size M', () => {
@@ -137,8 +137,8 @@ describe('Button Test >', () => {
         expect(mButton).toHaveStyle('padding: 8px 10px;')
 
         // Typograpy.Size14
-        expect(mButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo14}px;`)
-        expect(mButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}px;`)
+        expect(mButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo14}rem;`)
+        expect(mButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}rem;`)
       })
 
       it('Size L', () => {
@@ -150,9 +150,9 @@ describe('Button Test >', () => {
         expect(lButton).toHaveStyle('height: 44px;')
         expect(lButton).toHaveStyle('padding: 12px 10px;')
 
-        // Typograpy.Size14
-        expect(lButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo15}px;`)
-        expect(lButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh20}px;`)
+        // Typography.Size15
+        expect(lButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo15}rem;`)
+        expect(lButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh20}rem;`)
       })
 
       it('Size XL', () => {
@@ -164,9 +164,9 @@ describe('Button Test >', () => {
         expect(xlButton).toHaveStyle('height: 54px;')
         expect(xlButton).toHaveStyle('padding: 15px 14px;')
 
-        // Typograpy.Size16
-        expect(xlButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo18}px;`)
-        expect(xlButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh24}px;`)
+        // Typography.Size18
+        expect(xlButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo18}rem;`)
+        expect(xlButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh24}rem;`)
       })
     })
 

--- a/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -9,8 +9,8 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   background-color: transparent;
   border: none;
   outline: none;
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
   color: #000000D9;
 }
 
@@ -114,8 +114,8 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 }
 
 .c2 {
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 1.3rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: bold;
@@ -131,8 +131,8 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 }
 
 .c9 {
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 1.3rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -284,8 +284,8 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   background-color: transparent;
   border: none;
   outline: none;
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
   color: #000000D9;
 }
 
@@ -422,8 +422,8 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 }
 
 .c3 {
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 1.3rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: bold;
@@ -439,8 +439,8 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 }
 
 .c12 {
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 1.3rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -593,8 +593,8 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   background-color: transparent;
   border: none;
   outline: none;
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
   color: #000000D9;
 }
 
@@ -656,8 +656,8 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 }
 
 .c2 {
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 1.3rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: bold;
@@ -673,8 +673,8 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 }
 
 .c7 {
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 1.3rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -754,8 +754,8 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   background-color: transparent;
   border: none;
   outline: none;
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
   color: #000000D9;
 }
 
@@ -845,8 +845,8 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
 }
 
 .c3 {
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 1.3rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: bold;
@@ -862,8 +862,8 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
 }
 
 .c9 {
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 1.3rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;

--- a/src/components/Forms/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
+++ b/src/components/Forms/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`FormErrorMessage > Snapshot > 1`] = `
 .c0 {
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 1.3rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -36,8 +36,8 @@ exports[`FormErrorMessage > Snapshot > 1`] = `
 
 exports[`FormHelperText > Snapshot > 1`] = `
 .c0 {
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 1.3rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;

--- a/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
+++ b/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`FormLabel > Snapshot > 1`] = `
 .c0 {
-  font-size: 13px;
-  line-height: 18px;
+  font-size: 1.3rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: bold;

--- a/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -18,8 +18,8 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
 }
 
 .c3 {
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -159,8 +159,8 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
 }
 
 .c3 {
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;

--- a/src/components/Forms/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/Forms/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -36,8 +36,8 @@ exports[`TextArea 테스트 > SnapShot 테스트 > 1`] = `
   border: none;
   outline: none;
   -ms-overflow-style: none;
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
   color: #000000D9;
 }
 
@@ -62,23 +62,23 @@ exports[`TextArea 테스트 > SnapShot 테스트 > 1`] = `
 }
 
 .c1::-webkit-input-placeholder {
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
 }
 
 .c1::-moz-placeholder {
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
 }
 
 .c1:-ms-input-placeholder {
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
 }
 
 .c1::placeholder {
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
 }
 
 <div

--- a/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`SegmentedControl Snapshot 1`] = `
 .c4 {
-  font-size: 15px;
-  line-height: 20px;
+  font-size: 1.5rem;
+  line-height: 2rem;
   -webkit-letter-spacing: -0.1px;
   -moz-letter-spacing: -0.1px;
   -ms-letter-spacing: -0.1px;

--- a/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
+++ b/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
@@ -18,8 +18,8 @@ exports[`KeyValueListItem Snapshot > 1`] = `
 }
 
 .c5 {
-  font-size: 12px;
-  line-height: 16px;
+  font-size: 1.2rem;
+  line-height: 1.6rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: bold;

--- a/src/components/ListItem/__snapshots__/ListItem.test.tsx.snap
+++ b/src/components/ListItem/__snapshots__/ListItem.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`ListItem Snapshot > 1`] = `
 .c4 {
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;

--- a/src/components/SectionLabel/SectionLabel.test.tsx
+++ b/src/components/SectionLabel/SectionLabel.test.tsx
@@ -29,7 +29,7 @@ describe('SectionLabel', () => {
 
     expect(content.children.length).toBe(1)
     expect(content.children.item(0)).toHaveStyle('font-weight: bold;')
-    expect(content.children.item(0)).toHaveStyle('font-size: 13px;')
+    expect(content.children.item(0)).toHaveStyle('font-size: 1.3rem;')
   })
 
   it('renders number content as bold text with Typography.Size13', () => {
@@ -38,7 +38,7 @@ describe('SectionLabel', () => {
 
     expect(content.children.length).toBe(1)
     expect(content.children.item(0)).toHaveStyle('font-weight: bold;')
-    expect(content.children.item(0)).toHaveStyle('font-size: 13px;')
+    expect(content.children.item(0)).toHaveStyle('font-size: 1.3rem;')
   })
 
   it('renders element content as it is', () => {

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -23,7 +23,7 @@ describe('Text test >', () => {
 
     const renderedText = getByTestId(TEXT_TEST_ID)
 
-    expect(renderedText).toHaveStyle('font-size: 15px;')
+    expect(renderedText).toHaveStyle('font-size: 1.5rem;')
     expect(renderedText).toHaveStyle('font-weight: normal;')
     expect(renderedText).toHaveStyle('font-style: normal;')
     expect(renderedText).toHaveStyle('color: inherit;')
@@ -58,7 +58,7 @@ describe('Text test >', () => {
 
     const renderedText = getByTestId(TEXT_TEST_ID)
 
-    expect(renderedText).toHaveStyle('font-size: 24px;')
-    expect(renderedText).toHaveStyle('line-height: 32px;')
+    expect(renderedText).toHaveStyle('font-size: 2.4rem;')
+    expect(renderedText).toHaveStyle('line-height: 3.2rem;')
   })
 })

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`Tooltip test > Tooltip with contentInterpolation prop 1`] = `
 .c4 {
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -50,9 +50,9 @@ exports[`Tooltip test > Tooltip with contentInterpolation prop 1`] = `
 
 .c3 {
   display: -webkit-box;
-  max-height: 360px;
+  max-height: 36px;
   overflow: hidden;
-  line-height: 18px;
+  line-height: 1.8px;
   text-overflow: ellipsis;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 20;
@@ -93,8 +93,8 @@ exports[`Tooltip test > Tooltip with contentInterpolation prop 1`] = `
 
 exports[`Tooltip test > Tooltip with default props 1`] = `
 .c4 {
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -140,9 +140,9 @@ exports[`Tooltip test > Tooltip with default props 1`] = `
 
 .c3 {
   display: -webkit-box;
-  max-height: 360px;
+  max-height: 36px;
   overflow: hidden;
-  line-height: 18px;
+  line-height: 1.8px;
   text-overflow: ellipsis;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 20;

--- a/src/foundation/FoundationStyledComponent.tsx
+++ b/src/foundation/FoundationStyledComponent.tsx
@@ -136,10 +136,7 @@ interface FoundationCSSInterface {
 }
 
 /* eslint-disable-next-line func-names */
-const FoundationCSS: FoundationCSSInterface = function (...args) {
-  /* @ts-ignore */
-  return baseCSS(...args)
-}
+const FoundationCSS: FoundationCSSInterface = baseCSS
 
 function useFoundation() {
   return useContext(FoundationContext)
@@ -164,10 +161,7 @@ interface CreateFoundationGlobalStyle {
 }
 
 /* eslint-disable-next-line func-names */ /* @ts-ignore */
-const createFoundationGlobalStyle: CreateFoundationGlobalStyle = function (...args) {
-  /* @ts-ignore */
-  return baseCreateGlobalStyle(...args)
-}
+const createFoundationGlobalStyle: CreateFoundationGlobalStyle = baseCreateGlobalStyle
 
 export type {
   GlobalStyleProp,

--- a/src/foundation/FoundationStyledComponent.tsx
+++ b/src/foundation/FoundationStyledComponent.tsx
@@ -156,7 +156,7 @@ interface CreateFoundationGlobalStyle {
     ...interpolations: Array<Interpolation<ThemedStyledProps<P & { foundation?: FoundationWithGlobalStyle }, Foundation>>>
   ): GlobalStyleComponent<
   P & { foundation: FoundationWithGlobalStyle },
-  ThemedStyledProps<P & { foundation: FoundationWithGlobalStyle }, FoundationWithGlobalStyle>
+  ThemedStyledProps<P & { foundation: FoundationWithGlobalStyle }, Foundation>
   >
 }
 

--- a/src/foundation/FoundationStyledComponent.tsx
+++ b/src/foundation/FoundationStyledComponent.tsx
@@ -10,6 +10,7 @@
 /* External dependencies */
 import React, { createContext, useContext, forwardRef } from 'react'
 import styled, {
+  createGlobalStyle as baseCreateGlobalStyle,
   css as baseCSS,
   ThemedStyledFunction,
   ThemedStyledProps,
@@ -24,12 +25,11 @@ import styled, {
   SimpleInterpolation,
   CSSObject,
   keyframes,
+  GlobalStyleComponent,
 } from 'styled-components'
 
 /* Internal dependencies */
-import EnableCSSHoudini from 'Worklets/EnableCSSHoudini'
 import domElements from './utils/domElements'
-import ThemeVars from './ThemeVars'
 import { Foundation } from './Foundation'
 
 const FoundationContext = createContext<Foundation | null>(null)
@@ -43,12 +43,8 @@ function FoundationProvider({
   foundation,
   children,
 }: FoundationProviderProps) {
-  EnableCSSHoudini({ smoothCorners: true })
-
-  // TODO: 테마 스위칭 로직 구현을 bezier-react 내부로 이동하고, Hook을 통해 사용처에서 쉽게 가져다가 사용할 수 있도록 개선
   return (
     <FoundationContext.Provider value={foundation}>
-      <ThemeVars foundation={foundation} />
       { children }
     </FoundationContext.Provider>
   )
@@ -149,7 +145,36 @@ function useFoundation() {
   return useContext(FoundationContext)
 }
 
+type GlobalStyleProp = {
+  global?: CSSObject
+}
+
+type FoundationWithGlobalStyle = Foundation & GlobalStyleProp
+interface CreateFoundationGlobalStyle {
+  <P extends object>(
+    first:
+    | TemplateStringsArray
+    | CSSObject
+    | InterpolationFunction<ThemedStyledProps<P & { foundation?: FoundationWithGlobalStyle }, Foundation>>,
+    ...interpolations: Array<Interpolation<ThemedStyledProps<P & { foundation?: FoundationWithGlobalStyle }, Foundation>>>
+  ): GlobalStyleComponent<
+  P & { foundation: FoundationWithGlobalStyle },
+  ThemedStyledProps<P & { foundation: FoundationWithGlobalStyle }, FoundationWithGlobalStyle>
+  >
+}
+
+/* eslint-disable-next-line func-names */ /* @ts-ignore */
+const createFoundationGlobalStyle: CreateFoundationGlobalStyle = function (...args) {
+  /* @ts-ignore */
+  return baseCreateGlobalStyle(...args)
+}
+
+export type {
+  GlobalStyleProp,
+}
+
 export {
+  createFoundationGlobalStyle as createGlobalStyle,
   FoundationStyled as styled,
   FoundationCSS as css,
   FoundationProvider,

--- a/src/foundation/GlobalStyle.tsx
+++ b/src/foundation/GlobalStyle.tsx
@@ -1,0 +1,20 @@
+/* External dependencies */
+import { get } from 'lodash-es'
+
+/* Internal dependencies */
+import { createGlobalStyle, css } from './FoundationStyledComponent'
+
+export const GlobalStyle = createGlobalStyle`
+  html {
+    font-size: 62.5%; // 10/16 = 0.625
+  }
+
+  ${({ foundation }) => {
+    const globalStyleObject = get(foundation, 'global')
+    if (!globalStyleObject) {
+      return undefined
+    }
+
+    return css(globalStyleObject)
+  }}
+`

--- a/src/foundation/ThemeVars.ts
+++ b/src/foundation/ThemeVars.ts
@@ -1,9 +1,8 @@
 /* External dependencies */
-import { createGlobalStyle } from 'styled-components'
 import { isEmpty } from 'lodash-es'
 
 /* Internal dependencies */
-import { Foundation } from './Foundation'
+import { createGlobalStyle } from './FoundationStyledComponent'
 
 type ThemeRecord = Record<string, string>
 
@@ -16,11 +15,9 @@ function generateCSSVar(theme?: ThemeRecord, prefix?: string) {
   }), {} as ThemeRecord)
 }
 
-const ThemeVars = createGlobalStyle<{ foundation?: Foundation }>`
+export const ThemeVars = createGlobalStyle`
   :root {
     ${({ foundation }) => generateCSSVar(foundation?.theme)}
     ${({ foundation }) => generateCSSVar(foundation?.subTheme, 'inverted')}
   }
 `
-
-export default ThemeVars

--- a/src/foundation/Typography.ts
+++ b/src/foundation/Typography.ts
@@ -2,73 +2,73 @@
 import { css } from './FoundationStyledComponent'
 
 export enum TypoAbsoluteNumber {
-  Typo11 = 11,
-  Typo12 = 12,
-  Typo13 = 13,
-  Typo14 = 14,
-  Typo15 = 15,
-  Typo16 = 16,
-  Typo18 = 18,
-  Typo22 = 22,
-  Typo24 = 24,
+  Typo11 = 1.1,
+  Typo12 = 1.2,
+  Typo13 = 1.3,
+  Typo14 = 1.4,
+  Typo15 = 1.5,
+  Typo16 = 1.6,
+  Typo18 = 1.8,
+  Typo22 = 2.2,
+  Typo24 = 2.4,
 }
 
 export enum LineHeightAbsoluteNumber {
-  Lh16 = 16,
-  Lh18 = 18,
-  Lh20 = 20,
-  Lh22 = 22,
-  Lh24 = 24,
-  Lh28 = 28,
-  Lh32 = 32,
+  Lh16 = 1.6,
+  Lh18 = 1.8,
+  Lh20 = 2.0,
+  Lh22 = 2.2,
+  Lh24 = 2.4,
+  Lh28 = 2.8,
+  Lh32 = 3.2,
 }
 
 const Size11 = css`
-  font-size: ${TypoAbsoluteNumber.Typo11}px;
-  line-height: ${LineHeightAbsoluteNumber.Lh16}px;
+  font-size: ${TypoAbsoluteNumber.Typo11}rem;
+  line-height: ${LineHeightAbsoluteNumber.Lh16}rem;
 `
 
 const Size12 = css`
-  font-size: ${TypoAbsoluteNumber.Typo12}px;
-  line-height: ${LineHeightAbsoluteNumber.Lh16}px;
+  font-size: ${TypoAbsoluteNumber.Typo12}rem;
+  line-height: ${LineHeightAbsoluteNumber.Lh16}rem;
 `
 
 const Size13 = css`
-  font-size: ${TypoAbsoluteNumber.Typo13}px;
-  line-height: ${LineHeightAbsoluteNumber.Lh18}px;
+  font-size: ${TypoAbsoluteNumber.Typo13}rem;
+  line-height: ${LineHeightAbsoluteNumber.Lh18}rem;
 `
 
 const Size14 = css`
-  font-size: ${TypoAbsoluteNumber.Typo14}px;
-  line-height: ${LineHeightAbsoluteNumber.Lh18}px;
+  font-size: ${TypoAbsoluteNumber.Typo14}rem;
+  line-height: ${LineHeightAbsoluteNumber.Lh18}rem;
 `
 
 const Size15 = css`
-  font-size: ${TypoAbsoluteNumber.Typo15}px;
-  line-height: ${LineHeightAbsoluteNumber.Lh20}px;
+  font-size: ${TypoAbsoluteNumber.Typo15}rem;
+  line-height: ${LineHeightAbsoluteNumber.Lh20}rem;
   letter-spacing: -0.1px;
 `
 
 const Size16 = css`
-  font-size: ${TypoAbsoluteNumber.Typo16}px;
-  line-height: ${LineHeightAbsoluteNumber.Lh22}px;
+  font-size: ${TypoAbsoluteNumber.Typo16}rem;
+  line-height: ${LineHeightAbsoluteNumber.Lh22}rem;
   letter-spacing: -0.1px;
 `
 
 const Size18 = css`
-  font-size: ${TypoAbsoluteNumber.Typo18}px;
-  line-height: ${LineHeightAbsoluteNumber.Lh24}px;
+  font-size: ${TypoAbsoluteNumber.Typo18}rem;
+  line-height: ${LineHeightAbsoluteNumber.Lh24}rem;
 `
 
 const Size22 = css`
-  font-size: ${TypoAbsoluteNumber.Typo22}px;
-  line-height: ${LineHeightAbsoluteNumber.Lh28}px;
+  font-size: ${TypoAbsoluteNumber.Typo22}rem;
+  line-height: ${LineHeightAbsoluteNumber.Lh28}rem;
   letter-spacing: -0.4px;
 `
 
 const Size24 = css`
-  font-size: ${TypoAbsoluteNumber.Typo24}px;
-  line-height: ${LineHeightAbsoluteNumber.Lh32}px;
+  font-size: ${TypoAbsoluteNumber.Typo24}rem;
+  line-height: ${LineHeightAbsoluteNumber.Lh32}rem;
   letter-spacing: -0.4px;
 `
 

--- a/src/foundation/index.ts
+++ b/src/foundation/index.ts
@@ -11,6 +11,10 @@ export * from './Border'
 export * from './Typography'
 export * from './Mixins'
 
+// Theme
+export * from './ThemeVars'
+
 // Themed Styled Component, Interface
+export * from './GlobalStyle'
 export * from './Foundation'
 export * from './FoundationStyledComponent'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+/* Provider */
+export { default as BezierProvider } from 'Providers/BezierProvider'
+
 /* Foundation */
 export * from 'Foundation'
 

--- a/src/providers/BezierProvider.tsx
+++ b/src/providers/BezierProvider.tsx
@@ -1,0 +1,27 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { Foundation, FoundationProvider, GlobalStyle, GlobalStyleProp } from 'Foundation'
+import EnableCSSHoudini from 'Worklets/EnableCSSHoudini'
+
+interface BezierProviderProps {
+  foundation: Foundation & GlobalStyleProp
+  children: React.ReactNode
+}
+
+function BezierProvider({
+  foundation,
+  children,
+}: BezierProviderProps) {
+  EnableCSSHoudini({ smoothCorners: true })
+
+  return (
+    <FoundationProvider foundation={foundation}>
+      <GlobalStyle foundation={foundation} />
+      { children }
+    </FoundationProvider>
+  )
+}
+
+export default BezierProvider

--- a/src/providers/BezierProvider.tsx
+++ b/src/providers/BezierProvider.tsx
@@ -2,7 +2,7 @@
 import React from 'react'
 
 /* Internal dependencies */
-import { Foundation, FoundationProvider, GlobalStyle, GlobalStyleProp } from 'Foundation'
+import { Foundation, FoundationProvider, GlobalStyle, GlobalStyleProp, ThemeVars } from 'Foundation'
 import EnableCSSHoudini from 'Worklets/EnableCSSHoudini'
 
 interface BezierProviderProps {
@@ -19,6 +19,7 @@ function BezierProvider({
   return (
     <FoundationProvider foundation={foundation}>
       <GlobalStyle foundation={foundation} />
+      <ThemeVars foundation={foundation} />
       { children }
     </FoundationProvider>
   )

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -3,14 +3,15 @@ import React, { ReactElement } from 'react'
 import { render as baseRender, RenderOptions } from '@testing-library/react'
 
 /* Internal dependencies */
-import { FoundationProvider, LightFoundation } from 'Foundation'
+import { LightFoundation } from 'Foundation'
+import BezierProvider from 'Providers/BezierProvider'
 import { ChildrenProps } from 'Types/ComponentProps'
 
 function TestProviders({ children }: ChildrenProps) {
   return (
-    <FoundationProvider foundation={LightFoundation}>
+    <BezierProvider foundation={LightFoundation}>
       { children }
-    </FoundationProvider>
+    </BezierProvider>
   )
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
       "Foundation/*": ["src/foundation/*"],
       "Hooks/*": ["src/hooks/*"],
       "Layout/*": ["src/layout/*"],
+      "Providers/*": ["src/providers/*"],
       "Types/*": ["src/types/*"],
       "Utils/*": ["src/utils/*"],
       "Worklets/*": ["src/worklets/*"],


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
지금까지의 Typography14 라는 값은 14px를 의미했습니다
이 PR에서는 Typography{Number} 라는 값이 {Number}rem을 의미하도록 변경합니다.

하지만 변수명 변경이나 각 사용처에서의 글자 사이즈 변경 등 Breaking Change를 막기 위해 html 의 font size를 62.5%(10px) 로 고정하여  사용하게끔 설정했습니다

특정 상황에서 Typo의 사이즈를 변경할 수 있게 하기 위해서(html의 font-size를 조정함으로써) GlobalStyle을 주입할 수 있게 해당 코드를 추가해주었습니다. Global style을 inject할 수 있게 foundation에 추가적인 prop을 넣는 작업을 진행했습니다

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
- BezierProvider 작성
- Typography를 Rem단위로 변경
- 외부에서 html font size 변경 가능하게끔 Global Style Inject를 지원
- 이에 따른 테스트 코드 업데이트

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
