### PR TITLE
사파리에서 navItem, navGroup의 hover style이 적용되지 않는 버그 수정

### DIFF
--- a/src/components/Navigator/NavGroup/NavGroup.styled.ts
+++ b/src/components/Navigator/NavGroup/NavGroup.styled.ts
@@ -55,7 +55,15 @@ const activeItemStyle = css`
 const nonActiveItemStyle = css`
   color: ${({ foundation }) => foundation?.theme?.['txt-black-darkest']};
 
-  &:hover,
+  &:hover {
+    background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
+  }
+  
+  /*
+    ':focus-visible' Pseudo class는 Safari 15.4 이후 지원하기 때문에,
+    이를 ':hover' 와 ',' 연산자로 연결할 경우 hover, focus-visible 모두 작동하지 않는 이슈가 있음.
+    https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#browser_compatibility
+  */
   &:focus-visible {
     background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
   }

--- a/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -292,7 +292,10 @@ exports[`NavItem Test > Snapshot > not active 1`] = `
   color: #000000D9;
 }
 
-.c0:hover,
+.c0:hover {
+  background-color: #0000000D;
+}
+
 .c0:focus-visible {
   background-color: #0000000D;
 }

--- a/src/components/Navigator/NavItem/NavItem.styled.ts
+++ b/src/components/Navigator/NavItem/NavItem.styled.ts
@@ -33,8 +33,17 @@ const activeItemStyle = css`
 
 const nonActiveItemStyle = css`
   color: ${({ foundation }) => foundation?.theme?.['txt-black-darkest']};
-
-  &:hover,
+  
+  
+  &:hover {
+    background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
+  }
+  
+  /*
+    ':focus-visible' Pseudo class는 Safari 15.4 이후 지원하기 때문에,
+    이를 ':hover' 와 ',' 연산자로 연결할 경우 hover, focus-visible 모두 작동하지 않는 이슈가 있음.
+    https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#browser_compatibility
+  */
   &:focus-visible {
     background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
   }

--- a/src/components/Navigator/NavItem/__snapshots__/NavItem.test.tsx.snap
+++ b/src/components/Navigator/NavItem/__snapshots__/NavItem.test.tsx.snap
@@ -57,7 +57,10 @@ exports[`NavItem Test > Snapshot >  1`] = `
   color: #000000D9;
 }
 
-.c0:hover,
+.c0:hover {
+  background-color: #0000000D;
+}
+
 .c0:focus-visible {
   background-color: #0000000D;
 }


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
해당 PR은 사파리에서 navItem, navGroup의 hover style이 적용되지 않는 버그를 수정합니다.

# Details
1. 기존에 `:hover, :focus-visible {...}` 와 같이 `,`를 통해 키보드 포커스와 마우스 over에 대한 스타일을 정의하고 있었음
2. safari 15.4 이전 버전에서는 `:focus-visible`을 지원하지 않기 때문에, `,`를 통해 연결해준 hover 스타일 까지 작동이 안되고 있었음

## As-is
https://user-images.githubusercontent.com/14245930/161017342-cee2f2bd-71a8-44a0-a912-5d241abf5bcd.mov

## To-be
https://user-images.githubusercontent.com/14245930/161017372-07f05fd7-8135-4274-a3c0-55abc57d1b44.mov




## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [x] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
- [:focus-visible compatibility](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#browser_compatibility)
- [Notion QA](https://www.notion.so/channelio/21dda255845a49b5a969a92f49f25ebc)
