### PR TITLE
styled-components로 생성되는 className에 namespace 추가, 잘못된 FoundationStyled의 구현 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "tslib": "^2.3.1",
         "ttypescript": "^1.5.13",
         "typescript": "^4.4.3",
+        "typescript-plugin-styled-components": "^2.0.0",
         "typescript-transform-paths": "^3.3.1"
       },
       "engines": {
@@ -23470,11 +23471,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -30446,6 +30442,15 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/typescript-plugin-styled-components": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-plugin-styled-components/-/typescript-plugin-styled-components-2.0.0.tgz",
+      "integrity": "sha512-Wu7F96dwuphgiACHfu63vTbRRg6tkPwLnpFJwdxM70Y0PLfeKLRnvs2Yo5MAySMwE120ODMKk9W4TtJgY1ZumA==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": "^4.0"
       }
     },
     "node_modules/typescript-transform-paths": {
@@ -55694,6 +55699,13 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
       "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
+    },
+    "typescript-plugin-styled-components": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-plugin-styled-components/-/typescript-plugin-styled-components-2.0.0.tgz",
+      "integrity": "sha512-Wu7F96dwuphgiACHfu63vTbRRg6tkPwLnpFJwdxM70Y0PLfeKLRnvs2Yo5MAySMwE120ODMKk9W4TtJgY1ZumA==",
+      "dev": true,
+      "requires": {}
     },
     "typescript-transform-paths": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "tslib": "^2.3.1",
     "ttypescript": "^1.5.13",
     "typescript": "^4.4.3",
+    "typescript-plugin-styled-components": "^2.0.0",
     "typescript-transform-paths": "^3.3.1"
   },
   "peerDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,10 +6,15 @@ import commonjs from '@rollup/plugin-commonjs'
 import babel from '@rollup/plugin-babel'
 import { visualizer } from 'rollup-plugin-visualizer'
 import typescript from 'rollup-plugin-typescript2'
+import createStyledComponentsTransformer from 'typescript-plugin-styled-components'
 
 import packageJson from './package.json'
 
 const extensions = DEFAULT_EXTENSIONS.concat(['.ts', '.tsx'])
+
+const styledComponentsTransformer = createStyledComponentsTransformer({
+  displayName: true,
+})
 
 // Order Matters, must after rollup-plugin-node-resolve
 // See Also: https://www.npmjs.com/package/rollup-plugin-typescript2
@@ -18,6 +23,11 @@ const typescriptPlugin = typescript({
   tsconfig: './tsconfig.json',
   useTsconfigDeclarationDir: true,
   declarationDir: './build/src',
+  transformers: [
+    () => ({
+      before: [styledComponentsTransformer],
+    }),
+  ],
   tsconfigDefaults: {
     noEmit: false,
     emitDeclarationOnly: true,

--- a/src/foundation/FoundationStyledComponent.tsx
+++ b/src/foundation/FoundationStyledComponent.tsx
@@ -76,38 +76,33 @@ interface FoundationStyledInterface extends FoundationStyledComponentFactories {
   ): ThemedStyledFunction<C, Foundation, { foundation?: Foundation }>
 }
 
+function templateFunctionGenerator(BaseComponentGenerator: ThemedStyledFunction<any, any, object, string | number | symbol>) {
+  const customTemplateFn = (...args: TemplateStringsArray) => {
+    // @ts-ignore
+    const BaseComponent = BaseComponentGenerator(...args)
+    const BaseRefComponent = forwardRef((props, ref) => {
+      const currentFoundation = useContext(FoundationContext)
+      return (
+        <BaseComponent
+          ref={ref}
+          key={args.toString()}
+          foundation={currentFoundation}
+          {...props}
+        />
+      )
+    })
+    BaseRefComponent.toString = BaseComponent.toString
+    return BaseRefComponent
+  }
+  customTemplateFn.attrs = (attrs) => templateFunctionGenerator(BaseComponentGenerator.attrs(attrs))
+  customTemplateFn.withConfig = (config) => templateFunctionGenerator(BaseComponentGenerator.withConfig(config))
+  return customTemplateFn
+}
+
 /* eslint-disable-next-line func-names */ /* @ts-ignore */
 const FoundationStyled: FoundationStyledInterface = (tag) => {
   const tagTemplate = styled(tag)
-
-  function templateFunctionGenerator(BaseComponentGenerator) {
-    return function customTemplateFunction(...args: TemplateStringsArray) {
-      const BaseComponent = BaseComponentGenerator(...args)
-
-      const BaseRefComponent = forwardRef((props, ref) => {
-        const currentFoundation = useContext(FoundationContext)
-        return (
-          <BaseComponent
-            ref={ref}
-            key={args.toString()}
-            foundation={currentFoundation}
-            {...props}
-          />
-        )
-      })
-      BaseRefComponent.toString = BaseComponent.toString
-
-      return BaseRefComponent
-    }
-  }
-
-  const wrappedTemplateFunction = templateFunctionGenerator(tagTemplate)
-  // @ts-ignore
-  wrappedTemplateFunction.attrs = attrs => templateFunctionGenerator(tagTemplate.attrs(attrs))
-  // @ts-ignore
-  wrappedTemplateFunction.withConfig = config => templateFunctionGenerator(tagTemplate.withConfig(config))
-
-  return wrappedTemplateFunction
+  return templateFunctionGenerator(tagTemplate)
 };
 
 (domElements as Array<AnyStyledComponent>).forEach(element => {


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

사용처에서 hash collision을 막기 위해, styled-components로 생성되는 className에 namespace를 추가합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- `typescript-plugin-styled-components` 플러그인을 추가하여 className에 displayName을 추가합니다.
- 잘못된 `FoundationStyled` 의 구현을 수정합니다. consumer project에서 `babel-plugin-styled-components` 플러그인을 사용했을 때, 번들링된 파일에서 에러가 발생합니다. `attrs()` 메서드를 사용한 스타일 컴포넌트의 경우, 번들링 시 `attrs({ /* ... */ }).withConfig({ /* babel 플러그인이 주입하는 옵션 */})`  의 형태로 트랜스파일링 되는데, 현재 구현에선 메서드 체이닝이 불가능하여 에러가 발생합니다. 메서드 체이닝이 가능하도록 수정합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

- [React Rollup build with styled-components namespace issue](https://stackoverflow.com/questions/68168926/react-rollup-build-with-styled-components-namespace-issue)