### PR TITLE
Navgroup item wrapper의 padding-down 변경

### DIFF
--- a/src/components/Navigator/NavGroup/NavGroup.styled.ts
+++ b/src/components/Navigator/NavGroup/NavGroup.styled.ts
@@ -69,7 +69,7 @@ export const Item = styled.button<WrapperProps>`
 `
 
 export const ChildrenWrapper = styled.ul`
-  padding: 0;
+  padding: 0 0 8px;
   margin: 0;
 `
 


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
navgroup 디자인의 padding이 누락되어서 추가하는 PR입니다.

# Details
<img width="491" alt="Screenshot 2022-02-16 at 17 58 37" src="https://user-images.githubusercontent.com/14245930/154230226-256593e0-bd54-458b-b665-004eef12cbaf.png">


## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)