### PR TITLE
Button 의 최신 디자인 스펙 반영

### DIFF
--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -6,6 +6,7 @@ import { styled, css, SemanticNames } from 'Foundation'
 import DisabledOpacity from 'Constants/DisabledOpacity'
 import ButtonProps, { ButtonSize, ButtonStyleVariant, ButtonColorVariant } from './Button.types'
 
+// NOTE: ButtonSize 에 따른 버튼의 min-width, height
 const BUTTON_SIZE_VALUE = {
   [ButtonSize.XS]: 20,
   [ButtonSize.S]: 24,
@@ -28,6 +29,7 @@ function getSizeCSSFromButtonSize({
   `
 }
 
+// NOTE: ButtonSize에 따른 버튼 내 텍스트의 margin
 export const TEXT_MARGIN_VALUE: Record<ButtonSize, number> = {
   [ButtonSize.XS]: 3,
   [ButtonSize.S]: 3,
@@ -36,6 +38,11 @@ export const TEXT_MARGIN_VALUE: Record<ButtonSize, number> = {
   [ButtonSize.XL]: 4,
 }
 
+// NOTE: 버튼의 padding 값을 결정하는 경우 4가지 중 위의 3가지 key
+// 1. 해당 사이드에 텍스트가 있을 경우 - textSide
+// 2. 해당 사이드에 텍스트가 아닌 컨텐트가 있을 경우 (ex. 아이콘) - contentSide
+// 3. styleVariant 가 Floating 인 경우 - floating
+// 4. 버튼에 텍스트 없이 컨텐트만 있을 경우 => buttonSize 에 관계없이 padding 이 0 이라 이 경우만 따로 분기 처리
 type ButtonPaddingVariantKey = 'textSide' | 'contentSide' | 'floating'
 
 function getButtonPaddingVariantKey(styleVariant: ButtonStyleVariant, hasContent: boolean): ButtonPaddingVariantKey {
@@ -48,6 +55,8 @@ function getButtonPaddingVariantKey(styleVariant: ButtonStyleVariant, hasContent
   return 'textSide'
 }
 
+// NOTE: textSide엔 Text에 자체 margin 이 있어 TEXT_MARGIN_VALUE[ButtonSize.XS] 을 원래 스펙에서 빼줌
+// NOTE: floating 은 padding 이 버튼의 size value 의 절반에서 Text margin 값 만큼 빼줘야 스펙과 일치
 const BUTTON_HORIZONTAL_PADDING_VALUE: Record<ButtonSize, Record<ButtonPaddingVariantKey, number>> = {
   [ButtonSize.XS]: {
     textSide: 4 - TEXT_MARGIN_VALUE[ButtonSize.XS],
@@ -90,6 +99,7 @@ function getPaddingCSSFromSizeAndContents({
 }: GetPaddingCSSFromSizeAndContentsArgs) {
   const hasOnlyContent = isEmpty(text)
 
+  // NOTE: text 가 없는 버튼의 경우 padding 이 0
   if (hasOnlyContent) {
     return css`
       padding: 0;

--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -54,9 +54,8 @@ const BUTTON_CONTENT_GAP_VALUE: Record<ButtonSize, number> = {
 // 3. 버튼에 텍스트 없이 컨텐트만 있을 경우 => buttonSize 에 관계없이 padding 이 0 이라 이 경우만 따로 분기 처리
 type ButtonPaddingVariantKey = 'default' | 'floating'
 
-// NOTE: textSide엔 Text에 자체 margin 이 있어 TEXT_MARGIN_VALUE[ButtonSize.XS] 을 원래 스펙에서 빼줌
-// NOTE: floating 은 padding 이 버튼의 size value 의 절반에서 Text margin 값 만큼 빼줘야 스펙과 일치
-const BUTTON_HORIZONTAL_PADDING_VALUE: Record<ButtonSize, Record<ButtonPaddingVariantKey, number>> = {
+// NOTE: floating 은 padding 이 버튼의 size value 의 절반에서 Text padding 값 만큼 빼줘야 스펙과 일치
+export const BUTTON_HORIZONTAL_PADDING_VALUE: Record<ButtonSize, Record<ButtonPaddingVariantKey, number>> = {
   [ButtonSize.XS]: {
     default: 4,
     floating: (BUTTON_SIZE_VALUE[ButtonSize.XS] / 2) - TEXT_PADDING_VALUE[ButtonSize.XS],
@@ -70,11 +69,11 @@ const BUTTON_HORIZONTAL_PADDING_VALUE: Record<ButtonSize, Record<ButtonPaddingVa
     floating: (BUTTON_SIZE_VALUE[ButtonSize.M] / 2) - TEXT_PADDING_VALUE[ButtonSize.M],
   },
   [ButtonSize.L]: {
-    default: 10,
+    default: 12,
     floating: (BUTTON_SIZE_VALUE[ButtonSize.L] / 2) - TEXT_PADDING_VALUE[ButtonSize.L],
   },
   [ButtonSize.XL]: {
-    default: 14,
+    default: 20,
     floating: (BUTTON_SIZE_VALUE[ButtonSize.XL] / 2) - TEXT_PADDING_VALUE[ButtonSize.XL],
   },
 }
@@ -295,16 +294,19 @@ function getEffectCSSFromVariant(styleVariant?: ButtonProps['styleVariant'], siz
           return css`
             ${({ foundation }) => foundation?.rounding?.round6};
           `
+        case ButtonSize.L:
+          return css`
+            ${({ foundation }) => foundation?.rounding?.round12};
+          `
         case ButtonSize.XL:
           return css`
             ${({ foundation }) => foundation?.rounding?.round12};
           `
         case ButtonSize.S:
-        case ButtonSize.L:
         case ButtonSize.M:
         default:
           return css`
-            ${({ foundation }) => foundation?.rounding?.round8};
+            ${({ foundation }) => foundation?.rounding?.round16};
           `
       }
     }

--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -300,13 +300,13 @@ function getEffectCSSFromVariant(styleVariant?: ButtonProps['styleVariant'], siz
           `
         case ButtonSize.XL:
           return css`
-            ${({ foundation }) => foundation?.rounding?.round12};
+            ${({ foundation }) => foundation?.rounding?.round16};
           `
         case ButtonSize.S:
         case ButtonSize.M:
         default:
           return css`
-            ${({ foundation }) => foundation?.rounding?.round16};
+            ${({ foundation }) => foundation?.rounding?.round8};
           `
       }
     }

--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -17,13 +17,12 @@ const BUTTON_SIZE_VALUE = {
   [ButtonSize.XL]: 54,
 }
 
-interface GetSizeCSSFromButtonSizeArgs extends Pick<
-ButtonProps,
-'size'
-> {}
+interface GetSizeCSSFromButtonSizeArgs {
+  size: ButtonSize
+}
 
 function getSizeCSSFromButtonSize({
-  size = ButtonSize.M,
+  size,
 }: GetSizeCSSFromButtonSizeArgs) {
   return css`
     min-width: ${BUTTON_SIZE_VALUE[size]}px;
@@ -78,15 +77,15 @@ export const BUTTON_HORIZONTAL_PADDING_VALUE: Record<ButtonSize, Record<ButtonPa
   },
 }
 
-interface GetPaddingCSSFromSizeAndContentsArgs extends Pick<
-ButtonProps,
-'styleVariant' | 'text' | 'size'
-> {}
+interface GetPaddingCSSFromSizeAndContentsArgs extends Pick<ButtonProps, 'text'>{
+  styleVariant: ButtonStyleVariant
+  size: ButtonSize
+}
 
 function getPaddingCSSFromSizeAndContents({
-  styleVariant = ButtonStyleVariant.Primary,
+  styleVariant,
   text,
-  size = ButtonSize.M,
+  size,
 }: GetPaddingCSSFromSizeAndContentsArgs) {
   const hasOnlyContent = isEmpty(text)
 
@@ -272,7 +271,7 @@ function getColorCSS(
   `
 }
 
-function getEffectCSSFromVariant(styleVariant?: ButtonProps['styleVariant'], size?: ButtonProps['size']) {
+function getEffectCSSFromVariant(styleVariant: ButtonProps['styleVariant'], size: ButtonProps['size']) {
   switch (styleVariant) {
     case ButtonStyleVariant.Floating:
       return css`
@@ -313,11 +312,15 @@ function getEffectCSSFromVariant(styleVariant?: ButtonProps['styleVariant'], siz
   }
 }
 
-interface GetCSSFromVariantArgs extends Pick<ButtonProps, 'colorVariant' | 'styleVariant' | 'size' | 'disabled' | 'active'> {}
+interface GetCSSFromVariantArgs extends Pick<ButtonProps, 'disabled' | 'active'> {
+  size: ButtonSize
+  styleVariant: ButtonStyleVariant
+  colorVariant: ButtonColorVariant
+}
 
 function getCSSFromVariant({
-  colorVariant = ButtonColorVariant.Blue,
-  styleVariant = ButtonStyleVariant.Primary,
+  colorVariant,
+  styleVariant,
   size,
   disabled,
   active,
@@ -369,7 +372,16 @@ export const ButtonLoader = styled.div`
   justify-content: center;
 `
 
-export const ButtonWrapper = styled.button<ButtonProps>`
+interface ButtonWrapperProps extends Pick<
+ButtonProps,
+'as' | 'interpolation' | 'disabled' | 'active' | 'text'
+>{
+  size: ButtonSize
+  styleVariant: ButtonStyleVariant
+  colorVariant: ButtonColorVariant
+}
+
+export const ButtonWrapper = styled.button<ButtonWrapperProps>`
   position: relative;
   box-sizing: border-box;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};

--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -32,7 +32,7 @@ function getSizeCSSFromButtonSize({
 }
 
 // NOTE: ButtonSize에 따른 버튼 내 텍스트의 margin
-const TEXT_PADDING_VALUE: Record<ButtonSize, number> = {
+export const TEXT_PADDING_VALUE: Record<ButtonSize, number> = {
   [ButtonSize.XS]: 3,
   [ButtonSize.S]: 3,
   [ButtonSize.M]: 4,

--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -6,42 +6,105 @@ import { styled, css, SemanticNames } from 'Foundation'
 import DisabledOpacity from 'Constants/DisabledOpacity'
 import ButtonProps, { ButtonSize, ButtonStyleVariant, ButtonColorVariant } from './Button.types'
 
-interface GetSizeCSSFromButtonSizeArgs extends Pick<ButtonProps, 'size' | 'text'> {}
+const BUTTON_SIZE_VALUE = {
+  [ButtonSize.XS]: 20,
+  [ButtonSize.S]: 24,
+  [ButtonSize.M]: 36,
+  [ButtonSize.L]: 44,
+  [ButtonSize.XL]: 54,
+}
 
-function getSizeCSSFromButtonSize({ size, text }: GetSizeCSSFromButtonSizeArgs) {
-  switch (size) {
-    case ButtonSize.XS:
-      return css`
-        min-width: 20px;
-        height: 20px;
-        padding: 2px;
-      `
-    case ButtonSize.S:
-      return css`
-        min-width: 24px;
-        height: 24px;
-        padding: 3px ${isEmpty(text) ? 3 : 4}px;
-      `
-    case ButtonSize.L:
-      return css`
-        min-width: 44px;
-        height: 44px;
-        padding: 12px ${isEmpty(text) ? 12 : 10}px;
-      `
-    case ButtonSize.XL:
-      return css`
-        min-width: 54px;
-        height: 54px;
-        padding: 15px ${isEmpty(text) ? 15 : 14}px;
-      `
-    case ButtonSize.M:
-    default:
-      return css`
-        min-width: 36px;
-        height: 36px;
-        padding: 8px ${isEmpty(text) ? 8 : 10}px;
-      `
+interface GetSizeCSSFromButtonSizeArgs extends Pick<
+ButtonProps,
+'size'
+> {}
+
+function getSizeCSSFromButtonSize({
+  size = ButtonSize.M,
+}: GetSizeCSSFromButtonSizeArgs) {
+  return css`
+    min-width: ${BUTTON_SIZE_VALUE[size]}px;
+    height: ${BUTTON_SIZE_VALUE[size]}px;
+  `
+}
+
+export const TEXT_MARGIN_VALUE: Record<ButtonSize, number> = {
+  [ButtonSize.XS]: 3,
+  [ButtonSize.S]: 3,
+  [ButtonSize.M]: 4,
+  [ButtonSize.L]: 4,
+  [ButtonSize.XL]: 4,
+}
+
+type ButtonPaddingVariantKey = 'textSide' | 'contentSide' | 'floating'
+
+function getButtonPaddingVariantKey(styleVariant: ButtonStyleVariant, hasContent: boolean): ButtonPaddingVariantKey {
+  if (styleVariant === ButtonStyleVariant.Floating) {
+    return 'floating'
   }
+  if (hasContent) {
+    return 'contentSide'
+  }
+  return 'textSide'
+}
+
+const BUTTON_HORIZONTAL_PADDING_VALUE: Record<ButtonSize, Record<ButtonPaddingVariantKey, number>> = {
+  [ButtonSize.XS]: {
+    textSide: 4 - TEXT_MARGIN_VALUE[ButtonSize.XS],
+    contentSide: 2,
+    floating: (BUTTON_SIZE_VALUE[ButtonSize.XS] / 2) - TEXT_MARGIN_VALUE[ButtonSize.XS],
+  },
+  [ButtonSize.S]: {
+    textSide: 7 - TEXT_MARGIN_VALUE[ButtonSize.S],
+    contentSide: 4,
+    floating: (BUTTON_SIZE_VALUE[ButtonSize.S] / 2) - TEXT_MARGIN_VALUE[ButtonSize.S],
+  },
+  [ButtonSize.M]: {
+    textSide: 14 - TEXT_MARGIN_VALUE[ButtonSize.M],
+    contentSide: 10,
+    floating: (BUTTON_SIZE_VALUE[ButtonSize.M] / 2) - TEXT_MARGIN_VALUE[ButtonSize.M],
+  },
+  [ButtonSize.L]: {
+    textSide: 14 - TEXT_MARGIN_VALUE[ButtonSize.L],
+    contentSide: 10,
+    floating: (BUTTON_SIZE_VALUE[ButtonSize.L] / 2) - TEXT_MARGIN_VALUE[ButtonSize.L],
+  },
+  [ButtonSize.XL]: {
+    textSide: 18 - TEXT_MARGIN_VALUE[ButtonSize.XL],
+    contentSide: 14,
+    floating: (BUTTON_SIZE_VALUE[ButtonSize.XL] / 2) - TEXT_MARGIN_VALUE[ButtonSize.XL],
+  },
+}
+
+interface GetPaddingCSSFromSizeAndContentsArgs extends Pick<
+ButtonWrapperProps,
+'styleVariant' | 'text' | 'size' | 'hasLeftContent' | 'hasRightContent'
+> {}
+
+function getPaddingCSSFromSizeAndContents({
+  styleVariant = ButtonStyleVariant.Primary,
+  text,
+  size = ButtonSize.M,
+  hasLeftContent,
+  hasRightContent,
+}: GetPaddingCSSFromSizeAndContentsArgs) {
+  const hasOnlyContent = isEmpty(text)
+
+  if (hasOnlyContent) {
+    return css`
+      padding: 0;
+    `
+  }
+
+  const paddingRightValue = BUTTON_HORIZONTAL_PADDING_VALUE[size][getButtonPaddingVariantKey(styleVariant, hasRightContent)]
+  const paddingLeftValue = BUTTON_HORIZONTAL_PADDING_VALUE[size][getButtonPaddingVariantKey(styleVariant, hasLeftContent)]
+  return css`
+    padding:
+      0
+      ${paddingRightValue}px
+      0
+      ${paddingLeftValue}px;
+  `
 }
 
 interface ButtonSemanticNames {
@@ -298,7 +361,12 @@ export const ButtonLoader = styled.div`
   justify-content: center;
 `
 
-export const ButtonWrapper = styled.button<ButtonProps>`
+interface ButtonWrapperProps extends ButtonProps {
+  hasLeftContent: boolean
+  hasRightContent: boolean
+}
+
+export const ButtonWrapper = styled.button<ButtonWrapperProps>`
   position: relative;
   box-sizing: border-box;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
@@ -309,6 +377,7 @@ export const ButtonWrapper = styled.button<ButtonProps>`
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'box-shadow'])};
 
   ${getSizeCSSFromButtonSize}
+  ${getPaddingCSSFromSizeAndContents}
   ${getCSSFromVariant}
 
   ${({ interpolation }) => interpolation}

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -106,7 +106,7 @@ describe('Button Test >', () => {
 
         expect(xsButton).toHaveStyle('min-width: 20px;')
         expect(xsButton).toHaveStyle('height: 20px;')
-        expect(xsButton).toHaveStyle('padding: 0 1px 0 1px;')
+        expect(xsButton).toHaveStyle('padding: 0 4px 0 4px;')
 
         // Typograpy.Size13
         expect(xsButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}rem;`)

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -39,7 +39,7 @@ describe('Button Test >', () => {
       // Colors
       expect(primaryButton).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-absolute-white-dark']}`)
       expect(primaryButton).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-normal']}`)
-      expect(primaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R16}px;`)
+      expect(primaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R8}px;`)
       expect(primaryButton).toHaveStyle('overflow: hidden;')
     })
 
@@ -50,7 +50,7 @@ describe('Button Test >', () => {
       // Colors
       expect(secondaryButton).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-blue-normal']}`)
       expect(secondaryButton).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-lightest']}`)
-      expect(secondaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R16}px;`)
+      expect(secondaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R8}px;`)
       expect(secondaryButton).toHaveStyle('overflow: hidden;')
     })
 
@@ -61,7 +61,7 @@ describe('Button Test >', () => {
       // Colors
       expect(tertiaryButton).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-blue-normal']}`)
       expect(tertiaryButton).toHaveStyle('background-color: transparent')
-      expect(tertiaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R16}px;`)
+      expect(tertiaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R8}px;`)
       expect(tertiaryButton).toHaveStyle('overflow: hidden;')
     })
 
@@ -104,14 +104,34 @@ describe('Button Test >', () => {
 
   describe('Size Test >', () => {
     describe('with text >', () => {
+      it('size prop not given, default size is Size M', () => {
+        const { getByTestId } = renderButton()
+        const defaultButton = getByTestId(BUTTON_TEST_ID)
+        const defaultButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
+        const defaultButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.M].default
+
+        expect(defaultButton).toHaveStyle('min-width: 36px;')
+        expect(defaultButton).toHaveStyle('height: 36px;')
+        // eslint-disable-next-line max-len
+        expect(defaultButton).toHaveStyle(`padding: 0 ${defaultButtonPaddingDefault}px 0 ${defaultButtonPaddingDefault}px;`)
+
+        // Typograpy.Size14
+        expect(defaultButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo14}px;`)
+        expect(defaultButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}px;`)
+
+        // Text padding value by ButtonSize
+        expect(defaultButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.M]}px;`)
+      })
+
       it('Size XS', () => {
         const { getByTestId } = renderButton({ size: ButtonSize.XS })
         const xsButton = getByTestId(BUTTON_TEST_ID)
         const xsButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
+        const xsButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.XS].default
 
         expect(xsButton).toHaveStyle('min-width: 20px;')
         expect(xsButton).toHaveStyle('height: 20px;')
-        expect(xsButton).toHaveStyle('padding: 0 4px 0 4px;')
+        expect(xsButton).toHaveStyle(`padding: 0 ${xsButtonPaddingDefault}px 0 ${xsButtonPaddingDefault}px;`)
 
         // Typograpy.Size13
         expect(xsButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}rem;`)
@@ -125,10 +145,11 @@ describe('Button Test >', () => {
         const { getByTestId } = renderButton({ size: ButtonSize.S })
         const sButton = getByTestId(BUTTON_TEST_ID)
         const sButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
+        const sButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.S].default
 
         expect(sButton).toHaveStyle('min-width: 24px;')
         expect(sButton).toHaveStyle('height: 24px;')
-        expect(sButton).toHaveStyle('padding: 0 4px 0 4px;')
+        expect(sButton).toHaveStyle(`padding: 0 ${sButtonPaddingDefault}px 0 ${sButtonPaddingDefault}px;`)
 
         // Typograpy.Size13
         expect(sButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}rem;`)

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { LightFoundation, RoundAbsoluteNumber, TypoAbsoluteNumber, LineHeightAbsoluteNumber } from 'Foundation'
 import DisabledOpacity from 'Constants/DisabledOpacity'
 import { render } from 'Utils/testUtils'
-import Button, { BUTTON_TEST_ID, BUTTON_TEXT_TEST_ID } from './Button'
+import Button, { BUTTON_TEST_ID, BUTTON_TEXT_TEST_ID, BUTTON_INNER_CONTENT_TEST_ID } from './Button'
 import { ButtonStyleVariant, ButtonSize } from './Button.types'
 import { BUTTON_HORIZONTAL_PADDING_VALUE, TEXT_PADDING_VALUE } from './Button.styled'
 import type ButtonProps from './Button.types'
@@ -29,6 +29,8 @@ describe('Button Test >', () => {
     expect(defaultButton).toHaveStyle('position: relative;')
     expect(defaultButton).toHaveStyle('border: none;')
     expect(defaultButton).toHaveStyle('outline: none;')
+
+    expect(defaultButton).toMatchSnapshot()
   })
 
   describe('StyleVariant Test >', () => {
@@ -41,6 +43,8 @@ describe('Button Test >', () => {
       expect(primaryButton).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-normal']}`)
       expect(primaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R8}px;`)
       expect(primaryButton).toHaveStyle('overflow: hidden;')
+
+      expect(primaryButton).toMatchSnapshot()
     })
 
     it('Secondary', () => {
@@ -52,6 +56,8 @@ describe('Button Test >', () => {
       expect(secondaryButton).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-lightest']}`)
       expect(secondaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R8}px;`)
       expect(secondaryButton).toHaveStyle('overflow: hidden;')
+
+      expect(secondaryButton).toMatchSnapshot()
     })
 
     it('Tertiary', () => {
@@ -63,6 +69,8 @@ describe('Button Test >', () => {
       expect(tertiaryButton).toHaveStyle('background-color: transparent')
       expect(tertiaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R8}px;`)
       expect(tertiaryButton).toHaveStyle('overflow: hidden;')
+
+      expect(tertiaryButton).toMatchSnapshot()
     })
 
     it('Floating', () => {
@@ -78,6 +86,8 @@ describe('Button Test >', () => {
 
       // Padding
       expect(floatingButton).toHaveStyle(`padding: 0 ${mButtonPaddingFloating}px 0 ${mButtonPaddingFloating}px;`)
+
+      expect(floatingButton).toMatchSnapshot()
     })
   })
 
@@ -89,6 +99,8 @@ describe('Button Test >', () => {
       expect(disabledButton).toBeDisabled()
       expect(disabledButton).toHaveStyle(`opacity: ${DisabledOpacity};`)
       expect(disabledButton).toHaveStyle('cursor: not-allowed;')
+
+      expect(disabledButton).toMatchSnapshot()
     })
   })
 
@@ -99,6 +111,20 @@ describe('Button Test >', () => {
 
       expect(activatedButton).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-absolute-white-dark']};`)
       expect(activatedButton).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-dark']};`)
+
+      expect(activatedButton).toMatchSnapshot()
+    })
+  })
+
+  describe('Loading Test >', () => {
+    it('Active prop change Button to hover style', () => {
+      const { getByTestId } = renderButton({ loading: true })
+      const loangButton = getByTestId(BUTTON_TEST_ID)
+      const loadingButtonContents = getByTestId(BUTTON_INNER_CONTENT_TEST_ID)
+
+      expect(loadingButtonContents).toHaveStyle('visibility: hidden;')
+
+      expect(loangButton).toMatchSnapshot()
     })
   })
 
@@ -108,30 +134,32 @@ describe('Button Test >', () => {
         const { getByTestId } = renderButton()
         const defaultButton = getByTestId(BUTTON_TEST_ID)
         const defaultButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
-        const defaultButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.M].default
+        const defaultButtonPadding = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.M].default
 
         expect(defaultButton).toHaveStyle('min-width: 36px;')
         expect(defaultButton).toHaveStyle('height: 36px;')
         // eslint-disable-next-line max-len
-        expect(defaultButton).toHaveStyle(`padding: 0 ${defaultButtonPaddingDefault}px 0 ${defaultButtonPaddingDefault}px;`)
+        expect(defaultButton).toHaveStyle(`padding: 0 ${defaultButtonPadding}px 0 ${defaultButtonPadding}px;`)
 
         // Typograpy.Size14
-        expect(defaultButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo14}px;`)
-        expect(defaultButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}px;`)
+        expect(defaultButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo14}rem;`)
+        expect(defaultButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}rem;`)
 
         // Text padding value by ButtonSize
         expect(defaultButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.M]}px;`)
+
+        expect(defaultButton).toMatchSnapshot()
       })
 
       it('Size XS', () => {
         const { getByTestId } = renderButton({ size: ButtonSize.XS })
         const xsButton = getByTestId(BUTTON_TEST_ID)
         const xsButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
-        const xsButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.XS].default
+        const xsDefaultButtonPadding = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.XS].default
 
         expect(xsButton).toHaveStyle('min-width: 20px;')
         expect(xsButton).toHaveStyle('height: 20px;')
-        expect(xsButton).toHaveStyle(`padding: 0 ${xsButtonPaddingDefault}px 0 ${xsButtonPaddingDefault}px;`)
+        expect(xsButton).toHaveStyle(`padding: 0 ${xsDefaultButtonPadding}px 0 ${xsDefaultButtonPadding}px;`)
 
         // Typograpy.Size13
         expect(xsButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}rem;`)
