### PR TITLE
Tag, Badge 컴포넌트에 children props가 없을 경우 불필요한 여백이 생기는 오류 수정

### DIFF
--- a/src/components/TagBadge/Badge/Badge.test.tsx
+++ b/src/components/TagBadge/Badge/Badge.test.tsx
@@ -1,0 +1,66 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { RoundAbsoluteNumber } from 'Foundation'
+import { render } from 'Utils/testUtils'
+import {
+  TagBadgeSize,
+  getProperTagBadgePadding,
+} from 'Components/TagBadge/TagBadgeCommon'
+import { TAGBADGE_VERTICAL_PADDING } from 'Components/TagBadge/TagBadgeCommon/constants/TagBadgeStyle'
+import Badge, { BADGE_TEST_ID } from './Badge'
+import BadgeProps from './Badge.types'
+
+describe('Badge test >', () => {
+  let props: BadgeProps
+
+  beforeEach(() => {
+    props = {}
+  })
+
+  const renderBadge = (optionProps?: BadgeProps) => render(<Badge {...props} {...optionProps} />)
+
+  it('Snapshot >', () => {
+    const { getByTestId } = renderBadge()
+    const badge = getByTestId(BADGE_TEST_ID)
+
+    expect(badge).toMatchSnapshot()
+  })
+
+  describe('Size Test >', () => {
+    it('xs', () => {
+      const size = TagBadgeSize.XS
+      const { getByTestId } = renderBadge({ size })
+      const xsBadge = getByTestId(BADGE_TEST_ID)
+
+      expect(xsBadge).toHaveStyle(`padding: ${TAGBADGE_VERTICAL_PADDING}px ${getProperTagBadgePadding(size)}px`)
+      expect(xsBadge).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R4}px`)
+    })
+
+    it('s', () => {
+      const size = TagBadgeSize.S
+      const { getByTestId } = renderBadge({ size })
+      const xBadge = getByTestId(BADGE_TEST_ID)
+
+      expect(xBadge).toHaveStyle(`padding: ${TAGBADGE_VERTICAL_PADDING}px ${getProperTagBadgePadding(size)}px`)
+      expect(xBadge).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R6}px`)
+    })
+    it('m', () => {
+      const size = TagBadgeSize.M
+      const { getByTestId } = renderBadge({ size })
+      const mBadge = getByTestId(BADGE_TEST_ID)
+
+      expect(mBadge).toHaveStyle(`padding: ${TAGBADGE_VERTICAL_PADDING}px ${getProperTagBadgePadding(size)}px`)
+      expect(mBadge).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R6}px`)
+    })
+    it('l', () => {
+      const size = TagBadgeSize.L
+      const { getByTestId } = renderBadge({ size })
+      const lBadge = getByTestId(BADGE_TEST_ID)
+
+      expect(lBadge).toHaveStyle(`padding: ${TAGBADGE_VERTICAL_PADDING}px ${getProperTagBadgePadding(size)}px`)
+      expect(lBadge).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R6}px`)
+    })
+  })
+})

--- a/src/components/TagBadge/Badge/Badge.tsx
+++ b/src/components/TagBadge/Badge/Badge.tsx
@@ -1,5 +1,6 @@
 /* External dependencies */
 import React, { useMemo } from 'react'
+import { isEmpty } from 'lodash-es'
 
 /* Internal dependencies */
 import { Icon } from 'Components/Icon'
