### PR TITLE
[Select] rightContent 추가, iconComponent를 leftContent로 변경, text에 Ellipsis 적용

### DIFF
--- a/src/components/Forms/Inputs/Select/Select.stories.tsx
+++ b/src/components/Forms/Inputs/Select/Select.stories.tsx
@@ -5,6 +5,7 @@ import { Story, Meta } from '@storybook/react'
 
 /* Internal dependencies */
 import { getObjectFromEnum, getTitle } from 'Utils/storyUtils'
+import { Text } from 'Components/Text'
 import Select from './Select'
 import SelectProps, { SelectSize } from './Select.types'
 
@@ -18,16 +19,27 @@ export default {
         options: getObjectFromEnum(SelectSize),
       },
     },
+    wrapperSize: {
+      control: {
+        type: 'number',
+      },
+      defaultValue: 200,
+    },
   },
 } as Meta
 
-const Template: Story<SelectProps> = (args) => <Select {...args} />
+const Template: Story<SelectProps & { wrapperSize: number }> = ({ wrapperSize, ...args }) => (
+  <div style={{ width: wrapperSize }}>
+    <Select {...args} />
+  </div>
+)
 
 export const Primary = Template.bind({})
 Primary.args = {
-  placeholder: 'hello',
-  text: 'hello',
-  iconComponent: 'calendar',
+  placeholder: '날짜를 선택해주세요',
+  text: '2022. 7. 14.',
+  leftContent: 'calendar',
+  rightContent: (<Text marginLeft={4}>일</Text>),
   disabled: false,
   withoutChevron: false,
   hasError: false,

--- a/src/components/Forms/Inputs/Select/Select.styled.ts
+++ b/src/components/Forms/Inputs/Select/Select.styled.ts
@@ -1,8 +1,9 @@
 /* Internal dependencies */
-import { styled, css } from 'Foundation'
+import { styled, css, ellipsis } from 'Foundation'
 import DisabledOpacity from 'Constants/DisabledOpacity'
 import type { InterpolationProps } from 'Types/Foundation'
 import { Overlay } from 'Components/Overlay'
+import { Text } from 'Components/Text'
 import {
   inputTextStyle,
   inputWrapperStyle,
@@ -63,7 +64,7 @@ export const Trigger = styled.div<TriggerProps>`
   ${({ size }) => selectSizeConverter(size)};
 
   ${({ foundation }) => foundation?.rounding?.round8};
-  
+
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'box-shadow'])};
 
   ${({ focus }) => focus && css`
@@ -85,6 +86,11 @@ export const Trigger = styled.div<TriggerProps>`
 export const MainContentWrapper = styled.div`
   display: flex;
   align-items: center;
+  overflow: hidden;
+`
+
+export const TextContainer = styled(Text)`
+  ${ellipsis()}
 `
 
 interface DropdownProps extends InterpolationProps {

--- a/src/components/Forms/Inputs/Select/Select.test.tsx
+++ b/src/components/Forms/Inputs/Select/Select.test.tsx
@@ -172,4 +172,11 @@ describe('Select Test >', () => {
       expect(triggerText).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']};`)
     })
   })
+
+  describe('rightContent >', () => {
+    it('Snapshot >', () => {
+      const { container } = renderSelect({ text: 'lorem ipsum', rightContent: (<div>가나다</div>) })
+      expect(container.firstChild).toMatchSnapshot()
+    })
+  })
 })

--- a/src/components/Forms/Inputs/Select/Select.tsx
+++ b/src/components/Forms/Inputs/Select/Select.tsx
@@ -155,12 +155,12 @@ forwardedRef: Ref<SelectRef>,
             { RightComponent }
           </Styled.MainContentWrapper>
           { !withoutChevron && (
-          <Icon
-            name={`chevron-${isDropdownOpened ? 'up' : 'down'}` as const}
-            size={IconSize.XS}
-            color={chevronColor}
-            marginLeft={6}
-          />
+            <Icon
+              name={`chevron-${isDropdownOpened ? 'up' : 'down'}` as const}
+              size={IconSize.XS}
+              color={chevronColor}
+              marginLeft={6}
+            />
           ) }
         </Styled.Trigger>
 

