### PR TITLE
기획 변경으로 인하여 navgroup에 active prop 추가

### DIFF
--- a/src/components/Navigator/NavGroup/NavGroup.stories.tsx
+++ b/src/components/Navigator/NavGroup/NavGroup.stories.tsx
@@ -43,6 +43,7 @@ export const Primary: Story<NavGroupProps> = Template.bind({})
 
 Primary.args = {
   open: true,
+  active: false,
   name: 'general',
   content: '일반 설정',
   leftIcon: 'settings',

--- a/src/components/Navigator/NavGroup/NavGroup.styled.ts
+++ b/src/components/Navigator/NavGroup/NavGroup.styled.ts
@@ -5,6 +5,7 @@ import { Text } from 'Components/Text'
 
 interface WrapperProps extends InterpolationProps {
   open: boolean
+  active: boolean
 }
 
 export const LeftIconWrapper = styled.div`
@@ -46,6 +47,20 @@ const closedItemStyle = css`
   }
 `
 
+const activeItemStyle = css`
+  color: ${({ foundation }) => foundation?.theme?.['bgtxt-blue-normal']};
+  background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-blue-lightest']};
+`
+
+const nonActiveItemStyle = css`
+  color: ${({ foundation }) => foundation?.theme?.['txt-black-darkest']};
+
+  &:hover,
+  &:focus-visible {
+    background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
+  }
+`
+
 export const Item = styled.button<WrapperProps>`
   display: flex;
   align-items: center;
@@ -58,11 +73,7 @@ export const Item = styled.button<WrapperProps>`
   outline: 0;
   ${({ foundation }) => foundation?.rounding?.round6}
 
-  &:hover,
-  &:focus-visible {
-    background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
-  }
-
+  ${({ active }) => (active ? activeItemStyle : nonActiveItemStyle)}
   ${({ open }) => (open ? null : closedItemStyle)}
 
   ${({ interpolation }) => interpolation}

--- a/src/components/Navigator/NavGroup/NavGroup.test.tsx
+++ b/src/components/Navigator/NavGroup/NavGroup.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 /* Internal dependencies */
 import { render } from 'Utils/testUtils'
+import { Icon, IconSize } from 'Components/Icon'
 import NavGroup, { NAV_GROUP_TEST_ID } from './NavGroup'
 import type NavGroupProps from './NavGroup.types'
 
@@ -14,14 +15,23 @@ describe('NavItem Test >', () => {
       leftIcon: 'dot',
       name: 'general',
       content: 'test-content',
+      rightContent: <Icon name="dot" size={IconSize.XS} color="bgtxt-orange-normal" />,
     }
   })
 
-  const renderNavItem = (optionProps?: NavGroupProps) =>
+  const renderNavItem = (optionProps?: Partial<NavGroupProps>) =>
     render(<NavGroup {...props} {...optionProps} />)
 
-  it('Snapshot > ', () => {
-    const { getByTestId } = renderNavItem()
+  it('Snapshot > active', () => {
+    const { getByTestId } = renderNavItem({ active: true })
+
+    const rendered = getByTestId(NAV_GROUP_TEST_ID)
+
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('Snapshot > not active', () => {
+    const { getByTestId } = renderNavItem({ active: false })
 
     const rendered = getByTestId(NAV_GROUP_TEST_ID)
 

--- a/src/components/Navigator/NavGroup/NavGroup.tsx
+++ b/src/components/Navigator/NavGroup/NavGroup.tsx
@@ -31,6 +31,7 @@ function NavGroup({
   leftIcon,
   leftIconColor = 'txt-black-dark',
   open,
+  active,
   onClick = noop,
 }: NavGroupProps) {
   const handleClickItem = useCallback((e?: React.MouseEvent) => {
@@ -49,6 +50,7 @@ function NavGroup({
     <Wrapper role="none">
       <Item
         as={as}
+        active={active}
         open={open}
         style={style}
         className={className}
@@ -70,10 +72,7 @@ function NavGroup({
           ) }
         </LeftIconWrapper>
 
-        <ContentWrapper
-          typo={Typography.Size14}
-          color="txt-black-darkest"
-        >
+        <ContentWrapper typo={Typography.Size14}>
           { content }
         </ContentWrapper>
 

--- a/src/components/Navigator/NavGroup/NavGroup.types.ts
+++ b/src/components/Navigator/NavGroup/NavGroup.types.ts
@@ -4,6 +4,7 @@ import type {
   ChildrenProps,
   ContentProps,
   SideContentProps,
+  ActivatableProps,
   AdditionalColorProps,
 } from 'Types/ComponentProps'
 import { IconName } from 'Components/Icon'
@@ -21,4 +22,5 @@ export default interface NavGroupProps extends
   ContentProps,
   Pick<SideContentProps, 'rightContent'>,
   AdditionalColorProps<'leftIcon'>,
+  Pick<ActivatableProps, 'active'>,
   NavGroupOptions {}

--- a/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`NavItem Test > Snapshot >  1`] = `
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
-  color: #000000D9;
+  color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
   -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
