### PR TITLE
다크 테마의 txt-black-darkest 색상 변경

### DIFF
--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Tooltip test > Tooltip with contentInterpolation prop 1`] = `
   height: -moz-max-content;
   height: max-content;
   padding: 8px 14px;
-  color: #FFFFFFE6;
+  color: #FFFFFFCC;
   word-break: break-all;
   background-color: #313234;
   box-shadow: inset 0 0 2px 0 #FFFFFF14, 0 0 2px 1px #00000014, 0 2px 6px #00000026;
@@ -130,7 +130,7 @@ exports[`Tooltip test > Tooltip with default props 1`] = `
   height: -moz-max-content;
   height: max-content;
   padding: 8px 14px;
-  color: #FFFFFFE6;
+  color: #FFFFFFCC;
   word-break: break-all;
   background-color: #313234;
   box-shadow: inset 0 0 2px 0 #FFFFFF14, 0 0 2px 1px #00000014, 0 2px 6px #00000026;

--- a/src/foundation/Colors/Palette/index.ts
+++ b/src/foundation/Colors/Palette/index.ts
@@ -121,6 +121,7 @@ type AlphaGreyKey =
 
 type AlphaWhiteKey =
   | `${BasePaletteKey.White}_90`
+  | `${BasePaletteKey.White}_80`
   | `${BasePaletteKey.White}_60`
   | `${BasePaletteKey.White}_40`
   | `${BasePaletteKey.White}_20`
@@ -253,6 +254,7 @@ export const Palette: PaletteType = {
 
   // Alpha White
   white_90: getAlphaHex(PaletteWithoutAlpha.white, 90),
+  white_80: getAlphaHex(PaletteWithoutAlpha.white, 80),
   white_60: getAlphaHex(PaletteWithoutAlpha.white, 60),
   white_40: getAlphaHex(PaletteWithoutAlpha.white, 40),
   white_20: getAlphaHex(PaletteWithoutAlpha.white, 20),

--- a/src/foundation/Colors/Theme/presets/DarkTheme.ts
+++ b/src/foundation/Colors/Theme/presets/DarkTheme.ts
@@ -94,7 +94,7 @@ const DarkTheme: ThemeType = {
   'bgtxt-navy-lightest': Palette.navy300_20,
 
   // Text
-  'txt-black-darkest': Palette.white_90,
+  'txt-black-darkest': Palette.white_80,
   'txt-black-darker': Palette.white_60,
   'txt-black-dark': Palette.white_40,
   'txt-white-normal': Palette.grey900,


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

Palette에 white80 색상을 추가하고, 다크 테마의 `txt-black-darkest` 색상을 white90 -> 80으로 변경합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

다크 테마에서 글자색이 도드라져보이는 걸 완화하기 위한 변경입니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- [관련 채널톡 스레드](https://desk.channel.io/root/groups/Bezier-62019/61e0f3c7ae6e52a2f046)