### PR TITLE
Switch, SegmendtedControl, FormLabel 컴포넌트 색상 최신화

### DIFF
--- a/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/src/components/Forms/FormLabel/FormLabel.tsx
@@ -18,6 +18,7 @@ function FormLabel({
   as = 'label',
   bold = true,
   typo = Typography.Size13,
+  color = 'txt-black-darkest',
   children,
   ...rest
 }: FormLabelProps,
@@ -38,6 +39,7 @@ forwardedRef: React.Ref<HTMLLabelElement>,
       forwardedAs={as}
       bold={bold}
       typo={typo}
+      color={color}
     >
       { children }
     </Styled.Label>
@@ -45,6 +47,7 @@ forwardedRef: React.Ref<HTMLLabelElement>,
     as,
     typo,
     bold,
+    color,
     testId,
     children,
     forwardedRef,

--- a/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
+++ b/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`FormLabel > Snapshot > 1`] = `
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: bold;
-  color: inherit;
+  color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
   -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
@@ -25,6 +25,7 @@ exports[`FormLabel > Snapshot > 1`] = `
 
 <label
   class="c0 c1"
+  color="txt-black-darkest"
   data-testid="bezier-react-form-label"
 >
   label

--- a/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -81,9 +81,9 @@ export const Indicator = styled.div`
 `
 
 export const IndicatorBox = styled.div`
+  ${({ foundation }) => foundation?.elevation?.ev1()};
   width: 100%;
   height: 100%;
   background-color: ${({ foundation }) => foundation?.theme?.['bg-white-high']};
   border-radius: 6px;
-  ${({ foundation }) => foundation?.elevation?.ev1()};
 `

--- a/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -169,12 +169,12 @@ exports[`SegmentedControl Snapshot 1`] = `
 }
 
 .c2 {
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 1px 2px #00000014;
   width: 100%;
   height: 100%;
   background-color: #FFFFFF;
   border-radius: 6px;
-  background-color: #FFFFFF;
-  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 1px 2px #00000014;
 }
 
 <div

--- a/src/components/Forms/Switch/Switch.styled.ts
+++ b/src/components/Forms/Switch/Switch.styled.ts
@@ -14,7 +14,7 @@ export const Wrapper = styled.div<WrapperProps>`
     ${props => (
       props.checked
         ? props.foundation?.theme?.['bgtxt-green-normal']
-        : props.foundation?.theme?.['bg-black-light']
+        : props.foundation?.theme?.['bg-black-dark']
     )};
   border-radius: ${props => (props.size + PADDING) / 2}px;
   opacity: ${props => (props.disabled ? '.2' : 'initial')};
@@ -25,21 +25,22 @@ export const Wrapper = styled.div<WrapperProps>`
       ${props => (
         props.checked
           ? props.foundation?.theme?.['bgtxt-green-dark']
-          : props.foundation?.theme?.['bg-black-normal']
+          : props.foundation?.theme?.['bg-black-dark']
       )};
   }
 `
 /* eslint-enable @typescript-eslint/indent */
 
 export const Content = styled.div<ContentProps>`
+  ${({ foundation }) => foundation?.elevation?.ev2()};
+  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['transform'])};
+
   position: absolute;
   top: ${PADDING / 2}px;
   left: ${PADDING / 2}px;
   width: ${props => props.size}px;
   height: ${props => props.size}px;
-  background-color: ${props => props.foundation?.theme?.['bgtxt-absolute-white-normal']};
+  background-color: ${props => props.foundation?.theme?.['bgtxt-absolute-white-dark']};
   border-radius: 50%;
-  ${({ foundation }) => foundation?.elevation?.ev2()};
-  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['transform'])};
   transform: ${props => (props.checked ? `translateX(${props.size - PADDING}px)` : 'initial')};
 `


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

컴포넌트 색상을 최신화합니다. 다크모드에서도 올바른 색상으로 보이도록 합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

시안에 맞게 시맨틱 네임을 주입합니다.

- FormLabel 의 텍스트

기존에 ev 믹스인으로 인해 오버라이드되고 있었던 색상을 올바르게 변경합니다.

- Switch 컨트롤러
- SegmentedControl 각 아이템

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
없음. 피그마 참고 부탁드립니다.
