### PR TITLE
Navigator에서 active 상태일 때 LeftIcon의 색상이 blue가 되도록 수정

### DIFF
--- a/src/components/Navigator/NavGroup/NavGroup.stories.tsx
+++ b/src/components/Navigator/NavGroup/NavGroup.stories.tsx
@@ -47,6 +47,5 @@ Primary.args = {
   name: 'general',
   content: '일반 설정',
   leftIcon: 'settings',
-  leftIconColor: 'txt-black-dark',
   rightContent: <Icon name="dot" size={IconSize.XS} color="bgtxt-orange-normal" />,
 }

--- a/src/components/Navigator/NavGroup/NavGroup.test.tsx
+++ b/src/components/Navigator/NavGroup/NavGroup.test.tsx
@@ -2,9 +2,10 @@
 import React from 'react'
 
 /* Internal dependencies */
+import { LightTheme } from 'Foundation/Colors/Theme'
 import { render } from 'Utils/testUtils'
 import { Icon, IconSize } from 'Components/Icon'
-import NavGroup, { NAV_GROUP_TEST_ID } from './NavGroup'
+import NavGroup, { NAV_GROUP_TEST_ID, NAV_GROUP_LEFT_ICON_TEST_ID } from './NavGroup'
 import type NavGroupProps from './NavGroup.types'
 
 describe('NavGroup Test >', () => {
@@ -22,19 +23,39 @@ describe('NavGroup Test >', () => {
   const renderNavItem = (optionProps?: Partial<NavGroupProps>) =>
     render(<NavGroup {...props} {...optionProps} />)
 
-  it('Snapshot > active', () => {
-    const { getByTestId } = renderNavItem({ active: true })
+  describe('Snapshot >', () => {
+    it('Active', () => {
+      const { getByTestId } = renderNavItem({ active: true })
 
-    const rendered = getByTestId(NAV_GROUP_TEST_ID)
+      const rendered = getByTestId(NAV_GROUP_TEST_ID)
 
-    expect(rendered).toMatchSnapshot()
+      expect(rendered).toMatchSnapshot()
+    })
+
+    it('Not active', () => {
+      const { getByTestId } = renderNavItem({ active: false })
+
+      const rendered = getByTestId(NAV_GROUP_TEST_ID)
+
+      expect(rendered).toMatchSnapshot()
+    })
   })
 
-  it('Snapshot > not active', () => {
-    const { getByTestId } = renderNavItem({ active: false })
+  describe('LeftIcon Color', () => {
+    it('Icon color should be "bgtxt-blue-normal" when active prop is true', () => {
+      const { getByTestId } = renderNavItem({ active: true })
 
-    const rendered = getByTestId(NAV_GROUP_TEST_ID)
+      const rendered = getByTestId(NAV_GROUP_LEFT_ICON_TEST_ID)
 
-    expect(rendered).toMatchSnapshot()
+      expect(rendered).toHaveStyle(`color: ${LightTheme['bgtxt-blue-normal']}`)
+    })
+
+    it('Icon color should be "txt-black-dark" when active prop is false', () => {
+      const { getByTestId } = renderNavItem({ active: false })
+
+      const rendered = getByTestId(NAV_GROUP_LEFT_ICON_TEST_ID)
+
+      expect(rendered).toHaveStyle(`color: ${LightTheme['txt-black-dark']}`)
+    })
   })
 })

--- a/src/components/Navigator/NavGroup/NavGroup.test.tsx
+++ b/src/components/Navigator/NavGroup/NavGroup.test.tsx
@@ -7,7 +7,7 @@ import { Icon, IconSize } from 'Components/Icon'
 import NavGroup, { NAV_GROUP_TEST_ID } from './NavGroup'
 import type NavGroupProps from './NavGroup.types'
 
-describe('NavItem Test >', () => {
+describe('NavGroup Test >', () => {
   let props: NavGroupProps
 
   beforeEach(() => {

--- a/src/components/Navigator/NavGroup/NavGroup.tsx
+++ b/src/components/Navigator/NavGroup/NavGroup.tsx
@@ -17,6 +17,7 @@ import {
 } from './NavGroup.styled'
 
 export const NAV_GROUP_TEST_ID = 'bezier-react-nav-group'
+export const NAV_GROUP_LEFT_ICON_TEST_ID = 'bezier-react-nav-group-left-icon'
 
 function NavGroup({
   as,
@@ -64,6 +65,7 @@ function NavGroup({
         <LeftIconWrapper>
           { showLeftIcon && (
             <Icon
+              testId={NAV_GROUP_LEFT_ICON_TEST_ID}
               name={leftIcon}
               size={IconSize.S}
               color={active ? 'bgtxt-blue-normal' : 'txt-black-dark'}

--- a/src/components/Navigator/NavGroup/NavGroup.tsx
+++ b/src/components/Navigator/NavGroup/NavGroup.tsx
@@ -67,7 +67,7 @@ function NavGroup({
             <Icon
               name={leftIcon}
               size={IconSize.S}
-              color={leftIconColor}
+              color={active ? undefined : leftIconColor}
             />
           ) }
         </LeftIconWrapper>

--- a/src/components/Navigator/NavGroup/NavGroup.tsx
+++ b/src/components/Navigator/NavGroup/NavGroup.tsx
@@ -66,7 +66,7 @@ function NavGroup({
             <Icon
               name={leftIcon}
               size={IconSize.S}
-              color={active ? undefined : 'txt-black-dark'}
+              color={active ? 'bgtxt-blue-normal' : 'txt-black-dark'}
             />
           ) }
         </LeftIconWrapper>

--- a/src/components/Navigator/NavGroup/NavGroup.tsx
+++ b/src/components/Navigator/NavGroup/NavGroup.tsx
@@ -29,7 +29,6 @@ function NavGroup({
   content,
   rightContent,
   leftIcon,
-  leftIconColor = 'txt-black-dark',
   open,
   active,
   onClick = noop,
@@ -67,7 +66,7 @@ function NavGroup({
             <Icon
               name={leftIcon}
               size={IconSize.S}
-              color={active ? undefined : leftIconColor}
+              color={active ? undefined : 'txt-black-dark'}
             />
           ) }
         </LeftIconWrapper>

--- a/src/components/Navigator/NavGroup/NavGroup.types.ts
+++ b/src/components/Navigator/NavGroup/NavGroup.types.ts
@@ -5,7 +5,6 @@ import type {
   ContentProps,
   SideContentProps,
   ActivatableProps,
-  AdditionalColorProps,
 } from 'Types/ComponentProps'
 import { IconName } from 'Components/Icon'
 
@@ -21,6 +20,5 @@ export default interface NavGroupProps extends
   ChildrenProps,
   ContentProps,
   Pick<SideContentProps, 'rightContent'>,
-  AdditionalColorProps<'leftIcon'>,
   Pick<ActivatableProps, 'active'>,
   NavGroupOptions {}

--- a/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`NavItem Test > Snapshot > active 1`] = `
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin: 0px 0px 0px 0px;
-  color: #00000066;
+  color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
   -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
@@ -132,7 +132,6 @@ exports[`NavItem Test > Snapshot > active 1`] = `
   >
     <svg
       class="c2"
-      color="txt-black-dark"
       data-testid="bezier-react-icon"
       fill="none"
       foundation="[object Object]"

--- a/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`NavItem Test > Snapshot > active 1`] = `
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   margin: 0px 0px 0px 0px;
-  color: inherit;
+  color: #5E56F0;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
   -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
@@ -132,6 +132,7 @@ exports[`NavItem Test > Snapshot > active 1`] = `
   >
     <svg
       class="c2"
+      color="bgtxt-blue-normal"
       data-testid="bezier-react-icon"
       fill="none"
       foundation="[object Object]"

--- a/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NavItem Test > Snapshot > active 1`] = `
+exports[`NavGroup Test > Snapshot > active 1`] = `
 .c2 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -188,7 +188,7 @@ exports[`NavItem Test > Snapshot > active 1`] = `
 </button>
 `;
 
-exports[`NavItem Test > Snapshot > not active 1`] = `
+exports[`NavGroup Test > Snapshot > not active 1`] = `
 .c2 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;

--- a/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NavGroup Test > Snapshot > active 1`] = `
+exports[`NavGroup Test > Snapshot > Active 1`] = `
 .c2 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -133,7 +133,7 @@ exports[`NavGroup Test > Snapshot > active 1`] = `
     <svg
       class="c2"
       color="bgtxt-blue-normal"
-      data-testid="bezier-react-icon"
+      data-testid="bezier-react-nav-group-left-icon"
       fill="none"
       foundation="[object Object]"
       height="20"
@@ -188,7 +188,7 @@ exports[`NavGroup Test > Snapshot > active 1`] = `
 </button>
 `;
 
-exports[`NavGroup Test > Snapshot > not active 1`] = `
+exports[`NavGroup Test > Snapshot > Not active 1`] = `
 .c2 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -328,7 +328,7 @@ exports[`NavGroup Test > Snapshot > not active 1`] = `
     <svg
       class="c2"
       color="txt-black-dark"
-      data-testid="bezier-react-icon"
+      data-testid="bezier-react-nav-group-left-icon"
       fill="none"
       foundation="[object Object]"
       height="20"

--- a/src/components/Navigator/NavItem/NavItem.stories.tsx
+++ b/src/components/Navigator/NavItem/NavItem.stories.tsx
@@ -28,6 +28,5 @@ Primary.args = {
   content: '일반 설정',
   href: 'https://google.com',
   leftIcon: undefined,
-  leftIconColor: 'txt-black-dark',
   rightContent: <Icon name="error-filled" size={IconSize.XS} color="bgtxt-orange-normal" />,
 }

--- a/src/components/Navigator/NavItem/NavItem.test.tsx
+++ b/src/components/Navigator/NavItem/NavItem.test.tsx
@@ -16,11 +16,19 @@ describe('NavItem Test >', () => {
     }
   })
 
-  const renderNavItem = (optionProps?: NavItemProps) =>
+  const renderNavItem = (optionProps?: Partial<NavItemProps>) =>
     render(<NavItem {...props} {...optionProps} />)
 
-  it('Snapshot > ', () => {
-    const { getByTestId } = renderNavItem()
+  it('Snapshot > active', () => {
+    const { getByTestId } = renderNavItem({ active: true })
+
+    const rendered = getByTestId(NAV_ITEM_TEST_ID)
+
+    expect(rendered).toMatchSnapshot()
+  })
+
+  it('Snapshot > not active', () => {
+    const { getByTestId } = renderNavItem({ active: false })
 
     const rendered = getByTestId(NAV_ITEM_TEST_ID)
 

--- a/src/components/Navigator/NavItem/NavItem.test.tsx
+++ b/src/components/Navigator/NavItem/NavItem.test.tsx
@@ -2,8 +2,9 @@
 import React from 'react'
 
 /* Internal dependencies */
+import { LightTheme } from 'Foundation/Colors/Theme'
 import { render } from 'Utils/testUtils'
-import NavItem, { NAV_ITEM_TEST_ID } from './NavItem'
+import NavItem, { NAV_ITEM_LEFT_ICON_TEST_ID, NAV_ITEM_TEST_ID } from './NavItem'
 import type NavItemProps from './NavItem.types'
 
 describe('NavItem Test >', () => {
@@ -11,6 +12,7 @@ describe('NavItem Test >', () => {
 
   beforeEach(() => {
     props = {
+      leftIcon: 'dot',
       name: 'general',
       content: 'test-content',
     }
@@ -19,19 +21,39 @@ describe('NavItem Test >', () => {
   const renderNavItem = (optionProps?: Partial<NavItemProps>) =>
     render(<NavItem {...props} {...optionProps} />)
 
-  it('Snapshot > active', () => {
-    const { getByTestId } = renderNavItem({ active: true })
+  describe('Snapshot >', () => {
+    it('Active', () => {
+      const { getByTestId } = renderNavItem({ active: true })
 
-    const rendered = getByTestId(NAV_ITEM_TEST_ID)
+      const rendered = getByTestId(NAV_ITEM_TEST_ID)
 
-    expect(rendered).toMatchSnapshot()
+      expect(rendered).toMatchSnapshot()
+    })
+
+    it('Not active', () => {
+      const { getByTestId } = renderNavItem({ active: false })
+
+      const rendered = getByTestId(NAV_ITEM_TEST_ID)
+
+      expect(rendered).toMatchSnapshot()
+    })
   })
 
-  it('Snapshot > not active', () => {
-    const { getByTestId } = renderNavItem({ active: false })
+  describe('LeftIcon Color', () => {
+    it('Icon color should be "bgtxt-blue-normal" when active prop is true', () => {
+      const { getByTestId } = renderNavItem({ active: true })
 
-    const rendered = getByTestId(NAV_ITEM_TEST_ID)
+      const rendered = getByTestId(NAV_ITEM_LEFT_ICON_TEST_ID)
 
-    expect(rendered).toMatchSnapshot()
+      expect(rendered).toHaveStyle(`color: ${LightTheme['bgtxt-blue-normal']}`)
+    })
+
+    it('Icon color should be "txt-black-dark" when active prop is false', () => {
+      const { getByTestId } = renderNavItem({ active: false })
+
+      const rendered = getByTestId(NAV_ITEM_LEFT_ICON_TEST_ID)
+
+      expect(rendered).toHaveStyle(`color: ${LightTheme['txt-black-dark']}`)
+    })
   })
 })

--- a/src/components/Navigator/NavItem/NavItem.tsx
+++ b/src/components/Navigator/NavItem/NavItem.tsx
@@ -59,7 +59,7 @@ function NavItem({
             <Icon
               name={leftIcon}
               size={IconSize.S}
-              color={active ? undefined : 'txt-black-dark'}
+              color={active ? 'bgtxt-blue-normal' : 'txt-black-dark'}
             />
           ) }
         </LeftIconWrapper>

--- a/src/components/Navigator/NavItem/NavItem.tsx
+++ b/src/components/Navigator/NavItem/NavItem.tsx
@@ -15,6 +15,7 @@ import {
 } from './NavItem.styled'
 
 export const NAV_ITEM_TEST_ID = 'bezier-react-nav-item'
+export const NAV_ITEM_LEFT_ICON_TEST_ID = 'bezier-react-nav-item-left-icon'
 
 function NavItem({
   as,
@@ -57,6 +58,7 @@ function NavItem({
         <LeftIconWrapper>
           { showLeftIcon && (
             <Icon
+              testId={NAV_ITEM_LEFT_ICON_TEST_ID}
               name={leftIcon}
               size={IconSize.S}
               color={active ? 'bgtxt-blue-normal' : 'txt-black-dark'}

--- a/src/components/Navigator/NavItem/NavItem.tsx
+++ b/src/components/Navigator/NavItem/NavItem.tsx
@@ -28,7 +28,6 @@ function NavItem({
   target = '_self',
   rightContent,
   leftIcon,
-  leftIconColor = 'txt-black-dark',
   active,
   onClick = noop,
 }: NavItemProps) {
@@ -60,7 +59,7 @@ function NavItem({
             <Icon
               name={leftIcon}
               size={IconSize.S}
-              color={active ? undefined : leftIconColor}
+              color={active ? undefined : 'txt-black-dark'}
             />
           ) }
         </LeftIconWrapper>

--- a/src/components/Navigator/NavItem/NavItem.tsx
+++ b/src/components/Navigator/NavItem/NavItem.tsx
@@ -60,7 +60,7 @@ function NavItem({
             <Icon
               name={leftIcon}
               size={IconSize.S}
-              color={leftIconColor}
+              color={active ? undefined : leftIconColor}
             />
           ) }
         </LeftIconWrapper>

--- a/src/components/Navigator/NavItem/NavItem.types.ts
+++ b/src/components/Navigator/NavItem/NavItem.types.ts
@@ -5,7 +5,6 @@ import type {
   LinkProps,
   SideContentProps,
   ActivatableProps,
-  AdditionalColorProps,
 } from 'Types/ComponentProps'
 import { IconName } from 'Components/Icon'
 
@@ -21,6 +20,5 @@ export default interface NavItemProps extends
   ContentProps,
   LinkProps,
   Pick<SideContentProps, 'rightContent'>,
-  AdditionalColorProps<'leftIcon'>,
   Pick<ActivatableProps, 'active'>,
   NavItemOptions {}

--- a/src/components/Navigator/NavItem/__snapshots__/NavItem.test.tsx.snap
+++ b/src/components/Navigator/NavItem/__snapshots__/NavItem.test.tsx.snap
@@ -1,7 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NavItem Test > Snapshot > active 1`] = `
+exports[`NavItem Test > Snapshot > Active 1`] = `
 .c2 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0px 0px 0px 0px;
+  color: #5E56F0;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c3 {
   font-size: 1.4rem;
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
@@ -32,7 +48,7 @@ exports[`NavItem Test > Snapshot > active 1`] = `
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -66,9 +82,32 @@ exports[`NavItem Test > Snapshot > active 1`] = `
 >
   <div
     class="c1"
-  />
+  >
+    <svg
+      class="c2"
+      color="bgtxt-blue-normal"
+      data-testid="bezier-react-nav-item-left-icon"
+      fill="none"
+      foundation="[object Object]"
+      height="20"
+      marginbottom="0"
+      marginleft="0"
+      marginright="0"
+      margintop="0"
+      viewBox="0 0 24 24"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clip-rule="evenodd"
+        d="M17 12a5 5 0 1 1-10 0 5 5 0 0 1 10 0Z"
+        fill="currentColor"
+        fill-rule="evenodd"
+      />
+    </svg>
+  </div>
   <span
-    class="c2 c3"
+    class="c3 c4"
     data-testid="bezier-react-text"
   >
     test-content
@@ -76,8 +115,24 @@ exports[`NavItem Test > Snapshot > active 1`] = `
 </a>
 `;
 
-exports[`NavItem Test > Snapshot > not active 1`] = `
+exports[`NavItem Test > Snapshot > Not active 1`] = `
 .c2 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  margin: 0px 0px 0px 0px;
+  color: #00000066;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c3 {
   font-size: 1.4rem;
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
@@ -108,7 +163,7 @@ exports[`NavItem Test > Snapshot > not active 1`] = `
   margin-right: 8px;
 }
 
-.c3 {
+.c4 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -149,9 +204,32 @@ exports[`NavItem Test > Snapshot > not active 1`] = `
 >
   <div
     class="c1"
-  />
+  >
+    <svg
+      class="c2"
+      color="txt-black-dark"
+      data-testid="bezier-react-nav-item-left-icon"
+      fill="none"
+      foundation="[object Object]"
+      height="20"
+      marginbottom="0"
+      marginleft="0"
+      marginright="0"
+      margintop="0"
+      viewBox="0 0 24 24"
+      width="20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clip-rule="evenodd"
+        d="M17 12a5 5 0 1 1-10 0 5 5 0 0 1 10 0Z"
+        fill="currentColor"
+        fill-rule="evenodd"
+      />
+    </svg>
+  </div>
   <span
-    class="c2 c3"
+    class="c3 c4"
     data-testid="bezier-react-text"
   >
     test-content

--- a/src/components/Navigator/NavItem/__snapshots__/NavItem.test.tsx.snap
+++ b/src/components/Navigator/NavItem/__snapshots__/NavItem.test.tsx.snap
@@ -1,6 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NavItem Test > Snapshot >  1`] = `
+exports[`NavItem Test > Snapshot > active 1`] = `
+.c2 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: inherit;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 20px;
+  max-width: 20px;
+  margin-right: 8px;
+}
+
+.c3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 28px;
+  padding: 0 6px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  outline: 0;
+  overflow: hidden;
+  border-radius: 6px;
+  color: #5E56F0;
+  background-color: #5E56F01A;
+}
+
+<a
+  class="c0"
+  data-testid="bezier-react-nav-item"
+  role="menuitem"
+  target="_self"
+>
+  <div
+    class="c1"
+  />
+  <span
+    class="c2 c3"
+    data-testid="bezier-react-text"
+  >
+    test-content
+  </span>
+</a>
+`;
+
+exports[`NavItem Test > Snapshot > not active 1`] = `
 .c2 {
   font-size: 1.4rem;
   line-height: 1.8rem;


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
- Navigator의 요소들(NavGroup, NavItem)에서 active가 true이면 item의 background와 text의 color는 blue로 바뀝니다.
- 이때, leftIcon의 색상도 blue가 되도록 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
### As-is
|NavGroup|NavItem|
|-|-|
|<img width="413" alt="스크린샷 2022-04-21 오전 11 36 03" src="https://user-images.githubusercontent.com/57767891/164360505-211db704-70ef-475d-9aa2-8286bebfa560.png">|<img width="384" alt="스크린샷 2022-04-21 오전 11 36 12" src="https://user-images.githubusercontent.com/57767891/164360542-9636c6ab-0e66-45d2-abdc-3a237d33d274.png">|

### To-be
|NavGroup|NavItem|
|-|-|
|<img width="516" alt="스크린샷 2022-04-21 오전 11 34 04" src="https://user-images.githubusercontent.com/57767891/164360574-0109d5c4-0f50-4efa-b64c-bdd98357f78b.png">|<img width="587" alt="스크린샷 2022-04-21 오전 11 33 55" src="https://user-images.githubusercontent.com/57767891/164360594-26079211-020a-41cd-bcf7-26caba5d0f9b.png">|

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
