### PR TITLE
BezierProvider가 항상 :root에 theme variables를 주입하는 버그 수정

### DIFF
--- a/src/foundation/ThemeVars.ts
+++ b/src/foundation/ThemeVars.ts
@@ -7,8 +7,8 @@ import { createGlobalStyle } from './FoundationStyledComponent'
 
 type ThemeRecord = Record<string, string>
 
-interface ThemeVarsAdditionalType {
-  themeVarsScope?: AnyStyledComponent
+export interface ThemeVarsAdditionalType {
+  scope?: AnyStyledComponent
 }
 
 function generateCSSVar(theme?: ThemeRecord, prefix?: string) {
@@ -21,7 +21,7 @@ function generateCSSVar(theme?: ThemeRecord, prefix?: string) {
 }
 
 export const ThemeVars = createGlobalStyle<ThemeVarsAdditionalType>`
-  ${({ themeVarsScope }) => themeVarsScope ?? ':root'} {
+  ${({ scope }) => scope ?? ':root'} {
     ${({ foundation }) => generateCSSVar(foundation?.theme)}
     ${({ foundation }) => generateCSSVar(foundation?.subTheme, 'inverted')}
   }

--- a/src/foundation/ThemeVars.ts
+++ b/src/foundation/ThemeVars.ts
@@ -1,10 +1,15 @@
 /* External dependencies */
 import { isEmpty } from 'lodash-es'
+import { AnyStyledComponent } from 'styled-components'
 
 /* Internal dependencies */
 import { createGlobalStyle } from './FoundationStyledComponent'
 
 type ThemeRecord = Record<string, string>
+
+interface ThemeVarsAdditionalType {
+  themeVarsScope?: AnyStyledComponent
+}
 
 function generateCSSVar(theme?: ThemeRecord, prefix?: string) {
   if (!theme) { return undefined }
@@ -15,8 +20,8 @@ function generateCSSVar(theme?: ThemeRecord, prefix?: string) {
   }), {} as ThemeRecord)
 }
 
-export const ThemeVars = createGlobalStyle`
-  :root {
+export const ThemeVars = createGlobalStyle<ThemeVarsAdditionalType>`
+  ${({ themeVarsScope }) => themeVarsScope ?? ':root'} {
     ${({ foundation }) => generateCSSVar(foundation?.theme)}
     ${({ foundation }) => generateCSSVar(foundation?.subTheme, 'inverted')}
   }

--- a/src/providers/BezierProvider.stories.tsx
+++ b/src/providers/BezierProvider.stories.tsx
@@ -1,0 +1,52 @@
+/* External dependencies */
+import React from 'react'
+import base from 'paths.macro'
+import { Story, Meta } from '@storybook/react'
+
+/* Internal dependencies */
+import { styled, DarkFoundation, LightFoundation } from 'Foundation'
+import { getTitle } from 'Utils/storyUtils'
+import { ButtonSize, ButtonStyleVariant, ButtonColorVariant } from 'Components/Button/Button.types'
+import { Button } from 'Components/Button'
+import BezierProvider from './BezierProvider'
+
+interface BezierProviderStorybookProps {
+  foundation: 'dark' | 'light'
+}
+
+export default {
+  title: getTitle(base),
+  component: BezierProvider,
+  argTypes: {
+    foundation: {
+      control: {
+        type: 'select',
+        options: [
+          'light',
+          'dark',
+        ],
+      },
+    },
+  },
+} as Meta
+
+const ButtonWrapper = styled(Button)``
+
+const Template: Story<BezierProviderStorybookProps> = ({ foundation }) => (
+  <BezierProvider
+    foundation={foundation === 'dark' ? DarkFoundation : LightFoundation}
+    themeVarsScope={ButtonWrapper}
+  >
+    <ButtonWrapper
+      text="Try to switch foundation"
+      size={ButtonSize.M}
+      styleVariant={ButtonStyleVariant.Primary}
+      colorVariant={ButtonColorVariant.Blue}
+    />
+  </BezierProvider>
+)
+
+export const Primary: Story<BezierProviderStorybookProps> = Template.bind({})
+Primary.args = {
+  foundation: 'light',
+}

--- a/src/providers/BezierProvider.tsx
+++ b/src/providers/BezierProvider.tsx
@@ -1,5 +1,6 @@
 /* External dependencies */
 import React from 'react'
+import type { AnyStyledComponent } from 'styled-components'
 
 /* Internal dependencies */
 import { Foundation, FoundationProvider, GlobalStyle, GlobalStyleProp, ThemeVars } from 'Foundation'
@@ -8,18 +9,23 @@ import EnableCSSHoudini from 'Worklets/EnableCSSHoudini'
 interface BezierProviderProps {
   foundation: Foundation & GlobalStyleProp
   children: React.ReactNode
+  themeVarsScope?: AnyStyledComponent
 }
 
 function BezierProvider({
   foundation,
   children,
+  themeVarsScope,
 }: BezierProviderProps) {
   EnableCSSHoudini({ smoothCorners: true })
 
   return (
     <FoundationProvider foundation={foundation}>
       <GlobalStyle foundation={foundation} />
-      <ThemeVars foundation={foundation} />
+      <ThemeVars
+        foundation={foundation}
+        themeVarsScope={themeVarsScope}
+      />
       { children }
     </FoundationProvider>
   )

--- a/src/providers/BezierProvider.tsx
+++ b/src/providers/BezierProvider.tsx
@@ -1,15 +1,15 @@
 /* External dependencies */
 import React from 'react'
-import type { AnyStyledComponent } from 'styled-components'
 
 /* Internal dependencies */
 import { Foundation, FoundationProvider, GlobalStyle, GlobalStyleProp, ThemeVars } from 'Foundation'
+import type { ThemeVarsAdditionalType } from 'Foundation'
 import EnableCSSHoudini from 'Worklets/EnableCSSHoudini'
 
 interface BezierProviderProps {
   foundation: Foundation & GlobalStyleProp
   children: React.ReactNode
-  themeVarsScope?: AnyStyledComponent
+  themeVarsScope?: ThemeVarsAdditionalType['scope']
 }
 
 function BezierProvider({
@@ -24,7 +24,7 @@ function BezierProvider({
       <GlobalStyle foundation={foundation} />
       <ThemeVars
         foundation={foundation}
-        themeVarsScope={themeVarsScope}
+        scope={themeVarsScope}
       />
       { children }
     </FoundationProvider>


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
BezierProvider가 항상 `:root`에 SCSS theme variables를 주입하는 버그를 수정하고, foundation을 바꿀 수 있는 story를 storybook에 추가합니다.

# Related Issue
- #742

해결 방법에 대한 논의는 issue에 있습니다.
**해당 PR은 Method 1으로 진행되었으며, 다른 의견이 있으시면 코멘트 부탁드립니다.**

# Details
채널 데스크에서 미리보기 컴포넌트 구현을 새롭게 하면서, 데스크의 테마와 상관 없이 항상 LightTheme으로만 보여줘야하는 경우가 생겼습니다.
이를 구현하기 위해서 미리보기 컴포넌트에 `BezierProvider`를 감싸는 형태로 작업을 하였는데, `BezierProvider` 바깥의, Provider의 관심 밖인, SCSS theme variable을 사용하는 컴포넌트가 LightTheme color로 고정되는 버그가 발견되었습니다. 이는 `BezierProvider`가 사용 위치에 상관 없이 항상 `:root`에 주입을 하고 있기 때문입니다.

## Related PR
- channel-io/ch-desk-web#9454
- channel-io/ch-desk-web#9397

## To-be
이제 `BezierProvider`에 prop을 넘겨주면 `:root`가 아닌 해당 scope에 SCSS theme variables가 삽입됩니다.
![Screenshot 2022-03-23 at 22 46 16](https://user-images.githubusercontent.com/14245930/159714802-8369f312-8ca6-42d0-92e0-4a021dbfef73.png)

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References

- #742
- channel-io/ch-desk-web#9454
- channel-io/ch-desk-web#9397
