### PR TITLE
SegmentedControl 디자인 리뉴얼

### DIFF
--- a/src/components/Forms/SegmentedControl/SegmentedControl.const.ts
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.const.ts
@@ -1,0 +1,25 @@
+/* Internal dependencies */
+import { SegmentedControlSize } from './SegmentedControl.types'
+
+export const SIZE_TO_HEIGHT: Record<SegmentedControlSize, number> = {
+  [SegmentedControlSize.XS]: 22,
+  [SegmentedControlSize.S]: 24,
+  [SegmentedControlSize.M]: 32,
+  [SegmentedControlSize.L]: 36,
+}
+
+export const SIZE_TO_PADDING: Record<SegmentedControlSize, number> = {
+  [SegmentedControlSize.XS]: 1,
+  [SegmentedControlSize.S]: 2,
+  [SegmentedControlSize.M]: 2,
+  [SegmentedControlSize.L]: 4,
+}
+
+export const DIVIDER_WIDTH = 1
+
+export const SIZE_TO_DIVIDER_VERTICAL_MARGIN: Record<SegmentedControlSize, number> = {
+  [SegmentedControlSize.XS]: 7,
+  [SegmentedControlSize.S]: 8,
+  [SegmentedControlSize.M]: 8,
+  [SegmentedControlSize.L]: 10,
+}

