### PR TITLE
Select의 DefaultFocus의 시점 변경 및 width 변경

### DIFF
--- a/src/components/Forms/Inputs/Select/Select.styled.ts
+++ b/src/components/Forms/Inputs/Select/Select.styled.ts
@@ -59,6 +59,7 @@ export const Trigger = styled.button<TriggerProps>`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
   padding: 8px 12px;
   cursor: pointer;
   user-select: none;

--- a/src/components/Forms/Inputs/Select/Select.test.tsx
+++ b/src/components/Forms/Inputs/Select/Select.test.tsx
@@ -48,6 +48,7 @@ describe('Select Test >', () => {
 
       expect(defaultSelectTrigger).toHaveStyle('display: flex;')
       expect(defaultSelectTrigger).toHaveStyle('align-items: center;')
+      expect(defaultSelectTrigger).toHaveStyle('width: 100%;')
       expect(defaultSelectTrigger).toHaveStyle('justify-content: space-between;')
       expect(defaultSelectTrigger).toHaveStyle('padding: 8px 12px;')
       expect(defaultSelectTrigger).toHaveStyle('cursor: pointer;')
@@ -244,6 +245,33 @@ describe('Select Test >', () => {
       const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
 
       expect(trigger.children.item(1)).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']}`)
+    })
+  })
+
+  describe('defaultFocus >', () => {
+    it('should not show dropdown when the first time If the defaultFocus is false >', () => {
+      const { queryByTestId } = renderSelect({ defaultFocus: false })
+      const dropdown = queryByTestId(SELECT_DROPDOWN_TEST_ID)
+
+      expect(dropdown).toBeNull()
+    })
+
+    it('should show dropdown when the first time If the defaultFocus is true >', () => {
+      const { getByTestId } = renderSelect({ defaultFocus: true })
+      const dropdown = getByTestId(SELECT_DROPDOWN_TEST_ID)
+
+      expect(dropdown).toBeVisible()
+    })
+
+    it('should disappear dropdown when the other elements clicked >', () => {
+      const { body } = document
+
+      const { getByTestId } = renderSelect({ defaultFocus: true })
+      const dropdown = getByTestId(SELECT_DROPDOWN_TEST_ID)
+
+      userEvent.click(body)
+
+      expect(dropdown).not.toBeVisible()
     })
   })
 

--- a/src/components/Forms/Inputs/Select/Select.tsx
+++ b/src/components/Forms/Inputs/Select/Select.tsx
@@ -1,5 +1,14 @@
 /* External dependencies */
-import React, { useState, useCallback, useMemo, useRef, forwardRef, Ref, useImperativeHandle } from 'react'
+import React, {
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+  forwardRef,
+  Ref,
+  useImperativeHandle,
+  useEffect,
+} from 'react'
 import { isEmpty, noop } from 'lodash-es'
 
 /* Internal dependencies */
@@ -59,7 +68,7 @@ forwardedRef: Ref<SelectRef>,
   const containerRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLDivElement>(null)
 
-  const [isDropdownOpened, setIsDropdownOpened] = useState(defaultFocus)
+  const [isDropdownOpened, setIsDropdownOpened] = useState(false)
 
   const LeftComponent = useMemo(() => {
     if (isIconName(leftContent)) {
@@ -119,6 +128,16 @@ forwardedRef: Ref<SelectRef>,
     handleClickTrigger,
     handleHideDropdown,
     getDOMNode,
+  ])
+
+  useEffect(() => {
+    if (defaultFocus && !disabled && !readOnly) {
+      setIsDropdownOpened(true)
+    }
+  }, [
+    defaultFocus,
+    disabled,
+    readOnly,
   ])
 
   useImperativeHandle(forwardedRef, () => handle)

--- a/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -53,6 +53,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  width: 100%;
   padding: 8px 12px;
   cursor: pointer;
   -webkit-user-select: none;
@@ -205,6 +206,7 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  width: 100%;
   padding: 8px 12px;
   cursor: pointer;
   -webkit-user-select: none;


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
- Select의 DefaultFocus가 true일때에 DropDown이 간헐적으로 위치를 못잡던 문제를 해결합니다.
- Select의 Trigger가 Div에서 Button으로 수정됨에 따라, Select의 Trigger가 Container의 width만큼 확장되지 않는 문제를 해결합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
DefaultFocus가 true일때에, 스토리북 첫번째 랜딩 화면에서 DropDown이 제대로 위치를 잡지 못합니다.

<img width="938" alt="스크린샷 2022-02-23 오후 12 51 52" src="https://user-images.githubusercontent.com/60692645/155259011-74b053eb-8866-4082-a46f-1b2acbd1a42e.png">

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
