### PR TITLE
잘못 import된 avatar asset의 경로 변경

### DIFF
--- a/src/components/Avatars/Avatar/Avatar.tsx
+++ b/src/components/Avatars/Avatar/Avatar.tsx
@@ -4,8 +4,9 @@ import { noop, isEmpty } from 'lodash-es'
 
 /* Internal denpendencies */
 import { backgroundImageVariable } from 'Foundation'
-import defaultAvatarUrl from 'Components/Avatars/assets/defaultAvatar.svg'
 import { Status, StatusSize } from 'Components/Status'
+// eslint-disable-next-line no-restricted-imports
+import defaultAvatarUrl from '../assets/defaultAvatar.svg'
 import useProgressiveImage from './useProgressiveImage'
 import AvatarProps, { AvatarSize } from './Avatar.types'
 import { AvatarImage, AvatarImageWrapper, AvatarWrapper, StatusWrapper } from './Avatar.styled'


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
- 절대경로로 바뀐 avatar asset의 import 경로를 상대경로로 변경합니다.
# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
