### PR TITLE
fix(textarea): placeholder의 color를 추가 (like TextField)

### DIFF
--- a/src/components/Forms/Inputs/InputStyle.ts
+++ b/src/components/Forms/Inputs/InputStyle.ts
@@ -1,0 +1,8 @@
+/* Internal dependencies */
+import { css } from 'Foundation'
+
+export const inputPlaceholderStyle = css`
+  &::placeholder {
+    color: ${({ foundation }) => foundation?.theme?.['txt-black-dark']};
+  }
+`

--- a/src/components/Forms/Inputs/TextArea/TextArea.styled.ts
+++ b/src/components/Forms/Inputs/TextArea/TextArea.styled.ts
@@ -61,6 +61,7 @@ const TextAreaAutoSizeBase = styled(TextareaAutosize.default ?? TextareaAutosize
   ${Typography.Size14}
 
   &::placeholder {
+    color: ${({ foundation }) => foundation?.theme?.['txt-black-dark']};
     ${Typography.Size14}
   }
 

--- a/src/components/Forms/Inputs/TextArea/TextArea.styled.ts
+++ b/src/components/Forms/Inputs/TextArea/TextArea.styled.ts
@@ -6,6 +6,7 @@ import { hideScrollbars, SemanticNames, styled, Typography } from 'Foundation'
 import DisabledOpacity from 'Constants/DisabledOpacity'
 import { InterpolationProps } from 'Types/Foundation'
 import { erroredInputWrapperStyle, focusedInputWrapperStyle, inputWrapperStyle } from 'Components/Forms/Inputs/InputWrapperStyle'
+import { inputPlaceholderStyle } from 'Components/Forms/Inputs/InputStyle'
 
 interface WrapperProps extends InterpolationProps {
   focused: boolean
@@ -60,8 +61,9 @@ const TextAreaAutoSizeBase = styled(TextareaAutosize.default ?? TextareaAutosize
 
   ${Typography.Size14}
 
+  ${inputPlaceholderStyle}
+
   &::placeholder {
-    color: ${({ foundation }) => foundation?.theme?.['txt-black-dark']};
     ${Typography.Size14}
   }
 

--- a/src/components/Forms/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/Forms/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -45,21 +45,25 @@ exports[`TextArea 테스트 > SnapShot 테스트 > 1`] = `
 }
 
 .c1::-webkit-input-placeholder {
+  color: #00000066;
   font-size: 14px;
   line-height: 18px;
 }
 
 .c1::-moz-placeholder {
+  color: #00000066;
   font-size: 14px;
   line-height: 18px;
 }
 
 .c1:-ms-input-placeholder {
+  color: #00000066;
   font-size: 14px;
   line-height: 18px;
 }
 
 .c1::placeholder {
+  color: #00000066;
   font-size: 14px;
   line-height: 18px;
 }

--- a/src/components/Forms/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/Forms/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -46,24 +46,36 @@ exports[`TextArea 테스트 > SnapShot 테스트 > 1`] = `
 
 .c1::-webkit-input-placeholder {
   color: #00000066;
+}
+
+.c1::-moz-placeholder {
+  color: #00000066;
+}
+
+.c1:-ms-input-placeholder {
+  color: #00000066;
+}
+
+.c1::placeholder {
+  color: #00000066;
+}
+
+.c1::-webkit-input-placeholder {
   font-size: 14px;
   line-height: 18px;
 }
 
 .c1::-moz-placeholder {
-  color: #00000066;
   font-size: 14px;
   line-height: 18px;
 }
 
 .c1:-ms-input-placeholder {
-  color: #00000066;
   font-size: 14px;
   line-height: 18px;
 }
 
 .c1::placeholder {
-  color: #00000066;
   font-size: 14px;
   line-height: 18px;
 }

--- a/src/components/Forms/Inputs/TextField/TextField.styled.ts
+++ b/src/components/Forms/Inputs/TextField/TextField.styled.ts
@@ -7,6 +7,7 @@ import DisabledOpacity from 'Constants/DisabledOpacity'
 import { InterpolationProps } from 'Types/Foundation'
 import { Icon } from 'Components/Icon'
 import { inputWrapperStyle, focusedInputWrapperStyle, erroredInputWrapperStyle } from 'Components/Forms/Inputs/InputWrapperStyle'
+import { inputPlaceholderStyle } from 'Components/Forms/Inputs/InputStyle'
 import { TextFieldSize, TextFieldVariant } from './TextField.types'
 
 interface ClickableElementProps {
@@ -31,9 +32,7 @@ const Input = styled.input<InterpolationProps>`
   border: none;
   outline: none;
 
-  &::placeholder {
-    color: ${({ foundation }) => foundation?.theme?.['txt-black-dark']};
-  }
+  ${inputPlaceholderStyle}
 
   ${({ interpolation }) => interpolation}
 `


### PR DESCRIPTION
# Summary
https://github.com/channel-io/bezier-react/blob/612f134ad04bc33ee2df9ca6dbf1e5706be6c6aa/src/components/Forms/Inputs/TextField/TextField.styled.ts#L34-L36
해당 내용과 동일하게 color를 추가합니다. (디자인과 일치)

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
