### PR TITLE
Input 컴포넌트의 box-shadow 색상 스펙 최신화

### DIFF
--- a/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   user-select: none;
   background-color: #FCFCFC;
   color: #000000D9;
-  box-shadow: 0 1px 2px #00000008, inset 0 0 0 1px #0000000D;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
   height: 36px;
   overflow: hidden;
   border-radius: 8px;

--- a/src/components/Forms/Inputs/TextArea/TextArea.test.tsx
+++ b/src/components/Forms/Inputs/TextArea/TextArea.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent } from '@testing-library/dom'
 import React from 'react'
 
 /* Internal dependencies */
-import { Palette } from 'Foundation/Colors/Palette'
+import { LightFoundation } from 'Foundation'
 import disabledOpacity from 'Constants/DisabledOpacity'
 import { render } from 'Utils/testUtils'
 import TextArea, { TEXT_AREA_TEST_ID } from './TextArea'
@@ -71,7 +71,8 @@ describe('TextArea 테스트 >', () => {
     textareaElement.focus()
 
     jest.advanceTimersByTime(1000)
-    expect(rendered).toHaveStyle(`box-shadow: 0 0 0 3px ${Palette.blue400_20}, inset 0 0 0 1px ${Palette.blue400}`)
+    // eslint-disable-next-line max-len
+    expect(rendered).toHaveStyle(`box-shadow: 0 0 0 3px ${LightFoundation.theme['bgtxt-blue-light']}, inset 0 0 0 1px ${LightFoundation.theme['bgtxt-blue-normal']}`)
   })
 
   it('error 상태일 때는 그에 맞는 shadow 스타일을 가져야 한다', () => {
@@ -80,7 +81,8 @@ describe('TextArea 테스트 >', () => {
     const rendered = getByTestId(TEXT_AREA_TEST_ID)
 
     jest.advanceTimersByTime(1000)
-    expect(rendered).toHaveStyle(`box-shadow: 0 0 0 3px ${Palette.orange400_20}, inset 0 0 0 1px ${Palette.orange400}`)
+    // eslint-disable-next-line max-len
+    expect(rendered).toHaveStyle(`box-shadow: 0 0 0 3px ${LightFoundation.theme['bgtxt-orange-light']}, inset 0 0 0 1px ${LightFoundation.theme['bgtxt-orange-normal']}`)
   })
 
   describe('onFocus 테스트 >', () => {

--- a/src/components/Forms/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/Forms/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TextArea 테스트 > SnapShot 테스트 > 1`] = `
 .c0 {
-  box-shadow: 0 1px 2px #00000008, inset 0 0 0 1px #0000000D;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/components/Forms/Inputs/TextField/TextField.test.tsx
+++ b/src/components/Forms/Inputs/TextField/TextField.test.tsx
@@ -88,29 +88,29 @@ describe('TextField', () => {
     })).toBe('bg-grey-lighter')
   })
 
-  it('shoud have default style when have no props.', () => {
+  it('should have default style when have no props.', () => {
     const { getByTestId } = renderComponent()
     const rendered = getByTestId(TEXT_INPUT_TEST_ID)
     expect(rendered).toHaveStyle(`background-color: ${LightFoundation.theme['bg-grey-lightest']}`)
     // eslint-disable-next-line max-len
-    expect(rendered).toHaveStyle(`box-shadow: 0 1px 2px ${LightFoundation.theme['bg-black-lightest']}, inset 0 0 0 1px ${LightFoundation.theme['bg-black-lighter']}`)
+    expect(rendered).toHaveStyle(`box-shadow: 0 1px 2px ${LightFoundation.theme['bg-black-lighter']}, inset 0 0 0 1px ${LightFoundation.theme['bg-black-dark']}`)
   })
 
-  it('shoud have error style when "hasError" props is "true"', () => {
+  it('should have error style when "hasError" props is "true"', () => {
     const { getByTestId } = renderComponent({ hasError: true })
     const rendered = getByTestId(TEXT_INPUT_TEST_ID)
     expect(rendered).toHaveStyle(`background-color: ${LightFoundation.theme['bg-white-normal']}`)
     // eslint-disable-next-line max-len
-    expect(rendered).toHaveStyle(`box-shadow: 0 0 0 3px ${LightFoundation.theme['bgtxt-orange-lighter']}, inset 0 0 0 1px ${LightFoundation.theme['bgtxt-orange-normal']};`)
+    expect(rendered).toHaveStyle(`box-shadow: 0 0 0 3px ${LightFoundation.theme['bgtxt-orange-light']}, inset 0 0 0 1px ${LightFoundation.theme['bgtxt-orange-normal']}`)
   })
-  it('shoud have focused style when "input" focused', () => {
+
+  it('should have focused style when "input" focused', () => {
     const { getByTestId } = renderComponent()
     const rendered = getByTestId(TEXT_INPUT_TEST_ID)
     rendered.getElementsByTagName('input')[0].focus()
     expect(rendered).toHaveStyle(`background-color: ${LightFoundation.theme['bg-white-normal']}`)
     // eslint-disable-next-line max-len
-    expect(rendered).toHaveStyle(`box-shadow: 0 0 0 3px ${LightFoundation.theme['bgtxt-blue-lighter']}, inset 0 0 0 1px ${LightFoundation.theme['bgtxt-blue-normal']};
-    `)
+    expect(rendered).toHaveStyle(`box-shadow: 0 0 0 3px ${LightFoundation.theme['bgtxt-blue-light']}, inset 0 0 0 1px ${LightFoundation.theme['bgtxt-blue-normal']}`)
   })
 
   describe('callback should called', () => {

--- a/src/components/Forms/Inputs/mixins.ts
+++ b/src/components/Forms/Inputs/mixins.ts
@@ -12,16 +12,16 @@ export const inputPlaceholderStyle = css`
 `
 
 export const inputWrapperStyle = css`
-  box-shadow: 0 1px 2px ${({ foundation }) => foundation?.theme?.['bg-black-lightest']},
-    inset 0 0 0 1px ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
+  box-shadow: 0 1px 2px ${({ foundation }) => foundation?.theme?.['bg-black-lighter']},
+    inset 0 0 0 1px ${({ foundation }) => foundation?.theme?.['bg-black-dark']};
 `
 
 export const focusedInputWrapperStyle = css`
-  box-shadow: 0 0 0 3px ${({ foundation }) => foundation?.theme?.['bgtxt-blue-lighter']},
+  box-shadow: 0 0 0 3px ${({ foundation }) => foundation?.theme?.['bgtxt-blue-light']},
     inset 0 0 0 1px ${({ foundation }) => foundation?.theme?.['bgtxt-blue-normal']};
 `
 
 export const erroredInputWrapperStyle = css`
-  box-shadow: 0 0 0 3px ${({ foundation }) => foundation?.theme?.['bgtxt-orange-lighter']},
+  box-shadow: 0 0 0 3px ${({ foundation }) => foundation?.theme?.['bgtxt-orange-light']},
     inset 0 0 0 1px ${({ foundation }) => foundation?.theme?.['bgtxt-orange-normal']};
 `


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

Input 컴포넌트의 box-shadow 색상 스펙을 베지어 디자인 시스템 최신 버전에 맞게 업데이트합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

없음.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

없음.
