### PR TITLE
Select 컴포넌트의 트리거 버튼 type을 button으로 수정

### DIFF
--- a/src/components/Forms/Inputs/Select/Select.test.tsx
+++ b/src/components/Forms/Inputs/Select/Select.test.tsx
@@ -29,6 +29,32 @@ describe('Select Test >', () => {
 
   const renderSelect = (optionProps?: Partial<SelectProps>) => render(<Select {...props} {...optionProps} />)
 
+  describe('Event >', () => {
+    const renderFormWithSelect = (onSubmit: React.FormEventHandler) => render(
+      <form onSubmit={onSubmit}>
+        <Select {...props} />
+      </form>,
+    )
+
+    it('should fire click event when clicking the trigger button', () => {
+      const onClick = jest.fn()
+      const { getByTestId } = renderSelect({ onClickTrigger: onClick })
+      const rendered = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      fireEvent.click(rendered)
+      expect(onClick).toHaveBeenCalled()
+    })
+
+    it('should not fire submit event when clicking the trigger button', () => {
+      const onSubmit = jest.fn()
+      const { getByTestId } = renderFormWithSelect(onSubmit)
+      const rendered = getByTestId(SELECT_TRIGGER_TEST_ID)
+
+      fireEvent.click(rendered)
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+  })
+
   describe('Default Style >', () => {
     it('Snapshot >', () => {
       const { container } = renderSelect({ text: 'foo' })

--- a/src/components/Forms/Inputs/Select/Select.tsx
+++ b/src/components/Forms/Inputs/Select/Select.tsx
@@ -152,6 +152,7 @@ forwardedRef: Ref<SelectRef>,
       {...ownProps}
     >
       <Styled.Trigger
+        type="button"
         data-testid={triggerTestId}
         as={as}
         ref={triggerRef}

--- a/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   <button
     class="c1"
     data-testid="bezier-react-select-trigger"
+    type="button"
   >
     <div
       class="c2"
@@ -268,6 +269,7 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
   <button
     class="c1"
     data-testid="bezier-react-select-trigger"
+    type="button"
   >
     <div
       class="c2"


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

Select 컴포넌트의 트리거 버튼 클릭 시, 예기치 않은 submit 이벤트가 발생하고 있었습니다.
누락된 `type="button"` 을 추가합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- [x] 관련 테스트 코드 업데이트

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

없음