@@ -139,17 +167,32 @@ describe('Button Test >', () => {
 
         // Text padding value by ButtonSize
         expect(xsButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.XS]}px;`)
+
+        expect(xsButton).toMatchSnapshot()
+      })
+
+      it('Size XS - styleVariant: Floating', () => {
+        const { getByTestId } = renderButton({
+          size: ButtonSize.XS,
+          styleVariant: ButtonStyleVariant.Floating,
+        })
+        const xsFloatingButton = getByTestId(BUTTON_TEST_ID)
+        const xsFloatingButtonPadding = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.XS].floating
+
+        // padding value differs when styleVariant: Floating
+        expect(xsFloatingButton).toHaveStyle(`padding: 0 ${xsFloatingButtonPadding}px 0 ${xsFloatingButtonPadding}px;`)
+        expect(xsFloatingButton).toMatchSnapshot()
       })
 
       it('Size S', () => {
         const { getByTestId } = renderButton({ size: ButtonSize.S })
         const sButton = getByTestId(BUTTON_TEST_ID)
         const sButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
-        const sButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.S].default
+        const sDefaultButtonPadding = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.S].default
 
         expect(sButton).toHaveStyle('min-width: 24px;')
         expect(sButton).toHaveStyle('height: 24px;')
-        expect(sButton).toHaveStyle(`padding: 0 ${sButtonPaddingDefault}px 0 ${sButtonPaddingDefault}px;`)
+        expect(sButton).toHaveStyle(`padding: 0 ${sDefaultButtonPadding}px 0 ${sDefaultButtonPadding}px;`)
 
         // Typograpy.Size13
         expect(sButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}rem;`)
