### PR TITLE
Navigator 컴포넌트 rightContent에 여백 추가

### DIFF
--- a/src/components/Navigator/NavGroup/NavGroup.styled.ts
+++ b/src/components/Navigator/NavGroup/NavGroup.styled.ts
@@ -24,14 +24,17 @@ export const ChevronWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  min-width: 20px;
+  max-width: 20px;
   margin-left: 2px;
 `
 
 export const RightContentWrapper = styled.div`
   display: flex;
+  flex: 1 0 auto;
   align-items: center;
-  justify-content: center;
-  margin-left: auto;
+  justify-content: flex-end;
+  margin-left: 8px;
 `
 
 const closedItemStyle = css`

--- a/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -75,15 +75,18 @@ exports[`NavItem Test > Snapshot > active 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  margin-left: auto;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  margin-left: 8px;
 }
 
 .c0 {
@@ -260,15 +263,18 @@ exports[`NavItem Test > Snapshot > not active 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  margin-left: auto;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  margin-left: 8px;
 }
 
 .c0 {

--- a/src/components/Navigator/NavItem/NavItem.styled.ts
+++ b/src/components/Navigator/NavItem/NavItem.styled.ts
@@ -21,9 +21,10 @@ export const ContentWrapper = styled(Text)`
 
 export const RightContentWrapper = styled.div`
   display: flex;
+  flex: 1 0 auto;
   align-items: center;
-  justify-content: center;
-  margin-left: auto;
+  justify-content: flex-end;
+  margin-left: 8px;
 `
 
 const activeItemStyle = css`


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
해당 PR은 Navigator 컴포넌트 rightContent에 여백을 추가하고, 찌그러지지 않게 flex 스타일을 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
- 4월 릴리즈 QA 중에 버그가 제보되었습니다.
- content가 꽉 찰 경우 여백이 없고 **오른쪽 내용에 text가 있을 경우** 찌그러지는 버그입니다.
<img width="227" alt="Screenshot 2022-04-08 at 18 05 13" src="https://user-images.githubusercontent.com/14245930/162411469-a9a444c7-2dd9-4c79-a321-b2bf34449995.png">


## Navgroup
| as-is | to-be |
|:---:|:---:|
<img width="311" alt="Screenshot 2022-04-08 at 18 43 07" src="https://user-images.githubusercontent.com/14245930/162411181-a496677b-d5c3-41c7-a32a-01b1c3d1571e.png">|<img width="308" alt="Screenshot 2022-04-08 at 18 42 33" src="https://user-images.githubusercontent.com/14245930/162411265-9969de1f-faec-46fe-9306-1aa9da2551e0.png">


## NavItem
| as-is | to-be |
|:---:|:---:|
<img width="352" alt="Screenshot 2022-04-08 at 18 43 02" src="https://user-images.githubusercontent.com/14245930/162411543-7edbce42-c245-45d7-98bf-86b64db7f315.png">|<img width="326" alt="Screenshot 2022-04-08 at 18 42 43" src="https://user-images.githubusercontent.com/14245930/162411571-da01ebcb-79e8-4535-a6ce-0a16b6a70d40.png">


## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [x] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