--- a/src/components/Forms/Inputs/Select/Select.tsx
+++ b/src/components/Forms/Inputs/Select/Select.tsx
@@ -30,7 +30,8 @@ function Select({
   size = SelectSize.M,
   defaultFocus = false,
   placeholder = '',
-  iconComponent,
+  leftContent,
+  rightContent,
   iconColor = 'txt-black-dark',
   text,
   textColor = 'txt-black-darkest',
@@ -63,10 +64,10 @@ forwardedRef: Ref<SelectRef>,
   const [isDropdownOpened, setIsDropdownOpened] = useState(defaultFocus)
 
   const LeftComponent = useMemo(() => {
-    if (isIconName(iconComponent)) {
+    if (isIconName(leftContent)) {
       return (
         <Icon
-          name={iconComponent}
+          name={leftContent}
           size={IconSize.XS}
           color={iconColor}
           marginRight={6}
@@ -74,9 +75,27 @@ forwardedRef: Ref<SelectRef>,
       )
     }
 
-    return iconComponent
+    return leftContent
   }, [
-    iconComponent,
+    leftContent,
+    iconColor,
+  ])
+
+  const RightComponent = useMemo(() => {
+    if (isIconName(rightContent)) {
+      return (
+        <Icon
+          name={rightContent}
+          size={IconSize.XS}
+          color={iconColor}
+          marginRight={6}
+        />
+      )
+    }
+
+    return rightContent
+  }, [
+    rightContent,
     iconColor,
   ])
 
@@ -134,6 +153,7 @@ forwardedRef: Ref<SelectRef>,
             >
               { hasContent ? text : placeholder }
             </Text>
+            { RightComponent }
           </Styled.MainContentWrapper>
           { !withoutChevron && (
           <Icon

--- a/src/components/Forms/Inputs/Select/Select.tsx
+++ b/src/components/Forms/Inputs/Select/Select.tsx
@@ -5,7 +5,6 @@ import { isEmpty, noop } from 'lodash-es'
 /* Internal dependencies */
 import { Typography } from 'Foundation'
 import { Icon, IconSize, isIconName } from 'Components/Icon'
-import { Text } from 'Components/Text'
 import { OverlayPosition } from 'Components/Overlay'
 import useFormFieldProps from 'Components/Forms/useFormFieldProps'
 
@@ -146,13 +145,13 @@ forwardedRef: Ref<SelectRef>,
         >
           <Styled.MainContentWrapper>
             { LeftComponent }
-            <Text
+            <Styled.TextContainer
               testId={triggerTextTestId}
               typo={Typography.Size14}
               color={hasContent ? textColor : 'txt-black-dark'}
             >
               { hasContent ? text : placeholder }
-            </Text>
+            </Styled.TextContainer>
             { RightComponent }
           </Styled.MainContentWrapper>
           { !withoutChevron && (

--- a/src/components/Forms/Inputs/Select/Select.types.ts
+++ b/src/components/Forms/Inputs/Select/Select.types.ts
@@ -3,6 +3,7 @@ import type {
   BezierComponentProps,
   ChildrenProps,
   SizeProps,
+  SideContentProps,
   AdditionalStylableProps,
   AdditionalColorProps,
   AdditionalTestIdProps,
@@ -27,7 +28,6 @@ export interface SelectRef {
 interface SelectOptions {
   defaultFocus?: boolean
   placeholder?: string
-  iconComponent?: IconName | React.ReactNode
   text?: string
   withoutChevron?: boolean
   dropdownContainer?: HTMLElement | null
@@ -43,6 +43,7 @@ interface SelectProps extends
   BezierComponentProps,
   ChildrenProps,
   SizeProps<SelectSize>,
+  SideContentProps<IconName | React.ReactNode, IconName | React.ReactNode>,
   AdditionalTestIdProps<['trigger', 'triggerText', 'dropdown']>,
   AdditionalStylableProps<'dropdown'>,
   AdditionalColorProps<['icon', 'text', 'chevron']>,

--- a/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -140,3 +140,147 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   </div>
 </div>
 `;
+
+exports[`Select Test > rightContent > Snapshot > 1`] = `
+.c5 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0px 0px 0px 6px;
+  color: #00000099;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c3 {
+  font-size: 14px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: #000000D9;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 8px 12px;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: #FCFCFC;
+  color: #000000D9;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
+  height: 36px;
+  overflow: hidden;
+  border-radius: 8px;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+}
+
+.c1:hover {
+  background-color: #F7F7F8;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+.c4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-select-container"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-select-trigger"
+  >
+    <div
+      class="c2"
+    >
+      <span
+        class="c3 c4"
+        color="txt-black-darkest"
+        data-testid="bezier-react-select-trigger-text"
+      >
+        lorem ipsum
+      </span>
+      <div>
+        가나다
+      </div>
+    </div>
+    <svg
+      class="c5"
+      color="txt-black-darker"
+      data-testid="bezier-react-icon"
+      fill="none"
+      foundation="[object Object]"
+      height="16"
+      marginbottom="0"
+      marginleft="6"
+      marginright="0"
+      margintop="0"
+      viewBox="0 0 24 24"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clip-rule="evenodd"
+        d="M19.707 8.793a1 1 0 010 1.414l-7 7a1 1 0 01-1.414 0l-7-7a1 1 0 011.414-1.414L12 15.086l6.293-6.293a1 1 0 011.414 0z"
+        fill="currentColor"
+        fill-rule="evenodd"
+      />
+    </svg>
+  </div>
+</div>
+`;

--- a/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select Test > Default Style > Snapshot > 1`] = `
-.c4 {
+.c5 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -87,6 +87,13 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: hidden;
+}
+
+.c4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 <div
@@ -101,7 +108,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
       class="c2"
     >
       <span
-        class="c3"
+        class="c3 c4"
         color="txt-black-darkest"
         data-testid="bezier-react-select-trigger-text"
       >
@@ -109,7 +116,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
       </span>
     </div>
     <svg
-      class="c4"
+      class="c5"
       color="txt-black-darker"
       data-testid="bezier-react-icon"
       fill="none"


### PR DESCRIPTION
# Summary
<img width="202" alt="스크린샷 2022-01-13 오후 8 18 51" src="https://user-images.githubusercontent.com/33291896/149322438-9909bf6d-1b1a-45b1-a0da-91af76f6f3c1.png"> <img width="246" alt="스크린샷 2022-01-13 오후 8 19 00" src="https://user-images.githubusercontent.com/33291896/149322449-e1decff6-d175-43e5-9802-32515f755db4.png">

# Details

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