@@ -157,18 +200,33 @@ describe('Button Test >', () => {
 
         // Text padding value by ButtonSize
         expect(sButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.S]}px;`)
+
+        expect(sButton).toMatchSnapshot()
+      })
+
+      it('Size S - styleVariant: Floating', () => {
+        const { getByTestId } = renderButton({
+          size: ButtonSize.S,
+          styleVariant: ButtonStyleVariant.Floating,
+        })
+        const sFloatingButton = getByTestId(BUTTON_TEST_ID)
+        const sFloatingButtonPadding = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.S].floating
+
+        // padding value differs when styleVariant: Floating
+        expect(sFloatingButton).toHaveStyle(`padding: 0 ${sFloatingButtonPadding}px 0 ${sFloatingButtonPadding}px;`)
+        expect(sFloatingButton).toMatchSnapshot()
       })
 
       it('Size M', () => {
         const { getByTestId } = renderButton({ size: ButtonSize.M })
         const mButton = getByTestId(BUTTON_TEST_ID)
         const mButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
-        const mButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.M].default
+        const mDefaultButtonPadding = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.M].default
 
         expect(mButton).toHaveStyle('min-width: 36px;')
         expect(mButton).toHaveStyle('height: 36px;')
         // eslint-disable-next-line max-len
-        expect(mButton).toHaveStyle(`padding: 0 ${mButtonPaddingDefault}px 0 ${mButtonPaddingDefault}px;`)
+        expect(mButton).toHaveStyle(`padding: 0 ${mDefaultButtonPadding}px 0 ${mDefaultButtonPadding}px;`)
 
         // Typograpy.Size14
         expect(mButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo14}rem;`)
