### PR TITLE
Support "readOnly" prop in Select

### DIFF
--- a/src/components/Forms/Inputs/Select/Select.stories.tsx
+++ b/src/components/Forms/Inputs/Select/Select.stories.tsx
@@ -29,6 +29,7 @@ Primary.args = {
   text: 'hello',
   iconComponent: 'calendar',
   disabled: false,
+  readOnly: false,
   withoutChevron: false,
   hasError: false,
   size: SelectSize.M,

--- a/src/components/Forms/Inputs/Select/Select.styled.ts
+++ b/src/components/Forms/Inputs/Select/Select.styled.ts
@@ -21,6 +21,7 @@ interface TriggerProps {
   focus: boolean
   error: boolean
   disabled: boolean
+  readOnly: boolean
   size: SelectSize
 }
 
@@ -52,7 +53,11 @@ export const Trigger = styled.div<TriggerProps>`
   align-items: center;
   justify-content: space-between;
   padding: 8px 12px;
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  cursor: ${({ disabled, readOnly }) => {
+    if (disabled) { return 'not-allowed' }
+    if (readOnly) { return 'initial' }
+    return 'pointer'
+  }};
   user-select: none;
   background-color: ${({ foundation }) => foundation?.theme?.['bg-grey-lightest']};
 
@@ -63,7 +68,7 @@ export const Trigger = styled.div<TriggerProps>`
   ${({ size }) => selectSizeConverter(size)};
 
   ${({ foundation }) => foundation?.rounding?.round8};
-  
+
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'box-shadow'])};
 
   ${({ focus }) => focus && css`
@@ -77,9 +82,11 @@ export const Trigger = styled.div<TriggerProps>`
     opacity: ${DisabledOpacity};
   `};
 
-  &:hover {
-    background-color: ${({ foundation }) => foundation?.theme?.['bg-grey-lighter']};
-  }
+  ${({ disabled, readOnly }) => !disabled && !readOnly && css`
+    &:hover {
+      background-color: ${({ foundation }) => foundation?.theme?.['bg-grey-lighter']};
+    }
+  `}
 `
 
 export const MainContentWrapper = styled.div`

--- a/src/components/Forms/Inputs/Select/Select.test.tsx
+++ b/src/components/Forms/Inputs/Select/Select.test.tsx
@@ -1,5 +1,6 @@
 /* External dependencies */
 import React from 'react'
+import { fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 /* Internal dependencies */
@@ -170,6 +171,81 @@ describe('Select Test >', () => {
       const triggerText = getByTestId(SELECT_TRIGGER_TEXT_TEST_ID)
 
       expect(triggerText).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']};`)
+    })
+  })
+
+  describe('Disabled style', () => {
+    it('should have dimmed opacity', () => {
+      const { getByTestId } = renderSelect({ disabled: true })
+      const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      expect(trigger).toHaveStyle('opacity: 0.4')
+    })
+
+    it('should have not-allowed cursor style', () => {
+      const { getByTestId } = renderSelect({ disabled: true })
+      const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      expect(trigger).toHaveStyle('cursor: not-allowed')
+    })
+
+    it('should not show dropdown when clicked', () => {
+      const { getByTestId } = renderSelect({ disabled: true })
+      const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      userEvent.click(trigger)
+
+      expect(() => getByTestId(SELECT_DROPDOWN_TEST_ID)).toThrow() // element should not exist
+    })
+
+    it('should not update style when hovered', () => {
+      const { getByTestId } = renderSelect({ disabled: true })
+      const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      fireEvent.mouseOver(trigger)
+
+      expect(trigger).toHaveStyle(`background-color: ${LightFoundation.theme['bg-grey-lightest']}`)
+    })
+
+    it('overrides read-only style', () => {
+      const { getByTestId } = renderSelect({ readOnly: true, disabled: true })
+      const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      expect(trigger).toHaveStyle('opacity: 0.4')
+    })
+  })
+
+  describe('Read-only style', () => {
+    it('should have regular opacity', () => {
+      const { getByTestId } = renderSelect({ readOnly: true })
+      const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      expect(trigger).not.toHaveStyle('opacity: 0.4')
+    })
+
+    it('should have initial cursor style', () => {
+      const { getByTestId } = renderSelect({ readOnly: true })
+      const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      expect(trigger).toHaveStyle('cursor: initial')
+    })
+
+    it('should not show dropdown when clicked', () => {
+      const { getByTestId } = renderSelect({ readOnly: true })
+      const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      userEvent.click(trigger)
+
+      expect(() => getByTestId(SELECT_DROPDOWN_TEST_ID)).toThrow() // element should not exist
+    })
+
+    it('should not update style when hovered', () => {
+      const { getByTestId } = renderSelect({ readOnly: true })
+      const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      fireEvent.mouseOver(trigger)
+
+      expect(trigger).toHaveStyle(`background-color: ${LightFoundation.theme['bg-grey-lightest']}`)
     })
   })
 })

