### PR TITLE
fix(avatar-group): change ellipsis icon background color

### DIFF
--- a/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
+++ b/src/components/Avatars/AvatarGroup/AvatarGroup.styled.ts
@@ -79,6 +79,6 @@ export const AvatarEllipsisIcon = styled.div`
 
   ${({ foundation }) => smoothCorners({
     borderRadius: `${AVATAR_BORDER_RADIUS_PERCENTAGE}%`,
-    backgroundColor: foundation?.theme?.['bg-black-darkest'],
+    backgroundColor: foundation?.theme?.['bgtxt-absolute-black-lightest'],
   })}
 `

--- a/src/components/Avatars/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/src/components/Avatars/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`AvatarGroup > Snapshot > 1`] = `
   height: 100%;
   outline: none;
   margin: 0px;
-  background-color: #00000066;
+  background-color: #00000033;
   border-radius: 42%;
 }
 
@@ -120,7 +120,7 @@ exports[`AvatarGroup > Snapshot > 1`] = `
     box-shadow: none;
     --smooth-corners: 42%;
     --smooth-corners-shadow: 0 0 0 0 transparent;
-    --smooth-corners-bg-color: #00000066;
+    --smooth-corners-bg-color: #00000033;
     --smooth-corners-padding: 0;
     --smooth-corners-radius-unit: string;
   }


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

아바타 그룹의 생략 아이콘의 배경 색상을 다크모드에서도 동일하도록 absolute 시맨틱 컬러로 변경합니다

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

없음

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

<img width="400" alt="스크린샷 2022-01-18 오후 1 54 12" src="https://user-images.githubusercontent.com/58209009/149873198-89ffd9cb-cee5-4337-a26b-515e331cd6d2.png">
