### PR TITLE
fix(status): size prop 타입을 optional으로 수정

### DIFF
--- a/src/components/Status/Status.types.ts
+++ b/src/components/Status/Status.types.ts
@@ -11,5 +11,5 @@ export enum StatusSize {
 
 export interface StatusProps {
   type: StatusType
-  size: StatusSize
+  size?: StatusSize
 }


### PR DESCRIPTION
# Summary
#675 의 누락

# Details
https://github.com/channel-io/bezier-react/blob/a47dbc5625841730182db97258a1f95b08b40e0e/src/components/Status/Status.tsx#L12-L15
해당 default value를 사용하기 위해서 undefined size를 넣어줄 수 있도록 변경

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
