### PR TITLE
Avatar 기본 배경색 수정, AvatarGroup 보더 표시 로직 개선

### DIFF
--- a/src/components/Avatars/Avatar/Avatar.styled.ts
+++ b/src/components/Avatars/Avatar/Avatar.styled.ts
@@ -45,7 +45,7 @@ const smoothCornersFallbackBorderStyle = css`
     width: 100%;
     height: 100%;
     content: '';
-    background-color: ${({ foundation }) => `${foundation?.theme?.['bgtxt-absolute-white-dark']}`};
+    background-color: ${({ foundation }) => `${foundation?.theme?.['bg-white-normal']}`};
     border-radius: ${AVATAR_BORDER_RADIUS_PERCENTAGE}%;
   }
 `
@@ -66,7 +66,7 @@ export const AvatarImage = styled.div<AvatarProps>`
   ${({ foundation, showBorder }) => smoothCorners({
     shadow: showBorder ? `0 0 0 ${AVATAR_BORDER_WIDTH}px ${foundation?.theme?.['bg-white-high']}` : undefined,
     shadowBlur: showBorder ? AVATAR_BORDER_WIDTH : 0,
-    backgroundColor: foundation?.theme?.['bgtxt-absolute-white-dark'],
+    backgroundColor: foundation?.theme?.['bg-white-normal'],
     borderRadius: `${AVATAR_BORDER_RADIUS_PERCENTAGE}%`,
     hasBackgroundImage: true,
   })};

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.stories.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.stories.tsx
@@ -6,46 +6,9 @@ import { Story, Meta } from '@storybook/react'
 /* Internal dependencies */
 import { getTitle } from 'Utils/storyUtils'
 import { Avatar, AvatarSize } from 'Components/Avatars/Avatar'
+import MOCK_AVATAR_LIST from './__mocks__/avatarList'
 import AvatarGroupProps, { AvatarGroupEllipsisType } from './AvatarGroup.types'
 import AvatarGroup from './AvatarGroup'
-
-const MOCK_AVATAR_LIST = [
-  {
-    id: 1,
-    avatarUrl: 'https://bit.ly/code-beast',
-    name: 'Christian Nwamba',
-  },
-  {
-    id: 2,
-    avatarUrl: 'https://bit.ly/tioluwani-kolawole',
-    name: 'Kola Tioluwani',
-  },
-  {
-    id: 3,
-    avatarUrl: 'https://bit.ly/kent-c-dodds',
-    name: 'Kent Dodds',
-  },
-  {
-    id: 4,
-    avatarUrl: 'https://bit.ly/ryan-florence',
-    name: 'Ryan Florence',
-  },
-  {
-    id: 5,
-    avatarUrl: 'https://bit.ly/dan-abramov',
-    name: 'Dan Abrahmov',
-  },
-  {
-    id: 6,
-    avatarUrl: 'https://bit.ly/prosper-baba',
-    name: 'Prosper Otemuyiwa',
-  },
-  {
-    id: 7,
-    avatarUrl: 'https://bit.ly/sage-adebayo',
-    name: 'Segun Adebayo',
-  },
-]
 
 const avatarSizeList = Object.keys(AvatarSize)
   .filter(value => Number.isNaN(Number(value)) === true)

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.test.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.test.tsx
@@ -1,0 +1,57 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { render } from 'Utils/testUtils'
+import { Avatar } from 'Components/Avatars/Avatar'
+import MOCK_AVATAR_LIST from './__mocks__/avatarList'
+import AvatarGroup, { AVATAR_GROUP_TEST_ID } from './AvatarGroup'
+import { AvatarGroupEllipsisType } from './AvatarGroup.types'
+import type AvatarGroupProps from './AvatarGroup.types'
+
+jest.mock('Worklets/EnableCSSHoudini', () => ({
+  __esModule: true,
+  ...jest.requireActual('Worklets/EnableCSSHoudini') as object,
+  enableSmoothCorners: { current: true },
+}))
+
+// TODO: 테스트 강화
+describe('AvatarGroup >', () => {
+  let props: AvatarGroupProps
+
+  const testId = 'AVATAR'
+  const mockFallbackUrl = 'https://www.google.com'
+
+  beforeEach(() => {
+    props = {
+      max: 4,
+      spacing: 4,
+      ellipsisType: AvatarGroupEllipsisType.Icon,
+    }
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
+  const renderComponent = (otherProps?: AvatarGroupProps) => render(
+    <AvatarGroup {...props} {...otherProps}>
+      { MOCK_AVATAR_LIST.map(({ id, avatarUrl, name }) => (
+        <Avatar
+          testId={testId}
+          key={id}
+          avatarUrl={avatarUrl}
+          fallbackUrl={mockFallbackUrl}
+          name={name}
+        />
+      )) }
+    </AvatarGroup>,
+  )
+
+  it('Snapshot >', () => {
+    const { getByTestId } = renderComponent()
+    const rendered = getByTestId(AVATAR_GROUP_TEST_ID)
+
+    expect(rendered).toMatchSnapshot()
+  })
+})

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -17,8 +17,7 @@ import {
   AvatarEllipsisCount,
 } from './AvatarGroup.styled'
 
-// TODO: 테스트 코드 작성
-const AVATAR_GROUP_TEST_ID = 'bezier-react-avatar-group'
+export const AVATAR_GROUP_TEST_ID = 'bezier-react-avatar-group'
 
 const MAX_AVATAR_LIST_COUNT = 99
 

--- a/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -68,13 +68,15 @@ function AvatarGroup({
 }: AvatarGroupProps,
 forwardedRef: React.Ref<HTMLDivElement>,
 ) {
-  const renderAvatarElement = useCallback((avatar: React.ReactElement<AvatarProps>) => (
-    React.cloneElement(avatar, {
-      key: avatar.key ?? `${avatar.props.name}-${avatar.props.avatarUrl}`,
-      size,
-      showBorder: avatar.props.showBorder || spacing < 0,
-    })
-  ), [
+  const renderAvatarElement = useCallback((
+    avatar: React.ReactElement<AvatarProps>,
+    avatarListCount: number,
+  ) => {
+    const key = avatar.key ?? `${avatar.props.name}-${avatar.props.avatarUrl}`
+    const shouldShowBorder = avatarListCount > 1 && spacing < 0
+    const showBorder = avatar.props.showBorder || shouldShowBorder
+    return React.cloneElement(avatar, { key, size, showBorder })
+  }, [
     size,
     spacing,
   ])
@@ -86,7 +88,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
   const AvatarListComponent = useMemo(() => {
     if (avatarListCount <= max) {
       return React.Children.map(children, (avatar) => (
-        React.isValidElement(avatar) && renderAvatarElement(avatar)
+        React.isValidElement(avatar) && renderAvatarElement(avatar, avatarListCount)
       ))
     }
 
@@ -96,7 +98,11 @@ forwardedRef: React.Ref<HTMLDivElement>,
     return slicedAvatarList.map((avatar, index, arr) => {
       if (!React.isValidElement(avatar)) { return null }
 
-      if (!isLastIndex(arr, index)) { return renderAvatarElement(avatar) }
+      const AvatarElement = renderAvatarElement(avatar, slicedAvatarList.length)
+
+      if (!isLastIndex(arr, index)) {
+        return AvatarElement
+      }
 
       if (ellipsisType === AvatarGroupEllipsisType.Icon) {
         return (
@@ -113,7 +119,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
                 color="bgtxt-absolute-white-dark"
               />
             </AvatarEllipsisIcon>
-            { renderAvatarElement(avatar) }
+            { AvatarElement }
           </AvatarEllipsisIconWrapper>
         )
       }
@@ -123,7 +129,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
           <React.Fragment
             key="ellipsis"
           >
-            { renderAvatarElement(avatar) }
+            { AvatarElement }
             <AvatarEllipsisCountWrapper
               size={size}
               spacing={spacing}

--- a/src/components/Avatars/AvatarGroup/__mocks__/avatarList.ts
+++ b/src/components/Avatars/AvatarGroup/__mocks__/avatarList.ts
@@ -1,0 +1,39 @@
+const MOCK_AVATAR_LIST = [
+  {
+    id: 1,
+    avatarUrl: 'https://bit.ly/code-beast',
+    name: 'Christian Nwamba',
+  },
+  {
+    id: 2,
+    avatarUrl: 'https://bit.ly/tioluwani-kolawole',
+    name: 'Kola Tioluwani',
+  },
+  {
+    id: 3,
+    avatarUrl: 'https://bit.ly/kent-c-dodds',
+    name: 'Kent Dodds',
+  },
+  {
+    id: 4,
+    avatarUrl: 'https://bit.ly/ryan-florence',
+    name: 'Ryan Florence',
+  },
+  {
+    id: 5,
+    avatarUrl: 'https://bit.ly/dan-abramov',
+    name: 'Dan Abrahmov',
+  },
+  {
+    id: 6,
+    avatarUrl: 'https://bit.ly/prosper-baba',
+    name: 'Prosper Otemuyiwa',
+  },
+  {
+    id: 7,
+    avatarUrl: 'https://bit.ly/sage-adebayo',
+    name: 'Segun Adebayo',
+  },
+]
+
+export default MOCK_AVATAR_LIST

--- a/src/components/Avatars/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/src/components/Avatars/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
@@ -1,0 +1,233 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AvatarGroup > Snapshot > 1`] = `
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0px 0px 0px 0px;
+  color: #FFFFFF;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c3 {
+  position: relative;
+  box-sizing: content-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  outline: none;
+  margin: 0px;
+  background-color: #FFFFFF;
+  background-image: var(--background-image);
+  background-size: cover;
+  border-radius: 42%;
+}
+
+.c2 {
+  position: relative;
+  z-index: 1;
+}
+
+.c1 {
+  position: relative;
+  z-index: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c0 > * + * {
+  margin-left: 4px;
+}
+
+.c4 {
+  position: relative;
+}
+
+.c5 {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  outline: none;
+  margin: 0px;
+  background-color: #00000066;
+  border-radius: 42%;
+}
+
+@supports (background:paint(smooth-corners)) {
+  .c3 {
+    padding: 0px;
+    margin: 0px;
+    background: paint(smooth-corners);
+    border-radius: 0;
+    box-shadow: none;
+    border-image-source: var(--background-image);
+    --smooth-corners: 42%;
+    --smooth-corners-shadow: 0 0 0 0 transparent;
+    --smooth-corners-bg-color: #FFFFFF;
+    --smooth-corners-padding: 0;
+    --smooth-corners-radius-unit: string;
+  }
+}
+
+@supports (background:paint(smooth-corners)) {
+  .c5 {
+    padding: 0px;
+    margin: 0px;
+    background: paint(smooth-corners);
+    border-radius: 0;
+    box-shadow: none;
+    --smooth-corners: 42%;
+    --smooth-corners-shadow: 0 0 0 0 transparent;
+    --smooth-corners-bg-color: #00000066;
+    --smooth-corners-padding: 0;
+    --smooth-corners-radius-unit: string;
+  }
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-avatar-group"
+  spacing="4"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-avatar-wrapper"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        aria-label="Christian Nwamba"
+        class="c3"
+        data-testid="AVATAR"
+        role="img"
+        size="24"
+        style="--background-image: url(https://www.google.com);"
+      />
+    </div>
+  </div>
+  <div
+    class="c1"
+    data-testid="bezier-react-avatar-wrapper"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        aria-label="Kola Tioluwani"
+        class="c3"
+        data-testid="AVATAR"
+        role="img"
+        size="24"
+        style="--background-image: url(https://www.google.com);"
+      />
+    </div>
+  </div>
+  <div
+    class="c1"
+    data-testid="bezier-react-avatar-wrapper"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        aria-label="Kent Dodds"
+        class="c3"
+        data-testid="AVATAR"
+        role="img"
+        size="24"
+        style="--background-image: url(https://www.google.com);"
+      />
+    </div>
+  </div>
+  <div
+    class="c4"
+  >
+    <div
+      class="c5"
+    >
+      <svg
+        class="c6"
+        color="bgtxt-absolute-white-dark"
+        data-testid="bezier-react-icon"
+        fill="none"
+        foundation="[object Object]"
+        height="16"
+        marginbottom="0"
+        marginleft="0"
+        marginright="0"
+        margintop="0"
+        viewBox="0 0 24 24"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M4.5 14.5A2.507 2.507 0 012 12c0-1.375 1.125-2.5 2.5-2.5S7 10.625 7 12s-1.125 2.5-2.5 2.5zm7.5 0A2.507 2.507 0 019.5 12c0-1.375 1.125-2.5 2.5-2.5s2.5 1.125 2.5 2.5-1.125 2.5-2.5 2.5zm5-2.5c0 1.375 1.125 2.5 2.5 2.5S22 13.375 22 12s-1.125-2.5-2.5-2.5A2.507 2.507 0 0017 12z"
+          fill="currentColor"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </div>
+    <div
+      class="c1"
+      data-testid="bezier-react-avatar-wrapper"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          aria-label="Ryan Florence"
+          class="c3"
+          data-testid="AVATAR"
+          role="img"
+          size="24"
+          style="--background-image: url(https://www.google.com);"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

- `Avatar` 기본 배경색상을 고정 화이트에서, 다크 테마에선 검정색이 될 수 있도록 수정합니다.
- `AvatarGroup` 컴포넌트의 하위 `Avatar` 컴포넌트 보더 표시 로직을 수정합니다. 화면에 그려지는`Avatar` 컴포넌트가 하나뿐이라면, 보더를 표시하지 않도록 합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- 다크 테마 적용 시, smoothCorner가 적용된 `Avatar` 의 테두리가 지글지글해지는 현상이 발생하여 색상을 수정합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

없음