@@ -176,17 +234,32 @@ describe('Button Test >', () => {
 
         // Text padding value by ButtonSize
         expect(mButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.M]}px;`)
+
+        expect(mButton).toMatchSnapshot()
+      })
+
+      it('Size M - styleVariant: Floating', () => {
+        const { getByTestId } = renderButton({
+          size: ButtonSize.M,
+          styleVariant: ButtonStyleVariant.Floating,
+        })
+        const mFloatingButton = getByTestId(BUTTON_TEST_ID)
+        const mFloatingButtonPadding = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.M].floating
+
+        // padding value differs when styleVariant: Floating
+        expect(mFloatingButton).toHaveStyle(`padding: 0 ${mFloatingButtonPadding}px 0 ${mFloatingButtonPadding}px;`)
+        expect(mFloatingButton).toMatchSnapshot()
       })
 
       it('Size L', () => {
         const { getByTestId } = renderButton({ size: ButtonSize.L })
         const lButton = getByTestId(BUTTON_TEST_ID)
         const lButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
-        const lButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.L].default
+        const lDefaultButtonPadding = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.L].default
 
         expect(lButton).toHaveStyle('min-width: 44px;')
         expect(lButton).toHaveStyle('height: 44px;')
-        expect(lButton).toHaveStyle(`padding: 0 ${lButtonPaddingDefault}px 0 ${lButtonPaddingDefault}px;`)
+        expect(lButton).toHaveStyle(`padding: 0 ${lDefaultButtonPadding}px 0 ${lDefaultButtonPadding}px;`)
 
         // Typography.Size15
         expect(lButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo15}rem;`)
@@ -194,17 +267,32 @@ describe('Button Test >', () => {
 
         // Text padding value by ButtonSize
         expect(lButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.L]}px;`)
+
+        expect(lButton).toMatchSnapshot()
+      })
+
+      it('Size L - styleVariant: Floating', () => {
+        const { getByTestId } = renderButton({
+          size: ButtonSize.L,
+          styleVariant: ButtonStyleVariant.Floating,
+        })
+        const lFloatingButton = getByTestId(BUTTON_TEST_ID)
+        const lFloatingButtonPadding = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.L].floating
+
+        // padding value differs when styleVariant: Floating
+        expect(lFloatingButton).toHaveStyle(`padding: 0 ${lFloatingButtonPadding}px 0 ${lFloatingButtonPadding}px;`)
+        expect(lFloatingButton).toMatchSnapshot()
       })
 
       it('Size XL', () => {
         const { getByTestId } = renderButton({ size: ButtonSize.XL })
         const xlButton = getByTestId(BUTTON_TEST_ID)
         const xlButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
-        const xlButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.XL].default
+        const xlDefaultButtonPadding = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.XL].default
 
         expect(xlButton).toHaveStyle('min-width: 54px;')
         expect(xlButton).toHaveStyle('height: 54px;')
-        expect(xlButton).toHaveStyle(`padding: 0 ${xlButtonPaddingDefault}px 0 ${xlButtonPaddingDefault}px;`)
+        expect(xlButton).toHaveStyle(`padding: 0 ${xlDefaultButtonPadding}px 0 ${xlDefaultButtonPadding}px;`)
 
         // Typography.Size18
         expect(xlButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo18}rem;`)
