### PR TITLE
test(modal): fix modal style test removed padding

### DIFF
--- a/src/components/Modals/Modal/Modal.test.tsx
+++ b/src/components/Modals/Modal/Modal.test.tsx
@@ -236,7 +236,6 @@ describe('Modal', () => {
             it('Styles', async () => {
               const target = await renderResult.findByTestId('Modal__Contents__Title__CloseButton')
               expect(target).toHaveStyle('display: inline-block;')
-              expect(target).toHaveStyle('padding: 8px 8px;')
               expect(target).toHaveStyle('background-color: transparent;')
               expect(target).toHaveStyle('margin-top: -6px;')
               expect(target).toHaveStyle('margin-right: -6px;')


### PR DESCRIPTION
# Summary
https://github.com/channel-io/bezier-react/pull/734 머지 이후에 ci에서 test 에러가 발생하여 추가 작업을 진행합니다.

**PR에서 테스트 실패가 식별되지 않는 이슈가 있습니다.**

# Details
padding style test가 불필요하여 제거하였습니다.

## Browser Compatibility

테스트 코드만 제거한 것이라 추가하지 않았습니다.

### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# References

https://github.com/channel-io/bezier-react/pull/734
