### PR TITLE
NavGroup에 NavItem이 있는 경우 chevron이 항상 보이도록 수정

### DIFF
--- a/src/components/Navigator/NavGroup/NavGroup.styled.ts
+++ b/src/components/Navigator/NavGroup/NavGroup.styled.ts
@@ -4,7 +4,6 @@ import type { InterpolationProps } from 'Types/Foundation'
 import { Text } from 'Components/Text'
 
 interface WrapperProps extends InterpolationProps {
-  open: boolean
   active: boolean
 }
 
@@ -35,19 +34,6 @@ export const RightContentWrapper = styled.div`
   align-items: center;
   justify-content: flex-end;
   margin-left: 8px;
-`
-
-const closedItemStyle = css`
-  ${ChevronWrapper} {
-    visibility: hidden;
-  }
-
-  &:hover,
-  &:focus-visible {
-    ${ChevronWrapper} {
-      visibility: visible;
-    }
-  }
 `
 
 const activeItemStyle = css`
@@ -85,7 +71,6 @@ export const Item = styled.button<WrapperProps>`
   ${({ foundation }) => foundation?.rounding?.round6}
 
   ${({ active }) => (active ? activeItemStyle : nonActiveItemStyle)}
-  ${({ open }) => (open ? null : closedItemStyle)}
 
   ${({ interpolation }) => interpolation}
 `

--- a/src/components/Navigator/NavGroup/NavGroup.tsx
+++ b/src/components/Navigator/NavGroup/NavGroup.tsx
@@ -51,7 +51,6 @@ function NavGroup({
       <Item
         as={as}
         active={active}
-        open={open}
         style={style}
         className={className}
         interpolation={interpolation}

--- a/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -111,15 +111,6 @@ exports[`NavItem Test > Snapshot > active 1`] = `
   background-color: #5E56F01A;
 }
 
-.c0 .sc-eCApnc {
-  visibility: hidden;
-}
-
-.c0:hover .sc-eCApnc,
-.c0:focus-visible .sc-eCApnc {
-  visibility: visible;
-}
-
 <button
   aria-controls="generalMenu"
   aria-haspopup="false"
@@ -304,15 +295,6 @@ exports[`NavItem Test > Snapshot > not active 1`] = `
 
 .c0:focus-visible {
   background-color: #0000000D;
-}
-
-.c0 .sc-eCApnc {
-  visibility: hidden;
-}
-
-.c0:hover .sc-eCApnc,
-.c0:focus-visible .sc-eCApnc {
-  visibility: visible;
 }
 
 <button


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
- 기존에는 NavGroup이 close 상태일 때 hover 시에만 chevron이 보였습니다.
- NavGroup 안에 NavItem이 있는 경우라면 open 여부에 관계없이 항상 chevron이 보이도록 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
### As-is

https://user-images.githubusercontent.com/57767891/164386925-eaab755c-36f6-470f-88f2-84906bb05d00.mov


### To-be

https://user-images.githubusercontent.com/57767891/164386938-db8cece0-4892-4ee7-9c43-ca6382ee27f1.mov


## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
