### PR TITLE
Text 의 bold 옵션 시 font-weight 수정 

### DIFF
--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -31,7 +31,7 @@ describe('Banner >', () => {
 
     expect(bannerLink.tagName).toBe('A')
     expect(bannerLink.children.item(0)).toHaveStyle('text-decoration: underline;')
-    expect(bannerLink.children.item(0)).toHaveStyle('font-weight: bold;')
+    expect(bannerLink.children.item(0)).toHaveStyle('font-weight: 600;')
     expect(bannerLink.children.item(0)).toHaveStyle('font-size: 1.4rem;')
   })
 

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Button Test > Active Test > Active prop change Button to hover style 1`
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -105,7 +105,7 @@ exports[`Button Test > Disabled Test > Button can have disabled attribute 1`] = 
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -215,7 +215,7 @@ exports[`Button Test > Loading Test > Active prop change Button to hover style 1
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -342,7 +342,7 @@ exports[`Button Test > Reset CSS 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -444,7 +444,7 @@ exports[`Button Test > Size Test > with text > Size L - styleVariant: Floating 1
   letter-spacing: -0.1px;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -553,7 +553,7 @@ exports[`Button Test > Size Test > with text > Size L 1`] = `
   letter-spacing: -0.1px;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -651,7 +651,7 @@ exports[`Button Test > Size Test > with text > Size M - styleVariant: Floating 1
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -756,7 +756,7 @@ exports[`Button Test > Size Test > with text > Size M 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -854,7 +854,7 @@ exports[`Button Test > Size Test > with text > Size S - styleVariant: Floating 1
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -959,7 +959,7 @@ exports[`Button Test > Size Test > with text > Size S 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1057,7 +1057,7 @@ exports[`Button Test > Size Test > with text > Size XL - styleVariant: Floating 
   line-height: 2.4rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1162,7 +1162,7 @@ exports[`Button Test > Size Test > with text > Size XL 1`] = `
   line-height: 2.4rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1260,7 +1260,7 @@ exports[`Button Test > Size Test > with text > Size XS - styleVariant: Floating 
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1365,7 +1365,7 @@ exports[`Button Test > Size Test > with text > Size XS 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1463,7 +1463,7 @@ exports[`Button Test > Size Test > with text > size prop not given, default size
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1921,7 +1921,7 @@ exports[`Button Test > StyleVariant Test > Floating 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -2026,7 +2026,7 @@ exports[`Button Test > StyleVariant Test > Primary 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -2124,7 +2124,7 @@ exports[`Button Test > StyleVariant Test > Secondary 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -2222,7 +2222,7 @@ exports[`Button Test > StyleVariant Test > Tertiary 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;

--- a/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -426,7 +426,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -443,7 +443,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -677,7 +677,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -866,7 +866,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;

--- a/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
+++ b/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FormLabel > Snapshot > 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;

--- a/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
+++ b/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   line-height: 1.6rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;

--- a/src/components/SectionLabel/SectionLabel.test.tsx
+++ b/src/components/SectionLabel/SectionLabel.test.tsx
@@ -28,7 +28,7 @@ describe('SectionLabel', () => {
     const content = getByTestId(SECTION_LABEL_TEST_CONTENT_ID)
 
     expect(content.children.length).toBe(1)
-    expect(content.children.item(0)).toHaveStyle('font-weight: bold;')
+    expect(content.children.item(0)).toHaveStyle('font-weight: 600;')
     expect(content.children.item(0)).toHaveStyle('font-size: 1.3rem;')
   })
 
@@ -37,7 +37,7 @@ describe('SectionLabel', () => {
     const content = getByTestId(SECTION_LABEL_TEST_CONTENT_ID)
 
     expect(content.children.length).toBe(1)
-    expect(content.children.item(0)).toHaveStyle('font-weight: bold;')
+    expect(content.children.item(0)).toHaveStyle('font-weight: 600;')
     expect(content.children.item(0)).toHaveStyle('font-size: 1.3rem;')
   })
 

--- a/src/components/Text/Text.styled.ts
+++ b/src/components/Text/Text.styled.ts
@@ -23,7 +23,7 @@ const Text = styled.span<TextProps & TextStyledProps>`
   ${props => props.typo};
   margin: ${getMargin};
   font-style: ${props => (props.italic ? 'italic' : 'normal')};
-  font-weight: ${props => (props.bold ? 'bold' : 'normal')};
+  font-weight: ${props => (props.bold ? 600 : 'normal')};
   color: ${({ foundation, color }) => (color && foundation?.theme?.[color]) || 'inherit'};
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS('color')}

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -34,7 +34,7 @@ describe('Text test >', () => {
 
     const renderedText = getByTestId(TEXT_TEST_ID)
 
-    expect(renderedText).toHaveStyle('font-weight: bold;')
+    expect(renderedText).toHaveStyle('font-weight: 600;')
   })
 
   it('Text receives bold style', () => {


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

<img width="910" alt="스크린샷 2022-04-01 오후 2 42 36" src="https://user-images.githubusercontent.com/24905674/161202204-f616d0fb-370b-4422-8482-5348d95d08b9.png">

<img width="284" alt="스크린샷 2022-04-01 오후 2 42 52" src="https://user-images.githubusercontent.com/24905674/161202231-828f8f1f-e4ec-4ee8-8ee3-9a78a8aad67c.png">

<img width="657" alt="스크린샷 2022-04-01 오후 2 20 09" src="https://user-images.githubusercontent.com/24905674/161199732-815669e6-2e9e-4546-9742-50cc4647efe9.png">

- 베지어 Text 의 스펙 상 bold: true 일 때 `font-weight: 600` 입니다. 기존의 bezier-react 에선 bold 옵션이 `font-weight: bold (700)` 이었기에 스펙에 맞게 이를 수정합니다.

- Text 컴포넌트는 베지어 안에서 여러 곳에서 사용되는 컴포넌트라 이에 따라 영향을 받는 컴포넌트들의 테스트 코드와 스냅샷을 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->


## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
