### PR TITLE
fix(tooltip): tooltip이 contentInterpolation prop을 받도록 수정

### DIFF
--- a/src/components/Tooltip/Tooltip.styled.ts
+++ b/src/components/Tooltip/Tooltip.styled.ts
@@ -1,5 +1,6 @@
 /* Internal dependencies */
 import { styled, css, ellipsis, LineHeightAbsoluteNumber } from 'Foundation'
+import type { InterpolationProps } from 'Types/Foundation'
 
 interface ContentWrapperProps {
   disabled: boolean
@@ -24,7 +25,7 @@ export const ContentWrapper = styled.div<ContentWrapperProps>`
   `}
 `
 
-export const Content = styled.div`
+export const Content = styled.div<InterpolationProps>`
   box-sizing: border-box;
   width: max-content;
   max-width: 260px;
@@ -34,6 +35,8 @@ export const Content = styled.div`
   word-break: break-all;
   ${({ foundation }) => foundation?.elevation?.ev2(true)};
   ${({ foundation }) => foundation?.rounding?.round8};
+
+  ${({ interpolation }) => interpolation}
 `
 
 export const EllipsisableContent = styled.div`

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,66 @@
+/* External dependencies */
+import React from 'react'
+import { fireEvent } from '@testing-library/dom'
+
+/* Internal dependencies */
+import { css } from 'Foundation'
+import { render } from 'Utils/testUtils'
+import Tooltip, { TOOLTIP_TEST_ID } from './Tooltip'
+import TooltipProps from './Tooltip.types'
+
+const ROOT_TESTID = 'container'
+
+const RootTooltip: React.FC<TooltipProps> = ({ children, ...rests }) => (
+  <div id="main" data-testid={ROOT_TESTID}>
+    <Tooltip {...rests}>
+      { children }
+    </Tooltip>
+  </div>
+)
+
+describe('Tooltip test >', () => {
+  let props: TooltipProps
+
+  const content = 'Hovered'
+
+  beforeEach(() => {
+    props = {
+      children: 'Text',
+      content,
+    }
+
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const renderTooltip = (optionProps?: TooltipProps) => render(
+    <RootTooltip {...props} {...optionProps} />,
+  )
+
+  it('Tooltip with default props', () => {
+    const { getByTestId } = renderTooltip()
+    const rendered = getByTestId(ROOT_TESTID)
+
+    fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
+
+    jest.runAllTimers()
+
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('Tooltip with contentInterpolation prop', async () => {
+    const { getByTestId } = renderTooltip({
+      contentInterpolation: css`background-color: black;`,
+    })
+    const rendered = getByTestId(ROOT_TESTID)
+
+    fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
+
+    jest.runAllTimers()
+
+    expect(rendered).toMatchSnapshot()
+  })
+})

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -22,6 +22,7 @@ function Tooltip(
     testId = TOOLTIP_TEST_ID,
     className,
     contentClassName,
+    contentInterpolation,
     content = null,
     placement = TooltipPosition.BottomCenter,
     disabled = false,
@@ -159,6 +160,7 @@ function Tooltip(
         as={as}
         data-testid={testId}
         className={contentClassName}
+        interpolation={contentInterpolation}
         ref={mergedRef}
       >
         <EllipsisableContent>
@@ -171,6 +173,7 @@ function Tooltip(
     as,
     content,
     contentClassName,
+    contentInterpolation,
     contentWrapperStyle,
     disabled,
     keepInContainer,

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -190,7 +190,8 @@ function Tooltip(
   }, [disabled])
 
   useEffect(() => {
-    if (show && tooltipRef.current) {
+    if (show) {
+      if (!tooltipRef.current) { return }
       const newPlacement = getReplacement({
         tooltip: tooltipRef.current,
         keepInContainer,

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -13,8 +13,7 @@ import TooltipProps, { TooltipPosition } from './Tooltip.types'
 import { getReplacement, getTooltipStyle } from './utils'
 import { Container, ContentWrapper, Content, EllipsisableContent } from './Tooltip.styled'
 
-// TODO: 테스트 코드 작성
-const TOOLTIP_TEST_ID = 'bezier-react-tooltip'
+export const TOOLTIP_TEST_ID = 'bezier-react-tooltip'
 
 function Tooltip(
   {
@@ -216,6 +215,7 @@ function Tooltip(
   return (
     <Container
       ref={tooltipContainerRef}
+      data-testid={testId}
       className={className}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -1,0 +1,182 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tooltip test > Tooltip with contentInterpolation prop 1`] = `
+.c4 {
+  font-size: 14px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1000000000;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 260px;
+  height: -webkit-max-content;
+  height: -moz-max-content;
+  height: max-content;
+  padding: 8px 14px;
+  color: #FFFFFFE6;
+  word-break: break-all;
+  background-color: #313234;
+  box-shadow: inset 0 0 2px 0 #FFFFFF14, 0 0 2px 1px #00000014, 0 2px 6px #00000026;
+  overflow: hidden;
+  border-radius: 8px;
+  background-color: black;
+}
+
+.c3 {
+  display: -webkit-box;
+  max-height: 360px;
+  overflow: hidden;
+  line-height: 18px;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 20;
+}
+
+<div
+  data-testid="container"
+  id="main"
+>
+  <div
+    class="c0"
+    data-testid="bezier-react-tooltip"
+  >
+    Text
+  </div>
+  <div
+    class="c1"
+    style="position: fixed; top: 4px; left: 0px; transform: translate(-50%, 0%);"
+  >
+    <div
+      class="c2"
+      data-testid="bezier-react-tooltip"
+    >
+      <div
+        class="c3"
+      >
+        <span
+          class="c4"
+          data-testid="bezier-react-text"
+        >
+          Hovered
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Tooltip test > Tooltip with default props 1`] = `
+.c4 {
+  font-size: 14px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1000000000;
+}
+
+.c2 {
+  box-sizing: border-box;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 260px;
+  height: -webkit-max-content;
+  height: -moz-max-content;
+  height: max-content;
+  padding: 8px 14px;
+  color: #FFFFFFE6;
+  word-break: break-all;
+  background-color: #313234;
+  box-shadow: inset 0 0 2px 0 #FFFFFF14, 0 0 2px 1px #00000014, 0 2px 6px #00000026;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.c3 {
+  display: -webkit-box;
+  max-height: 360px;
+  overflow: hidden;
+  line-height: 18px;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 20;
+}
+
+<div
+  data-testid="container"
+  id="main"
+>
+  <div
+    class="c0"
+    data-testid="bezier-react-tooltip"
+  >
+    Text
+  </div>
+  <div
+    class="c1"
+    style="position: fixed; top: 4px; left: 0px; transform: translate(-50%, 0%);"
+  >
+    <div
+      class="c2"
+      data-testid="bezier-react-tooltip"
+    >
+      <div
+        class="c3"
+      >
+        <span
+          class="c4"
+          data-testid="bezier-react-text"
+        >
+          Hovered
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
# Summary
styled-component 기반으로 사용시 contentClassName 를 대체할 수 있는 contentInterpolation를 추가

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
