### PR TITLE
FormGroup Component

### DIFF
--- a/src/components/Forms/Checkbox/Checkbox.tsx
+++ b/src/components/Forms/Checkbox/Checkbox.tsx
@@ -33,7 +33,6 @@ function Checkbox(
 ) {
   const {
     disabled,
-    Wrapper,
     ...ownProps
   } = useFormFieldProps(rest)
 
@@ -66,28 +65,26 @@ function Checkbox(
   }, [checkStatus])
 
   return (
-    <Wrapper>
-      <Styled.Wrapper
-        ref={forwardedRef}
+    <Styled.Wrapper
+      ref={forwardedRef}
+      disabled={disabled}
+      onClick={disabled ? noop : onClick}
+      data-testid={testId}
+      {...ownProps}
+    >
+      <Styled.Checker
         disabled={disabled}
-        onClick={disabled ? noop : onClick}
-        data-testid={testId}
-        {...ownProps}
+        checkStatus={checkStatus}
+        data-testid={checkerTestId}
       >
-        <Styled.Checker
-          disabled={disabled}
-          checkStatus={checkStatus}
-          data-testid={checkerTestId}
-        >
-          { CheckIcon }
-        </Styled.Checker>
-        { !isEmpty(children) ? (
-          <Styled.Content className={contentClassName}>
-            { children }
-          </Styled.Content>
-        ) : null }
-      </Styled.Wrapper>
-    </Wrapper>
+        { CheckIcon }
+      </Styled.Checker>
+      { !isEmpty(children) ? (
+        <Styled.Content className={contentClassName}>
+          { children }
+        </Styled.Content>
+      ) : null }
+    </Styled.Wrapper>
   )
 }
 

--- a/src/components/Forms/FormControl/FormControl.stories.tsx
+++ b/src/components/Forms/FormControl/FormControl.stories.tsx
@@ -9,6 +9,7 @@ import { SegmentedControl } from 'Components/Forms/SegmentedControl'
 import { Radio } from 'Components/Forms/Radio'
 import { Checkbox } from 'Components/Forms/Checkbox'
 import { Text } from 'Components/Text'
+import { FormGroup } from 'Components/Forms/FormGroup'
 import { FormLabel } from 'Components/Forms/FormLabel'
 import { TextField } from 'Components/Forms/Inputs/TextField'
 import { TextArea } from 'Components/Forms/Inputs/TextArea'
@@ -35,6 +36,7 @@ export const Primary: Story<FormControlProps> = Template.bind({})
 Primary.args = {
   id: 'form',
   labelPosition: 'top',
+  leftLabelWrapperHeight: undefined,
   hasError: false,
   disabled: false,
   readOnly: false,
@@ -80,14 +82,42 @@ const WithMultiFormTemplate: Story<FormControlProps> = (args) => (
 
     <FormControl {...args}>
       <FormLabel help="Lorem Ipsum">Label</FormLabel>
-      <Checkbox>Option</Checkbox>
+      <FormGroup direction="row" gap={10}>
+        <Checkbox>Option</Checkbox>
+        <Checkbox>Option</Checkbox>
+        <Checkbox>Option</Checkbox>
+        <Checkbox>Option</Checkbox>
+      </FormGroup>
       <FormHelperText>Description</FormHelperText>
       <FormErrorMessage>Error!</FormErrorMessage>
     </FormControl>
 
     <FormControl {...args}>
       <FormLabel help="Lorem Ipsum">Label</FormLabel>
-      <Radio>Option</Radio>
+      <FormGroup direction="row" gap={20}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+          }}
+        >
+          <Radio>Immediately</Radio>
+          <Radio>Year(s)</Radio>
+          <Radio>Seasons</Radio>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+          }}
+        >
+          <Radio>Hour(s)</Radio>
+          <Radio>Day(s)</Radio>
+          <Radio>Minute(s)</Radio>
+        </div>
+      </FormGroup>
       <FormHelperText>Description</FormHelperText>
       <FormErrorMessage>Error!</FormErrorMessage>
     </FormControl>
