### PR TITLE
feat(status): statusSize 추가, AvatarSize에 맞게 StatusSize 지정

### DIFF
--- a/src/components/Avatars/Avatar/Avatar.styled.ts
+++ b/src/components/Avatars/Avatar/Avatar.styled.ts
@@ -3,7 +3,8 @@ import { styled, css, smoothCorners } from 'Foundation'
 import { enableSmoothCorners } from 'Worklets/EnableCSSHoudini'
 import type { InterpolationProps } from 'Types/Foundation'
 import DisabledOpacity from 'Constants/DisabledOpacity'
-import { AVATAR_STATUS_GAP, AVATAR_BORDER_WIDTH, AVATAR_BORDER_RADIUS_PERCENTAGE } from 'Components/Avatars/AvatarStyle'
+import { StatusSize } from 'Components/Status'
+import { AVATAR_BORDER_WIDTH, AVATAR_BORDER_RADIUS_PERCENTAGE } from 'Components/Avatars/AvatarStyle'
 import { AvatarSize } from './Avatar.types'
 
 interface AvatarWrapperProps extends InterpolationProps {
@@ -15,10 +16,16 @@ interface AvatarProps extends InterpolationProps {
   showBorder: boolean
 }
 
-function calcStatusGap(showBorder: boolean) {
-  return `${showBorder && enableSmoothCorners.current
-    ? (AVATAR_BORDER_WIDTH * 2) - AVATAR_STATUS_GAP
-    : -AVATAR_STATUS_GAP}px`
+interface StatusWrapperProps extends Pick<AvatarProps, 'showBorder'> {
+  size: StatusSize
+}
+
+function calcStatusGap(props: StatusWrapperProps) {
+  let size = (props.size >= StatusSize.L ? 4 : -2)
+  if (props.showBorder && enableSmoothCorners.current) {
+    size += AVATAR_BORDER_WIDTH * 2
+  }
+  return size
 }
 
 const disabledStyle = css`
@@ -81,8 +88,8 @@ export const AvatarWrapper = styled.div<AvatarWrapperProps>`
   ${({ interpolation }) => interpolation}
 `
 
-export const StatusWrapper = styled.div<Pick<AvatarProps, 'showBorder'>>`
+export const StatusWrapper = styled.div<StatusWrapperProps>`
   position: absolute;
-  right: ${({ showBorder }) => calcStatusGap(showBorder)};
-  bottom: ${({ showBorder }) => calcStatusGap(showBorder)};
+  right: ${props => calcStatusGap(props)}px;
+  bottom: ${props => calcStatusGap(props)}px;
 `

--- a/src/components/Avatars/Avatar/Avatar.styled.ts
+++ b/src/components/Avatars/Avatar/Avatar.styled.ts
@@ -20,12 +20,12 @@ interface StatusWrapperProps extends Pick<AvatarProps, 'showBorder'> {
   size: StatusSize
 }
 
-function calcStatusGap(props: StatusWrapperProps) {
-  let size = (props.size >= StatusSize.L ? 4 : -2)
-  if (props.showBorder && enableSmoothCorners.current) {
-    size += AVATAR_BORDER_WIDTH * 2
+function calcStatusGap({ showBorder, size }: StatusWrapperProps) {
+  let gap = (size >= StatusSize.L ? 4 : -2)
+  if (showBorder && enableSmoothCorners.current) {
+    gap += AVATAR_BORDER_WIDTH * 2
   }
-  return size
+  return gap
 }
 
 const disabledStyle = css`
@@ -90,6 +90,6 @@ export const AvatarWrapper = styled.div<AvatarWrapperProps>`
 
 export const StatusWrapper = styled.div<StatusWrapperProps>`
   position: absolute;
-  right: ${props => calcStatusGap(props)}px;
-  bottom: ${props => calcStatusGap(props)}px;
+  right: ${calcStatusGap}px;
+  bottom: ${calcStatusGap}px;
 `

--- a/src/components/Avatars/Avatar/Avatar.test.tsx
+++ b/src/components/Avatars/Avatar/Avatar.test.tsx
@@ -3,8 +3,15 @@ import React from 'react'
 
 /* Internal dependencies */
 import { render } from 'Utils/testUtils'
-import Avatar, { AVATAR_TEST_ID } from './Avatar'
-import AvatarProps from './Avatar.types'
+import { StatusType } from 'Components/Status'
+import Avatar, { AVATAR_TEST_ID, STATUS_WRAPPER_TEST_ID } from './Avatar'
+import AvatarProps, { AvatarSize } from './Avatar.types'
+
+jest.mock('Worklets/EnableCSSHoudini', () => ({
+  __esModule: true,
+  ...jest.requireActual('Worklets/EnableCSSHoudini') as object,
+  enableSmoothCorners: { current: true },
+}))
 
 // TODO: 테스트 코드 보강
 describe('Avatar test >', () => {
@@ -21,8 +28,12 @@ describe('Avatar test >', () => {
     }
   })
 
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
   // NOTE: unavailable smoothCorners
-  const renderAvatar = (optionProps?: AvatarProps) => render(
+  const renderAvatar = (optionProps?: Partial<AvatarProps>) => render(
     <Avatar {...props} {...optionProps} />,
   )
 
@@ -31,5 +42,33 @@ describe('Avatar test >', () => {
     const avatar = getByTestId(AVATAR_TEST_ID)
 
     expect(avatar).toMatchSnapshot()
+  })
+
+  it('should have right -2px, bottom -2px style on StatusWrapper', () => {
+    const { getByTestId } = renderAvatar({ status: StatusType.Online })
+    const statusWrapper = getByTestId(STATUS_WRAPPER_TEST_ID)
+
+    expect(statusWrapper).toMatchSnapshot()
+  })
+
+  it('should have right 2px, bottom 2px style on StatusWrapper when show border', () => {
+    const { getByTestId } = renderAvatar({ status: StatusType.Online, showBorder: true })
+    const statusWrapper = getByTestId(STATUS_WRAPPER_TEST_ID)
+
+    expect(statusWrapper).toMatchSnapshot()
+  })
+
+  it('should have right 4px, bottom 4px style on StatusWrapper when size grater then 90', () => {
+    const { getByTestId } = renderAvatar({ status: StatusType.Online, size: AvatarSize.Size90 })
+    const statusWrapper = getByTestId(STATUS_WRAPPER_TEST_ID)
+
+    expect(statusWrapper).toMatchSnapshot()
+  })
+
+  it('should have right 8px, bottom 8px style on StatusWrapper when size grater then 90 and show border', () => {
+    const { getByTestId } = renderAvatar({ status: StatusType.Online, size: AvatarSize.Size90, showBorder: true })
+    const statusWrapper = getByTestId(STATUS_WRAPPER_TEST_ID)
+
+    expect(statusWrapper).toMatchSnapshot()
   })
 })

--- a/src/components/Avatars/Avatar/Avatar.tsx
+++ b/src/components/Avatars/Avatar/Avatar.tsx
@@ -4,7 +4,7 @@ import { noop, isEmpty } from 'lodash-es'
 
 /* Internal dependencies */
 import { smoothCornersStyle } from 'Foundation'
-import { Status } from 'Components/Status'
+import { Status, StatusSize } from 'Components/Status'
 // eslint-disable-next-line no-restricted-imports
 import defaultAvatarUrl from '../assets/defaultAvatar.svg'
 import useProgressiveImage from './useProgressiveImage'
@@ -14,6 +14,7 @@ import { AvatarImage, AvatarImageWrapper, AvatarWrapper, StatusWrapper } from '.
 // TODO: 테스트 코드 작성
 const AVATAR_WRAPPER_TEST_ID = 'bezier-react-avatar-wrapper'
 export const AVATAR_TEST_ID = 'bezier-react-avatar'
+export const STATUS_WRAPPER_TEST_ID = 'bezier-react-status-wrapper'
 
 function Avatar({
   avatarUrl = '',
@@ -45,11 +46,15 @@ forwardedRef: React.Ref<HTMLDivElement>,
       return null
     }
 
+    const statusSize = size >= AvatarSize.Size90 ? StatusSize.L : StatusSize.M
     const Contents = (() => {
       if (children) { return children }
       if (status) {
         return (
-          <Status type={status} />
+          <Status
+            type={status}
+            size={statusSize}
+          />
         )
       }
       return null
@@ -57,6 +62,8 @@ forwardedRef: React.Ref<HTMLDivElement>,
 
     return (
       <StatusWrapper
+        data-testid={STATUS_WRAPPER_TEST_ID}
+        size={statusSize}
         showBorder={showBorder}
       >
         { Contents }
@@ -64,6 +71,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
     )
   }, [
     status,
+    size,
     showBorder,
     children,
   ])

--- a/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -54,3 +54,203 @@ exports[`Avatar test > Snapshot 1`] = `
   style="--background-image: url(https://www.google.com);"
 />
 `;
+
+exports[`Avatar test > should have right -2px, bottom -2px style on StatusWrapper 1`] = `
+.c1 {
+  box-sizing: border-box;
+  border-color: #FFFFFF;
+  border-style: solid solid solid solid;
+  border-width: 2px;
+  position: relative;
+  box-sizing: content-box;
+  width: 8px;
+  height: 8px;
+  background-color: #FFFFFF;
+  border-radius: 50%;
+}
+
+.c1::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 8px;
+  height: 8px;
+  content: '';
+  background-color: #31A552;
+  border-radius: 50%;
+}
+
+.c0 {
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+}
+
+@supports (background:paint(smooth-corners)) {
+
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-status-wrapper"
+  size="8"
+>
+  <div
+    class="c1"
+    color="bgtxt-green-normal"
+    data-testid="bezier-react-status"
+    size="8"
+  />
+</div>
+`;
+
+exports[`Avatar test > should have right 2px, bottom 2px style on StatusWrapper when show border 1`] = `
+.c1 {
+  box-sizing: border-box;
+  border-color: #FFFFFF;
+  border-style: solid solid solid solid;
+  border-width: 2px;
+  position: relative;
+  box-sizing: content-box;
+  width: 8px;
+  height: 8px;
+  background-color: #FFFFFF;
+  border-radius: 50%;
+}
+
+.c1::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 8px;
+  height: 8px;
+  content: '';
+  background-color: #31A552;
+  border-radius: 50%;
+}
+
+.c0 {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+}
+
+@supports (background:paint(smooth-corners)) {
+
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-status-wrapper"
+  size="8"
+>
+  <div
+    class="c1"
+    color="bgtxt-green-normal"
+    data-testid="bezier-react-status"
+    size="8"
+  />
+</div>
+`;
+
+exports[`Avatar test > should have right 4px, bottom 4px style on StatusWrapper when size grater then 90 1`] = `
+.c1 {
+  box-sizing: border-box;
+  border-color: #FFFFFF;
+  border-style: solid solid solid solid;
+  border-width: 3px;
+  position: relative;
+  box-sizing: content-box;
+  width: 14px;
+  height: 14px;
+  background-color: #FFFFFF;
+  border-radius: 50%;
+}
+
+.c1::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 14px;
+  height: 14px;
+  content: '';
+  background-color: #31A552;
+  border-radius: 50%;
+}
+
+.c0 {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+}
+
+@supports (background:paint(smooth-corners)) {
+
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-status-wrapper"
+  size="14"
+>
+  <div
+    class="c1"
+    color="bgtxt-green-normal"
+    data-testid="bezier-react-status"
+    size="14"
+  />
+</div>
+`;
+
+exports[`Avatar test > should have right 8px, bottom 8px style on StatusWrapper when size grater then 90 and show border 1`] = `
+.c1 {
+  box-sizing: border-box;
+  border-color: #FFFFFF;
+  border-style: solid solid solid solid;
+  border-width: 3px;
+  position: relative;
+  box-sizing: content-box;
+  width: 14px;
+  height: 14px;
+  background-color: #FFFFFF;
+  border-radius: 50%;
+}
+
+.c1::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 14px;
+  height: 14px;
+  content: '';
+  background-color: #31A552;
+  border-radius: 50%;
+}
+
+.c0 {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+}
+
+@supports (background:paint(smooth-corners)) {
+
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-status-wrapper"
+  size="14"
+>
+  <div
+    class="c1"
+    color="bgtxt-green-normal"
+    data-testid="bezier-react-status"
+    size="14"
+  />
+</div>
+`;

--- a/src/components/Avatars/AvatarStyle.ts
+++ b/src/components/Avatars/AvatarStyle.ts
@@ -1,7 +1,5 @@
 export const AVATAR_BORDER_RADIUS_PERCENTAGE = 42
 
-export const AVATAR_STATUS_GAP = 2
-
 export const AVATAR_BORDER_WIDTH = 2
 
 export const AVATAR_GROUP_DEFAULT_SPACING = 4

--- a/src/components/Status/Status.stories.tsx
+++ b/src/components/Status/Status.stories.tsx
@@ -6,7 +6,7 @@ import { Story, Meta } from '@storybook/react'
 /* Internal dependencies */
 import { styled } from 'Foundation'
 import { getTitle } from 'Utils/storyUtils'
-import { StatusProps, StatusType } from './Status.types'
+import { StatusProps, StatusSize, StatusType } from './Status.types'
 import Status from './Status'
 
 export default {
@@ -40,4 +40,5 @@ const Template: Story<StatusProps> = (args) => (
 export const Primary: Story<StatusProps> = Template.bind({})
 Primary.args = {
   type: StatusType.Online,
+  size: StatusSize.M,
 }

--- a/src/components/Status/Status.styled.ts
+++ b/src/components/Status/Status.styled.ts
@@ -14,13 +14,16 @@ interface StatusCircleProps {
 }
 
 export const StatusCircle = styled.div<StatusCircleProps>`
-  ${({ foundation, size }) => foundation?.border?.getBorder(getStatusCircleBorderSize(size), foundation?.theme?.['bdr-white'])};
+  ${({ foundation, size }) => foundation?.border?.getBorder(
+    getStatusCircleBorderSize(size),
+    foundation?.theme?.['bg-white-high'],
+  )};
 
   position: relative;
   box-sizing: content-box;
   width: ${({ size }) => size}px;
   height: ${({ size }) => size}px;
-  background-color: ${({ foundation }) => foundation?.theme?.['bg-white-normal']};
+  background-color: ${({ foundation }) => foundation?.theme?.['bg-white-high']};
   border-radius: 50%;
 
   &::after {
@@ -31,7 +34,7 @@ export const StatusCircle = styled.div<StatusCircleProps>`
     width: ${({ size }) => size}px;
     height: ${({ size }) => size}px;
     content: '';
-    background-color: ${({ foundation, color = 'bg-white-normal' }) => foundation?.theme?.[color]};
+    background-color: ${({ foundation, color = 'bg-white-high' }) => foundation?.theme?.[color]};
     border-radius: 50%;
   }
 `

--- a/src/components/Status/Status.styled.ts
+++ b/src/components/Status/Status.styled.ts
@@ -1,21 +1,25 @@
-/* Internal denpendencies */
+/* Internal dependencies */
 import { styled, absoluteCenter, SemanticNames } from 'Foundation'
 import { Icon } from 'Components/Icon'
+import { StatusSize } from './Status.types'
 
-const STATUS_CIRCLE_SIZE = 8
-const STATUS_CIRCLE_BORDER_WIDTH = 2
+function getStatusCircleBorderSize(size: StatusSize) {
+  if (size >= StatusSize.L) { return 3 }
+  return 2
+}
 
 interface StatusCircleProps {
   color: SemanticNames
+  size: StatusSize
 }
 
 export const StatusCircle = styled.div<StatusCircleProps>`
-  ${({ foundation }) => foundation?.border?.getBorder(STATUS_CIRCLE_BORDER_WIDTH, foundation?.theme?.['bdr-white'])};
+  ${({ foundation, size }) => foundation?.border?.getBorder(getStatusCircleBorderSize(size), foundation?.theme?.['bdr-white'])};
 
   position: relative;
   box-sizing: content-box;
-  width: ${STATUS_CIRCLE_SIZE}px;
-  height: ${STATUS_CIRCLE_SIZE}px;
+  width: ${({ size }) => size}px;
+  height: ${({ size }) => size}px;
   background-color: ${({ foundation }) => foundation?.theme?.['bg-white-normal']};
   border-radius: 50%;
 
@@ -24,8 +28,8 @@ export const StatusCircle = styled.div<StatusCircleProps>`
     top: 0;
     left: 0;
     display: block;
-    width: ${STATUS_CIRCLE_SIZE}px;
-    height: ${STATUS_CIRCLE_SIZE}px;
+    width: ${({ size }) => size}px;
+    height: ${({ size }) => size}px;
     content: '';
     background-color: ${({ foundation, color = 'bg-white-normal' }) => foundation?.theme?.[color]};
     border-radius: 50%;

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 /* Internal denpendencies */
 import { IconSize } from 'Components/Icon'
-import { StatusType, StatusProps } from './Status.types'
+import { StatusType, StatusSize, StatusProps } from './Status.types'
 import { StatusCircle, LockIcon } from './Status.styled'
 
 // TODO: 테스트 코드 작성
@@ -11,12 +11,14 @@ const STATUS_TEST_ID = 'bezier-react-status'
 
 function Status({
   type,
+  size = StatusSize.M,
 }: StatusProps) {
   if (type === StatusType.Lock) {
     return (
       <StatusCircle
         data-testid={STATUS_TEST_ID}
         color="bg-white-normal"
+        size={size}
       >
         <LockIcon
           name="lock"
@@ -31,6 +33,7 @@ function Status({
     <StatusCircle
       data-testid={STATUS_TEST_ID}
       color={type === StatusType.Online ? 'bgtxt-green-normal' : 'bg-black-dark'}
+      size={size}
     />
   )
 }

--- a/src/components/Status/Status.types.ts
+++ b/src/components/Status/Status.types.ts
@@ -4,6 +4,12 @@ export enum StatusType {
   Lock = 'Lock',
 }
 
+export enum StatusSize {
+  M = 8,
+  L = 14,
+}
+
 export interface StatusProps {
   type: StatusType
+  size: StatusSize
 }

--- a/src/components/Status/index.ts
+++ b/src/components/Status/index.ts
@@ -1,5 +1,5 @@
 import Status from './Status'
-import { StatusType } from './Status.types'
+import { StatusType, StatusSize } from './Status.types'
 import type { StatusProps } from './Status.types'
 
 export type {
@@ -9,4 +9,5 @@ export type {
 export {
   Status,
   StatusType,
+  StatusSize,
 }


### PR DESCRIPTION
# Summary
<img width="463" alt="스크린샷 2021-12-20 오후 4 56 55" src="https://user-images.githubusercontent.com/33291896/146732313-752dec84-22a1-4622-8275-2dc30cb524db.png">

위 디자인을 구현합니다.

# Details
14px 크기의 Status를 추가하고, 적절한 AvatarSize에 대해 StatusSize를 자동으로 지정합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)