@@ -212,6 +300,21 @@ describe('Button Test >', () => {
 
         // Text padding value by ButtonSize
         expect(xlButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.XL]}px;`)
+
+        expect(xlButton).toMatchSnapshot()
+      })
+
+      it('Size XL - styleVariant: Floating', () => {
+        const { getByTestId } = renderButton({
+          size: ButtonSize.XL,
+          styleVariant: ButtonStyleVariant.Floating,
+        })
+        const xlFloatingButton = getByTestId(BUTTON_TEST_ID)
+        const xlFloatingButtonPadding = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.XL].floating
+
+        // padding value differs when styleVariant: Floating
+        expect(xlFloatingButton).toHaveStyle(`padding: 0 ${xlFloatingButtonPadding}px 0 ${xlFloatingButtonPadding}px;`)
+        expect(xlFloatingButton).toMatchSnapshot()
       })
     })
 
@@ -223,42 +326,52 @@ describe('Button Test >', () => {
         expect(xsButton).toHaveStyle('min-width: 20px;')
         expect(xsButton).toHaveStyle('height: 20px;')
         expect(xsButton).toHaveStyle('padding: 0px;')
+
+        expect(xsButton).toMatchSnapshot()
       })
 
       it('Size S', () => {
         const { getByTestId } = renderButton({ text: '', size: ButtonSize.S })
-        const xsButton = getByTestId(BUTTON_TEST_ID)
+        const sButton = getByTestId(BUTTON_TEST_ID)
 
-        expect(xsButton).toHaveStyle('min-width: 24px;')
-        expect(xsButton).toHaveStyle('height: 24px;')
-        expect(xsButton).toHaveStyle('padding: 0;')
+        expect(sButton).toHaveStyle('min-width: 24px;')
+        expect(sButton).toHaveStyle('height: 24px;')
+        expect(sButton).toHaveStyle('padding: 0;')
+
+        expect(sButton).toMatchSnapshot()
       })
 
       it('Size M', () => {
         const { getByTestId } = renderButton({ text: '', size: ButtonSize.M })
-        const xsButton = getByTestId(BUTTON_TEST_ID)
+        const mButton = getByTestId(BUTTON_TEST_ID)
 
-        expect(xsButton).toHaveStyle('min-width: 36px;')
-        expect(xsButton).toHaveStyle('height: 36px;')
-        expect(xsButton).toHaveStyle('padding: 0;')
+        expect(mButton).toHaveStyle('min-width: 36px;')
+        expect(mButton).toHaveStyle('height: 36px;')
+        expect(mButton).toHaveStyle('padding: 0;')
+
+        expect(mButton).toMatchSnapshot()
       })
 
       it('Size L', () => {
         const { getByTestId } = renderButton({ text: '', size: ButtonSize.L })
-        const xsButton = getByTestId(BUTTON_TEST_ID)
+        const lButton = getByTestId(BUTTON_TEST_ID)
 
-        expect(xsButton).toHaveStyle('min-width: 44px;')
-        expect(xsButton).toHaveStyle('height: 44px;')
-        expect(xsButton).toHaveStyle('padding: 0;')
+        expect(lButton).toHaveStyle('min-width: 44px;')
+        expect(lButton).toHaveStyle('height: 44px;')
+        expect(lButton).toHaveStyle('padding: 0;')
+
+        expect(lButton).toMatchSnapshot()
       })
 
       it('Size XL', () => {
         const { getByTestId } = renderButton({ text: '', size: ButtonSize.XL })
-        const xsButton = getByTestId(BUTTON_TEST_ID)
+        const xlButton = getByTestId(BUTTON_TEST_ID)
 
-        expect(xsButton).toHaveStyle('min-width: 54px;')
-        expect(xsButton).toHaveStyle('height: 54px;')
-        expect(xsButton).toHaveStyle('padding: 0;')
+        expect(xlButton).toHaveStyle('min-width: 54px;')
+        expect(xlButton).toHaveStyle('height: 54px;')
+        expect(xlButton).toHaveStyle('padding: 0;')
+
+        expect(xlButton).toMatchSnapshot()
       })
     })
   })

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -106,7 +106,7 @@ describe('Button Test >', () => {
 
         expect(xsButton).toHaveStyle('min-width: 20px;')
         expect(xsButton).toHaveStyle('height: 20px;')
-        expect(xsButton).toHaveStyle('padding: 2px;')
+        expect(xsButton).toHaveStyle('padding: 0 1px 0 1px;')
 
         // Typograpy.Size13
         expect(xsButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}rem;`)
