### PR TITLE
폼 컴포넌트 개선 및 공통 Hook export

### DIFF
--- a/src/components/Forms/FormControl/FormControl.test.tsx
+++ b/src/components/Forms/FormControl/FormControl.test.tsx
@@ -1,15 +1,13 @@
 /* External dependencies */
 import React from 'react'
+import { isInaccessible } from '@testing-library/react'
 
 /* Internal dependencies */
 import { render } from 'Utils/testUtils'
-import { FormLabel } from 'Components/Forms/FormLabel'
-import { TextField } from 'Components/Forms/Inputs/TextField'
-import { FormHelperText, FormErrorMessage } from 'Components/Forms/FormHelperText'
+import { SingleFieldForm, MultipleFieldForm, MOCK_CONSTS } from './__mocks__/forms'
 import FormControl, { FORM_CONTROL_TEST_ID } from './FormControl'
 import type FormControlProps from './FormControl.types'
 
-// TODO: 테스트 보강
 describe('FormControl >', () => {
   let props: FormControlProps
 
@@ -30,22 +28,175 @@ describe('FormControl >', () => {
     </FormControl>,
   )
 
-  const defaultChildren = (
-    <>
-      <FormLabel help="Lorem Ipsum">Label</FormLabel>
-      <TextField placeholder="Placeholder" />
-      <FormHelperText>Description</FormHelperText>
-      <FormErrorMessage>Error!</FormErrorMessage>
-    </>
-  )
+  describe('Snapshot >', () => {
+    it('With single field', () => {
+      const { getByTestId } = renderComponent({
+        children: SingleFieldForm,
+      })
 
-  it('Snapshot >', () => {
-    const { getByTestId } = renderComponent({
-      children: defaultChildren,
+      const rendered = getByTestId(FORM_CONTROL_TEST_ID)
+      expect(rendered).toMatchSnapshot()
     })
 
-    const rendered = getByTestId(FORM_CONTROL_TEST_ID)
+    it('With single field and left label position', () => {
+      const { getByTestId } = renderComponent({
+        labelPosition: 'left',
+        children: SingleFieldForm,
+      })
 
-    expect(rendered).toMatchSnapshot()
+      const rendered = getByTestId(FORM_CONTROL_TEST_ID)
+      expect(rendered).toMatchSnapshot()
+    })
+
+    it('With multiple field', () => {
+      const { container } = renderComponent({
+        children: MultipleFieldForm,
+      })
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('With multiple field and left label position', () => {
+      const { container } = renderComponent({
+        labelPosition: 'left',
+        children: MultipleFieldForm,
+      })
+
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  describe('Accessibility >', () => {
+    it('With single field', () => {
+      const { container } = renderComponent({
+        children: SingleFieldForm,
+      })
+
+      expect(isInaccessible(container)).toBe(false)
+    })
+
+    it('With multiple field', () => {
+      const { container } = renderComponent({
+        children: MultipleFieldForm,
+      })
+
+      expect(isInaccessible(container)).toBe(false)
+    })
+  })
+
+  describe('Single field form >', () => {
+    it('The FormLabel component should have the correct attribute', () => {
+      const { getByText, getByLabelText } = renderComponent({
+        children: SingleFieldForm,
+      })
+
+      const labelNode = getByText(MOCK_CONSTS.LABEL_TEXT)
+      const inputId = getByLabelText(MOCK_CONSTS.LABEL_TEXT).id
+
+      expect(labelNode).toHaveAttribute('for', inputId)
+      expect(labelNode.id).toBe(`${inputId}-label`)
+    })
+
+    it('The Field(Input) component should have the correct attribute', () => {
+      const { getByText, getByLabelText } = renderComponent({
+        children: SingleFieldForm,
+      })
+
+      const inputNode = getByLabelText(MOCK_CONSTS.LABEL_TEXT)
+      const helperTextNode = getByText(MOCK_CONSTS.HELPER_TEXT_TEXT)
+
+      expect(inputNode).toHaveAttribute('aria-describedby', helperTextNode.id)
+    })
+
+    it('The Field(Input) component should have the correct attribute when the "hasError" prop is true', () => {
+      const { getByText, getByLabelText } = renderComponent({
+        children: SingleFieldForm,
+        hasError: true,
+      })
+
+      const inputNode = getByLabelText(MOCK_CONSTS.LABEL_TEXT)
+      const errorMessageNode = getByText(MOCK_CONSTS.ERROR_MESSAGE_TEXT)
+
+      expect(inputNode).toHaveAttribute('aria-describedby', errorMessageNode.id)
+    })
+
+    it('The FormHelperText component is only visible when the "hasError" prop is false', () => {
+      const { getByText, queryByText } = renderComponent({
+        children: SingleFieldForm,
+        hasError: false,
+      })
+
+      const helperTextNode = getByText(MOCK_CONSTS.HELPER_TEXT_TEXT)
+      const errorMessageNode = queryByText(MOCK_CONSTS.ERROR_MESSAGE_TEXT)
+
+      expect(helperTextNode).toBeVisible()
+      expect(errorMessageNode).toBeNull()
+    })
+
+    it('The FormErrorMessage component is only visible when the "hasError" prop is true', () => {
+      const { getByText, queryByText } = renderComponent({
+        children: SingleFieldForm,
+        hasError: true,
+      })
+
+      const errorMessageNode = getByText(MOCK_CONSTS.ERROR_MESSAGE_TEXT)
+      const helperTextNode = queryByText(MOCK_CONSTS.HELPER_TEXT_TEXT)
+
+      expect(errorMessageNode).toBeVisible()
+      expect(helperTextNode).toBeNull()
+    })
+  })
+
+  describe('Multiple(Group) field form >', () => {
+    it('The FormLabel for group element should not have "for" attribute', () => {
+      const { getByText } = renderComponent({
+        children: MultipleFieldForm,
+      })
+
+      const groupLabelNode = getByText(MOCK_CONSTS.LABEL_TEXT)
+
+      expect(groupLabelNode).not.toHaveAttribute('for')
+    })
+
+    it('The FormGroup component should have the correct attribute', () => {
+      const { getByRole, getByText } = renderComponent({
+        children: MultipleFieldForm,
+      })
+
+      const groupNode = getByRole('group')
+      const groupLabelNode = getByText(MOCK_CONSTS.LABEL_TEXT)
+      const groupHelperTextNode = getByText(MOCK_CONSTS.HELPER_TEXT_TEXT)
+
+      expect(groupNode).toHaveAttribute('aria-labelledby', groupLabelNode.id)
+      expect(groupNode).toHaveAttribute('aria-describedby', groupHelperTextNode.id)
+    })
+
+    it('The FormGroup component should have the correct attribute when the "hasError" prop is true', () => {
+      const { getByRole, getByText } = renderComponent({
+        children: MultipleFieldForm,
+        hasError: true,
+      })
+
+      const groupNode = getByRole('group')
+      const groupLabelNode = getByText(MOCK_CONSTS.LABEL_TEXT)
+      const groupErrorMessageNode = getByText(MOCK_CONSTS.ERROR_MESSAGE_TEXT)
+
+      expect(groupNode).toHaveAttribute('aria-labelledby', groupLabelNode.id)
+      expect(groupNode).toHaveAttribute('aria-describedby', groupErrorMessageNode.id)
+    })
+
+    it('The Field(Input) component inside FormGroup should have a unique ID that is not FormGroup ID', () => {
+      const { getByRole, getByLabelText } = renderComponent({
+        children: MultipleFieldForm,
+      })
+
+      const groupNodeId = getByRole('group').id
+      const firstInnerInputNodeId = getByLabelText(MOCK_CONSTS.FIRST_FIELD_LABEL_TEXT).id
+      const secondInnerInputNodeId = getByLabelText(MOCK_CONSTS.SECOND_FIELD_LABEL_TEXT).id
+
+      expect(firstInnerInputNodeId).not.toEqual(groupNodeId)
+      expect(secondInnerInputNodeId).not.toEqual(groupNodeId)
+      expect(firstInnerInputNodeId).not.toEqual(secondInnerInputNodeId)
+    })
   })
 })

--- a/src/components/Forms/FormControl/FormControl.tsx
+++ b/src/components/Forms/FormControl/FormControl.tsx
@@ -36,7 +36,14 @@ function FormControl({
   const helperTextId = `${id}-help-text`
   const errorMessageId = `${id}-error-message`
 
-  const fieldLabelId = useMemo(() => {
+  const fieldId = useMemo(() => (
+    hasMultipleFields ? undefined : id
+  ), [
+    id,
+    hasMultipleFields,
+  ])
+
+  const describerId = useMemo(() => {
     if (hasErrorMessage) { return errorMessageId }
     if (hasHelperText) { return helperTextId }
     return undefined
@@ -53,19 +60,19 @@ function FormControl({
   const getGroupProps = useCallback<GroupPropsGetter>(ownProps => ({
     id: groupId,
     'aria-labelledby': labelId,
-    'aria-describedby': fieldLabelId,
+    'aria-describedby': describerId,
     setIsRendered: setHasMultipleFields,
     ...ownProps,
   }), [
     groupId,
     labelId,
-    fieldLabelId,
+    describerId,
     setHasMultipleFields,
   ])
 
   const getLabelProps = useCallback<LabelPropsGetter>(ownProps => ({
     id: labelId,
-    htmlFor: hasMultipleFields ? undefined : id,
+    htmlFor: fieldId,
     Wrapper: labelPosition === 'top'
       ? Styled.TopLabelWrapper
       : (({ children: labelElement }) => (
@@ -75,21 +82,20 @@ function FormControl({
       )),
     ...ownProps,
   }), [
-    id,
+    fieldId,
     labelId,
     labelPosition,
     leftLabelWrapperHeight,
-    hasMultipleFields,
   ])
 
   const getFieldProps = useCallback<FieldPropsGetter>(ownProps => ({
-    id: hasMultipleFields ? undefined : id,
-    'aria-describedby': hasMultipleFields ? undefined : fieldLabelId,
+    id: fieldId,
+    'aria-describedby': hasMultipleFields ? undefined : describerId,
     ...formCommonProps,
     ...ownProps,
   }), [
-    id,
-    fieldLabelId,
+    fieldId,
+    describerId,
     formCommonProps,
     hasMultipleFields,
   ])

--- a/src/components/Forms/FormControl/FormControl.tsx
+++ b/src/components/Forms/FormControl/FormControl.tsx
@@ -36,12 +36,7 @@ function FormControl({
   const helperTextId = `${id}-help-text`
   const errorMessageId = `${id}-error-message`
 
-  const fieldId = useMemo(() => (
-    hasMultipleFields ? undefined : id
-  ), [
-    id,
-    hasMultipleFields,
-  ])
+  const fieldId = hasMultipleFields ? undefined : id
 
   const describerId = useMemo(() => {
     if (hasErrorMessage) { return errorMessageId }

--- a/src/components/Forms/FormControl/FormControl.tsx
+++ b/src/components/Forms/FormControl/FormControl.tsx
@@ -83,7 +83,7 @@ function FormControl({
   ])
 
   const getFieldProps = useCallback<FieldPropsGetter>(ownProps => ({
-    id,
+    id: hasMultipleFields ? undefined : id,
     'aria-describedby': hasMultipleFields ? undefined : fieldLabelId,
     ...formCommonProps,
     ...ownProps,

--- a/src/components/Forms/FormControl/FormControl.types.ts
+++ b/src/components/Forms/FormControl/FormControl.types.ts
@@ -7,7 +7,7 @@ interface FormControlOptions {
   leftLabelWrapperHeight?: number
 }
 
-export interface FormControlContextCommonValue extends IdentifierProps {}
+export interface FormControlContextCommonValue extends Partial<IdentifierProps> {}
 
 export interface FormControlAriaProps {
   'aria-labelledby'?: string

--- a/src/components/Forms/FormControl/__mocks__/forms.tsx
+++ b/src/components/Forms/FormControl/__mocks__/forms.tsx
@@ -1,0 +1,47 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { FormControl } from 'Components/Forms/FormControl'
+import { FormGroup } from 'Components/Forms/FormGroup'
+import { FormLabel } from 'Components/Forms/FormLabel'
+import { TextField } from 'Components/Forms/Inputs/TextField'
+import { FormHelperText, FormErrorMessage } from 'Components/Forms/FormHelperText'
+
+export const MOCK_CONSTS = {
+  LABEL_TEXT: 'Label',
+  HELPER_TEXT_TEXT: 'Description',
+  ERROR_MESSAGE_TEXT: 'Error!',
+
+  FIRST_FIELD_LABEL_TEXT: 'First Inner Label',
+  SECOND_FIELD_LABEL_TEXT: 'Second Inner Label',
+}
+
+export const SingleFieldForm = (
+  <>
+    <FormLabel>{ MOCK_CONSTS.LABEL_TEXT }</FormLabel>
+    <TextField />
+    <FormHelperText>{ MOCK_CONSTS.HELPER_TEXT_TEXT }</FormHelperText>
+    <FormErrorMessage>{ MOCK_CONSTS.ERROR_MESSAGE_TEXT }</FormErrorMessage>
+  </>
+)
+
+export const MultipleFieldForm = (
+  <>
+    <FormLabel>
+      { MOCK_CONSTS.LABEL_TEXT }
+    </FormLabel>
+    <FormGroup>
+      <FormControl>
+        <FormLabel>{ MOCK_CONSTS.FIRST_FIELD_LABEL_TEXT }</FormLabel>
+        <TextField />
+      </FormControl>
+      <FormControl hasError>
+        <FormLabel>{ MOCK_CONSTS.SECOND_FIELD_LABEL_TEXT }</FormLabel>
+        <TextField />
+      </FormControl>
+    </FormGroup>
+    <FormHelperText>{ MOCK_CONSTS.HELPER_TEXT_TEXT }</FormHelperText>
+    <FormErrorMessage>{ MOCK_CONSTS.ERROR_MESSAGE_TEXT }</FormErrorMessage>
+  </>
+)

--- a/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -1,23 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FormControl > Snapshot > 1`] = `
-.c7 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  margin: 0px 0px 0px 0px;
-  color: #00000066;
-  -webkit-transition-delay: 0ms;
-  transition-delay: 0ms;
-  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
-  transition-timing-function: cubic-bezier(.3,0,0,1);
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-property: color;
-  transition-property: color;
-}
-
-.c9 {
+exports[`FormControl > Snapshot > With multiple field 1`] = `
+.c6 {
   width: 100%;
   height: 100%;
   padding: 0;
@@ -30,23 +14,607 @@ exports[`FormControl > Snapshot > 1`] = `
   color: #000000D9;
 }
 
-.c9::-webkit-input-placeholder {
+.c6::-webkit-input-placeholder {
   color: #00000066;
 }
 
-.c9::-moz-placeholder {
+.c6::-moz-placeholder {
   color: #00000066;
 }
 
-.c9:-ms-input-placeholder {
+.c6:-ms-input-placeholder {
   color: #00000066;
 }
 
-.c9::placeholder {
+.c6::placeholder {
   color: #00000066;
+}
+
+.c5 {
+  position: relative;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 36px;
+  padding: 0 12px;
+  background-color: #FCFCFC;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: border-color,box-shadow;
+  transition-property: border-color,box-shadow;
+}
+
+.c7 {
+  position: relative;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 36px;
+  padding: 0 12px;
+  background-color: #FFFFFF;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
+  box-shadow: 0 0 0 3px #F4800B4D, inset 0 0 0 1px #F4800B;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: border-color,box-shadow;
+  transition-property: border-color,box-shadow;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  padding: 0 2px;
+  margin-bottom: 4px;
 }
 
 .c8 {
+  padding: 0 2px;
+  margin-top: 4px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.c2 {
+  font-size: 13px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: #000000D9;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c9 {
+  font-size: 13px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: #00000066;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c3 {
+  display: block;
+  text-align: left;
+}
+
+.c10 {
+  display: block;
+  text-align: left;
+}
+
+@supports not(gap:6px) {
+  .c4 {
+    margin-top: -6px;
+    margin-left: -6px;
+  }
+
+  .c4 > * {
+    margin-top: 6px;
+    margin-left: 6px;
+  }
+}
+
+<div>
+  <div
+    class="c0"
+    data-testid="bezier-react-form-control"
+  >
+    <div
+      class="c0 c1"
+    >
+      <label
+        class="c2 c3"
+        color="txt-black-darkest"
+        data-testid="bezier-react-form-label"
+        id="form-label"
+      >
+        Label
+      </label>
+    </div>
+    <div
+      aria-describedby="form-help-text"
+      aria-labelledby="form-label"
+      class="c4"
+      data-testid="bezier-react-form-group"
+      direction="column"
+      id="form-group"
+      role="group"
+    >
+      <div
+        class="c0"
+        data-testid="bezier-react-form-control"
+      >
+        <div
+          class="c0 c1"
+        >
+          <label
+            class="c2 c3"
+            color="txt-black-darkest"
+            data-testid="bezier-react-form-label"
+            for="field-1"
+            id="field-1-label"
+          >
+            First Inner Label
+          </label>
+        </div>
+        <div
+          class="c5"
+          data-testid="bezier-react-text-input"
+          size="36"
+        >
+          <input
+            autocomplete="off"
+            class="c6"
+            id="field-1"
+            size="36"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="c0"
+        data-testid="bezier-react-form-control"
+      >
+        <div
+          class="c0 c1"
+        >
+          <label
+            class="c2 c3"
+            color="txt-black-darkest"
+            data-testid="bezier-react-form-label"
+            for="field-2"
+            id="field-2-label"
+          >
+            Second Inner Label
+          </label>
+        </div>
+        <div
+          class="c7"
+          data-testid="bezier-react-text-input"
+          size="36"
+        >
+          <input
+            aria-invalid="true"
+            autocomplete="off"
+            class="c6"
+            id="field-2"
+            size="36"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0 c8"
+    >
+      <p
+        class="c9 c10"
+        color="txt-black-dark"
+        data-testid="bezier-react-form-helper-text"
+        id="form-help-text"
+      >
+        Description
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FormControl > Snapshot > With multiple field and left label position 1`] = `
+.c8 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  cursor: auto;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  font-size: 14px;
+  line-height: 18px;
+  color: #000000D9;
+}
+
+.c8::-webkit-input-placeholder {
+  color: #00000066;
+}
+
+.c8::-moz-placeholder {
+  color: #00000066;
+}
+
+.c8:-ms-input-placeholder {
+  color: #00000066;
+}
+
+.c8::placeholder {
+  color: #00000066;
+}
+
+.c7 {
+  position: relative;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 36px;
+  padding: 0 12px;
+  background-color: #FCFCFC;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: border-color,box-shadow;
+  transition-property: border-color,box-shadow;
+}
+
+.c9 {
+  position: relative;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 36px;
+  padding: 0 12px;
+  background-color: #FFFFFF;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
+  box-shadow: 0 0 0 3px #F4800B4D, inset 0 0 0 1px #F4800B;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: border-color,box-shadow;
+  transition-property: border-color,box-shadow;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c6 {
+  padding: 0 2px;
+  margin-bottom: 4px;
+}
+
+.c10 {
+  padding: 0 2px;
+  margin-top: 4px;
+}
+
+.c1 {
+  display: grid;
+  grid-template-rows: repeat(2,auto);
+  grid-template-columns: minmax(150px,auto) 1fr;
+  grid-column-gap: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-row: 1 / 1;
+  grid-column: 1 / 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-self: start;
+  -ms-flex-item-align: start;
+  align-self: start;
+  height: 36px;
+}
+
+.c11 {
+  grid-row: 2 / 2;
+  grid-column: 2;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.c3 {
+  font-size: 13px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: #000000D9;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c12 {
+  font-size: 13px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: #00000066;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c4 {
+  display: block;
+  text-align: left;
+}
+
+.c13 {
+  display: block;
+  text-align: left;
+}
+
+@supports not(gap:6px) {
+  .c5 {
+    margin-top: -6px;
+    margin-left: -6px;
+  }
+
+  .c5 > * {
+    margin-top: 6px;
+    margin-left: 6px;
+  }
+}
+
+<div>
+  <div
+    class="c0 c1"
+    data-testid="bezier-react-form-control"
+  >
+    <div
+      class="c0 c2"
+      height="36"
+    >
+      <label
+        class="c3 c4"
+        color="txt-black-darkest"
+        data-testid="bezier-react-form-label"
+        id="form-label"
+      >
+        Label
+      </label>
+    </div>
+    <div
+      aria-describedby="form-help-text"
+      aria-labelledby="form-label"
+      class="c5"
+      data-testid="bezier-react-form-group"
+      direction="column"
+      id="form-group"
+      role="group"
+    >
+      <div
+        class="c0"
+        data-testid="bezier-react-form-control"
+      >
+        <div
+          class="c0 c6"
+        >
+          <label
+            class="c3 c4"
+            color="txt-black-darkest"
+            data-testid="bezier-react-form-label"
+            for="field-3"
+            id="field-3-label"
+          >
+            First Inner Label
+          </label>
+        </div>
+        <div
+          class="c7"
+          data-testid="bezier-react-text-input"
+          size="36"
+        >
+          <input
+            autocomplete="off"
+            class="c8"
+            id="field-3"
+            size="36"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="c0"
+        data-testid="bezier-react-form-control"
+      >
+        <div
+          class="c0 c6"
+        >
+          <label
+            class="c3 c4"
+            color="txt-black-darkest"
+            data-testid="bezier-react-form-label"
+            for="field-4"
+            id="field-4-label"
+          >
+            Second Inner Label
+          </label>
+        </div>
+        <div
+          class="c9"
+          data-testid="bezier-react-text-input"
+          size="36"
+        >
+          <input
+            aria-invalid="true"
+            autocomplete="off"
+            class="c8"
+            id="field-4"
+            size="36"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0 c10 c11"
+    >
+      <p
+        class="c12 c13"
+        color="txt-black-dark"
+        data-testid="bezier-react-form-helper-text"
+        id="form-help-text"
+      >
+        Description
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FormControl > Snapshot > With single field 1`] = `
+.c5 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  cursor: auto;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  font-size: 14px;
+  line-height: 18px;
+  color: #000000D9;
+}
+
+.c5::-webkit-input-placeholder {
+  color: #00000066;
+}
+
+.c5::-moz-placeholder {
+  color: #00000066;
+}
+
+.c5:-ms-input-placeholder {
+  color: #00000066;
+}
+
+.c5::placeholder {
+  color: #00000066;
+}
+
+.c4 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -82,9 +650,198 @@ exports[`FormControl > Snapshot > 1`] = `
   margin-bottom: 4px;
 }
 
-.c10 {
+.c6 {
   padding: 0 2px;
   margin-top: 4px;
+}
+
+.c2 {
+  font-size: 13px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: #000000D9;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c7 {
+  font-size: 13px;
+  line-height: 18px;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: #00000066;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c3 {
+  display: block;
+  text-align: left;
+}
+
+.c8 {
+  display: block;
+  text-align: left;
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-form-control"
+>
+  <div
+    class="c0 c1"
+  >
+    <label
+      class="c2 c3"
+      color="txt-black-darkest"
+      data-testid="bezier-react-form-label"
+      for="form"
+      id="form-label"
+    >
+      Label
+    </label>
+  </div>
+  <div
+    class="c4"
+    data-testid="bezier-react-text-input"
+    size="36"
+  >
+    <input
+      aria-describedby="form-help-text"
+      autocomplete="off"
+      class="c5"
+      id="form"
+      size="36"
+      value=""
+    />
+  </div>
+  <div
+    class="c0 c6"
+  >
+    <p
+      class="c7 c8"
+      color="txt-black-dark"
+      data-testid="bezier-react-form-helper-text"
+      id="form-help-text"
+    >
+      Description
+    </p>
+  </div>
+</div>
+`;
+
+exports[`FormControl > Snapshot > With single field and left label position 1`] = `
+.c6 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  cursor: auto;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  font-size: 14px;
+  line-height: 18px;
+  color: #000000D9;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #00000066;
+}
+
+.c6::-moz-placeholder {
+  color: #00000066;
+}
+
+.c6:-ms-input-placeholder {
+  color: #00000066;
+}
+
+.c6::placeholder {
+  color: #00000066;
+}
+
+.c5 {
+  position: relative;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 36px;
+  padding: 0 12px;
+  background-color: #FCFCFC;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: border-color,box-shadow;
+  transition-property: border-color,box-shadow;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c7 {
+  padding: 0 2px;
+  margin-top: 4px;
+}
+
+.c1 {
+  display: grid;
+  grid-template-rows: repeat(2,auto);
+  grid-template-columns: minmax(150px,auto) 1fr;
+  grid-column-gap: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-row: 1 / 1;
+  grid-column: 1 / 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-self: start;
+  -ms-flex-item-align: start;
+  align-self: start;
+  height: 36px;
+}
+
+.c8 {
+  grid-row: 2 / 2;
+  grid-column: 2;
 }
 
 .c3 {
@@ -104,7 +861,7 @@ exports[`FormControl > Snapshot > 1`] = `
   transition-property: color;
 }
 
-.c11 {
+.c9 {
   font-size: 13px;
   line-height: 18px;
   margin: 0px 0px 0px 0px;
@@ -121,119 +878,53 @@ exports[`FormControl > Snapshot > 1`] = `
   transition-property: color;
 }
 
-.c5 {
-  position: relative;
-}
-
 .c4 {
   display: block;
   text-align: left;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  margin-left: 6px;
-}
-
-.c6:hover > .{
-  color: #000000D9;
-}
-
-.c12 {
+.c10 {
   display: block;
   text-align: left;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
   data-testid="bezier-react-form-control"
 >
   <div
-    class="c0 c1"
+    class="c0 c2"
+    height="36"
   >
-    <div
-      class="c2"
+    <label
+      class="c3 c4"
+      color="txt-black-darkest"
+      data-testid="bezier-react-form-label"
+      for="form"
+      id="form-label"
     >
-      <label
-        class="c3 c4"
-        color="txt-black-darkest"
-        data-testid="bezier-react-form-label"
-        for="form"
-        id="form-label"
-      >
-        Label
-      </label>
-      <div
-        class="c5 c6"
-        data-testid="bezier-react-tooltip"
-      >
-        <svg
-          class="c7 "
-          color="txt-black-dark"
-          data-testid="bezier-react-form-label-help"
-          fill="none"
-          foundation="[object Object]"
-          height="16"
-          marginbottom="0"
-          marginleft="0"
-          marginright="0"
-          margintop="0"
-          viewBox="0 0 24 24"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zm.83 12.541h-1.9v-.708c0-1.156.625-2.24 1.672-2.9.867-.546 1.337-.939 1.337-1.447 0-1.014-1-1.561-1.94-1.561-1.035 0-1.942.73-1.942 1.56h-1.9c0-1.875 1.758-3.46 3.841-3.46 2.154 0 3.842 1.52 3.842 3.46 0 1.655-1.393 2.533-2.225 3.056-.236.15-.784.573-.784 1.292v.708zm-.889 3.631a1.244 1.244 0 110-2.487 1.244 1.244 0 010 2.487z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </div>
-    </div>
+      Label
+    </label>
   </div>
   <div
-    class="c8"
+    class="c5"
     data-testid="bezier-react-text-input"
     size="36"
   >
     <input
       aria-describedby="form-help-text"
       autocomplete="off"
-      class="c9"
+      class="c6"
       id="form"
-      placeholder="Placeholder"
       size="36"
       value=""
     />
   </div>
   <div
-    class="c0 c10"
+    class="c0 c7 c8"
   >
     <p
-      class="c11 c12"
+      class="c9 c10"
       color="txt-black-dark"
       data-testid="bezier-react-form-helper-text"
       id="form-help-text"

--- a/src/components/Forms/FormGroup/FormGroup.tsx
+++ b/src/components/Forms/FormGroup/FormGroup.tsx
@@ -12,6 +12,7 @@ function FormGroup({
   testId = FORM_GROUP_TEST_ID,
   gap = 6,
   direction = 'column',
+  role = 'group',
   children,
   ...rest
 }: FormGroupProps,
@@ -41,7 +42,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
       ref={forwardedRef}
       gap={gap}
       direction={direction}
-      role="group"
+      role={role}
     >
       { children }
     </Styled.Stack>

--- a/src/components/Forms/FormGroup/FormGroup.tsx
+++ b/src/components/Forms/FormGroup/FormGroup.tsx
@@ -22,7 +22,10 @@ forwardedRef: React.Ref<HTMLDivElement>,
   const {
     setIsRendered,
     ...ownProps
-  } = contextValue?.getGroupProps(rest) ?? { setIsRendered: undefined }
+  } = contextValue?.getGroupProps(rest) ?? {
+    setIsRendered: undefined,
+    ...rest,
+  }
 
   useEffect(() => {
     setIsRendered?.(true)

--- a/src/components/Forms/FormGroup/FormGroup.types.ts
+++ b/src/components/Forms/FormGroup/FormGroup.types.ts
@@ -4,6 +4,7 @@ import type { BezierComponentProps, ChildrenProps } from 'Types/ComponentProps'
 interface FormGroupOptions {
   gap?: number
   direction?: 'column' | 'row'
+  role?: string
 }
 
 interface FormGroupProps extends

--- a/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -33,10 +33,10 @@ forwardedRef: ForwardedRef,
     Wrapper,
     ...ownProps
   } = getProps?.(rest) ?? {
-    ...rest,
     visible: true,
     setIsRendered: undefined,
     Wrapper: React.Fragment,
+    ...rest,
   }
 
   const shouldRendered = useMemo(() => (

--- a/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/src/components/Forms/FormLabel/FormLabel.tsx
@@ -26,7 +26,10 @@ forwardedRef: React.Ref<HTMLLabelElement>,
 ) {
   const contextValue = useFormControlContext()
 
-  const { Wrapper, ...ownProps } = contextValue?.getLabelProps(rest) ?? { Wrapper: React.Fragment }
+  const { Wrapper, ...ownProps } = contextValue?.getLabelProps(rest) ?? {
+    Wrapper: React.Fragment,
+    ...rest,
+  }
 
   const LabelComponent = useMemo(() => (
     <Styled.Label

--- a/src/components/Forms/useFormFieldProps.ts
+++ b/src/components/Forms/useFormFieldProps.ts
@@ -6,6 +6,7 @@ import { ariaAttr } from 'Utils/domUtils'
 import type { FormComponentProps } from 'Components/Forms/Form.types'
 import useFormControlContext from './useFormControlContext'
 
+// TODO: 테스트 추가
 function useFormFieldProps<Props extends FormComponentProps>(props?: Props) {
   const contextValue = useFormControlContext()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,11 @@ export * from 'Types/Utils'
 export { default as LayoutHeaderType } from 'Layout/types/LayoutHeaderType'
 export { default as TabsSize } from 'Components/Tabs/TabsSize'
 
+/* Hooks */
+export { default as useEventHandler } from 'Hooks/useEventHandler'
+export { default as useMergeRefs } from 'Hooks/useMergeRefs'
+export { default as useId } from 'Hooks/useId'
+
 /* Utils */
 export { getRootElement } from 'Utils/domUtils'
 export * as StyleUtils from 'Utils/styleUtils'


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

폼 컴포넌트의 잘못된 구현을 수정하고, 오버라이드할 수 있는 속성을 추가합니다.
공통 Hook을 export하여 사용처에서 사용할 수 있도록 합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- FormGroup, FormLabel 컴포넌트를 FormControl 외부에서 사용했을 때 속성을 오버라이드할 수 없었던 문제 수정
- FormGroup이 존재할 때 하위 Field에 id를 전달하지 않도록 수정
  - 기존엔 FormControl -> FormGroup  -> FormControl -> Fields... 구조이기때문에 상위 FormControl 컨텍스트를 하위 FormControl 컨텍스트가 오버라이드해서 정상적으로 field id가 들어가게되나, 하위 FormControl을 생략한 케이스의 경우 상위 FormControl에서 generate한 field id가 그대로 들어가므로 이를 방지하고자 했습니다
- FormGroup의 role 속성을 오버라이드할 수 있도록 수정
  -  radiogroup, checkboxgroup 등의 속성으로 오버라이드할 수 있도록 합니다
- 공통 Hook을 export하여 사용처에서 사용할 수 있도록 개선
- FormControl 테스트 보강

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

없음
