### PR TITLE
TooltipContent lazy evaluation

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -97,6 +97,7 @@ export const Primary = Template.bind({})
 Primary.args = {
   // eslint-disable-next-line max-len
   content: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.',
+  lazy: true,
   placement: TooltipPosition.BottomCenter,
   offset: 4,
   disabled: false,

--- a/src/components/Tooltip/Tooltip.styled.ts
+++ b/src/components/Tooltip/Tooltip.styled.ts
@@ -4,7 +4,6 @@ import type { InterpolationProps } from 'Types/Foundation'
 
 interface ContentWrapperProps {
   disabled: boolean
-  isHidden: boolean
 }
 
 export const Container = styled.div`
@@ -18,10 +17,6 @@ export const ContentWrapper = styled.div<ContentWrapperProps>`
 
   ${({ disabled }) => disabled && css`
     display: none;
-  `}
-
-  ${({ isHidden }) => isHidden && css`
-    visibility: hidden;
   `}
 `
 

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -42,50 +42,48 @@ describe('Tooltip test >', () => {
   )
 
   it('Tooltip with default props', () => {
-    act(() => {
-      const { getByTestId } = renderTooltip()
-      const rendered = getByTestId(ROOT_TESTID)
+    const { getByTestId } = renderTooltip()
+    const rendered = getByTestId(ROOT_TESTID)
 
+    act(() => {
       fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
 
       jest.runAllTimers()
-
-      expect(rendered).toMatchSnapshot()
     })
+
+    expect(rendered).toMatchSnapshot()
   })
 
   it('Tooltip with contentInterpolation prop', async () => {
-    act(() => {
-      const { getByTestId } = renderTooltip({
-        contentInterpolation: css`background-color: black;`,
-      })
-      const rendered = getByTestId(ROOT_TESTID)
+    const { getByTestId } = renderTooltip({
+      contentInterpolation: css`background-color: black;`,
+    })
+    const rendered = getByTestId(ROOT_TESTID)
 
+    act(() => {
       fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
 
       jest.runAllTimers()
-
-      expect(rendered).toMatchSnapshot()
     })
+
+    expect(rendered).toMatchSnapshot()
   })
 
   it('TooltipContent not rendered at first', async () => {
-    act(() => {
-      const { container } = renderTooltip()
+    const { queryByTestId } = renderTooltip()
 
-      expect(container.querySelector(`[data-testid="${TOOLTIP_CONTENT_TEST_ID}"]`)).toBeNull()
-    })
+    expect(queryByTestId(TOOLTIP_CONTENT_TEST_ID)).toBeNull()
   })
 
   it('TooltipContent rendered after mouseover', async () => {
     act(() => {
-      const { container, getByTestId } = renderTooltip()
+      const { getByTestId, queryByTestId } = renderTooltip()
 
       fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
 
       jest.runAllTimers()
 
-      expect(container.querySelector(`[data-testid="${TOOLTIP_CONTENT_TEST_ID}"]`)).toBeVisible()
+      expect(queryByTestId(TOOLTIP_CONTENT_TEST_ID)).toBeVisible()
     })
   })
 })

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,11 +1,12 @@
 /* External dependencies */
 import React from 'react'
+import { act } from 'react-dom/test-utils'
 import { fireEvent } from '@testing-library/dom'
 
 /* Internal dependencies */
 import { css } from 'Foundation'
 import { render } from 'Utils/testUtils'
-import Tooltip, { TOOLTIP_TEST_ID } from './Tooltip'
+import Tooltip, { TOOLTIP_TEST_ID, TOOLTIP_CONTENT_TEST_ID } from './Tooltip'
 import TooltipProps from './Tooltip.types'
 
 const ROOT_TESTID = 'container'
@@ -41,26 +42,50 @@ describe('Tooltip test >', () => {
   )
 
   it('Tooltip with default props', () => {
-    const { getByTestId } = renderTooltip()
-    const rendered = getByTestId(ROOT_TESTID)
+    act(() => {
+      const { getByTestId } = renderTooltip()
+      const rendered = getByTestId(ROOT_TESTID)
 
-    fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
+      fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
 
-    jest.runAllTimers()
+      jest.runAllTimers()
 
-    expect(rendered).toMatchSnapshot()
+      expect(rendered).toMatchSnapshot()
+    })
   })
 
   it('Tooltip with contentInterpolation prop', async () => {
-    const { getByTestId } = renderTooltip({
-      contentInterpolation: css`background-color: black;`,
+    act(() => {
+      const { getByTestId } = renderTooltip({
+        contentInterpolation: css`background-color: black;`,
+      })
+      const rendered = getByTestId(ROOT_TESTID)
+
+      fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
+
+      jest.runAllTimers()
+
+      expect(rendered).toMatchSnapshot()
     })
-    const rendered = getByTestId(ROOT_TESTID)
+  })
 
-    fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
+  it('TooltipContent not rendered at first', async () => {
+    act(() => {
+      const { container } = renderTooltip()
 
-    jest.runAllTimers()
+      expect(container.querySelector(`[data-testid="${TOOLTIP_CONTENT_TEST_ID}"]`)).toBeNull()
+    })
+  })
 
-    expect(rendered).toMatchSnapshot()
+  it('TooltipContent rendered after mouseover', async () => {
+    act(() => {
+      const { container, getByTestId } = renderTooltip()
+
+      fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
+
+      jest.runAllTimers()
+
+      expect(container.querySelector(`[data-testid="${TOOLTIP_CONTENT_TEST_ID}"]`)).toBeVisible()
+    })
   })
 })

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -76,14 +76,26 @@ describe('Tooltip test >', () => {
   })
 
   it('TooltipContent rendered after mouseover', async () => {
-    act(() => {
-      const { getByTestId, queryByTestId } = renderTooltip()
+    const { getByTestId, queryByTestId } = renderTooltip()
 
+    act(() => {
       fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
 
       jest.runAllTimers()
-
-      expect(queryByTestId(TOOLTIP_CONTENT_TEST_ID)).toBeVisible()
     })
+
+    expect(queryByTestId(TOOLTIP_CONTENT_TEST_ID)).toBeVisible()
+  })
+
+  it('Tooltip with disabled prop not rendered even after mouseover', async () => {
+    const { getByTestId, queryByTestId } = renderTooltip({ disabled: true })
+
+    act(() => {
+      fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
+
+      jest.runAllTimers()
+    })
+
+    expect(queryByTestId(TOOLTIP_CONTENT_TEST_ID)).toBeNull()
   })
 })

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -38,7 +38,7 @@ function Tooltip(
   const tooltipContainerRef = useRef<HTMLDivElement>(null)
   const timerRef = useRef<ReturnType<Window['setTimeout']>>()
 
-  useEffect(() => {
+  useEffect(function hideTooltipContentWhenDisabled() {
     if (disabled) {
       setShow(false)
     }

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -1,5 +1,14 @@
+/* External dependencies */
+import { Ref } from 'react'
 /* Internal dependencies */
-import { BezierComponentProps, ChildrenProps, ContentProps, DisableProps, AdditionalStylableProps } from 'Types/ComponentProps'
+import {
+  BezierComponentProps,
+  RenderConfigProps,
+  ChildrenProps,
+  ContentProps,
+  DisableProps,
+  AdditionalStylableProps,
+} from 'Types/ComponentProps'
 
 interface TooltipOptions {
   placement?: TooltipPosition
@@ -17,7 +26,25 @@ export default interface TooltipProps extends
   DisableProps,
   AdditionalStylableProps<'content'>,
   React.HTMLAttributes<HTMLDivElement>,
-  TooltipOptions {}
+  TooltipOptions {
+  contentTestId?: string
+  lazy?: boolean
+}
+
+export interface TooltipContentProps extends Pick<
+TooltipOptions,
+'keepInContainer' |
+'placement' |
+'offset' |
+'allowHover'
+>,
+  RenderConfigProps,
+  ContentProps,
+  AdditionalStylableProps<'content'>,
+  DisableProps {
+  tooltipContainer: HTMLDivElement | null
+  forwardedRef: Ref<any>
+}
 
 export interface GetTooltipStyle extends Required<Pick<TooltipOptions, 'placement' | 'offset' | 'allowHover'>> {
   tooltipContainer: HTMLDivElement

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -17,6 +17,8 @@ interface TooltipOptions {
   allowHover?: boolean
   delayShow?: number
   delayHide?: number
+  contentTestId?: string
+  lazy?: boolean
 }
 
 export default interface TooltipProps extends
@@ -27,8 +29,6 @@ export default interface TooltipProps extends
   AdditionalStylableProps<'content'>,
   React.HTMLAttributes<HTMLDivElement>,
   TooltipOptions {
-  contentTestId?: string
-  lazy?: boolean
 }
 
 export interface TooltipContentProps extends Pick<
@@ -43,7 +43,7 @@ TooltipOptions,
   AdditionalStylableProps<'content'>,
   DisableProps {
   tooltipContainer: HTMLDivElement | null
-  forwardedRef: Ref<any>
+  forwardedRef: Ref<HTMLDivElement>
 }
 
 export interface GetTooltipStyle extends Required<Pick<TooltipOptions, 'placement' | 'offset' | 'allowHover'>> {

--- a/src/components/Tooltip/TooltipContent.test.tsx
+++ b/src/components/Tooltip/TooltipContent.test.tsx
@@ -1,0 +1,90 @@
+/* External dependencies */
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { fireEvent } from '@testing-library/dom'
+
+/* Internal dependencies */
+import { render } from 'Utils/testUtils'
+import Tooltip, { TOOLTIP_TEST_ID } from './Tooltip'
+import TooltipProps from './Tooltip.types'
+
+const ROOT_TESTID = 'container'
+
+const RootTooltip: React.FC<TooltipProps> = ({ children, ...rests }) => (
+  <div id="main" data-testid={ROOT_TESTID}>
+    <Tooltip {...rests}>
+      { children }
+    </Tooltip>
+  </div>
+)
+
+describe('TooltipContent test >', () => {
+  let props: TooltipProps
+
+  const PLAIN_TEXT_CONTENT = 'plain text content'
+
+  const ARRAY_TEXT_CONTENT_PREFIX = 'array text content'
+  const ARRAY_TEXT_CONTENT = [
+    `${ARRAY_TEXT_CONTENT_PREFIX} 1`,
+    `${ARRAY_TEXT_CONTENT_PREFIX} 2`,
+    `${ARRAY_TEXT_CONTENT_PREFIX} 3`,
+  ]
+
+  const LINEBREAK_TEXT_CONTENT_PREFIX = 'linebreak text content'
+  const LINEBREAK_TEXT_CONTENT = 'linebreak text content 1 \n linebreak text content 2 \n linebreak text content 3'
+
+  beforeEach(() => {
+    props = {
+      children: 'Text',
+    }
+
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const renderTooltip = (optionProps?: TooltipProps) => render(
+    <RootTooltip {...props} {...optionProps} />,
+  )
+
+  it('TooltipContent with plain text content >', () => {
+    const { getByTestId, queryByText } = renderTooltip({ content: PLAIN_TEXT_CONTENT })
+    const rendered = getByTestId(ROOT_TESTID)
+
+    act(() => {
+      fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
+
+      jest.runAllTimers()
+    })
+
+    expect(rendered).toContainElement(queryByText(PLAIN_TEXT_CONTENT))
+  })
+
+  it('TooltipContent with array of text contents >', () => {
+    const { getByTestId, queryAllByText } = renderTooltip({ content: ARRAY_TEXT_CONTENT })
+
+    act(() => {
+      fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
+
+      jest.runAllTimers()
+    })
+
+    expect(queryAllByText(ARRAY_TEXT_CONTENT_PREFIX, { exact: false }).length).toEqual(ARRAY_TEXT_CONTENT.length)
+  })
+
+  it('TooltipContent with linebreak text contents >', () => {
+    const { getByTestId, queryAllByText } = renderTooltip({ content: LINEBREAK_TEXT_CONTENT })
+
+    act(() => {
+      fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
+
+      jest.runAllTimers()
+    })
+
+    const linebreakCount = LINEBREAK_TEXT_CONTENT.match(/\n/g)?.length ?? 0
+
+    expect(queryAllByText(LINEBREAK_TEXT_CONTENT_PREFIX, { exact: false }).length).toEqual(linebreakCount + 1)
+  })
+})

--- a/src/components/Tooltip/TooltipContent.tsx
+++ b/src/components/Tooltip/TooltipContent.tsx
@@ -1,0 +1,139 @@
+/* External dependencies */
+import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react'
+import ReactDOM from 'react-dom'
+import { isEmpty, isString, isArray } from 'lodash-es'
+
+/* Internal dependencies */
+import { Typography } from 'Foundation'
+import useMergeRefs from 'Hooks/useMergeRefs'
+import useEventHandler from 'Hooks/useEventHandler'
+import { getRootElement } from 'Utils/domUtils'
+import { Text } from 'Components/Text'
+import { TooltipContentProps, TooltipPosition } from './Tooltip.types'
+import { getReplacement, getTooltipStyle } from './utils'
+import { ContentWrapper, Content, EllipsisableContent } from './Tooltip.styled'
+
+function getNewLineComponent(strContent: string) {
+  return (
+    strContent.split('\n').map((str, index) => {
+      if (index === 0) {
+        return (
+          <Text key={str} typo={Typography.Size14}>
+            { str }
+          </Text>
+        )
+      }
+
+      return (
+        <>
+          <br />
+          <Text key={str} typo={Typography.Size14}>
+            { str }
+          </Text>
+        </>
+      )
+    })
+  )
+}
+
+function getContentComponent(content?: React.ReactNode) {
+  if (isArray(content)) {
+    return content.map(item => {
+      if (isString(item)) {
+        return getNewLineComponent(item)
+      }
+
+      return item
+    })
+  }
+
+  if (isString(content)) {
+    return getNewLineComponent(content)
+  }
+
+  return content
+}
+
+const TooltipContent: React.FC<TooltipContentProps> = ({
+  as,
+  content,
+  contentClassName,
+  contentInterpolation,
+  disabled = false,
+  keepInContainer = false,
+  placement = TooltipPosition.BottomCenter,
+  tooltipContainer,
+  offset = 4,
+  allowHover = false,
+  testId,
+  forwardedRef,
+}) => {
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const tooltipWrapperRef = useRef<HTMLDivElement>(null)
+  const mergedRef = useMergeRefs<HTMLDivElement>(tooltipRef, forwardedRef)
+  const [replacement, setReplacement] = useState(placement)
+
+  const handleClickTooltip = useCallback((event: HTMLElementEventMap['click']) => {
+    event.stopPropagation()
+  }, [])
+
+  useEventHandler(tooltipRef.current, 'click', handleClickTooltip)
+
+  useEffect(() => {
+    if (!tooltipRef.current) { return }
+    const newPlacement = getReplacement({
+      tooltip: tooltipRef.current,
+      keepInContainer,
+      placement,
+    })
+    setReplacement(newPlacement)
+  }, [
+    keepInContainer,
+    placement,
+  ])
+
+  const ContentComponent = useMemo(() => getContentComponent(content), [content])
+
+  const contentWrapperStyle = useMemo(() => {
+    if (tooltipContainer) {
+      return getTooltipStyle({
+        tooltipContainer,
+        placement: replacement,
+        offset,
+        allowHover,
+      })
+    }
+
+    return {}
+  }, [
+    tooltipContainer,
+    replacement,
+    offset,
+    allowHover,
+  ])
+
+  return (
+    ReactDOM.createPortal(
+      <ContentWrapper
+        ref={tooltipWrapperRef}
+        disabled={disabled || isEmpty(content)}
+        style={contentWrapperStyle}
+      >
+        <Content
+          as={as}
+          data-testid={testId}
+          className={contentClassName}
+          interpolation={contentInterpolation}
+          ref={mergedRef}
+        >
+          <EllipsisableContent>
+            { ContentComponent }
+          </EllipsisableContent>
+        </Content>
+      </ContentWrapper>,
+      getRootElement(),
+    )
+  )
+}
+
+export default TooltipContent

--- a/src/components/Tooltip/TooltipContent.tsx
+++ b/src/components/Tooltip/TooltipContent.tsx
@@ -25,12 +25,12 @@ function getNewLineComponent(strContent: string) {
       }
 
       return (
-        <>
+        <React.Fragment key={str}>
           <br />
-          <Text key={str} typo={Typography.Size14}>
+          <Text typo={Typography.Size14}>
             { str }
           </Text>
-        </>
+        </React.Fragment>
       )
     })
   )

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Tooltip test > Tooltip with contentInterpolation prop 1`] = `
   >
     <div
       class="c2"
-      data-testid="bezier-react-tooltip"
+      data-testid="bezier-react-tooltip-content"
     >
       <div
         class="c3"
@@ -164,7 +164,7 @@ exports[`Tooltip test > Tooltip with default props 1`] = `
   >
     <div
       class="c2"
