### PR TITLE
Select 컴포넌트 구현을 button 엘리먼트로 변경 및 디자인 최신화

### DIFF
--- a/src/components/Forms/Inputs/Select/Select.styled.ts
+++ b/src/components/Forms/Inputs/Select/Select.styled.ts
@@ -19,10 +19,10 @@ export const Container = styled.div<InterpolationProps>`
 `
 
 interface TriggerProps {
-  focus: boolean
-  error: boolean
+  hasError: boolean
   disabled: boolean
   readOnly: boolean
+  active: boolean
   size: SelectSize
 }
 
@@ -48,43 +48,52 @@ function selectSizeConverter(size: SelectSize) {
   }
 }
 
-export const Trigger = styled.div<TriggerProps>`
+const focusedStyle = css`
+  ${focusedInputWrapperStyle};
+  background-color: ${({ foundation }) => foundation?.theme?.['bg-grey-lighter']};
+`
+
+export const Trigger = styled.button<TriggerProps>`
+  all: unset;
   box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 8px 12px;
-  cursor: ${({ disabled, readOnly }) => {
-    if (disabled) { return 'not-allowed' }
-    if (readOnly) { return 'initial' }
-    return 'pointer'
-  }};
+  cursor: pointer;
   user-select: none;
   background-color: ${({ foundation }) => foundation?.theme?.['bg-grey-lightest']};
 
   ${inputTextStyle}
 
-  ${inputWrapperStyle};
+  ${inputWrapperStyle}
 
-  ${({ size }) => selectSizeConverter(size)};
+  ${({ size }) => selectSizeConverter(size)}
 
-  ${({ foundation }) => foundation?.rounding?.round8};
+  ${({ foundation }) => foundation?.rounding?.round8}
 
-  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'box-shadow'])};
+  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'box-shadow'])}
 
-  ${({ focus }) => focus && css`
-    ${focusedInputWrapperStyle};
+  ${({ active }) => active && focusedStyle}
+
+  ${({ hasError }) => hasError && erroredInputWrapperStyle}
+
+  ${({ readOnly }) => readOnly && css`
+    cursor: initial;
     background-color: ${({ foundation }) => foundation?.theme?.['bg-grey-lighter']};
-  `};
+  `}
 
-  ${({ error }) => error && erroredInputWrapperStyle};
-
-  ${({ disabled }) => disabled && css`
+  &:disabled {
+    cursor: not-allowed;
     opacity: ${DisabledOpacity};
-  `};
+  }
 
-  ${({ disabled, readOnly }) => !disabled && !readOnly && css`
-    &:hover {
+  &:not(:disabled):focus {
+    ${focusedStyle}
+  }
+
+  ${({ readOnly }) => !readOnly && css`
+    &:not(:disabled):hover {
       background-color: ${({ foundation }) => foundation?.theme?.['bg-grey-lighter']};
     }
   `}

--- a/src/components/Forms/Inputs/Select/Select.test.tsx
+++ b/src/components/Forms/Inputs/Select/Select.test.tsx
@@ -239,15 +239,6 @@ describe('Select Test >', () => {
       expect(() => getByTestId(SELECT_DROPDOWN_TEST_ID)).toThrow() // element should not exist
     })
 
-    it('should not update style when hovered', () => {
-      const { getByTestId } = renderSelect({ readOnly: true })
-      const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
-
-      fireEvent.mouseOver(trigger)
-
-      expect(trigger).toHaveStyle(`background-color: ${LightFoundation.theme['bg-grey-lightest']}`)
-    })
-
     it('should have chevron with txt-black-dark color', () => {
       const { getByTestId } = renderSelect({ readOnly: true })
       const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)

--- a/src/components/Forms/Inputs/Select/Select.tsx
+++ b/src/components/Forms/Inputs/Select/Select.tsx
@@ -137,10 +137,10 @@ forwardedRef: Ref<SelectRef>,
         as={as}
         ref={triggerRef}
         size={size}
-        focus={isDropdownOpened && !disabled}
-        error={hasError}
+        hasError={hasError}
         disabled={disabled}
         readOnly={readOnly}
+        active={isDropdownOpened}
         onClick={handleClickTrigger}
       >
         <Styled.MainContentWrapper>

--- a/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
 }
 
 .c1 {
+  all: unset;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -74,7 +75,17 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   transition-property: background-color,box-shadow;
 }
 
-.c1:hover {
+.c1:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.c1:not(:disabled):focus {
+  box-shadow: 0 0 0 3px #5E56F04D, inset 0 0 0 1px #5E56F0;
+  background-color: #F7F7F8;
+}
+
+.c1:not(:disabled):hover {
   background-color: #F7F7F8;
 }
 
@@ -100,7 +111,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   class="c0"
   data-testid="bezier-react-select-container"
 >
-  <div
+  <button
     class="c1"
     data-testid="bezier-react-select-trigger"
   >
@@ -137,7 +148,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
         fill-rule="evenodd"
       />
     </svg>
-  </div>
+  </button>
 </div>
 `;
 
@@ -180,6 +191,7 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
 }
 
 .c1 {
+  all: unset;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -215,7 +227,17 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
   transition-property: background-color,box-shadow;
 }
 
-.c1:hover {
+.c1:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.c1:not(:disabled):focus {
+  box-shadow: 0 0 0 3px #5E56F04D, inset 0 0 0 1px #5E56F0;
+  background-color: #F7F7F8;
+}
+
+.c1:not(:disabled):hover {
   background-color: #F7F7F8;
 }
 
@@ -241,7 +263,7 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
   class="c0"
   data-testid="bezier-react-select-container"
 >
-  <div
+  <button
     class="c1"
     data-testid="bezier-react-select-trigger"
   >
@@ -281,6 +303,6 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
         fill-rule="evenodd"
       />
     </svg>
-  </div>
+  </button>
 </div>
 `;

--- a/src/components/Forms/Inputs/mixins.ts
+++ b/src/components/Forms/Inputs/mixins.ts
@@ -1,8 +1,13 @@
 /* Internal dependencies */
 import { css } from 'Foundation'
+import { FormComponentProps } from 'Components/Forms/Form.types'
 
 export const inputTextStyle = css`
   color: ${({ foundation }) => foundation?.theme?.['txt-black-darkest']};
+
+  ${(props: FormComponentProps) => props?.readOnly && css`
+    color: ${({ foundation }) => foundation?.theme?.['txt-black-darker']};
+  `}
 `
 
 export const inputPlaceholderStyle = css`


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

fix #700, fix #708

- `Select` 컴포넌트 구현을 `button` 엘리먼트로 변경합니다 
- 인풋 컴포넌트(`TextField`, `TextArea`, `Select`) read-only 상태의 디자인 변경사항을 적용합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- `Trigger` 의 엘리먼트 타입을 `button` 으로 변경. 키보드 포커싱이 가능해져, 엔터키를 통해 드롭다운을 열고 닫을 수 있게 됩니다
- read-only 상태의 배경 색상과 텍스트 색상 변경
- 스타일링 방식을 최대한 Native Selector를 사용하도록 리팩토링
- 일관성을 가지도록 변수명 리팩토링

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit : Safari의 버그로 버튼 키보드 포커스가 되지 않습니다.
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

- [Figma](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=0%3A1)
