### PR TITLE
fix(avatar): border-color 변경

### DIFF
--- a/src/components/Avatars/Avatar/Avatar.styled.ts
+++ b/src/components/Avatars/Avatar/Avatar.styled.ts
@@ -34,7 +34,7 @@ const disabledStyle = css`
 
 const smoothCornersFallbackBorderStyle = css`
   &::after {
-    ${({ foundation }) => foundation?.border?.getBorder(AVATAR_BORDER_WIDTH, foundation?.theme?.['bgtxt-absolute-white-dark'])};
+    ${({ foundation }) => foundation?.border?.getBorder(AVATAR_BORDER_WIDTH, foundation?.theme?.['bg-white-high'])};
 
     position: absolute;
     top: -${AVATAR_BORDER_WIDTH}px;
@@ -64,7 +64,7 @@ export const AvatarImage = styled.div<AvatarProps>`
   ${({ showBorder }) => (!enableSmoothCorners.current && showBorder) && smoothCornersFallbackBorderStyle}
 
   ${({ foundation, showBorder }) => smoothCorners({
-    shadow: showBorder ? `0 0 0 ${AVATAR_BORDER_WIDTH}px ${foundation?.theme?.['bgtxt-absolute-white-dark']}` : undefined,
+    shadow: showBorder ? `0 0 0 ${AVATAR_BORDER_WIDTH}px ${foundation?.theme?.['bg-white-high']}` : undefined,
     shadowBlur: showBorder ? AVATAR_BORDER_WIDTH : 0,
     backgroundColor: foundation?.theme?.['bgtxt-absolute-white-dark'],
     borderRadius: `${AVATAR_BORDER_RADIUS_PERCENTAGE}%`,

--- a/src/components/Avatars/Avatar/Avatar.test.tsx
+++ b/src/components/Avatars/Avatar/Avatar.test.tsx
@@ -3,8 +3,10 @@ import React from 'react'
 
 /* Internal dependencies */
 import { render } from 'Utils/testUtils'
+import DisabledOpacity from 'Constants/DisabledOpacity'
 import { StatusType } from 'Components/Status'
-import Avatar, { AVATAR_TEST_ID, STATUS_WRAPPER_TEST_ID } from './Avatar'
+import { AVATAR_BORDER_RADIUS_PERCENTAGE } from 'Components/Avatars/AvatarStyle'
+import Avatar, { AVATAR_TEST_ID, AVATAR_WRAPPER_TEST_ID, STATUS_WRAPPER_TEST_ID } from './Avatar'
 import AvatarProps, { AvatarSize } from './Avatar.types'
 
 jest.mock('Worklets/EnableCSSHoudini', () => ({
@@ -13,8 +15,7 @@ jest.mock('Worklets/EnableCSSHoudini', () => ({
   enableSmoothCorners: { current: true },
 }))
 
-// TODO: 테스트 코드 보강
-describe('Avatar test >', () => {
+describe('Avatar >', () => {
   let props: AvatarProps
 
   const mockAvatarUrl = 'https://bit.ly/dan-abramov'
@@ -39,9 +40,38 @@ describe('Avatar test >', () => {
 
   it('Snapshot', () => {
     const { getByTestId } = renderAvatar()
-    const avatar = getByTestId(AVATAR_TEST_ID)
+    const img = getByTestId(AVATAR_TEST_ID)
 
-    expect(avatar).toMatchSnapshot()
+    expect(img).toMatchSnapshot()
+  })
+
+  it('renders image with correct style', () => {
+    const { getByTestId } = renderAvatar()
+    const img = getByTestId(AVATAR_TEST_ID)
+
+    expect(img).toHaveStyle('position: relative')
+    expect(img).toHaveStyle('box-sizing: content-box')
+    expect(img).toHaveStyle('display: flex')
+    expect(img).toHaveStyle('outline: none')
+    expect(img).toHaveStyle('background-image: var(--background-image)')
+    expect(img).toHaveStyle(`--background-image: url(${mockFallbackUrl})`)
+    expect(img).toHaveStyle('background-size: cover')
+    expect(img).toHaveStyle(`border-radius: ${AVATAR_BORDER_RADIUS_PERCENTAGE}%`)
+  })
+
+  it('renders disabled style', () => {
+    const { getByTestId } = renderAvatar({ disabled: true })
+    const wrapper = getByTestId(AVATAR_WRAPPER_TEST_ID)
+
+    expect(wrapper).toHaveStyle(`opacity: ${DisabledOpacity}`)
+  })
+
+  it('renders border style', () => {
+    const { getByTestId } = renderAvatar({ showBorder: true })
+    const img = getByTestId(AVATAR_TEST_ID)
+
+    // NOTE(@ed): psuedo element 스타일 테스트가 어려워, 스냅샷 테스트로 대체
+    expect(img).toMatchSnapshot()
   })
 
   it('should have right -2px, bottom -2px style on StatusWrapper', () => {

--- a/src/components/Avatars/Avatar/Avatar.tsx
+++ b/src/components/Avatars/Avatar/Avatar.tsx
@@ -11,8 +11,7 @@ import useProgressiveImage from './useProgressiveImage'
 import AvatarProps, { AvatarSize } from './Avatar.types'
 import { AvatarImage, AvatarImageWrapper, AvatarWrapper, StatusWrapper } from './Avatar.styled'
 
-// TODO: 테스트 코드 작성
-const AVATAR_WRAPPER_TEST_ID = 'bezier-react-avatar-wrapper'
+export const AVATAR_WRAPPER_TEST_ID = 'bezier-react-avatar-wrapper'
 export const AVATAR_TEST_ID = 'bezier-react-avatar'
 export const STATUS_WRAPPER_TEST_ID = 'bezier-react-status-wrapper'
 

--- a/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Avatar test > Snapshot 1`] = `
+exports[`Avatar > Snapshot 1`] = `
 .c0 {
   position: relative;
   box-sizing: content-box;
@@ -55,7 +55,62 @@ exports[`Avatar test > Snapshot 1`] = `
 />
 `;
 
-exports[`Avatar test > should have right -2px, bottom -2px style on StatusWrapper 1`] = `
+exports[`Avatar > renders border style 1`] = `
+.c0 {
+  position: relative;
+  box-sizing: content-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  outline: none;
+  margin: 0px;
+  background-color: #FFFFFF;
+  background-image: var(--background-image);
+  background-size: cover;
+  border-radius: 42%;
+}
+
+@supports (background:paint(smooth-corners)) {
+  .c0 {
+    padding: 4px;
+    margin: -4px;
+    background: paint(smooth-corners);
+    border-radius: 0;
+    box-shadow: none;
+    border-image-source: var(--background-image);
+    --smooth-corners: 42%;
+    --smooth-corners-shadow: 0 0 0 2px #FFFFFF;
+    --smooth-corners-bg-color: #FFFFFF;
+    --smooth-corners-padding: 4;
+    --smooth-corners-radius-unit: string;
+  }
+}
+
+<div
+  aria-label="Name"
+  class="c0"
+  data-testid="bezier-react-avatar"
+  role="img"
+  size="24"
+  style="--background-image: url(https://www.google.com);"
+/>
+`;
+
+exports[`Avatar > should have right -2px, bottom -2px style on StatusWrapper 1`] = `
 .c1 {
   box-sizing: border-box;
   border-color: #FFFFFF;
@@ -105,7 +160,7 @@ exports[`Avatar test > should have right -2px, bottom -2px style on StatusWrappe
 </div>
 `;
 
-exports[`Avatar test > should have right 2px, bottom 2px style on StatusWrapper when show border 1`] = `
+exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when show border 1`] = `
 .c1 {
   box-sizing: border-box;
   border-color: #FFFFFF;
@@ -155,7 +210,7 @@ exports[`Avatar test > should have right 2px, bottom 2px style on StatusWrapper 
 </div>
 `;
 
-exports[`Avatar test > should have right 4px, bottom 4px style on StatusWrapper when size grater then 90 1`] = `
+exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when size grater then 90 1`] = `
 .c1 {
   box-sizing: border-box;
   border-color: #FFFFFF;
@@ -205,7 +260,7 @@ exports[`Avatar test > should have right 4px, bottom 4px style on StatusWrapper 
 </div>
 `;
 
-exports[`Avatar test > should have right 8px, bottom 8px style on StatusWrapper when size grater then 90 and show border 1`] = `
+exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when size grater then 90 and show border 1`] = `
 .c1 {
   box-sizing: border-box;
   border-color: #FFFFFF;


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

`Avatar` 컴포넌트의 border color를 변경합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
기존의 #FFF 고정값에서, 테마에 따라 색상이 변경될 수 있도록 합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- [이전 메세지](https://desk.channel.io/root/groups/Bezier-62019/6113c08672c1b7a09d60)