-      data-testid="bezier-react-tooltip"
+      data-testid="bezier-react-tooltip-content"
     >
       <div
         class="c3"


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

- Tooltip 내 TooltipContent 에 대한 lazy evaluation 옵션 추가
- Tooltip 리팩토링 (Tooltip, TooltipContent 분리)

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

### As-Is

- Tooltip 컴포넌트 내에 있지 않아도 될 함수들을 모두 memoize 해서 컴포넌트 내부에서 갖고있었음.
- show 되기 전의 TooltipContent 에 대한 style, component 등 모든 객체를 initialize 한 채로 갖고 있었음.
- Tooltip 컴포넌트의 memoization 이 없음.

### To-Be
- Tooltip 컴포넌트 내에 있지 않아도 될 함수들은 모두 컴포넌트 바깥으로 static 한 함수로
- TooltipContent 에 대한 style, component 등 모든 객체를 TooltipContent: React.FC 라는 새로운 컴포넌트 안으로 옮김.
- Tooltip 에 lazy: boolean prop을 추가하고, lazy = true 일 때는 TooltipContent 를 필요할 때 lazy 하게 evaluate 함


## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

[노션](https://www.notion.so/channelio/TooltipContent-lazy-evaluation-1e4b27f3d65b4910be2e43f2b36e5179)