@@ -72,6 +72,7 @@ exports[`NavItem Test > Snapshot >  1`] = `
   outline: 0;
   overflow: hidden;
   border-radius: 6px;
+  color: #000000D9;
 }
 
 .c0:hover,
@@ -123,7 +124,6 @@ exports[`NavItem Test > Snapshot >  1`] = `
   </div>
   <span
     class="c3 c4"
-    color="txt-black-darkest"
     data-testid="bezier-react-text"
   >
     test-content

--- a/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -1,12 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NavItem Test > Snapshot >  1`] = `
+exports[`NavItem Test > Snapshot > active 1`] = `
 .c2 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin: 0px 0px 0px 0px;
   color: #00000066;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0px 0px 0px 0px;
+  color: #F4800B;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
   -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
@@ -52,6 +68,207 @@ exports[`NavItem Test > Snapshot >  1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-left: auto;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+  height: 28px;
+  padding: 0 6px;
+  cursor: pointer;
+  background-color: transparent;
+  border: 0;
+  outline: 0;
+  overflow: hidden;
+  border-radius: 6px;
+  color: #5E56F0;
+  background-color: #5E56F01A;
+}
+
+.c0 .sc-eCApnc {
+  visibility: hidden;
+}
+
+.c0:hover .sc-eCApnc,
+.c0:focus-visible .sc-eCApnc {
+  visibility: visible;
+}
+
+<button
+  aria-controls="generalMenu"
+  aria-haspopup="false"
+  class="c0"
+  data-testid="bezier-react-nav-group"
+  role="menuitem"
+>
+  <div
+    class="c1"
+  >
+    <svg
+      class="c2"
+      color="txt-black-dark"
+      data-testid="bezier-react-icon"
+      fill="none"
+      foundation="[object Object]"
+      height="20"
+      marginbottom="0"
+      marginleft="0"
+      marginright="0"
+      margintop="0"
+      viewBox="0 0 24 24"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clip-rule="evenodd"
+        d="M17 12a5 5 0 11-10 0 5 5 0 0110 0z"
+        fill="currentColor"
+        fill-rule="evenodd"
+      />
+    </svg>
+  </div>
+  <span
+    class="c3 c4"
+    data-testid="bezier-react-text"
+  >
+    test-content
+  </span>
+  <div
+    class="c5"
+  >
+    <svg
+      class="c6"
+      color="bgtxt-orange-normal"
+      data-testid="bezier-react-icon"
+      fill="none"
+      foundation="[object Object]"
+      height="16"
+      marginbottom="0"
+      marginleft="0"
+      marginright="0"
+      margintop="0"
+      viewBox="0 0 24 24"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clip-rule="evenodd"
+        d="M17 12a5 5 0 11-10 0 5 5 0 0110 0z"
+        fill="currentColor"
+        fill-rule="evenodd"
+      />
+    </svg>
+  </div>
+</button>
+`;
+
+exports[`NavItem Test > Snapshot > not active 1`] = `
+.c2 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0px 0px 0px 0px;
+  color: #00000066;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0px 0px 0px 0px;
+  color: #F4800B;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c3 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 20px;
+  max-width: 20px;
+  margin-right: 8px;
+}
+
+.c4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-left: auto;
 }
 
 .c0 {
@@ -128,5 +345,31 @@ exports[`NavItem Test > Snapshot >  1`] = `
   >
     test-content
   </span>
+  <div
+    class="c5"
+  >
+    <svg
+      class="c6"
+      color="bgtxt-orange-normal"
+      data-testid="bezier-react-icon"
+      fill="none"
+      foundation="[object Object]"
+      height="16"
+      marginbottom="0"
+      marginleft="0"
+      marginright="0"
+      margintop="0"
+      viewBox="0 0 24 24"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clip-rule="evenodd"
+        d="M17 12a5 5 0 11-10 0 5 5 0 0110 0z"
+        fill="currentColor"
+        fill-rule="evenodd"
+      />
+    </svg>
+  </div>
 </button>
 `;


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
아코디언 UX가 변경되면서 작동 요구사항에 navgroup에 active가 되는 기능 구현입니다.

# Details
<img width="324" alt="Screenshot 2022-02-17 at 17 41 59" src="https://user-images.githubusercontent.com/14245930/154437977-ca5427f5-ede2-4efc-ae23-7234c762e3f2.png">


## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