@@ -97,6 +127,7 @@ const WithMultiFormTemplate: Story<FormControlProps> = (args) => (
 export const WithMultiForm: Story<FormControlProps> = WithMultiFormTemplate.bind({})
 WithMultiForm.args = {
   labelPosition: 'top',
+  leftLabelWrapperHeight: undefined,
   hasError: false,
   disabled: false,
   readOnly: false,

--- a/src/components/Forms/FormControl/FormControl.styled.ts
+++ b/src/components/Forms/FormControl/FormControl.styled.ts
@@ -27,15 +27,17 @@ export const Grid = styled(Box)`
   align-items: center;
 `
 
-// TODO: row, column을 자동으로 할당해주도록 구현
-export const FieldWrapper = styled(Box)`
-  grid-row: 1 / 1;
-  grid-column: 2;
-`
+interface LeftLabelWrapperProps {
+  height: number
+}
 
-export const LeftLabelWrapper = styled(Box)`
+export const LeftLabelWrapper = styled(Box)<LeftLabelWrapperProps>`
+  display: flex;
   grid-row: 1 / 1;
   grid-column: 1 / 1;
+  align-items: center;
+  align-self: start;
+  height: ${({ height }) => height}px;
 `
 
 export const LeftHelperTextWrapper = styled(TopHelperTextWrapper)`

--- a/src/components/Forms/FormControl/FormControl.test.tsx
+++ b/src/components/Forms/FormControl/FormControl.test.tsx
@@ -1,0 +1,51 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { render } from 'Utils/testUtils'
+import { FormLabel } from 'Components/Forms/FormLabel'
+import { TextField } from 'Components/Forms/Inputs/TextField'
+import { FormHelperText, FormErrorMessage } from 'Components/Forms/FormHelperText'
+import FormControl, { FORM_CONTROL_TEST_ID } from './FormControl'
+import type FormControlProps from './FormControl.types'
+
+// TODO: 테스트 보강
+describe('FormControl >', () => {
+  let props: FormControlProps
+
+  beforeEach(() => {
+    props = {
+      id: 'form',
+      labelPosition: 'top',
+      leftLabelWrapperHeight: undefined,
+      hasError: false,
+      disabled: false,
+      readOnly: false,
+    }
+  })
+
+  const renderComponent = ({ children, ...rest }: FormControlProps) => render(
+    <FormControl {...props} {...rest}>
+      { children }
+    </FormControl>,
+  )
+
+  const defaultChildren = (
+    <>
+      <FormLabel help="Lorem Ipsum">Label</FormLabel>
+      <TextField placeholder="Placeholder" />
+      <FormHelperText>Description</FormHelperText>
+      <FormErrorMessage>Error!</FormErrorMessage>
+    </>
+  )
+
+  it('Snapshot >', () => {
+    const { getByTestId } = renderComponent({
+      children: defaultChildren,
+    })
+
+    const rendered = getByTestId(FORM_CONTROL_TEST_ID)
+
+    expect(rendered).toMatchSnapshot()
+  })
+})

--- a/src/components/Forms/FormControl/FormControl.tsx
+++ b/src/components/Forms/FormControl/FormControl.tsx
@@ -16,8 +16,7 @@ import FormControlProps, {
 } from './FormControl.types'
 import * as Styled from './FormControl.styled'
 
-// TODO: 테스트 작성
-const FORM_CONTROL_TEST_ID = 'bezier-react-form-control'
+export const FORM_CONTROL_TEST_ID = 'bezier-react-form-control'
 
 function FormControl({
   id: idProp,

--- a/src/components/Forms/FormControl/FormControl.tsx
+++ b/src/components/Forms/FormControl/FormControl.tsx
@@ -17,11 +17,11 @@ import FormControlProps, {
 import * as Styled from './FormControl.styled'
 
 // TODO: 테스트 작성
-const FORM_CONTROL_TEXT_TEST_ID = 'bezier-react-form-control'
+const FORM_CONTROL_TEST_ID = 'bezier-react-form-control'
 
 function FormControl({
   id: idProp,
-  testId = FORM_CONTROL_TEXT_TEST_ID,
+  testId = FORM_CONTROL_TEST_ID,
   labelPosition = 'top',
   leftLabelWrapperHeight = TextFieldSize.M,
   children,

--- a/src/components/Forms/FormControl/FormControl.tsx
+++ b/src/components/Forms/FormControl/FormControl.tsx
@@ -48,13 +48,6 @@ function FormControl({
     helperTextId,
   ])
 
-  const labelHtmlFor = useMemo(() => (
-    hasMultipleFields ? undefined : id
-  ), [
-    id,
-    hasMultipleFields,
-  ])
-
   const bezierProps = useMemo(() => pickBezierComponentProps(rest), [rest])
   const formCommonProps = useMemo(() => omitBezierComponentProps(rest), [rest])
 
@@ -73,7 +66,7 @@ function FormControl({
 
   const getLabelProps = useCallback<LabelPropsGetter>(ownProps => ({
     id: labelId,
-    htmlFor: labelHtmlFor,
+    htmlFor: hasMultipleFields ? undefined : id,
     Wrapper: labelPosition === 'top'
       ? Styled.TopLabelWrapper
       : (({ children: labelElement }) => (
@@ -83,21 +76,23 @@ function FormControl({
       )),
     ...ownProps,
   }), [
-    labelHtmlFor,
+    id,
     labelId,
     labelPosition,
     leftLabelWrapperHeight,
+    hasMultipleFields,
   ])
 
   const getFieldProps = useCallback<FieldPropsGetter>(ownProps => ({
     id,
-    'aria-describedby': fieldLabelId,
+    'aria-describedby': hasMultipleFields ? undefined : fieldLabelId,
     ...formCommonProps,
     ...ownProps,
   }), [
     id,
     fieldLabelId,
     formCommonProps,
+    hasMultipleFields,
   ])
 
   const getHelperTextProps = useCallback<HelperTextPropsGetter>(ownProps => ({

--- a/src/components/Forms/FormControl/FormControl.types.ts
+++ b/src/components/Forms/FormControl/FormControl.types.ts
@@ -4,24 +4,34 @@ import type { FormComponentProps } from 'Components/Forms/Form.types'
 
 interface FormControlOptions {
   labelPosition?: 'top' | 'left'
+  leftLabelWrapperHeight?: number
 }
 
-export interface FormControlContextCommonValue extends IdentifierProps {
+export interface FormControlContextCommonValue extends IdentifierProps {}
+
+export interface FormControlAriaProps {
+  'aria-labelledby'?: string
+  'aria-describedby'?: string
+}
+
+interface WrapperProps {
   Wrapper: React.FunctionComponent
 }
 
-type PropsGetter<ExtraReturnType = {}> = <Props = {}>(props: Props)
-  => Props & FormControlContextCommonValue & ExtraReturnType
-
-export type LabelPropsGetter = PropsGetter
-
-export type FieldPropsGetter = PropsGetter<{
-  'aria-describedby'?: string
-}>
-
-export type HelperTextPropsGetter = PropsGetter<{
-  visible: boolean
+interface SetRenderedProps {
   setIsRendered: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+type PropsGetter<ExtraReturnType = {}> = <Props = {}>(props: Props) => Props & FormControlContextCommonValue & ExtraReturnType
+
+export type GroupPropsGetter = PropsGetter<SetRenderedProps & FormControlAriaProps>
+
+export type LabelPropsGetter = PropsGetter<WrapperProps>
+
+export type FieldPropsGetter = PropsGetter<Omit<FormControlAriaProps, 'aria-labelledby'>>
+
+export type HelperTextPropsGetter = PropsGetter<WrapperProps & SetRenderedProps & {
+  visible: boolean
 }>
 
 export type ErrorMessagePropsGetter = HelperTextPropsGetter
@@ -31,6 +41,7 @@ export interface FormControlContextValue extends FormComponentProps {
   labelId: string
   helperTextId: string
   errorMessageId: string
+  getGroupProps: GroupPropsGetter
   getLabelProps: LabelPropsGetter
   getFieldProps: FieldPropsGetter
   getHelperTextProps: HelperTextPropsGetter
@@ -40,5 +51,5 @@ export interface FormControlContextValue extends FormComponentProps {
 export default interface FormControlProps extends
   BezierComponentProps,
   ChildrenProps,
-  Omit<FormComponentProps, 'aria-describedby'>,
+  FormComponentProps,
   FormControlOptions {}

--- a/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -1,0 +1,245 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormControl > Snapshot > 1`] = `
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0px 0px 0px 0px;
+  color: #00000066;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c9 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  cursor: auto;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  font-size: 14px;
+  line-height: 18px;
+  color: #000000D9;
+}
+
+.c9::-webkit-input-placeholder {
+  color: #00000066;
+}
+
+.c9::-moz-placeholder {
+  color: #00000066;
+}
+
+.c9:-ms-input-placeholder {
+  color: #00000066;
+}
+
+.c9::placeholder {
+  color: #00000066;
+}
+
+.c8 {
+  position: relative;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 36px;
+  padding: 0 12px;
+  background-color: #FCFCFC;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: border-color,box-shadow;
+  transition-property: border-color,box-shadow;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  padding: 0 2px;
+  margin-bottom: 4px;
+}
+
+.c10 {
+  padding: 0 2px;
+  margin-top: 4px;
+}
+
+.c3 {
+  font-size: 13px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: #000000D9;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c11 {
+  font-size: 13px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: #00000066;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c5 {
+  position: relative;
+}
+
+.c4 {
+  display: block;
+  text-align: left;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-left: 6px;
+}
+
+.c6:hover > .{
+  color: #000000D9;
+}
+
+.c12 {
+  display: block;
+  text-align: left;
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-form-control"
+>
+  <div
+    class="c0 c1"
+  >
+    <div
+      class="c2"
+    >
+      <label
+        class="c3 c4"
+        color="txt-black-darkest"
+        data-testid="bezier-react-form-label"
+        for="form"
+        id="form-label"
+      >
+        Label
+      </label>
+      <div
+        class="c5 c6"
+        data-testid="bezier-react-tooltip"
+      >
+        <svg
+          class="c7 "
+          color="txt-black-dark"
+          data-testid="bezier-react-form-label-help"
+          fill="none"
+          foundation="[object Object]"
+          height="16"
+          marginbottom="0"
+          marginleft="0"
+          marginright="0"
+          margintop="0"
+          viewBox="0 0 24 24"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zm.83 12.541h-1.9v-.708c0-1.156.625-2.24 1.672-2.9.867-.546 1.337-.939 1.337-1.447 0-1.014-1-1.561-1.94-1.561-1.035 0-1.942.73-1.942 1.56h-1.9c0-1.875 1.758-3.46 3.841-3.46 2.154 0 3.842 1.52 3.842 3.46 0 1.655-1.393 2.533-2.225 3.056-.236.15-.784.573-.784 1.292v.708zm-.889 3.631a1.244 1.244 0 110-2.487 1.244 1.244 0 010 2.487z"
+            fill="currentColor"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c8"
+    data-testid="bezier-react-text-input"
+    size="36"
+  >
+    <input
+      aria-describedby="form-help-text"
+      autocomplete="off"
+      class="c9"
+      id="form"
+      placeholder="Placeholder"
+      size="36"
+      value=""
+    />
+  </div>
+  <div
+    class="c0 c10"
+  >
+    <p
+      class="c11 c12"
+      color="txt-black-dark"
+      data-testid="bezier-react-form-helper-text"
+      id="form-help-text"
+    >
+      Description
+    </p>
+  </div>
+</div>
+`;

--- a/src/components/Forms/FormControl/index.ts
+++ b/src/components/Forms/FormControl/index.ts
@@ -1,12 +1,13 @@
 import FormControl from './FormControl'
 import FormControlContext from './FormControlContext'
 import type FormControlProps from './FormControl.types'
-import type { FormControlContextValue, FormControlContextCommonValue } from './FormControl.types'
+import type { FormControlContextValue, FormControlContextCommonValue, FormControlAriaProps } from './FormControl.types'
 
 export type {
   FormControlProps,
   FormControlContextValue,
   FormControlContextCommonValue,
+  FormControlAriaProps,
 }
 
 export {

--- a/src/components/Forms/FormGroup/FormGroup.stories.tsx
+++ b/src/components/Forms/FormGroup/FormGroup.stories.tsx
@@ -1,0 +1,43 @@
+/* External dependencies */
+import React from 'react'
+import base from 'paths.macro'
+import type { Story, Meta } from '@storybook/react'
+
+/* Internal dependencies */
+import { getTitle } from 'Utils/storyUtils'
+import { Checkbox } from 'Components/Forms/Checkbox'
+import FormGroup from './FormGroup'
+import FormGroupProps from './FormGroup.types'
+
+export default {
+  title: getTitle(base),
+  component: FormGroup,
+  argTypes: {
+    gap: {
+      control: {
+        type: 'number',
+      },
+    },
+    direction: {
+      control: {
+        type: 'radio',
+        options: ['column', 'row'],
+      },
+    },
+  },
+} as Meta
+
+const Template: Story<FormGroupProps> = props => (
+  <FormGroup {...props}>
+    <Checkbox>Option</Checkbox>
+    <Checkbox>Option</Checkbox>
+    <Checkbox>Option</Checkbox>
+    <Checkbox>Option</Checkbox>
+  </FormGroup>
+)
+
+export const Primary: Story<FormGroupProps> = Template.bind({})
+Primary.args = {
+  gap: 6,
+  direction: 'column',
+}

--- a/src/components/Forms/FormGroup/FormGroup.styled.ts
+++ b/src/components/Forms/FormGroup/FormGroup.styled.ts
@@ -1,0 +1,32 @@
+/* Internal dependencies */
+import { styled, css } from 'Foundation'
+import { InjectedInterpolation } from 'Types/Foundation'
+import type FormGroupProps from './FormGroup.types'
+
+// TODO: Mixin으로 옮기기보다, Stack 컴포넌트가 prop을 통해 이 믹스인을 내부적으로 사용하도록 하기
+function gap(spacing: number): InjectedInterpolation {
+  return css`
+    gap: ${spacing}px;
+
+    @supports not(gap: ${spacing}px) {
+      margin-top: ${-spacing}px;
+      margin-left: ${-spacing}px;
+
+      > * {
+        margin-top: ${spacing}px;
+        margin-left: ${spacing}px;
+      }
+    }
+  `
+}
+
+type StackProps = Required<Pick<FormGroupProps, 'gap' | 'direction' | 'interpolation'>>
+
+// TODO: Stack 컴포넌트로 교체
+export const Stack = styled.div<StackProps>`
+  display: flex;
+  flex-direction: ${({ direction }) => direction};
+  flex-wrap: wrap;
+  ${({ gap: spacing }) => gap(spacing)}
+  ${({ interpolation }) => interpolation}
+`

--- a/src/components/Forms/FormGroup/FormGroup.test.tsx
+++ b/src/components/Forms/FormGroup/FormGroup.test.tsx
@@ -1,0 +1,27 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { render } from 'Utils/testUtils'
+import FormGroup, { FORM_GROUP_TEST_ID } from './FormGroup'
+import type FormGroupProps from './FormGroup.types'
+
+describe('FormGroup >', () => {
+  let props: FormGroupProps
+
+  beforeEach(() => {
+    props = {
+      gap: 6,
+      direction: 'column',
+    }
+  })
+
+  const renderComponent = () => render(<FormGroup {...props} />)
+
+  it('Snapshot >', () => {
+    const { getByTestId } = renderComponent()
+    const rendered = getByTestId(FORM_GROUP_TEST_ID)
+
+    expect(rendered).toMatchSnapshot()
+  })
+})

--- a/src/components/Forms/FormGroup/FormGroup.tsx
+++ b/src/components/Forms/FormGroup/FormGroup.tsx
@@ -6,7 +6,10 @@ import useFormControlContext from 'Components/Forms/useFormControlContext'
 import type FormGroupProps from './FormGroup.types'
 import * as Styled from './FormGroup.styled'
 
+export const FORM_GROUP_TEST_ID = 'bezier-react-form-group'
+
 function FormGroup({
+  testId = FORM_GROUP_TEST_ID,
   gap = 6,
   direction = 'column',
   children,
@@ -31,6 +34,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
   return (
     <Styled.Stack
       {...ownProps}
+      data-testid={testId}
       ref={forwardedRef}
       gap={gap}
       direction={direction}

--- a/src/components/Forms/FormGroup/FormGroup.tsx
+++ b/src/components/Forms/FormGroup/FormGroup.tsx
@@ -1,0 +1,44 @@
+/* External dependencies */
+import React, { forwardRef, useEffect } from 'react'
+
+/* Internal dependencies */
+import useFormControlContext from 'Components/Forms/useFormControlContext'
+import type FormGroupProps from './FormGroup.types'
+import * as Styled from './FormGroup.styled'
+
+function FormGroup({
+  gap = 6,
+  direction = 'column',
+  children,
+  ...rest
+}: FormGroupProps,
+forwardedRef: React.Ref<HTMLDivElement>,
+) {
+  const contextValue = useFormControlContext()
+
+  const {
+    setIsRendered,
+    ...ownProps
+  } = contextValue?.getGroupProps(rest) ?? { setIsRendered: undefined }
+
+  useEffect(() => {
+    setIsRendered?.(true)
+    return function cleanUp() {
+      setIsRendered?.(false)
+    }
+  }, [setIsRendered])
+
+  return (
+    <Styled.Stack
+      {...ownProps}
+      ref={forwardedRef}
+      gap={gap}
+      direction={direction}
+      role="group"
+    >
+      { children }
+    </Styled.Stack>
+  )
+}
+
+export default forwardRef(FormGroup)

--- a/src/components/Forms/FormGroup/FormGroup.types.ts
+++ b/src/components/Forms/FormGroup/FormGroup.types.ts
@@ -1,0 +1,14 @@
+/* Internal dependencies */
+import type { BezierComponentProps, ChildrenProps } from 'Types/ComponentProps'
+
+interface FormGroupOptions {
+  gap?: number
+  direction?: 'column' | 'row'
+}
+
+interface FormGroupProps extends
+  BezierComponentProps,
+  ChildrenProps,
+  FormGroupOptions {}
+
+export default FormGroupProps

--- a/src/components/Forms/FormGroup/__snapshots__/FormGroup.test.tsx.snap
+++ b/src/components/Forms/FormGroup/__snapshots__/FormGroup.test.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormGroup > Snapshot > 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+@supports not(gap:6px) {
+  .c0 {
+    margin-top: -6px;
+    margin-left: -6px;
+  }
+
+  .c0 > * {
+    margin-top: 6px;
+    margin-left: 6px;
+  }
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-form-group"
+  direction="column"
+  role="group"
+/>
+`;

--- a/src/components/Forms/FormGroup/index.ts
+++ b/src/components/Forms/FormGroup/index.ts
@@ -1,0 +1,5 @@
+import FormGroup from './FormGroup'
+import type FormGroupProps from './FormGroup.types'
+
+export { FormGroup }
+export type { FormGroupProps }

--- a/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/src/components/Forms/FormLabel/FormLabel.tsx
@@ -26,10 +26,7 @@ forwardedRef: React.Ref<HTMLLabelElement>,
 ) {
   const contextValue = useFormControlContext()
 
-  const { Wrapper, ...ownProps } = contextValue?.getLabelProps(rest) ?? {
-    ...rest,
-    Wrapper: React.Fragment,
-  }
+  const { Wrapper, ...ownProps } = contextValue?.getLabelProps(rest) ?? { Wrapper: React.Fragment }
 
   const LabelComponent = useMemo(() => (
     <Styled.Label

--- a/src/components/Forms/Inputs/Select/Select.tsx
+++ b/src/components/Forms/Inputs/Select/Select.tsx
@@ -53,7 +53,6 @@ forwardedRef: Ref<SelectRef>,
     disabled,
     readOnly,
     hasError,
-    Wrapper,
     ...ownProps
   } = useFormFieldProps(rest)
 
@@ -128,63 +127,61 @@ forwardedRef: Ref<SelectRef>,
 
   // TODO: 접근성을 지키도록 개선
   return (
-    <Wrapper>
-      <Styled.Container
-        data-testid={testId}
-        ref={containerRef}
-        {...ownProps}
+    <Styled.Container
+      data-testid={testId}
+      ref={containerRef}
+      {...ownProps}
+    >
+      <Styled.Trigger
+        data-testid={triggerTestId}
+        as={as}
+        ref={triggerRef}
+        size={size}
+        focus={isDropdownOpened && !disabled}
+        error={hasError}
+        disabled={disabled}
+        readOnly={readOnly}
+        onClick={handleClickTrigger}
       >
-        <Styled.Trigger
-          data-testid={triggerTestId}
-          as={as}
-          ref={triggerRef}
-          size={size}
-          focus={isDropdownOpened && !disabled}
-          error={hasError}
-          disabled={disabled}
-          readOnly={readOnly}
-          onClick={handleClickTrigger}
-        >
-          <Styled.MainContentWrapper>
-            { LeftComponent }
-            <Styled.TextContainer
-              testId={triggerTextTestId}
-              typo={Typography.Size14}
-              color={hasContent ? textColor : 'txt-black-dark'}
-            >
-              { hasContent ? text : placeholder }
-            </Styled.TextContainer>
-            { RightComponent }
-          </Styled.MainContentWrapper>
-          { !withoutChevron && (
-            <Icon
-              name={`chevron-${isDropdownOpened ? 'up' : 'down'}` as const}
-              size={IconSize.XS}
-              color={readOnly ? 'txt-black-dark' : 'txt-black-darker'}
-              marginLeft={6}
-            />
-          ) }
-        </Styled.Trigger>
+        <Styled.MainContentWrapper>
+          { LeftComponent }
+          <Styled.TextContainer
+            testId={triggerTextTestId}
+            typo={Typography.Size14}
+            color={hasContent ? textColor : 'txt-black-dark'}
+          >
+            { hasContent ? text : placeholder }
+          </Styled.TextContainer>
+          { RightComponent }
+        </Styled.MainContentWrapper>
+        { !withoutChevron && (
+        <Icon
+          name={`chevron-${isDropdownOpened ? 'up' : 'down'}` as const}
+          size={IconSize.XS}
+          color={readOnly ? 'txt-black-dark' : 'txt-black-darker'}
+          marginLeft={6}
+        />
+        ) }
+      </Styled.Trigger>
 
-        <Styled.Dropdown
-          style={dropdownStyle}
-          className={dropdownClassName}
-          testId={dropdownTestId}
-          withTransition
-          show={isDropdownOpened && !disabled}
-          zIndex={dropdownZIndex}
-          marginX={dropdownMarginX}
-          marginY={dropdownMarginY}
-          target={triggerRef.current}
-          container={dropdownContainer || containerRef.current}
-          position={dropdownPosition}
-          interpolation={dropdownInterpolation}
-          onHide={handleHideDropdown}
-        >
-          { children }
-        </Styled.Dropdown>
-      </Styled.Container>
-    </Wrapper>
+      <Styled.Dropdown
+        style={dropdownStyle}
+        className={dropdownClassName}
+        testId={dropdownTestId}
+        withTransition
+        show={isDropdownOpened && !disabled}
+        zIndex={dropdownZIndex}
+        marginX={dropdownMarginX}
+        marginY={dropdownMarginY}
+        target={triggerRef.current}
+        container={dropdownContainer || containerRef.current}
+        position={dropdownPosition}
+        interpolation={dropdownInterpolation}
+        onHide={handleHideDropdown}
+      >
+        { children }
+      </Styled.Dropdown>
+    </Styled.Container>
   )
 }
 

--- a/src/components/Forms/Inputs/TextArea/TextArea.tsx
+++ b/src/components/Forms/Inputs/TextArea/TextArea.tsx
@@ -33,7 +33,6 @@ forwardedRef: Ref<HTMLTextAreaElement>,
     disabled,
     readOnly,
     hasError,
-    Wrapper,
     ...ownProps
   } = useFormFieldProps(rest)
 
@@ -84,30 +83,28 @@ forwardedRef: Ref<HTMLTextAreaElement>,
   }, [])
 
   return (
-    <Wrapper>
-      <Styled.Wrapper
-        className={className}
-        interpolation={interpolation}
-        focused={focused}
-        hasError={hasError}
+    <Styled.Wrapper
+      className={className}
+      interpolation={interpolation}
+      focused={focused}
+      hasError={hasError}
+      disabled={disabled}
+      bgColor={bgColorSemanticName}
+      data-testid={testId}
+    >
+      <Styled.TextAreaAutoSizeBase
+        {...ownProps}
+        ref={mergedInputRef}
+        value={value}
         disabled={disabled}
-        bgColor={bgColorSemanticName}
-        data-testid={testId}
-      >
-        <Styled.TextAreaAutoSizeBase
-          {...ownProps}
-          ref={mergedInputRef}
-          value={value}
-          disabled={disabled}
-          readOnly={readOnly}
-          maxRows={maxRows}
-          minRows={minRows}
-          onChange={onChange}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-        />
-      </Styled.Wrapper>
-    </Wrapper>
+        readOnly={readOnly}
+        maxRows={maxRows}
+        minRows={minRows}
+        onChange={onChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+      />
+    </Styled.Wrapper>
   )
 }
 

--- a/src/components/Forms/Inputs/TextField/TextField.tsx
+++ b/src/components/Forms/Inputs/TextField/TextField.tsx
@@ -58,7 +58,6 @@ forwardedRef: Ref<TextFieldRef>,
     disabled,
     readOnly,
     hasError,
-    Wrapper,
     ...ownProps
   } = useFormFieldProps(rest)
 
@@ -340,45 +339,43 @@ forwardedRef: Ref<TextFieldRef>,
   ])
 
   return (
-    <Wrapper>
-      <Styled.Wrapper
-        className={wrapperClassName}
-        variant={variant}
+    <Styled.Wrapper
+      className={wrapperClassName}
+      variant={variant}
+      size={size}
+      bgColor={wrapperBgColorSemanticName}
+      borderRadius={wrapperBorderRadius}
+      hasError={hasError}
+      disabled={disabled}
+      focused={focused}
+      interpolation={wrapperInterpolation}
+      data-testid={testId}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onMouseDown={focus}
+    >
+      { leftComponent }
+      <Styled.Input
+        type={type}
+        className={inputClassName}
+        interpolation={inputInterpolation}
+        ref={inputRef}
+        value={normalizedValue}
+        name={name}
         size={size}
-        bgColor={wrapperBgColorSemanticName}
-        borderRadius={wrapperBorderRadius}
-        hasError={hasError}
+        autoComplete={autoComplete}
+        readOnly={readOnly}
         disabled={disabled}
-        focused={focused}
-        interpolation={wrapperInterpolation}
-        data-testid={testId}
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
-        onMouseDown={focus}
-      >
-        { leftComponent }
-        <Styled.Input
-          type={type}
-          className={inputClassName}
-          interpolation={inputInterpolation}
-          ref={inputRef}
-          value={normalizedValue}
-          name={name}
-          size={size}
-          autoComplete={autoComplete}
-          readOnly={readOnly}
-          disabled={disabled}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          onKeyUp={handleKeyUp}
-          {...ownProps}
-        />
-        { activeClear && clearComponent }
-        { rightComponent }
-      </Styled.Wrapper>
-    </Wrapper>
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
+        {...ownProps}
+      />
+      { activeClear && clearComponent }
+      { rightComponent }
+    </Styled.Wrapper>
   )
 }
 

--- a/src/components/Forms/Inputs/TextField/TextField.tsx
+++ b/src/components/Forms/Inputs/TextField/TextField.tsx
@@ -247,7 +247,7 @@ forwardedRef: Ref<TextFieldRef>,
       ) : item
   ), [])
 
-  const leftComponent = useMemo(() => {
+  const LeftComponent = useMemo(() => {
     if (isNil(leftContent)) {
       return null
     }
@@ -291,7 +291,7 @@ forwardedRef: Ref<TextFieldRef>,
     )
   ), [])
 
-  const rightComponent = useMemo(() => {
+  const RightComponent = useMemo(() => {
     if (isNil(rightContent) || isEmpty(rightContent)) {
       return null
     }
@@ -318,7 +318,7 @@ forwardedRef: Ref<TextFieldRef>,
     renderRightItem,
   ])
 
-  const clearComponent = useMemo(() => (
+  const ClearComponent = useMemo(() => (
     <Styled.ClearIconWrapper
       onClick={handleClear}
     >
@@ -354,7 +354,7 @@ forwardedRef: Ref<TextFieldRef>,
       onMouseLeave={() => setHovered(false)}
       onMouseDown={focus}
     >
-      { leftComponent }
+      { LeftComponent }
       <Styled.Input
         type={type}
         className={inputClassName}
@@ -373,8 +373,8 @@ forwardedRef: Ref<TextFieldRef>,
         onKeyUp={handleKeyUp}
         {...ownProps}
       />
-      { activeClear && clearComponent }
-      { rightComponent }
+      { activeClear && ClearComponent }
+      { RightComponent }
     </Styled.Wrapper>
   )
 }

--- a/src/components/Forms/Radio/Radio.tsx
+++ b/src/components/Forms/Radio/Radio.tsx
@@ -35,7 +35,6 @@ function Radio(
 ) {
   const {
     disabled,
-    Wrapper,
     ...ownProps
   } = useFormFieldProps(rest)
 
@@ -64,27 +63,25 @@ function Radio(
   ])
 
   return (
-    <Wrapper>
-      <StyledRadioWrapper
-        ref={forwardedRef}
-        data-testid={testId}
+    <StyledRadioWrapper
+      ref={forwardedRef}
+      data-testid={testId}
+      disabled={disabled}
+      onClick={handleClick}
+      onMouseEnter={handleMouseOver}
+      onMouseLeave={handleMouseLeave}
+      {...ownProps}
+    >
+      <StyledRadioHandle
+        as={as}
+        data-testid={handleTestId}
+        className={dotClassName}
+        checked={checked}
         disabled={disabled}
-        onClick={handleClick}
-        onMouseEnter={handleMouseOver}
-        onMouseLeave={handleMouseLeave}
-        {...ownProps}
-      >
-        <StyledRadioHandle
-          as={as}
-          data-testid={handleTestId}
-          className={dotClassName}
-          checked={checked}
-          disabled={disabled}
-          hovered={hovered}
-        />
-        { children }
-      </StyledRadioWrapper>
-    </Wrapper>
+        hovered={hovered}
+      />
+      { children }
+    </StyledRadioWrapper>
   )
 }
 

--- a/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -31,7 +31,6 @@ function SegmentedControl(
 ) {
   const {
     disabled,
-    Wrapper,
     ...ownProps
   } = useFormFieldProps(rest)
 
@@ -109,19 +108,17 @@ function SegmentedControl(
   ])
 
   return (
-    <Wrapper>
-      <Styled.Wrapper
-        {...ownProps}
-        ref={wrapperRef}
-        disabled={disabled}
-        wrapperWidth={width}
-        wrapperHeight={height}
-        data-testid={testId}
-      >
-        { IndicatorComponent }
-        { Content }
-      </Styled.Wrapper>
-    </Wrapper>
+    <Styled.Wrapper
+      {...ownProps}
+      ref={wrapperRef}
+      disabled={disabled}
+      wrapperWidth={width}
+      wrapperHeight={height}
+      data-testid={testId}
+    >
+      { IndicatorComponent }
+      { Content }
+    </Styled.Wrapper>
   )
 }
 

--- a/src/components/Forms/Switch/Switch.tsx
+++ b/src/components/Forms/Switch/Switch.tsx
@@ -24,7 +24,6 @@ function Switch(
 ): ReactElement {
   const {
     disabled,
-    Wrapper,
     ...ownProps
   } = useFormFieldProps(rest)
 
@@ -39,22 +38,20 @@ function Switch(
   ])
 
   return (
-    <Wrapper>
-      <Styled.Wrapper
-        {...ownProps}
-        ref={forwardedRef}
+    <Styled.Wrapper
+      {...ownProps}
+      ref={forwardedRef}
+      size={size}
+      checked={checked}
+      disabled={disabled}
+      onClick={handleClick}
+      data-testid={testId}
+    >
+      <Styled.Content
         size={size}
         checked={checked}
-        disabled={disabled}
-        onClick={handleClick}
-        data-testid={testId}
-      >
-        <Styled.Content
-          size={size}
-          checked={checked}
-        />
-      </Styled.Wrapper>
-    </Wrapper>
+      />
+    </Styled.Wrapper>
   )
 }
 

--- a/src/components/Forms/useFormFieldProps.ts
+++ b/src/components/Forms/useFormFieldProps.ts
@@ -1,5 +1,5 @@
 /* External dependencies */
-import { Fragment, useMemo } from 'react'
+import { useMemo } from 'react'
 
 /* Internal dependencies */
 import { ariaAttr } from 'Utils/domUtils'
@@ -10,10 +10,7 @@ function useFormFieldProps<Props extends FormComponentProps>(props?: Props) {
   const contextValue = useFormControlContext()
 
   const formFieldProps = useMemo(() => {
-    const mergedProps = contextValue?.getFieldProps(props) ?? {
-      ...props,
-      Wrapper: Fragment,
-    }
+    const mergedProps = contextValue?.getFieldProps(props) ?? { ...props }
 
     const {
       disabled = false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export * from 'Components/Forms/Inputs/TextField'
 export * from 'Components/Forms/Inputs/TextArea'
 export * from 'Components/Forms/Inputs/mixins'
 export * from 'Components/Forms/FormControl'
+export * from 'Components/Forms/FormGroup'
 export * from 'Components/Forms/FormLabel'
 export * from 'Components/Forms/FormHelperText'
 


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->

# Summary

<!-- 수정 내용에 대한 요약  -->

`FormGroup` 컴포넌트를 추가합니다. 여러 폼 필드를 묶을 때 사용하는 Wrapper Component입니다. `Checkbox`, `Radio`, `TextField` 등 다양한 필드와 함께 사용할 수 있습니다. `FormControl` 과 함께 사용 시, 접근성 속성이 여러 필드에 중복되어 지정되는걸 방지하기 위해서 각 필드로 전달되는 접근성 관련 속성들을 `FormGroup` 에서 대신 전달받습니다. 

# Details

<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

## TO-BE

### Usage

1. FormGroup만 단독으로 사용하면 Stack 컴포넌트(flex, gap속성이 있는 div)와 똑같이 동작합니다.

<img width="276" alt="스크린샷 2022-01-19 오후 8 34 29" src="https://user-images.githubusercontent.com/58209009/150122194-39641e08-8f5e-43fc-9227-47ef178d2ac5.png">

```tsx
<FormGroup>
  <Checkbox>Option</Checkbox>
  <Checkbox>Option</Checkbox>
  <Checkbox>Option</Checkbox>
  <Checkbox>Option</Checkbox>
</FormGroup>
```

2. FormControl과 함께 조합해서 사용하는 케이스

<img width="494" alt="스크린샷 2022-01-19 오후 8 38 32" src="https://user-images.githubusercontent.com/58209009/150122805-15a0d79e-4374-4871-a69e-05f538cd2c77.png">

```tsx
<FormControl style={{ width: 400 }} labelPosition="left" {...args}>
  <FormLabel>선택 항목</FormLabel>
  <FormGroup>
    <FormControl {...args} hasError={false}>
      <TextField placeholder="선택 항목 추가" />
      <FormErrorMessage>Error!</FormErrorMessage>
    </FormControl>
    <FormControl {...args} hasError={false}>
      <TextField placeholder="선택 항목 추가" />
      <FormErrorMessage>Error!</FormErrorMessage>
    </FormControl>
  </FormGroup>
  <FormHelperText>Description</FormHelperText>
</FormControl>
```

더 다양한 케이스는 `FormControl` 스토리북을 확인해주세요.

### FormControl의 Field별 Wrapper 삭제

`FormControl` 에서 각 필드에 내려주던 `Wrapper` 컴포넌트를 제거합니다. https://github.com/channel-io/bezier-react/pull/669#issuecomment-997696834 에서 고민했듯, 필드가 여러 개 있는 경우 `FormControl` 컴포넌트에서 레이아웃의 책임을 담당하기가 어려웠습니다. 하위로 전달하는 `Wrapper` 컴포넌트를 모두 제거하여 `FormControl` 컴포넌트가 레이아웃을 담당하는 책임을 아예 제거하려고 시도했으나, Label, HelperText의 경우엔 각 폼 필드와의 관계 없이 스스로 패딩, 마진값을 가지는 건 적절하지 않다고 생각해 적용하지 않았습니다. 대신 필드의 `Wrapper` 만 `FormGroup` 이라는 컴포넌트로 분리하여 여러 개의 필드가 하나의 FormControl 컨텍스트를 공유했을 때 발생하는 레이아웃, 접근성 속성 문제를 해결했습니다.

### 고민거리

여전히 해결하지 못한 문제가 있습니다. 위 코멘트에 적었듯 1. 여러 개의 필드가 있고, 2. `labelPosition === 'left'` 일 때, Label이 첫번째 필드의 높이인 채로, 상단에 붙어서 정렬되어야 합니다. 하나의 필드가 있을 땐 그리드 상에서 단순히 세로 가운데 정렬을 하면 해결되지만 여러 필드일 경우엔 이야기가 다릅니다. 이를 해결하고자 시도해보았는데 아직 마땅한 해결책을 찾지 못했습니다. 

1. 첫번째 필드가 마운트될 때 ref를 통해 엘리먼트의 높이를 계산: 이 엘리먼트의 높이가 전체 컴포넌트 높이와 같지 않을 수 있습니다. 풀어서 설명하자면, ref 속성이 전체 Wrapper가 아닌 내부의 input 엘리먼트등에 지정된 케이스가 있어 다양한 필드에 대해 일관성있게 높이값을 가져올 수가 없습니다.
2. FormGroup의 첫번째 child에 접근하기. 어떠한 ReactNode도 올 수 있기 때문에 높이값을 가져올 수 없습니다.
3. 자동으로 그리드를 설정해주는 기능 구현. 그리드 순서 등 고려해야될 사항이 너무 많아 오버엔지니어링이라고 생각했습니다.

차선책으로 해당 값을 `FormControl` 의 prop을 통해 전달할 수 있도록 하고, 디자인 시안에서 가장 많이 사용되고 있는 36px로  기본 값을 지정했습니다. 대부분의 유즈케이스에서 잘 동작할거라고 생각합니다.

## Browser Compatibility

OS / Engine 호환성을 반드시 확인해주세요.

### Windows

- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)

### macOS

- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# References

<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

- [Figma - Web Component](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=0%3A1)