--- a/src/components/Forms/SegmentedControl/SegmentedControl.const.ts
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.const.ts
@@ -19,10 +19,10 @@ export const SIZE_TO_PADDING: Record<SegmentedControlSize, number> = {
 export const DIVIDER_WIDTH = 1
 
 export const SIZE_TO_DIVIDER_VERTICAL_MARGIN: Record<SegmentedControlSize, number> = {
-  [SegmentedControlSize.XS]: 7,
-  [SegmentedControlSize.S]: 8,
-  [SegmentedControlSize.M]: 8,
-  [SegmentedControlSize.L]: 10,
+  [SegmentedControlSize.XS]: 1,
+  [SegmentedControlSize.S]: 2,
+  [SegmentedControlSize.M]: 2,
+  [SegmentedControlSize.L]: 4,
 }
 
 export const SIZE_TO_OPTION_TYPOGRAPHY: Record<SegmentedControlSize, ReturnType<typeof css>> = {

--- a/src/components/Forms/SegmentedControl/SegmentedControl.const.ts
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.const.ts
@@ -17,6 +17,7 @@ export const SIZE_TO_PADDING: Record<SegmentedControlSize, number> = {
 }
 
 export const DIVIDER_WIDTH = 1
+export const DIVIDER_SIDE_MARGIN = 6
 
 export const SIZE_TO_DIVIDER_VERTICAL_MARGIN: Record<SegmentedControlSize, number> = {
   [SegmentedControlSize.XS]: 1,

--- a/src/components/Forms/SegmentedControl/SegmentedControl.const.ts
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.const.ts
@@ -1,4 +1,5 @@
 /* Internal dependencies */
+import { css, Typography } from 'Foundation'
 import { SegmentedControlSize } from './SegmentedControl.types'
 
 export const SIZE_TO_HEIGHT: Record<SegmentedControlSize, number> = {
@@ -22,4 +23,11 @@ export const SIZE_TO_DIVIDER_VERTICAL_MARGIN: Record<SegmentedControlSize, numbe
   [SegmentedControlSize.S]: 8,
   [SegmentedControlSize.M]: 8,
   [SegmentedControlSize.L]: 10,
+}
+
+export const SIZE_TO_OPTION_TYPOGRAPHY: Record<SegmentedControlSize, ReturnType<typeof css>> = {
+  [SegmentedControlSize.XS]: Typography.Size13,
+  [SegmentedControlSize.S]: Typography.Size14,
+  [SegmentedControlSize.M]: Typography.Size14,
+  [SegmentedControlSize.L]: Typography.Size14,
 }

--- a/src/components/Forms/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.stories.tsx
@@ -118,9 +118,7 @@ const PrimaryStory: Story<SegmentedControlProps> = ({ size, width, selectedOptio
     selectedOptionIndex={selectedOptionIndex}
     {...otherProps}
   >
-    { ['Open', 'Snoozed', 'Closed'].map((item) => (
-      <Text key={item} bold>{ item }</Text>
-    )) }
+    { ['Open', 'Snoozed', 'Closed'] }
   </SegmentedControl>
 )
 
@@ -173,9 +171,7 @@ const PlaygroundStory: Story<SegmentedControlProps> = ({ size, width, ...otherPr
         onChangeOption={handleChangeOption}
         {...otherProps}
       >
-        { items.map((n) => (
-          <Text key={`span-${n}`} bold>{ n }</Text>
-        )) }
+        { items }
       </SegmentedControl>
 
       <ItemList>

--- a/src/components/Forms/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.stories.tsx
@@ -10,7 +10,7 @@ import { getTitle } from 'Utils/storyUtils'
 import { Text } from 'Components/Text'
 import { Icon } from 'Components/Icon'
 import SegmentedControl from './SegmentedControl'
-import SegmentedControlProps from './SegmentedControl.types'
+import SegmentedControlProps, { SegmentedControlSize } from './SegmentedControl.types'
 
 export default {
   title: getTitle(base),
@@ -21,9 +21,10 @@ export default {
         type: 'text',
       },
     },
-    height: {
+    size: {
       control: {
-        type: 'text',
+        type: 'radio',
+        options: [...Object.values(SegmentedControlSize)],
       },
     },
   },
@@ -110,10 +111,10 @@ const Input = styled.input`
   }
 `
 
-const PrimaryStory: Story<SegmentedControlProps> = ({ width, height, selectedOptionIndex, ...otherProps }) => (
+const PrimaryStory: Story<SegmentedControlProps> = ({ size, width, selectedOptionIndex, ...otherProps }) => (
   <SegmentedControl
+    size={size}
     width={width}
-    height={height}
     selectedOptionIndex={selectedOptionIndex}
     {...otherProps}
   >
@@ -123,7 +124,7 @@ const PrimaryStory: Story<SegmentedControlProps> = ({ width, height, selectedOpt
   </SegmentedControl>
 )
 
-const PlaygroundStory: Story<SegmentedControlProps> = ({ width, height, ...otherProps }) => {
+const PlaygroundStory: Story<SegmentedControlProps> = ({ size, width, ...otherProps }) => {
   const inputWrapper = useRef<HTMLInputElement>(null)
 
   const [items, setItems] = useState<any>(range(0, 5) as any[])
@@ -166,8 +167,8 @@ const PlaygroundStory: Story<SegmentedControlProps> = ({ width, height, ...other
   return (
     <Wrapper>
       <SegmentedControl
+        size={size}
         width={width}
-        height={height}
         selectedOptionIndex={currentIndex}
         onChangeOption={handleChangeOption}
         {...otherProps}
@@ -214,13 +215,13 @@ export const Playground = PlaygroundStory.bind({})
 
 Primary.args = {
   disabled: false,
+  size: SegmentedControlSize.M,
   width: '400px',
-  height: '36px',
   selectedOptionIndex: 0,
 }
 
 Playground.args = {
   disabled: false,
+  size: SegmentedControlSize.M,
   width: '400px',
-  height: '36px',
 }

--- a/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -139,11 +139,10 @@ export const IndicatorBox = styled.div`
   background-color: ${({ foundation }) => foundation?.theme?.['bg-white-high']};
 `
 
-export const Divider = styled.div<StyledDividerProps>`
+export const DividerContainer = styled.div<StyledDividerProps>`
   position: absolute;
   top: ${({ size }) => SIZE_TO_DIVIDER_VERTICAL_MARGIN[size]}px;
   bottom: ${({ size }) => SIZE_TO_DIVIDER_VERTICAL_MARGIN[size]}px;
-  background-color: ${({ foundation }) => foundation?.theme['bg-black-light']};
 
   ${({ hidden }) => hidden && `
     visibility: hidden;

--- a/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -38,12 +38,30 @@ const verticalPaddingStyle = css<{ size: SegmentedControlSize }>`
   padding: ${({ size }) => SIZE_TO_PADDING[size]}px 0;
 `
 
-const roundingStyle = css<{ size: SegmentedControlSize }>`
+const wrapperRoundingStyle = css<{ size: SegmentedControlSize }>`
   ${({ foundation, size }) => ({
     [SegmentedControlSize.XS]: foundation?.rounding.round6,
     [SegmentedControlSize.S]: foundation?.rounding.round8,
     [SegmentedControlSize.M]: foundation?.rounding.round8,
     [SegmentedControlSize.L]: foundation?.rounding.round12,
+  })[size]}
+`
+
+const itemRoundingStyle = css<{ size: SegmentedControlSize }>`
+  ${({ foundation, size }) => ({
+    [SegmentedControlSize.XS]: foundation?.rounding.round4,
+    [SegmentedControlSize.S]: foundation?.rounding.round6,
+    [SegmentedControlSize.M]: foundation?.rounding.round6,
+    [SegmentedControlSize.L]: foundation?.rounding.round6,
+  })[size]}
+`
+
+const indicatorRoundingStyle = css<{ size: SegmentedControlSize }>`
+  ${({ foundation, size }) => ({
+    [SegmentedControlSize.XS]: foundation?.rounding.round4,
+    [SegmentedControlSize.S]: foundation?.rounding.round6,
+    [SegmentedControlSize.M]: foundation?.rounding.round6,
+    [SegmentedControlSize.L]: foundation?.rounding.round8,
   })[size]}
 `
 
@@ -62,7 +80,7 @@ export const Wrapper = styled.div<StyledWrapperProps>`
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS('background-color')};
 
   ${heightStyle}
-  ${roundingStyle}
+  ${wrapperRoundingStyle}
   ${verticalPaddingStyle}
 `
 
@@ -94,7 +112,7 @@ export const OptionItemWrapper = styled.div<StyledOptionItemWrapperProps>`
   }
 
   ${heightStyle}
-  ${roundingStyle}
+  ${itemRoundingStyle}
 `
 
 export const Indicator = styled.div<StyledIndicatorProps>`
@@ -111,7 +129,7 @@ export const Indicator = styled.div<StyledIndicatorProps>`
   will-change: transform;
 
   ${heightStyle}
-  ${roundingStyle}
+  ${indicatorRoundingStyle}
 `
 
 export const IndicatorBox = styled.div`

--- a/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -1,17 +1,51 @@
 /* Internal dependencies */
-import { styled, Transition } from 'Foundation'
+import { css, styled, Transition } from 'Foundation'
 import disabledOpacity from 'Constants/DisabledOpacity'
 import { toLength } from 'Utils/styleUtils'
 import type { BezierComponentProps } from 'Types/ComponentProps'
+import {
+  SIZE_TO_DIVIDER_VERTICAL_MARGIN,
+  SIZE_TO_HEIGHT,
+  SIZE_TO_PADDING,
+} from './SegmentedControl.const'
+import { SegmentedControlSize } from './SegmentedControl.types'
 import type { SegmentedControlItemProps } from './SegmentedControl.types'
 
 interface StyledWrapperProps extends BezierComponentProps {
   disabled?: boolean
+  size: SegmentedControlSize
   wrapperWidth: number | string
-  wrapperHeight: number | string
 }
 
-interface StyledOptionItemWrapperProps extends SegmentedControlItemProps {}
+interface StyledOptionItemWrapperProps extends SegmentedControlItemProps {
+  size: SegmentedControlSize
+}
+
+interface StyledIndicatorProps {
+  size: SegmentedControlSize
+}
+
+interface StyledDividerProps {
+  size: SegmentedControlSize
+  hidden: boolean
+}
+
+const heightStyle = css<{ size: SegmentedControlSize }>`
+  height: ${({ size }) => SIZE_TO_HEIGHT[size]}px;
+`
+
+const verticalPaddingStyle = css<{ size: SegmentedControlSize }>`
+  padding: ${({ size }) => SIZE_TO_PADDING[size]}px 0;
+`
+
+const roundingStyle = css<{ size: SegmentedControlSize }>`
+  ${({ foundation, size }) => ({
+    [SegmentedControlSize.XS]: foundation?.rounding.round6,
+    [SegmentedControlSize.S]: foundation?.rounding.round8,
+    [SegmentedControlSize.M]: foundation?.rounding.round8,
+    [SegmentedControlSize.L]: foundation?.rounding.round12,
+  })[size]}
+`
 
 export const Wrapper = styled.div<StyledWrapperProps>`
   position: relative;
@@ -20,17 +54,19 @@ export const Wrapper = styled.div<StyledWrapperProps>`
   align-items: center;
   width: ${({ wrapperWidth }) => toLength(wrapperWidth, '100%')};
   min-width: 50px;
-  height: ${({ wrapperHeight }) => toLength(wrapperHeight, 'auto')};
   overflow: hidden;
-  font-size: 14px;
+  /* font-size: 14px;
   font-weight: bold;
-  line-height: 18px;
+  line-height: 18px; */
   background-color: ${props => props.foundation?.theme?.['bg-black-lighter']};
-  border-radius: 8px;
   ${({ disabled }) => disabled && `
     opacity: ${disabledOpacity};
   `}
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS('background-color')};
+
+  ${heightStyle}
+  ${roundingStyle}
+  ${verticalPaddingStyle}
 `
 
 export const OptionItemWrapper = styled.div<StyledOptionItemWrapperProps>`
@@ -40,11 +76,11 @@ export const OptionItemWrapper = styled.div<StyledOptionItemWrapperProps>`
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  padding: 0 4px;
+  /* padding: 0 4px; */
   overflow: hidden;
-  font-size: inherit;
+  /* font-size: inherit;
   font-weight: inherit;
-  line-height: inherit;
+  line-height: inherit; */
   color: ${props => (
     props.active
       ? props.foundation?.theme?.['txt-black-darkest']
@@ -63,21 +99,26 @@ export const OptionItemWrapper = styled.div<StyledOptionItemWrapperProps>`
       background-color: ${props.foundation?.theme?.['bg-black-lighter']};
     ` : '')}
   }
+
+  ${heightStyle}
+  ${roundingStyle}
 `
 
-export const Indicator = styled.div`
+export const Indicator = styled.div<StyledIndicatorProps>`
   position: absolute;
   box-sizing: border-box;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  padding: 2px;
   cursor: default;
   ${({ foundation }) => (
     foundation?.transition?.getTransitionsCSS('transform', Transition.TransitionDuration.M)
   )};
   will-change: transform;
+
+  ${heightStyle}
+  ${roundingStyle}
 `
 
 export const IndicatorBox = styled.div`
@@ -85,5 +126,15 @@ export const IndicatorBox = styled.div`
   width: 100%;
   height: 100%;
   background-color: ${({ foundation }) => foundation?.theme?.['bg-white-high']};
-  border-radius: 6px;
+`
+
+export const Divider = styled.div<StyledDividerProps>`
+  position: absolute;
+  top: ${({ size }) => SIZE_TO_DIVIDER_VERTICAL_MARGIN[size]}px;
+  bottom: ${({ size }) => SIZE_TO_DIVIDER_VERTICAL_MARGIN[size]}px;
+  background-color: ${({ foundation }) => foundation?.theme['bg-black-light']};
+
+  ${({ hidden }) => hidden && `
+    visibility: hidden;
+  `}
 `

--- a/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -55,9 +55,6 @@ export const Wrapper = styled.div<StyledWrapperProps>`
   width: ${({ wrapperWidth }) => toLength(wrapperWidth, '100%')};
   min-width: 50px;
   overflow: hidden;
-  /* font-size: 14px;
-  font-weight: bold;
-  line-height: 18px; */
   background-color: ${props => props.foundation?.theme?.['bg-black-lighter']};
   ${({ disabled }) => disabled && `
     opacity: ${disabledOpacity};
@@ -76,11 +73,7 @@ export const OptionItemWrapper = styled.div<StyledOptionItemWrapperProps>`
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  /* padding: 0 4px; */
   overflow: hidden;
-  /* font-size: inherit;
-  font-weight: inherit;
-  line-height: inherit; */
   color: ${props => (
     props.active
       ? props.foundation?.theme?.['txt-black-darkest']

--- a/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -1,13 +1,17 @@
 /* External dependencies */
 import React, { Ref, forwardRef, useState, useEffect, useMemo, useCallback } from 'react'
 import { v4 as uuid } from 'uuid'
-import { noop, isNumber } from 'lodash-es'
+import { noop, isNumber, range } from 'lodash-es'
 import { useResizeDetector } from 'react-resize-detector'
 
 /* Internal dependencies */
 import useMergeRefs from 'Hooks/useMergeRefs'
 import useFormFieldProps from 'Components/Forms/useFormFieldProps'
-import SegmentedControlProps from './SegmentedControl.types'
+import {
+  DIVIDER_WIDTH,
+  SIZE_TO_PADDING,
+} from './SegmentedControl.const'
+import SegmentedControlProps, { SegmentedControlSize } from './SegmentedControl.types'
 import * as Styled from './SegmentedControl.styled'
 
 export const SEGMENTED_CONTROL_TEST_ID = 'bezier-react-segmented-control'
@@ -15,11 +19,28 @@ const SEGMENTED_CONTROL_OPTION_ITEM_TEST_ID_PREFIX = 'bezier-react-segmented-con
 export const segmentedControlOptionItemTestId = (index: number) =>
   [SEGMENTED_CONTROL_OPTION_ITEM_TEST_ID_PREFIX, index.toString()].join('-')
 
+const itemWidth = (width: number, numItems: number, size: SegmentedControlSize): number =>
+  (width - (2 * SIZE_TO_PADDING[size]) - ((numItems - 1) * DIVIDER_WIDTH)) / Math.max(1, numItems)
+
+const itemLeft = (width: number, numItems: number, size: SegmentedControlSize) =>
+  (index: number): number => (
+    SIZE_TO_PADDING[size]
+      + (itemWidth(width, numItems, size) * index)
+      + (DIVIDER_WIDTH * index)
+  )
+
+const dividerLeft = (width: number, numItems: number, size: SegmentedControlSize) =>
+  (index: number): number => (
+    SIZE_TO_PADDING[size]
+      + (itemWidth(width, numItems, size) * index)
+      + (DIVIDER_WIDTH * (index - 1))
+  )
+
 function SegmentedControl(
   {
     testId = SEGMENTED_CONTROL_TEST_ID,
     width = '100%',
-    height = 36,
+    size = SegmentedControlSize.M,
     /* OptionItemHost props */
     selectedOptionIndex = 0,
     onChangeOption = noop,
@@ -35,15 +56,28 @@ function SegmentedControl(
   } = useFormFieldProps(rest)
 
   const [currentIndex, setCurrentIndex] = useState<number>(selectedOptionIndex)
-  const [wrapperHeight, setWrapperHeight] = useState<number>(0)
   const [wrapperWidth, setWrapperWidth] = useState<number>(0)
 
   const numItems = useMemo(() => React.Children.count(children), [children])
-  const optionItemWidth = wrapperWidth / Math.max(1, numItems)
 
-  const updateDimensions = useCallback((_width?: number, _height?: number) => {
+  const optionItemWidth = itemWidth(wrapperWidth, numItems, size)
+  const optionItemLeft = useMemo(() => (
+    itemLeft(wrapperWidth, numItems, size)
+  ), [
+    wrapperWidth,
+    numItems,
+    size,
+  ])
+  const dividerItemLeft = useMemo(() => (
+    dividerLeft(wrapperWidth, numItems, size)
+  ), [
+    wrapperWidth,
+    numItems,
+    size,
+  ])
+
+  const updateDimensions = useCallback((_width?: number) => {
     if (isNumber(_width)) { setWrapperWidth(_width) }
-    if (isNumber(_height)) { setWrapperHeight(_height) }
   }, [])
 
   const { ref: resizeDetectorRef } = useResizeDetector({ onResize: updateDimensions })
@@ -67,10 +101,10 @@ function SegmentedControl(
       data-testid={segmentedControlOptionItemTestId(index)}
       disabled={disabled}
       active={index === currentIndex}
+      size={size}
       style={{
         width: optionItemWidth,
-        height: wrapperHeight,
-        left: optionItemWidth * index,
+        left: optionItemLeft(index),
       }}
       onClick={() => (disabled ? noop : handleClickOptionItem(index))}
     >
@@ -78,9 +112,10 @@ function SegmentedControl(
     </Styled.OptionItemWrapper>
   ), [
     disabled,
+    size,
     currentIndex,
-    wrapperHeight,
     optionItemWidth,
+    optionItemLeft,
     handleClickOptionItem,
   ])
 
@@ -91,20 +126,41 @@ function SegmentedControl(
     renderOption,
   ])
 
+  const Dividers = useMemo(() => (
+    range(1, numItems)
+      .map(index => (
+        <Styled.Divider
+          key={`divider-${index.toString(36)}`}
+          size={size}
+          hidden={index === currentIndex || index === currentIndex + 1}
+          style={{
+            width: DIVIDER_WIDTH,
+            left: dividerItemLeft(index),
+          }}
+        />
+      ))
+  ), [
+    size,
+    numItems,
+    currentIndex,
+    dividerItemLeft,
+  ])
+
   const IndicatorComponent = useMemo(() => (
     <Styled.Indicator
+      size={size}
       style={{
         width: optionItemWidth,
-        height: wrapperHeight,
-        transform: `translateX(${optionItemWidth * currentIndex}px)`,
+        transform: `translateX(${optionItemLeft(currentIndex)}px)`,
       }}
     >
       <Styled.IndicatorBox />
     </Styled.Indicator>
   ), [
+    size,
     currentIndex,
-    wrapperHeight,
     optionItemWidth,
+    optionItemLeft,
   ])
 
   return (
@@ -112,12 +168,13 @@ function SegmentedControl(
       {...ownProps}
       ref={wrapperRef}
       disabled={disabled}
+      size={size}
       wrapperWidth={width}
-      wrapperHeight={height}
       data-testid={testId}
     >
       { IndicatorComponent }
       { Content }
+      { Dividers }
     </Styled.Wrapper>
   )
 }

--- a/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -6,6 +6,7 @@ import { useResizeDetector } from 'react-resize-detector'
 
 /* Internal dependencies */
 import useMergeRefs from 'Hooks/useMergeRefs'
+import { Divider } from 'Components/Divider'
 import useFormFieldProps from 'Components/Forms/useFormFieldProps'
 import { Text } from 'Components/Text'
 import {
@@ -36,6 +37,7 @@ const dividerLeft = (width: number, numItems: number, size: SegmentedControlSize
     SIZE_TO_PADDING[size]
       + (itemWidth(width, numItems, size) * index)
       + (DIVIDER_WIDTH * (index - 1))
+      - 6 // Side margin of divider component.
   )
 
 function SegmentedControl(
@@ -136,15 +138,16 @@ function SegmentedControl(
   const Dividers = useMemo(() => (
     range(1, numItems)
       .map(index => (
-        <Styled.Divider
+        <Styled.DividerContainer
           key={`divider-${index.toString(36)}`}
           size={size}
           hidden={index === currentIndex || index === currentIndex + 1}
           style={{
-            width: DIVIDER_WIDTH,
             left: dividerItemLeft(index),
           }}
-        />
+        >
+          <Divider orientation="vertical" />
+        </Styled.DividerContainer>
       ))
   ), [
     size,

--- a/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -7,8 +7,10 @@ import { useResizeDetector } from 'react-resize-detector'
 /* Internal dependencies */
 import useMergeRefs from 'Hooks/useMergeRefs'
 import useFormFieldProps from 'Components/Forms/useFormFieldProps'
+import { Text } from 'Components/Text'
 import {
   DIVIDER_WIDTH,
+  SIZE_TO_OPTION_TYPOGRAPHY,
   SIZE_TO_PADDING,
 } from './SegmentedControl.const'
 import SegmentedControlProps, { SegmentedControlSize } from './SegmentedControl.types'
@@ -108,7 +110,12 @@ function SegmentedControl(
       }}
       onClick={() => (disabled ? noop : handleClickOptionItem(index))}
     >
-      { Element }
+      <Text
+        typo={SIZE_TO_OPTION_TYPOGRAPHY[size]}
+        bold
+      >
+        { Element }
+      </Text>
     </Styled.OptionItemWrapper>
   ), [
     disabled,

--- a/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -11,6 +11,7 @@ import useFormFieldProps from 'Components/Forms/useFormFieldProps'
 import { Text } from 'Components/Text'
 import {
   DIVIDER_WIDTH,
+  DIVIDER_SIDE_MARGIN,
   SIZE_TO_OPTION_TYPOGRAPHY,
   SIZE_TO_PADDING,
 } from './SegmentedControl.const'
@@ -37,7 +38,7 @@ const dividerLeft = (width: number, numItems: number, size: SegmentedControlSize
     SIZE_TO_PADDING[size]
       + (itemWidth(width, numItems, size) * index)
       + (DIVIDER_WIDTH * (index - 1))
-      - 6 // Side margin of divider component.
+      - DIVIDER_SIDE_MARGIN
   )
 
 function SegmentedControl(

--- a/src/components/Forms/SegmentedControl/SegmentedControl.types.ts
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.types.ts
@@ -21,7 +21,13 @@ export enum SegmentedControlSize {
 
 interface SegmentedControlOptions {
   width?: CSSSizingProperty
-  height?: CSSSizingProperty
+
+  /**
+   * Size variant of this SegmentedControl.
+   *
+   * @default SegmentedControlSize.M
+   */
+  size?: SegmentedControlSize
 }
 
 export default interface SegmentedControlProps extends

--- a/src/components/Forms/SegmentedControl/SegmentedControl.types.ts
+++ b/src/components/Forms/SegmentedControl/SegmentedControl.types.ts
@@ -12,6 +12,13 @@ type SegmentedControlBaseProps = BezierComponentProps & ChildrenProps & FormComp
 
 type CSSSizingProperty = number | string | ExplicitDefaulting | BoxSizingUnit
 
+export enum SegmentedControlSize {
+  XS = 'xs',
+  S = 's',
+  M = 'm',
+  L = 'l',
+}
+
 interface SegmentedControlOptions {
   width?: CSSSizingProperty
   height?: CSSSizingProperty

--- a/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -39,6 +39,19 @@ exports[`SegmentedControl Snapshot 1`] = `
   transition-property: color;
 }
 
+.c8 {
+  box-sizing: content-box;
+  margin: 6px;
+  border: 0;
+  border-color: #00000014;
+  border-style: solid;
+}
+
+.c9 {
+  height: calc(100% - 12px);
+  border-left-width: 1px;
+}
+
 .c0 {
   position: relative;
   display: -webkit-inline-box;
@@ -194,17 +207,15 @@ exports[`SegmentedControl Snapshot 1`] = `
 
 .c7 {
   position: absolute;
-  top: 8px;
-  bottom: 8px;
-  background-color: #00000014;
+  top: 2px;
+  bottom: 2px;
   visibility: hidden;
 }
 
-.c8 {
+.c10 {
   position: absolute;
-  top: 8px;
-  bottom: 8px;
-  background-color: #00000014;
+  top: 2px;
+  bottom: 2px;
 }
 
 <div
@@ -290,16 +301,34 @@ exports[`SegmentedControl Snapshot 1`] = `
   <div
     class="c7"
     hidden=""
-    style="width: 1px; left: 0.25px;"
-  />
+    style="left: -5.75px;"
+  >
+    <hr
+      aria-orientation="vertical"
+      class="c8 c9"
+      data-testid="bezier-react-divider"
+    />
+  </div>
   <div
     class="c7"
     hidden=""
-    style="width: 1px; left: -0.5px;"
-  />
+    style="left: -6.5px;"
+  >
+    <hr
+      aria-orientation="vertical"
+      class="c8 c9"
+      data-testid="bezier-react-divider"
+    />
+  </div>
   <div
-    class="c8"
-    style="width: 1px; left: -1.25px;"
-  />
+    class="c10"
+    style="left: -7.25px;"
+  >
+    <hr
+      aria-orientation="vertical"
+      class="c8 c9"
+      data-testid="bezier-react-divider"
+    />
+  </div>
 </div>
 `;

--- a/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -37,13 +37,8 @@ exports[`SegmentedControl Snapshot 1`] = `
   align-items: center;
   width: 144px;
   min-width: 50px;
-  height: 36px;
   overflow: hidden;
-  font-size: 14px;
-  font-weight: bold;
-  line-height: 18px;
   background-color: #0000000D;
-  border-radius: 8px;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
   -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
@@ -52,6 +47,10 @@ exports[`SegmentedControl Snapshot 1`] = `
   transition-duration: 150ms;
   -webkit-transition-property: background-color;
   transition-property: background-color;
+  height: 32px;
+  overflow: hidden;
+  border-radius: 8px;
+  padding: 2px 0;
 }
 
 .c3 {
@@ -72,11 +71,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0 4px;
   overflow: hidden;
-  font-size: inherit;
-  font-weight: inherit;
-  line-height: inherit;
   color: #00000066;
   cursor: pointer;
   -webkit-transition-delay: 0ms;
@@ -91,6 +86,9 @@ exports[`SegmentedControl Snapshot 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  height: 32px;
+  overflow: hidden;
+  border-radius: 8px;
 }
 
 .c3:hover {
@@ -115,11 +113,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0 4px;
   overflow: hidden;
-  font-size: inherit;
-  font-weight: inherit;
-  line-height: inherit;
   color: #000000D9;
   cursor: auto;
   -webkit-transition-delay: 0ms;
@@ -134,6 +128,9 @@ exports[`SegmentedControl Snapshot 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  height: 32px;
+  overflow: hidden;
+  border-radius: 8px;
 }
 
 .c1 {
@@ -154,7 +151,6 @@ exports[`SegmentedControl Snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 2px;
   cursor: default;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -166,6 +162,9 @@ exports[`SegmentedControl Snapshot 1`] = `
   -webkit-transition-property: transform;
   transition-property: transform;
   will-change: transform;
+  height: 32px;
+  overflow: hidden;
+  border-radius: 8px;
 }
 
 .c2 {
@@ -174,7 +173,21 @@ exports[`SegmentedControl Snapshot 1`] = `
   width: 100%;
   height: 100%;
   background-color: #FFFFFF;
-  border-radius: 6px;
+}
+
+.c6 {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  background-color: #00000014;
+  visibility: hidden;
+}
+
+.c7 {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  background-color: #00000014;
 }
 
 <div
@@ -183,7 +196,7 @@ exports[`SegmentedControl Snapshot 1`] = `
 >
   <div
     class="c1"
-    style="width: 0px; height: 0px; transform: translateX(0px);"
+    style="width: -1.75px; transform: translateX(1.25px);"
   >
     <div
       class="c2"
@@ -192,7 +205,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   <div
     class="c3"
     data-testid="bezier-react-segmented-control-option-item-0"
-    style="width: 0px; height: 0px; left: 0px;"
+    style="width: -1.75px; left: 2px;"
   >
     <span
       class="c4"
@@ -204,7 +217,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   <div
     class="c5"
     data-testid="bezier-react-segmented-control-option-item-1"
-    style="width: 0px; height: 0px; left: 0px;"
+    style="width: -1.75px; left: 1.25px;"
   >
     <span
       class="c4"
@@ -216,7 +229,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   <div
     class="c3"
     data-testid="bezier-react-segmented-control-option-item-2"
-    style="width: 0px; height: 0px; left: 0px;"
+    style="width: -1.75px; left: 0.5px;"
   >
     <span
       class="c4"
@@ -228,7 +241,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   <div
     class="c3"
     data-testid="bezier-react-segmented-control-option-item-3"
-    style="width: 0px; height: 0px; left: 0px;"
+    style="width: -1.75px; left: -0.25px;"
   >
     <span
       class="c4"
@@ -237,5 +250,19 @@ exports[`SegmentedControl Snapshot 1`] = `
       3
     </span>
   </div>
+  <div
+    class="c6"
+    hidden=""
+    style="width: 1px; left: 0.25px;"
+  />
+  <div
+    class="c6"
+    hidden=""
+    style="width: 1px; left: -0.5px;"
+  />
+  <div
+    class="c7"
+    style="width: 1px; left: -1.25px;"
+  />
 </div>
 `;

--- a/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -2,6 +2,23 @@
 
 exports[`SegmentedControl Snapshot 1`] = `
 .c4 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: bold;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c5 {
   font-size: 1.5rem;
   line-height: 2rem;
   -webkit-letter-spacing: -0.1px;
@@ -95,7 +112,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   background-color: #0000000D;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   box-sizing: border-box;
   display: -webkit-box;
@@ -175,7 +192,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   background-color: #FFFFFF;
 }
 
-.c6 {
+.c7 {
   position: absolute;
   top: 8px;
   bottom: 8px;
@@ -183,7 +200,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   visibility: hidden;
 }
 
-.c7 {
+.c8 {
   position: absolute;
   top: 8px;
   bottom: 8px;
@@ -211,11 +228,16 @@ exports[`SegmentedControl Snapshot 1`] = `
       class="c4"
       data-testid="bezier-react-text"
     >
-      0
+      <span
+        class="c5"
+        data-testid="bezier-react-text"
+      >
+        0
+      </span>
     </span>
   </div>
   <div
-    class="c5"
+    class="c6"
     data-testid="bezier-react-segmented-control-option-item-1"
     style="width: -1.75px; left: 1.25px;"
   >
@@ -223,7 +245,12 @@ exports[`SegmentedControl Snapshot 1`] = `
       class="c4"
       data-testid="bezier-react-text"
     >
-      1
+      <span
+        class="c5"
+        data-testid="bezier-react-text"
+      >
+        1
+      </span>
     </span>
   </div>
   <div
@@ -235,7 +262,12 @@ exports[`SegmentedControl Snapshot 1`] = `
       class="c4"
       data-testid="bezier-react-text"
     >
-      2
+      <span
+        class="c5"
+        data-testid="bezier-react-text"
+      >
+        2
+      </span>
     </span>
   </div>
   <div
@@ -247,21 +279,26 @@ exports[`SegmentedControl Snapshot 1`] = `
       class="c4"
       data-testid="bezier-react-text"
     >
-      3
+      <span
+        class="c5"
+        data-testid="bezier-react-text"
+      >
+        3
+      </span>
     </span>
   </div>
   <div
-    class="c6"
+    class="c7"
     hidden=""
     style="width: 1px; left: 0.25px;"
   />
   <div
-    class="c6"
+    class="c7"
     hidden=""
     style="width: 1px; left: -0.5px;"
   />
   <div
-    class="c7"
+    class="c8"
     style="width: 1px; left: -1.25px;"
   />
 </div>

--- a/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   user-select: none;
   height: 32px;
   overflow: hidden;
-  border-radius: 8px;
+  border-radius: 6px;
 }
 
 .c3:hover {
@@ -147,7 +147,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   user-select: none;
   height: 32px;
   overflow: hidden;
-  border-radius: 8px;
+  border-radius: 6px;
 }
 
 .c1 {
@@ -181,7 +181,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   will-change: transform;
   height: 32px;
   overflow: hidden;
-  border-radius: 8px;
+  border-radius: 6px;
 }
 
 .c2 {

--- a/src/components/Forms/SegmentedControl/index.ts
+++ b/src/components/Forms/SegmentedControl/index.ts
@@ -1,5 +1,6 @@
 /* Internal dependencies */
 import SegmentedControl from './SegmentedControl'
+import { SegmentedControlSize } from './SegmentedControl.types'
 import type SegmentedControlProps from './SegmentedControl.types'
 
 export type {
@@ -8,4 +9,5 @@ export type {
 
 export {
   SegmentedControl,
+  SegmentedControlSize,
 }


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

Fixes #689

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- `SegmentedControlSize` enum 추가
- `SegmentedControlProps`
  - delete `height` prop (** BREAKING CHANGE)
  - support `size` prop
- `size`에 따라 height, padding 등 조정
- item 사이에 divider 추가

### TODO

#707 도 수정하려면 item에 해당하는 컴포넌트도 export하여 각 item에 대해 `name`, `value` 등을 지정할 수 있도록 해야 할 듯 싶습니다.
인터페이스 조정이 추가적으로 필요하여 PR을 분리합니다.

```tsx
<SegmentedControl ...>
  <SegmetedControlItem name="???" value="???" ... />
  <SegmetedControlItem name="???" value="???" ... />
  <SegmetedControlItem name="???" value="???" ... />
</SegmentedControl>
```

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- #689