### PR TITLE
Ellipsis 의 text size가 rem 반영이 되지 않았던 문제를 수정

### DIFF
--- a/src/components/Toast/Toast.styled.ts
+++ b/src/components/Toast/Toast.styled.ts
@@ -1,5 +1,5 @@
 /* Internal dependencies */
-import { ellipsis, Foundation, styled, Transition } from 'Foundation'
+import { ellipsis, Foundation, LineHeightAbsoluteNumber, styled, Transition } from 'Foundation'
 import ToastElementProps, { ToastAppearance, ToastContainerProps, ToastPlacement } from './Toast.types'
 import { getIconColor, getPlacement, initPosition, showedToastTranslateXStyle } from './utils'
 
@@ -101,7 +101,7 @@ export const Content = styled.div<Pick<ToastElementProps, 'actionContent' | 'onC
 `
 
 export const EllipsisableContent = styled.div`
-  ${ellipsis(5, 18)};
+  ${ellipsis(5, LineHeightAbsoluteNumber.Lh18)};
 
   overflow: visible;
   word-break: break-word;

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -50,9 +50,9 @@ exports[`Tooltip test > Tooltip with contentInterpolation prop 1`] = `
 
 .c3 {
   display: -webkit-box;
-  max-height: 36px;
+  max-height: 36rem;
   overflow: hidden;
-  line-height: 1.8px;
+  line-height: 1.8rem;
   text-overflow: ellipsis;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 20;
@@ -140,9 +140,9 @@ exports[`Tooltip test > Tooltip with default props 1`] = `
 
 .c3 {
   display: -webkit-box;
-  max-height: 36px;
+  max-height: 36rem;
   overflow: hidden;
-  line-height: 1.8px;
+  line-height: 1.8rem;
   text-overflow: ellipsis;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 20;

--- a/src/foundation/Mixin.test.tsx
+++ b/src/foundation/Mixin.test.tsx
@@ -44,9 +44,9 @@ describe('Mixin test >', () => {
       const renderedComponent = getByTestId(ELLIPSIS_TEST_ID)
       expect(renderedComponent).toHaveStyle(`
         display: -webkit-box;
-        max-height: 50px;
+        max-height: 50rem;
         overflow: hidden;
-        line-height: 10px;
+        line-height: 10rem;
         text-overflow: ellipsis;
       `)
     })

--- a/src/foundation/Mixins.ts
+++ b/src/foundation/Mixins.ts
@@ -48,9 +48,9 @@ export function ellipsis(line?: number, lineHeight?: number): ReturnType<typeof 
   /* stylelint-disable value-no-vendor-prefix, property-no-vendor-prefix */
   return css`
       display: -webkit-box;
-      max-height: ${(line * lineHeight)}px;
+      max-height: ${(line * lineHeight)}rem;
       overflow: hidden;
-      line-height: ${lineHeight}px;
+      line-height: ${lineHeight}rem;
       text-overflow: ellipsis;
       -webkit-box-orient: vertical;
       -webkit-line-clamp: ${line};


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
#665 이후 데스크에서 사용하는 font-size의 단위는 PX가 아니라 REM이 되었습니다.
ellipsis function은 여전히 px단위였고 데스크에서 문제가 있었습니다. 이를 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
### AS-IS
<img width="559" alt="image" src="https://user-images.githubusercontent.com/33861398/154470538-8ee707ef-6f9a-4f88-a498-a452beba2bd4.png">
잘리던 모습
### TO-BE
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/33861398/154470416-41984732-5322-4a7d-a0cb-e9ec360d5e4e.png">
rem 단위로 잘 나타남.
## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