@@ -31,6 +32,8 @@ function Badge({
   testId = BADGE_TEST_ID,
   ...props
 }: BadgeProps) {
+  const hasChildren = useMemo(() => !isEmpty(children), [children])
+
   const bgSemanticName = useMemo(() => (getProperTagBadgeBgColor(variant)), [variant])
   const textSemanticName = useMemo(() => (getProperBadgeTextColor(variant)), [variant])
 
@@ -58,12 +61,14 @@ function Badge({
     >
       { IconComponent }
 
-      <TagBadgeText
-        horizontalPadding={BADGE_TEXT_HORIZONTAL_PADDING}
-        typo={getProperTagBadgeTypo(size)}
-      >
-        { children }
-      </TagBadgeText>
+      { hasChildren && (
+        <TagBadgeText
+          horizontalPadding={BADGE_TEXT_HORIZONTAL_PADDING}
+          typo={getProperTagBadgeTypo(size)}
+        >
+            { children }
+        </TagBadgeText>
+      ) }
     </TagBadgeStyled.Wrapper>
   )
 }

--- a/src/components/TagBadge/Badge/Badge.tsx
+++ b/src/components/TagBadge/Badge/Badge.tsx
@@ -20,7 +20,7 @@ import {
 import BadgeProps from './Badge.types'
 
 // TODO: 테스트 코드 작성
-const BADGE_TEST_ID = 'bezier-react-badge'
+export const BADGE_TEST_ID = 'bezier-react-badge'
 
 function Badge({
   size = TagBadgeSize.M,
@@ -32,7 +32,7 @@ function Badge({
   testId = BADGE_TEST_ID,
   ...props
 }: BadgeProps) {
-  const hasChildren = useMemo(() => !isEmpty(children), [children])
+  const hasChildren = !isEmpty(children)
 
   const bgSemanticName = useMemo(() => (getProperTagBadgeBgColor(variant)), [variant])
   const textSemanticName = useMemo(() => (getProperBadgeTextColor(variant)), [variant])

--- a/src/components/TagBadge/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/src/components/TagBadge/Badge/__snapshots__/Badge.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Badge test > Snapshot > 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 6px;
+}
+
+<div
+  class="c0"
+  color="txt-black-darkest"
+  data-testid="bezier-react-badge"
+  style="padding: 1px 4px; color: rgba(0, 0, 0, 0.851); background-color: rgba(0, 0, 0, 0.051);"
+/>
+`;

--- a/src/components/TagBadge/Tag/Tag.test.tsx
+++ b/src/components/TagBadge/Tag/Tag.test.tsx
@@ -1,0 +1,66 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { RoundAbsoluteNumber } from 'Foundation'
+import { render } from 'Utils/testUtils'
+import {
+  TagBadgeSize,
+  getProperTagBadgePadding,
+} from 'Components/TagBadge/TagBadgeCommon'
+import { TAGBADGE_VERTICAL_PADDING } from 'Components/TagBadge/TagBadgeCommon/constants/TagBadgeStyle'
+import Tag, { TAG_TEST_ID } from './Tag'
+import TagProps from './Tag.types'
+
+describe('Tag test >', () => {
+  let props: TagProps
+
+  beforeEach(() => {
+    props = {}
+  })
+
+  const renderTag = (optionProps?: TagProps) => render(<Tag {...props} {...optionProps} />)
+
+  it('Snapshot >', () => {
+    const { getByTestId } = renderTag()
+    const tag = getByTestId(TAG_TEST_ID)
+
+    expect(tag).toMatchSnapshot()
+  })
+
+  describe('Size Test >', () => {
+    it('xs', () => {
+      const size = TagBadgeSize.XS
+      const { getByTestId } = renderTag({ size })
+      const xsTag = getByTestId(TAG_TEST_ID)
+
+      expect(xsTag).toHaveStyle(`padding: ${TAGBADGE_VERTICAL_PADDING}px ${getProperTagBadgePadding(size)}px`)
+      expect(xsTag).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R4}px`)
+    })
+
+    it('s', () => {
+      const size = TagBadgeSize.S
+      const { getByTestId } = renderTag({ size })
+      const sTag = getByTestId(TAG_TEST_ID)
+
+      expect(sTag).toHaveStyle(`padding: ${TAGBADGE_VERTICAL_PADDING}px ${getProperTagBadgePadding(size)}px`)
+      expect(sTag).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R6}px`)
+    })
+    it('m', () => {
+      const size = TagBadgeSize.M
+      const { getByTestId } = renderTag({ size })
+      const mTag = getByTestId(TAG_TEST_ID)
+
+      expect(mTag).toHaveStyle(`padding: ${TAGBADGE_VERTICAL_PADDING}px ${getProperTagBadgePadding(size)}px`)
+      expect(mTag).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R6}px`)
+    })
+    it('l', () => {
+      const size = TagBadgeSize.L
+      const { getByTestId } = renderTag({ size })
+      const lTag = getByTestId(TAG_TEST_ID)
+
+      expect(lTag).toHaveStyle(`padding: ${TAGBADGE_VERTICAL_PADDING}px ${getProperTagBadgePadding(size)}px`)
+      expect(lTag).toHaveStyle(`border-radius: ${RoundAbsoluteNumber.R6}px`)
+    })
+  })
+})

--- a/src/components/TagBadge/Tag/Tag.tsx
+++ b/src/components/TagBadge/Tag/Tag.tsx
@@ -19,7 +19,7 @@ import Styled from './Tag.styled'
 import TagProps from './Tag.types'
 
 // TODO: 테스트 코드 작성