@@ -120,7 +120,7 @@ describe('Button Test >', () => {
 
         expect(sButton).toHaveStyle('min-width: 24px;')
         expect(sButton).toHaveStyle('height: 24px;')
-        expect(sButton).toHaveStyle('padding: 3px 4px;')
+        expect(sButton).toHaveStyle('padding: 0 4px 0 4px;')
 
         // Typograpy.Size13
         expect(sButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}rem;`)
@@ -134,7 +134,7 @@ describe('Button Test >', () => {
 
         expect(mButton).toHaveStyle('min-width: 36px;')
         expect(mButton).toHaveStyle('height: 36px;')
-        expect(mButton).toHaveStyle('padding: 8px 10px;')
+        expect(mButton).toHaveStyle('padding: 0 10px 0 10px;')
 
         // Typograpy.Size14
         expect(mButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo14}rem;`)
@@ -148,7 +148,7 @@ describe('Button Test >', () => {
 
         expect(lButton).toHaveStyle('min-width: 44px;')
         expect(lButton).toHaveStyle('height: 44px;')
-        expect(lButton).toHaveStyle('padding: 12px 10px;')
+        expect(lButton).toHaveStyle('padding: 0 10px 0 10px;')
 
         // Typography.Size15
         expect(lButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo15}rem;`)
@@ -162,7 +162,7 @@ describe('Button Test >', () => {
 
         expect(xlButton).toHaveStyle('min-width: 54px;')
         expect(xlButton).toHaveStyle('height: 54px;')
-        expect(xlButton).toHaveStyle('padding: 15px 14px;')
+        expect(xlButton).toHaveStyle('padding: 0 14px 0 14px;')
 
         // Typography.Size18
         expect(xlButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo18}rem;`)
@@ -177,7 +177,7 @@ describe('Button Test >', () => {
 
         expect(xsButton).toHaveStyle('min-width: 20px;')
         expect(xsButton).toHaveStyle('height: 20px;')
-        expect(xsButton).toHaveStyle('padding: 2px;')
+        expect(xsButton).toHaveStyle('padding: 0px;')
       })
 
       it('Size S', () => {
@@ -186,7 +186,7 @@ describe('Button Test >', () => {
 
         expect(xsButton).toHaveStyle('min-width: 24px;')
         expect(xsButton).toHaveStyle('height: 24px;')
-        expect(xsButton).toHaveStyle('padding: 3px 3px;')
+        expect(xsButton).toHaveStyle('padding: 0;')
       })
 
       it('Size M', () => {
@@ -195,7 +195,7 @@ describe('Button Test >', () => {
 
         expect(xsButton).toHaveStyle('min-width: 36px;')
         expect(xsButton).toHaveStyle('height: 36px;')
-        expect(xsButton).toHaveStyle('padding: 8px 8px;')
+        expect(xsButton).toHaveStyle('padding: 0;')
       })
 
       it('Size L', () => {
@@ -204,7 +204,7 @@ describe('Button Test >', () => {
 
         expect(xsButton).toHaveStyle('min-width: 44px;')
         expect(xsButton).toHaveStyle('height: 44px;')
-        expect(xsButton).toHaveStyle('padding: 12px 12px;')
+        expect(xsButton).toHaveStyle('padding: 0;')
       })
 
       it('Size XL', () => {
@@ -213,7 +213,7 @@ describe('Button Test >', () => {
 
         expect(xsButton).toHaveStyle('min-width: 54px;')
         expect(xsButton).toHaveStyle('height: 54px;')
-        expect(xsButton).toHaveStyle('padding: 15px 15px;')
+        expect(xsButton).toHaveStyle('padding: 0;')
       })
     })
   })

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -7,7 +7,7 @@ import DisabledOpacity from 'Constants/DisabledOpacity'
 import { render } from 'Utils/testUtils'
 import Button, { BUTTON_TEST_ID, BUTTON_TEXT_TEST_ID } from './Button'
 import { ButtonStyleVariant, ButtonSize } from './Button.types'
-import { BUTTON_HORIZONTAL_PADDING_VALUE } from './Button.styled'
+import { BUTTON_HORIZONTAL_PADDING_VALUE, TEXT_PADDING_VALUE } from './Button.styled'
 import type ButtonProps from './Button.types'
 
 describe('Button Test >', () => {
@@ -68,12 +68,16 @@ describe('Button Test >', () => {
     it('Floating', () => {
       const { getByTestId } = renderButton({ styleVariant: ButtonStyleVariant.Floating })
       const floatingButton = getByTestId(BUTTON_TEST_ID)
+      const mButtonPaddingFloating = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.M].floating
 
       // Colors
       expect(floatingButton).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-absolute-white-dark']}`)
       expect(floatingButton).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-normal']}`)
       expect(floatingButton).toHaveStyle('border-radius: 1000px;')
       expect(floatingButton).toHaveStyle('overflow: hidden;')
+
+      // Padding
+      expect(floatingButton).toHaveStyle(`padding: 0 ${mButtonPaddingFloating}px 0 ${mButtonPaddingFloating}px;`)
     })
   })
 
@@ -112,6 +116,9 @@ describe('Button Test >', () => {
         // Typograpy.Size13
         expect(xsButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}rem;`)
         expect(xsButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}rem;`)
+
+        // Text padding value by ButtonSize
+        expect(xsButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.XS]}px;`)
       })
 
       it('Size S', () => {
@@ -126,6 +133,9 @@ describe('Button Test >', () => {
         // Typograpy.Size13
         expect(sButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo13}rem;`)
         expect(sButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}rem;`)
+
+        // Text padding value by ButtonSize
+        expect(sButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.S]}px;`)
       })
 
       it('Size M', () => {
@@ -142,6 +152,9 @@ describe('Button Test >', () => {
         // Typograpy.Size14
         expect(mButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo14}rem;`)
         expect(mButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh18}rem;`)
+
+        // Text padding value by ButtonSize
+        expect(mButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.M]}px;`)
       })
 
       it('Size L', () => {
@@ -157,6 +170,9 @@ describe('Button Test >', () => {
         // Typography.Size15
         expect(lButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo15}rem;`)
         expect(lButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh20}rem;`)
+
+        // Text padding value by ButtonSize
+        expect(lButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.L]}px;`)
       })
 
       it('Size XL', () => {
@@ -172,6 +188,9 @@ describe('Button Test >', () => {
         // Typography.Size18
         expect(xlButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo18}rem;`)
         expect(xlButtonText).toHaveStyle(`line-height: ${LineHeightAbsoluteNumber.Lh24}rem;`)
+
+        // Text padding value by ButtonSize
+        expect(xlButtonText).toHaveStyle(`padding: 0 ${TEXT_PADDING_VALUE[ButtonSize.XL]}px;`)
       })
     })
 

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -7,6 +7,7 @@ import DisabledOpacity from 'Constants/DisabledOpacity'
 import { render } from 'Utils/testUtils'
 import Button, { BUTTON_TEST_ID, BUTTON_TEXT_TEST_ID } from './Button'
 import { ButtonStyleVariant, ButtonSize } from './Button.types'
+import { BUTTON_HORIZONTAL_PADDING_VALUE } from './Button.styled'
 import type ButtonProps from './Button.types'
 
 describe('Button Test >', () => {
@@ -38,7 +39,7 @@ describe('Button Test >', () => {
       // Colors
       expect(primaryButton).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-absolute-white-dark']}`)
       expect(primaryButton).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-normal']}`)
-      expect(primaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R8}px;`)
+      expect(primaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R16}px;`)
       expect(primaryButton).toHaveStyle('overflow: hidden;')
     })
 
@@ -49,7 +50,7 @@ describe('Button Test >', () => {
       // Colors
       expect(secondaryButton).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-blue-normal']}`)
       expect(secondaryButton).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-blue-lightest']}`)
-      expect(secondaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R8}px;`)
+      expect(secondaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R16}px;`)
       expect(secondaryButton).toHaveStyle('overflow: hidden;')
     })
 
@@ -60,7 +61,7 @@ describe('Button Test >', () => {
       // Colors
       expect(tertiaryButton).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-blue-normal']}`)
       expect(tertiaryButton).toHaveStyle('background-color: transparent')
-      expect(tertiaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R8}px;`)
+      expect(tertiaryButton).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R16}px;`)
       expect(tertiaryButton).toHaveStyle('overflow: hidden;')
     })
 
@@ -131,10 +132,12 @@ describe('Button Test >', () => {
         const { getByTestId } = renderButton({ size: ButtonSize.M })
         const mButton = getByTestId(BUTTON_TEST_ID)
         const mButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
+        const mButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.M].default
 
         expect(mButton).toHaveStyle('min-width: 36px;')
         expect(mButton).toHaveStyle('height: 36px;')
-        expect(mButton).toHaveStyle('padding: 0 10px 0 10px;')
+        // eslint-disable-next-line max-len
+        expect(mButton).toHaveStyle(`padding: 0 ${mButtonPaddingDefault}px 0 ${mButtonPaddingDefault}px;`)
 
         // Typograpy.Size14
         expect(mButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo14}rem;`)
@@ -145,10 +148,11 @@ describe('Button Test >', () => {
         const { getByTestId } = renderButton({ size: ButtonSize.L })
         const lButton = getByTestId(BUTTON_TEST_ID)
         const lButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
+        const lButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.L].default
 
         expect(lButton).toHaveStyle('min-width: 44px;')
         expect(lButton).toHaveStyle('height: 44px;')
-        expect(lButton).toHaveStyle('padding: 0 10px 0 10px;')
+        expect(lButton).toHaveStyle(`padding: 0 ${lButtonPaddingDefault}px 0 ${lButtonPaddingDefault}px;`)
 
         // Typography.Size15
         expect(lButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo15}rem;`)