--- a/src/components/Forms/Inputs/Select/Select.test.tsx
+++ b/src/components/Forms/Inputs/Select/Select.test.tsx
@@ -247,5 +247,12 @@ describe('Select Test >', () => {
 
       expect(trigger).toHaveStyle(`background-color: ${LightFoundation.theme['bg-grey-lightest']}`)
     })
+
+    it('should have chevron with txt-black-dark color', () => {
+      const { getByTestId } = renderSelect({ readOnly: true })
+      const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      expect(trigger.children.item(1)).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']}`)
+    })
   })
 })

--- a/src/components/Forms/Inputs/Select/Select.tsx
+++ b/src/components/Forms/Inputs/Select/Select.tsx
@@ -35,7 +35,6 @@ function Select({
   text,
   textColor = 'txt-black-darkest',
   withoutChevron = false,
-  chevronColor = 'txt-black-darker',
   dropdownStyle,
   dropdownClassName,
   dropdownContainer,
@@ -142,7 +141,7 @@ forwardedRef: Ref<SelectRef>,
           <Icon
             name={`chevron-${isDropdownOpened ? 'up' : 'down'}` as const}
             size={IconSize.XS}
-            color={chevronColor}
+            color={readOnly ? 'txt-black-dark' : 'txt-black-darker'}
             marginLeft={6}
           />
           ) }

--- a/src/components/Forms/Inputs/Select/Select.tsx
+++ b/src/components/Forms/Inputs/Select/Select.tsx
@@ -52,6 +52,7 @@ forwardedRef: Ref<SelectRef>,
 ) {
   const {
     disabled,
+    readOnly,
     hasError,
     Wrapper,
     ...ownProps
@@ -81,12 +82,13 @@ forwardedRef: Ref<SelectRef>,
   ])
 
   const handleClickTrigger = useCallback((event: React.MouseEvent) => {
-    if (!disabled) {
+    if (!disabled && !readOnly) {
       setIsDropdownOpened(prevState => !prevState)
       onClickTrigger(event)
     }
   }, [
     disabled,
+    readOnly,
     onClickTrigger,
   ])
 
@@ -123,6 +125,7 @@ forwardedRef: Ref<SelectRef>,
           focus={isDropdownOpened && !disabled}
           error={hasError}
           disabled={disabled}
+          readOnly={readOnly}
           onClick={handleClickTrigger}
         >
           <Styled.MainContentWrapper>

--- a/src/components/Forms/Inputs/Select/Select.types.ts
+++ b/src/components/Forms/Inputs/Select/Select.types.ts
@@ -45,7 +45,7 @@ interface SelectProps extends
   SizeProps<SelectSize>,
   AdditionalTestIdProps<['trigger', 'triggerText', 'dropdown']>,
   AdditionalStylableProps<'dropdown'>,
-  AdditionalColorProps<['icon', 'text', 'chevron']>,
+  AdditionalColorProps<['icon', 'text']>,
   FormComponentProps,
   SelectOptions {}
 


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

- 인터페이스만 열려 있고 실제로 동작하지 않는 Select의 `readOnly` prop이 잘 동작하도록 합니다. [스펙](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=6810%3A0)
- Select의 chevronColor prop을 drop합니다. (스펙상 커스터마이징 불가능합니다.) read-only일 때 chevron color를 txt-black-dark로 한 단계 낮춥니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->


https://user-images.githubusercontent.com/25701854/148726265-c6276e86-784c-42b6-8f24-6ab8981d3c80.mov



## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- [스펙](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=6810%3A0)