-const TAG_TEST_ID = 'bezier-react-tag'
+export const TAG_TEST_ID = 'bezier-react-tag'
 
 function Tag({
   size = TagBadgeSize.M,

--- a/src/components/TagBadge/Tag/Tag.tsx
+++ b/src/components/TagBadge/Tag/Tag.tsx
@@ -1,6 +1,6 @@
 /* External dependencies */
 import React, { useMemo } from 'react'
-import { isNil } from 'lodash-es'
+import { isNil, isEmpty } from 'lodash-es'
 
 /* Internal dependencies */
 import {
@@ -33,6 +33,8 @@ function Tag({
   testId = TAG_TEST_ID,
   ...props
 }: TagProps) {
+  const hasChildren = useMemo(() => !isEmpty(children), [children])
+
   const bgSemanticName = useMemo(() => (
     givenColor || getProperTagBadgeBgColor(variant)
   ), [
@@ -59,12 +61,14 @@ function Tag({
       rounding={getProperTagBadgeRounding(size)}
       bgColor={bgSemanticName}
     >
-      <TagBadgeText
-        horizontalPadding={TAG_TEXT_HORIZONTAL_PADDING}
-        typo={getProperTagBadgeTypo(size)}
-      >
-        { children }
-      </TagBadgeText>
+      { hasChildren && (
+        <TagBadgeText
+          horizontalPadding={TAG_TEXT_HORIZONTAL_PADDING}
+          typo={getProperTagBadgeTypo(size)}
+        >
+            { children }
+        </TagBadgeText>
+      ) }
 
       { CloseIconComponent }
     </TagBadgeStyled.Wrapper>

--- a/src/components/TagBadge/Tag/__snapshots__/Tag.test.tsx.snap
+++ b/src/components/TagBadge/Tag/__snapshots__/Tag.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tag test > Snapshot > 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 6px;
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-tag"
+  style="padding: 1px 4px; color: rgba(0, 0, 0, 0.851); background-color: rgba(0, 0, 0, 0.051);"
+/>
+`;

--- a/src/components/TagBadge/TagBadgeCommon/TagBadgeText/TagBadgeText.tsx
+++ b/src/components/TagBadge/TagBadgeCommon/TagBadgeText/TagBadgeText.tsx
@@ -1,5 +1,6 @@
 /* External dependencies */
-import React from 'react'
+import React, { useMemo } from 'react'
+import { isEmpty } from 'lodash-es'
 
 /* Internal dependencies */
 import { Text } from 'Components/Text'
@@ -15,15 +16,20 @@ function TagBadgeText({
   horizontalPadding,
   children,
 }: TagBadgeTextProps) {
+  const hasChildren = useMemo(() => !isEmpty(children), [children])
   return (
-    <Styled.Wrapper
-      data-testid={testId}
-      horizontalPadding={horizontalPadding}
-    >
-      <Text typo={typo}>
-        { children }
-      </Text>
-    </Styled.Wrapper>
+    <>
+      { hasChildren && (
+        <Styled.Wrapper
+          data-testid={testId}
+          horizontalPadding={horizontalPadding}
+        >
+          <Text typo={typo}>
+            { children }
+          </Text>
+        </Styled.Wrapper>
+      ) }
+    </>
   )
 }
 

--- a/src/components/TagBadge/TagBadgeCommon/TagBadgeText/TagBadgeText.tsx
+++ b/src/components/TagBadge/TagBadgeCommon/TagBadgeText/TagBadgeText.tsx
@@ -1,6 +1,5 @@
 /* External dependencies */
-import React, { useMemo } from 'react'
-import { isEmpty } from 'lodash-es'
+import React from 'react'
 
 /* Internal dependencies */
 import { Text } from 'Components/Text'
@@ -16,21 +15,15 @@ function TagBadgeText({
   horizontalPadding,
   children,
 }: TagBadgeTextProps) {
-  const hasChildren = useMemo(() => !isEmpty(children), [children])
-
   return (
-    <>
-      { hasChildren && (
-        <Styled.Wrapper
-          data-testid={testId}
-          horizontalPadding={horizontalPadding}
-        >
-          <Text typo={typo}>
-            { children }
-          </Text>
-        </Styled.Wrapper>
-      ) }
-    </>
+    <Styled.Wrapper
+      data-testid={testId}
+      horizontalPadding={horizontalPadding}
+    >
+      <Text typo={typo}>
+        { children }
+      </Text>
+    </Styled.Wrapper>
   )
 }
 

--- a/src/components/TagBadge/TagBadgeCommon/TagBadgeText/TagBadgeText.tsx
+++ b/src/components/TagBadge/TagBadgeCommon/TagBadgeText/TagBadgeText.tsx
@@ -17,6 +17,7 @@ function TagBadgeText({
   children,
 }: TagBadgeTextProps) {
   const hasChildren = useMemo(() => !isEmpty(children), [children])
+
   return (
     <>
       { hasChildren && (


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
`Tag`, `Badge` 컴포넌트에 `children` props가 없을 경우 불필요한 여백이 생기는 오류를 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
아래와 같이 `children`이 없는 경우에도 padding을 가진 `TagBadgeText` 컴포넌트가 랜더링 되고 있어 좌우에 여백이 생기고 있었습니다.
실제로 `children`이 없는 경우엔 `TagBadgeText` 컴포넌트는 렌더링 될 필요가 없으므로 렌더링을 차단하는 방향으로 개선합니다.


**DOM**
<img width="237" alt="스크린샷 2022-04-15 오후 11 30 13" src="https://user-images.githubusercontent.com/49897409/163587110-e034a583-0a76-48de-9969-88d43ba5ade5.png">


**code**
```jsx
<TagBadgeText
  horizontalPadding={BADGE_TEXT_HORIZONTAL_PADDING}
  typo={getProperTagBadgeTypo(size)}
>
  { children }
</TagBadgeText>
```

fix 후 아래와 같이 개선해 볼 수 있을 것 같습니다
**(bug-fix와 같이 있던 @quino0627 feedback)**
- https://github.com/channel-io/bezier-react/issues/755

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- https://github.com/channel-io/bezier-react/issues/745