@@ -159,10 +163,11 @@ describe('Button Test >', () => {
         const { getByTestId } = renderButton({ size: ButtonSize.XL })
         const xlButton = getByTestId(BUTTON_TEST_ID)
         const xlButtonText = getByTestId(BUTTON_TEXT_TEST_ID)
+        const xlButtonPaddingDefault = BUTTON_HORIZONTAL_PADDING_VALUE[ButtonSize.XL].default
 
         expect(xlButton).toHaveStyle('min-width: 54px;')
         expect(xlButton).toHaveStyle('height: 54px;')
-        expect(xlButton).toHaveStyle('padding: 0 14px 0 14px;')
+        expect(xlButton).toHaveStyle(`padding: 0 ${xlButtonPaddingDefault}px 0 ${xlButtonPaddingDefault}px;`)
 
         // Typography.Size18
         expect(xlButtonText).toHaveStyle(`font-size: ${TypoAbsoluteNumber.Typo18}rem;`)

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,7 +5,6 @@ import { flattenDeep, fromPairs, isArray, noop, values } from 'lodash-es'
 /* Internal dependencies */
 import { Typography, SemanticNames } from 'Foundation'
 import { Icon, IconSize, isIconName } from 'Components/Icon'
-import { Text } from 'Components/Text'
 import { Spinner, SpinnerSize } from 'Components/Spinner'
 import ButtonProps, { SideContent, ButtonSize, ButtonStyleVariant, ButtonColorVariant } from './Button.types'
 import * as Styled from './Button.styled'
@@ -107,19 +106,15 @@ function Button(
 ) {
   const [isHovered, setIsHovered] = useState(false)
 
-  // TODO(@ed): Text에 Padding 속성을 열어주고, M 이상인 경우 상하 1px 패딩 추가
-  const textMargin = Styled.TEXT_MARGIN_VALUE[size]
-
   const typography = useMemo(() => {
     switch (size) {
       case ButtonSize.XS:
       case ButtonSize.S:
         return Typography.Size13
-      case ButtonSize.L:
-        return Typography.Size15
       case ButtonSize.XL:
         return Typography.Size18
       case ButtonSize.M:
+      case ButtonSize.L:
       default:
         return Typography.Size14
     }
@@ -153,13 +148,12 @@ function Button(
 
   const iconSize = useMemo(() => {
     switch (size) {
-      case ButtonSize.S:
       case ButtonSize.XS:
+      case ButtonSize.S:
         return IconSize.XS
-      case ButtonSize.XL:
-        return IconSize.Normal
-      case ButtonSize.L:
       case ButtonSize.M:
+      case ButtonSize.L:
+      case ButtonSize.XL:
       default:
         return IconSize.S
     }
@@ -241,8 +235,6 @@ function Button(
       active={active}
       styleVariant={styleVariant}
       colorVariant={colorVariant}
-      hasLeftContent={!!leftContent}
-      hasRightContent={!!rightContent}
       text={text}
       data-testid={testId}
       onClick={handleClick}
@@ -250,20 +242,22 @@ function Button(
       onMouseLeave={handleMouseLeave}
       onBlur={onBlur}
     >
-      <Styled.ButtonContents visible={!loading}>
+      <Styled.ButtonContents
+        visible={!loading}
+        buttonSize={size}
+      >
         { renderSideContent(leftContent, false) }
 
         { text && (
-          <Text
+          <Styled.ContentText
             testId={BUTTON_TEXT_TEST_ID}
             typo={typography}
             bold
             color={overridedTextColor}
-            marginRight={textMargin}
-            marginLeft={textMargin}
+            buttonSize={size}
           >
             { text }
-          </Text>
+          </Styled.ContentText>
         ) }
 
         { renderSideContent(rightContent, true) }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -108,18 +108,7 @@ function Button(
   const [isHovered, setIsHovered] = useState(false)
 
   // TODO(@ed): Text에 Padding 속성을 열어주고, M 이상인 경우 상하 1px 패딩 추가
-  const textMargin = useMemo(() => {
-    switch (size) {
-      case ButtonSize.S:
-      case ButtonSize.XS:
-        return 3
-      case ButtonSize.XL:
-      case ButtonSize.L:
-      case ButtonSize.M:
-      default:
-        return 4
-    }
-  }, [size])
+  const textMargin = Styled.TEXT_MARGIN_VALUE[size]
 
   const typography = useMemo(() => {
     switch (size) {
@@ -252,6 +241,8 @@ function Button(
       active={active}
       styleVariant={styleVariant}
       colorVariant={colorVariant}
+      hasLeftContent={!!leftContent}
+      hasRightContent={!!rightContent}
       text={text}
       data-testid={testId}
       onClick={handleClick}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -111,25 +111,13 @@ function Button(
       case ButtonSize.XS:
       case ButtonSize.S:
         return Typography.Size13
+      case ButtonSize.L:
+        return Typography.Size15
       case ButtonSize.XL:
         return Typography.Size18
       case ButtonSize.M:
-      case ButtonSize.L:
       default:
         return Typography.Size14
-    }
-  }, [size])
-
-  const iconMargin = useMemo(() => {
-    switch (size) {
-      case ButtonSize.S:
-      case ButtonSize.XS:
-        return 0
-      case ButtonSize.XL:
-      case ButtonSize.L:
-      case ButtonSize.M:
-      default:
-        return 2
     }
   }, [size])
 
@@ -151,9 +139,10 @@ function Button(
       case ButtonSize.XS:
       case ButtonSize.S:
         return IconSize.XS
+      case ButtonSize.XL:
+        return IconSize.Normal
       case ButtonSize.M:
       case ButtonSize.L:
-      case ButtonSize.XL:
       default:
         return IconSize.S
     }
@@ -201,14 +190,12 @@ function Button(
     disabled,
   ])
 
-  const renderSideContent = useCallback((content?: SideContent, isRightIcon?: boolean) => {
+  const renderSideContent = useCallback((content?: SideContent) => {
     if (isIconName(content)) {
       return (
         <Icon
           name={content}
           size={iconSize}
-          marginRight={(text && !isRightIcon) ? iconMargin : 0}
-          marginLeft={(text && isRightIcon) ? iconMargin : 0}
           color={overridedIconAndSpinnerColor}
         />
       )
@@ -216,9 +203,7 @@ function Button(
 
     return content
   }, [
-    text,
     iconSize,
-    iconMargin,
     overridedIconAndSpinnerColor,
   ])
 
@@ -246,7 +231,7 @@ function Button(
         visible={!loading}
         buttonSize={size}
       >
-        { renderSideContent(leftContent, false) }
+        { renderSideContent(leftContent) }
 
         { text && (
           <Styled.ContentText
@@ -260,7 +245,7 @@ function Button(
           </Styled.ContentText>
         ) }
 
-        { renderSideContent(rightContent, true) }
+        { renderSideContent(rightContent) }
       </Styled.ButtonContents>
 
       { loading && (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -10,6 +10,7 @@ import ButtonProps, { SideContent, ButtonSize, ButtonStyleVariant, ButtonColorVa
 import * as Styled from './Button.styled'
 
 export const BUTTON_TEST_ID = 'bezier-react-button'
+export const BUTTON_INNER_CONTENT_TEST_ID = 'bezier-react-button-inner-content'
 export const BUTTON_TEXT_TEST_ID = 'bezier-react-button-text'
 
 type VariantTuple = `${ButtonColorVariant},${ButtonStyleVariant},${ButtonSize}`
@@ -228,6 +229,7 @@ function Button(
       onBlur={onBlur}
     >
       <Styled.ButtonContents
+        data-testid={BUTTON_INNER_CONTENT_TEST_ID}
         visible={!loading}
         buttonSize={size}
       >

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,2316 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button Test > Active Test > Active prop change Button to hover style 1`] = `
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 10px 0 10px;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+  background-color: #4E40C9;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Disabled Test > Button can have disabled attribute 1`] = `
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: not-allowed;
+  border: none;
+  outline: none;
+  opacity: 0.4;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 10px 0 10px;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  disabled=""
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Loading Test > Active prop change Button to hover style 1`] = `
+.c5 {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-style: solid;
+  border-width: 2px;
+  border-top-color: transparent;
+  border-right-color: inherit;
+  border-bottom-color: inherit;
+  border-left-color: inherit;
+  border-radius: 50%;
+  -webkit-animation: epmXAj 1s infinite linear;
+  animation: epmXAj 1s infinite linear;
+}
+
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: hidden;
+  gap: 2px;
+}
+
+.c4 {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 10px 0 10px;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+  <div
+    class="c4"
+  >
+    <div
+      class="c5"
+      data-testid="bezier-react-spinner"
+      size="16"
+    />
+  </div>
+</button>
+`;
+
+exports[`Button Test > Reset CSS 1`] = `
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 10px 0 10px;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > with text > Size L - styleVariant: Floating 1`] = `
+.c2 {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  -webkit-letter-spacing: -0.1px;
+  -moz-letter-spacing: -0.1px;
+  -ms-letter-spacing: -0.1px;
+  letter-spacing: -0.1px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 44px;
+  height: 44px;
+  padding: 0 18px 0 18px;
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 12px #00000026;
+  overflow: hidden;
+  border-radius: 1000px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 20px #00000038;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > with text > Size L 1`] = `
+.c2 {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  -webkit-letter-spacing: -0.1px;
+  -moz-letter-spacing: -0.1px;
+  -ms-letter-spacing: -0.1px;
+  letter-spacing: -0.1px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 44px;
+  height: 44px;
+  padding: 0 12px 0 12px;
+  overflow: hidden;
+  border-radius: 12px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > with text > Size M - styleVariant: Floating 1`] = `
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 14px 0 14px;
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 12px #00000026;
+  overflow: hidden;
+  border-radius: 1000px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 20px #00000038;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > with text > Size M 1`] = `
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 10px 0 10px;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > with text > Size S - styleVariant: Floating 1`] = `
+.c2 {
+  font-size: 1.3rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 0px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 9px 0 9px;
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 12px #00000026;
+  overflow: hidden;
+  border-radius: 1000px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 20px #00000038;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 3px;
+}
+
+@supports not(gap:0px) {
+  .c1 {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+
+  .c1 > * {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > with text > Size S 1`] = `
+.c2 {
+  font-size: 1.3rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 0px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 4px 0 4px;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 3px;
+}
+
+@supports not(gap:0px) {
+  .c1 {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+
+  .c1 > * {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > with text > Size XL - styleVariant: Floating 1`] = `
+.c2 {
+  font-size: 1.8rem;
+  line-height: 2.4rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 54px;
+  height: 54px;
+  padding: 0 23px 0 23px;
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 12px #00000026;
+  overflow: hidden;
+  border-radius: 1000px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 20px #00000038;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > with text > Size XL 1`] = `
+.c2 {
+  font-size: 1.8rem;
+  line-height: 2.4rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 54px;
+  height: 54px;
+  padding: 0 20px 0 20px;
+  overflow: hidden;
+  border-radius: 16px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > with text > Size XS - styleVariant: Floating 1`] = `
+.c2 {
+  font-size: 1.3rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 0px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 7px 0 7px;
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 12px #00000026;
+  overflow: hidden;
+  border-radius: 1000px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 20px #00000038;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 3px;
+}
+
+@supports not(gap:0px) {
+  .c1 {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+
+  .c1 > * {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > with text > Size XS 1`] = `
+.c2 {
+  font-size: 1.3rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 0px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 4px 0 4px;
+  overflow: hidden;
+  border-radius: 6px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 3px;
+}
+
+@supports not(gap:0px) {
+  .c1 {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+
+  .c1 > * {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > with text > size prop not given, default size is Size M 1`] = `
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 10px 0 10px;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > without text > Size L 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 44px;
+  height: 44px;
+  padding: 0;
+  overflow: hidden;
+  border-radius: 12px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > without text > Size M 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > without text > Size S 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 0px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 24px;
+  height: 24px;
+  padding: 0;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+@supports not(gap:0px) {
+  .c1 {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+
+  .c1 > * {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > without text > Size XL 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 54px;
+  height: 54px;
+  padding: 0;
+  overflow: hidden;
+  border-radius: 16px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    
+  </div>
+</button>
+`;
+
+exports[`Button Test > Size Test > without text > Size XS 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 0px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 20px;
+  height: 20px;
+  padding: 0;
+  overflow: hidden;
+  border-radius: 6px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+@supports not(gap:0px) {
+  .c1 {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+
+  .c1 > * {
+    margin-top: 0px;
+    margin-left: 0px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    
+  </div>
+</button>
+`;
+
+exports[`Button Test > StyleVariant Test > Floating 1`] = `
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 14px 0 14px;
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 12px #00000026;
+  overflow: hidden;
+  border-radius: 1000px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 20px #00000038;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > StyleVariant Test > Primary 1`] = `
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 10px 0 10px;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #FFFFFF;
+  background-color: #5E56F0;
+}
+
+.c0:hover {
+  background-color: #4E40C9;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > StyleVariant Test > Secondary 1`] = `
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 10px 0 10px;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #5E56F0;
+  background-color: #5E56F01A;
+}
+
+.c0:hover {
+  background-color: #5E56F033;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;
+
+exports[`Button Test > StyleVariant Test > Tertiary 1`] = `
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  visibility: visible;
+  gap: 2px;
+}
+
+.c0 {
+  position: relative;
+  box-sizing: border-box;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  opacity: 1;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: background-color,box-shadow;
+  transition-property: background-color,box-shadow;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 10px 0 10px;
+  overflow: hidden;
+  border-radius: 8px;
+  color: #5E56F0;
+  background-color: transparent;
+}
+
+.c0:hover {
+  color: #4E40C9;
+  background-color: #5E56F01A;
+}
+
+.c3 {
+  padding: 0 4px;
+}
+
+@supports not(gap:2px) {
+  .c1 {
+    margin-top: -2px;
+    margin-left: -2px;
+  }
+
+  .c1 > * {
+    margin-top: 2px;
+    margin-left: 2px;
+  }
+}
+
+<button
+  class="c0"
+  data-testid="bezier-react-button"
+  type="button"
+>
+  <div
+    class="c1"
+    data-testid="bezier-react-button-inner-content"
+  >
+    <span
+      class="c2 c3"
+      data-testid="bezier-react-button-text"
+    >
+      Test Button
+    </span>
+  </div>
+</button>
+`;

--- a/src/components/Forms/FormGroup/FormGroup.styled.ts
+++ b/src/components/Forms/FormGroup/FormGroup.styled.ts
@@ -1,24 +1,7 @@
 /* Internal dependencies */
-import { styled, css } from 'Foundation'
-import { InjectedInterpolation } from 'Types/Foundation'
+import { styled } from 'Foundation'
+import { gap } from 'Utils/styleUtils'
 import type FormGroupProps from './FormGroup.types'
-
-// TODO: Mixin으로 옮기기보다, Stack 컴포넌트가 prop을 통해 이 믹스인을 내부적으로 사용하도록 하기
-function gap(spacing: number): InjectedInterpolation {
-  return css`
-    gap: ${spacing}px;
-
-    @supports not(gap: ${spacing}px) {
-      margin-top: ${-spacing}px;
-      margin-left: ${-spacing}px;
-
-      > * {
-        margin-top: ${spacing}px;
-        margin-left: ${spacing}px;
-      }
-    }
-  `
-}
 
 type StackProps = Required<Pick<FormGroupProps, 'gap' | 'direction' | 'interpolation'>>
 

--- a/src/utils/styleUtils.ts
+++ b/src/utils/styleUtils.ts
@@ -15,7 +15,9 @@ import {
 } from 'lodash-es'
 
 /* Internal dependencies */
+import { css } from 'Foundation'
 import { ExplicitDefaulting, AbsoluteUnit, RelativeUnit, BoxSizingUnit, CSSUnits } from 'Types/CSS'
+import { InjectedInterpolation } from 'Types/Foundation'
 import { isNumberString } from './stringUtils'
 
 export const UnitValues: string[] = [
@@ -81,3 +83,19 @@ export function toLength(value: any, defaultValueOrOption?: string | CSSUnitOpti
   return defaultValue
 }
 /* eslint-enable max-len */
+
+export function gap(spacing: number): InjectedInterpolation {
+  return css`
+    gap: ${spacing}px;
+
+    @supports not(gap: ${spacing}px) {
+      margin-top: ${-spacing}px;
+      margin-left: ${-spacing}px;
+
+      > * {
+        margin-top: ${spacing}px;
+        margin-left: ${spacing}px;
+      }
+    }
+  `
+}


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

[피그마](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=39%3A2) 에 있는 스펙에 맞게 Button 의 padding 값 결정 로직을 업데이트했습니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

기존의 Button 의 padding 값 결정 로직은 text prop 의 유무로 결정되었습니다.

```typescript
case ButtonSize.L:
  return css`
    min-width: 44px;
    height: 44px;
    padding: 12px ${isEmpty(text) ? 12 : 10}px;
  `
```

새로운 디자인 스펙 상 버튼의 padding 은 다음과 같은 케이스마다 다릅니다.

1. 버튼에 text 가 없는 경우
2. styleVariant 가 Floating 인 경우
3. padding이 들어갈 곳 바로 옆에 텍스트가 있는 경우
4. padding이 들어갈 곳 바로 옆에 컨텐츠(ex. 아이콘)가 있는 경우

이에 따라 로직을 분리했습니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

[피그마](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=39%3A2)
