### PR TITLE
Button 컴포넌트 스펙 최신화

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -151,8 +151,8 @@ describe('Button Test >', () => {
         expect(lButton).toHaveStyle('padding: 12px 10px;')
 
         // Typograpy.Size14
-        expect(lButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo14}px;`)
-        expect(lButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}px;`)
+        expect(lButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo15}px;`)
+        expect(lButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh20}px;`)
       })
 
       it('Size XL', () => {
@@ -165,8 +165,8 @@ describe('Button Test >', () => {
         expect(xlButton).toHaveStyle('padding: 15px 14px;')
 
         // Typograpy.Size16
-        expect(xlButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo16}px;`)
-        expect(xlButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh22}px;`)
+        expect(xlButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo18}px;`)
+        expect(xlButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh24}px;`)
       })
     })
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -107,6 +107,7 @@ function Button(
 ) {
   const [isHovered, setIsHovered] = useState(false)
 
+  // TODO(@ed): Text에 Padding 속성을 열어주고, M 이상인 경우 상하 1px 패딩 추가
   const textMargin = useMemo(() => {
     switch (size) {
       case ButtonSize.S:
@@ -125,9 +126,10 @@ function Button(
       case ButtonSize.XS:
       case ButtonSize.S:
         return Typography.Size13
-      case ButtonSize.XL:
-        return Typography.Size16
       case ButtonSize.L:
+        return Typography.Size15
+      case ButtonSize.XL:
+        return Typography.Size18
       case ButtonSize.M:
       default:
         return Typography.Size14
@@ -166,6 +168,7 @@ function Button(
       case ButtonSize.XS:
         return IconSize.XS
       case ButtonSize.XL:
+        return IconSize.Normal
       case ButtonSize.L:
       case ButtonSize.M:
       default:


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
Button 컴포넌트의 스펙을 베지어 디자인 시스템 스펙에 맞게 최신화합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
- 사이즈 `L` : Typo14 -> Typo15
- 사이즈 `XL` : Typo16 -> Typo18, IconSize.S -> IconSize.Normal

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- [Figma - Bezier Components](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=0%3A1)
