### PR TITLE
Divider 컴포넌트 마이그레이션

### DIFF
--- a/src/components/Divider/Divider.test.tsx
+++ b/src/components/Divider/Divider.test.tsx
@@ -41,6 +41,20 @@ describe('Divider >', () => {
     expect(divider).toHaveStyle('margin: 6px')
   })
 
+  it('renders with an aria attribute for web accessibility - horizontal', () => {
+    const { getByTestId } = renderDivider()
+    const divider = getByTestId(DIVIDER_TEST_ID)
+
+    expect(divider).toHaveAttribute('aria-orientation', 'horizontal')
+  })
+
+  it('renders with an aria attribute for web accessibility - vertical', () => {
+    const { getByTestId } = renderDivider({ orientation: 'vertical' })
+    const divider = getByTestId(DIVIDER_TEST_ID)
+
+    expect(divider).toHaveAttribute('aria-orientation', 'vertical')
+  })
+
   it('renders horizontal divider with correct style', () => {
     const { getByTestId } = renderDivider()
     const divider = getByTestId(DIVIDER_TEST_ID)

--- a/src/components/SectionLabel/SectionLabel.styled.ts
+++ b/src/components/SectionLabel/SectionLabel.styled.ts
@@ -81,12 +81,6 @@ const Wrapper = styled.div<ClickableElementProps & InterpolationProps>`
   ${({ interpolation }) => interpolation}
 `
 
-const Divider = styled.div`
-  height: 1px;
-  margin: 0 6px;
-  background-color: ${({ foundation }) => foundation?.theme?.['bdr-grey-light']};
-`
-
 export default {
   LeftIcon,
   LeftContentWrapper,
@@ -97,5 +91,4 @@ export default {
   RightItemWrapper,
   ChildrenWrapper,
   Wrapper,
-  Divider,
 }

--- a/src/components/SectionLabel/SectionLabel.test.tsx
+++ b/src/components/SectionLabel/SectionLabel.test.tsx
@@ -10,6 +10,7 @@ import SectionLabel, {
   SECTION_LABEL_TEST_CONTENT_ID,
   SECTION_LABEL_TEST_LEFT_CONTENT_ID,
   SECTION_LABEL_TEST_RIGHT_CONTENT_ID,
+  SECTION_LABEL_TEST_HELP_CONTENT_ID,
 } from './SectionLabel'
 import type SectionLabelProps from './SectionLabel.types'
 
@@ -83,6 +84,38 @@ describe('SectionLabel', () => {
 
     const leftIcon = leftContent.children.item(0)
     expect(leftIcon?.id).toBe('foo')
+  })
+
+  it('renders help content with default color if the help prop exists', () => {
+    const { getByTestId } = renderComponent({
+      help: {
+        tooltipContent: <div>happy</div>,
+      },
+    })
+    const helpContent = getByTestId(SECTION_LABEL_TEST_HELP_CONTENT_ID)
+
+    expect(helpContent.children.length).toBe(1)
+
+    const helpIcon = helpContent.children.item(0)
+    expect(helpIcon).toHaveAttribute('data-testid', ICON_TEST_ID)
+    expect(helpIcon).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']};`)
+  })
+
+  it('renders help content with specified icon and icon color', () => {
+    const { getByTestId } = renderComponent({
+      help: {
+        icon: 'weather-snow',
+        tooltipContent: <div>happy</div>,
+        iconColor: 'txt-white-normal',
+      },
+    })
+    const helpContent = getByTestId(SECTION_LABEL_TEST_HELP_CONTENT_ID)
+
+    expect(helpContent.children.length).toBe(1)
+
+    const helpIcon = helpContent.children.item(0)
+    expect(helpIcon).toHaveAttribute('data-testid', ICON_TEST_ID)
+    expect(helpIcon).toHaveStyle(`color: ${LightFoundation.theme['txt-white-normal']};`)
   })
 
   it('does not render right content if given null', () => {

--- a/src/components/SectionLabel/SectionLabel.test.tsx
+++ b/src/components/SectionLabel/SectionLabel.test.tsx
@@ -6,10 +6,12 @@ import { LightFoundation } from 'Foundation'
 import { render } from 'Utils/testUtils'
 import { BUTTON_TEST_ID } from 'Components/Button/Button'
 import { ICON_TEST_ID } from 'Components/Icon/Icon'
+import { DIVIDER_TEST_ID } from 'Components/Divider/Divider'
 import SectionLabel, {
   SECTION_LABEL_TEST_CONTENT_ID,
   SECTION_LABEL_TEST_LEFT_CONTENT_ID,
   SECTION_LABEL_TEST_RIGHT_CONTENT_ID,
+  SECTION_LABEL_TEST_ID,
   SECTION_LABEL_TEST_HELP_CONTENT_ID,
 } from './SectionLabel'
 import type SectionLabelProps from './SectionLabel.types'
@@ -171,5 +173,15 @@ describe('SectionLabel', () => {
     expect(rightContent.children.item(0)?.id).toBe('foo')
     expect(rightContent.children.item(1)?.id).toBe('bar')
     expect(rightContent.children.item(2)?.id).toBe('foobar')
+  })
+
+  it('renders with divider if the divider prop is true', () => {
+    const { getByTestId } = renderComponent({
+      divider: true,
+    })
+
+    const content = getByTestId(SECTION_LABEL_TEST_ID)
+
+    expect(content.children.item(0)).toHaveAttribute('data-testid', DIVIDER_TEST_ID)
   })
 })

--- a/src/components/SectionLabel/SectionLabel.tsx
+++ b/src/components/SectionLabel/SectionLabel.tsx
@@ -15,6 +15,7 @@ import SectionLabelProps, { SectionLabelItemProps } from './SectionLabel.types'
 export const SECTION_LABEL_TEST_CONTENT_ID = 'bezier-react-section-label-content'
 export const SECTION_LABEL_TEST_LEFT_CONTENT_ID = 'bezier-react-section-label-left-content'
 export const SECTION_LABEL_TEST_RIGHT_CONTENT_ID = 'bezier-react-section-label-right-content'
+export const SECTION_LABEL_TEST_HELP_CONTENT_ID = 'bezier-react-section-label-help-content'
 
 function renderSectionLabelActionItem(props: SectionLabelItemProps, key?: string): React.ReactElement {
   if (!('icon' in props)) {
@@ -156,7 +157,7 @@ function SectionLabel({
 
   const helpContent = useMemo(() => !isNil(help) && (
     <Tooltip content={help.tooltipContent}>
-      <Styled.HelpIconWrapper>
+      <Styled.HelpIconWrapper data-testid={SECTION_LABEL_TEST_HELP_CONTENT_ID}>
         <Icon
           name={help.icon ?? 'help-filled'}
           size={IconSize.XS}

--- a/src/components/SectionLabel/SectionLabel.tsx
+++ b/src/components/SectionLabel/SectionLabel.tsx
@@ -7,6 +7,7 @@ import { v4 as uuid } from 'uuid'
 import { Typography } from 'Foundation'
 import { Button, ButtonColorVariant, ButtonSize, ButtonStyleVariant } from 'Components/Button'
 import { Icon, IconSize } from 'Components/Icon'
+import { Divider } from 'Components/Divider'
 import { Tooltip } from 'Components/Tooltip'
 import Styled from './SectionLabel.styled'
 import SectionLabelProps, { SectionLabelItemProps } from './SectionLabel.types'
@@ -167,8 +168,7 @@ function SectionLabel({
 
   return (
     <div>
-      { /* FIXME: Bezier Divider로 변경 */ }
-      { divider && <Styled.Divider /> }
+      { divider && <Divider orientation="horizontal" /> }
       <Styled.Wrapper
         className={wrapperClassName}
         clickable={!isNil(onClick)}

--- a/src/components/SectionLabel/SectionLabel.tsx
+++ b/src/components/SectionLabel/SectionLabel.tsx
@@ -12,6 +12,7 @@ import { Tooltip } from 'Components/Tooltip'
 import Styled from './SectionLabel.styled'
 import SectionLabelProps, { SectionLabelItemProps } from './SectionLabel.types'
 
+export const SECTION_LABEL_TEST_ID = 'bezier-react-section-label'
 export const SECTION_LABEL_TEST_CONTENT_ID = 'bezier-react-section-label-content'
 export const SECTION_LABEL_TEST_LEFT_CONTENT_ID = 'bezier-react-section-label-left-content'
 export const SECTION_LABEL_TEST_RIGHT_CONTENT_ID = 'bezier-react-section-label-right-content'
@@ -168,7 +169,7 @@ function SectionLabel({
   ), [help])
 
   return (
-    <div>
+    <div data-testid={SECTION_LABEL_TEST_ID}>
       { divider && <Divider orientation="horizontal" /> }
       <Styled.Wrapper
         className={wrapperClassName}


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
- Divider 컴포넌트가 베지어에 생겨, 기존 스타일 컴포넌트로 적용되었던 Divider 컴포넌트를 마이그레이션 해주었습니다.
# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
