### PR TITLE
Avatar에  AvatarSize 72를 추가

### DIFF
--- a/src/components/Avatars/Avatar/Avatar.styled.ts
+++ b/src/components/Avatars/Avatar/Avatar.styled.ts
@@ -3,7 +3,6 @@ import { styled, css, smoothCorners } from 'Foundation'
 import { enableSmoothCorners } from 'Worklets/EnableCSSHoudini'
 import type { InterpolationProps } from 'Types/Foundation'
 import DisabledOpacity from 'Constants/DisabledOpacity'
-import { StatusSize } from 'Components/Status'
 import { AVATAR_BORDER_WIDTH, AVATAR_BORDER_RADIUS_PERCENTAGE } from 'Components/Avatars/AvatarStyle'
 import { AvatarSize } from './Avatar.types'
 
@@ -16,12 +15,10 @@ interface AvatarProps extends InterpolationProps {
   showBorder: boolean
 }
 
-interface StatusWrapperProps extends Pick<AvatarProps, 'showBorder'> {
-  size: StatusSize
-}
+interface StatusWrapperProps extends Pick<AvatarProps, 'showBorder' | 'size'> {}
 
 function calcStatusGap({ showBorder, size }: StatusWrapperProps) {
-  let gap = (size >= StatusSize.L ? 4 : -2)
+  let gap = (size >= AvatarSize.Size72 ? 4 : -2)
   if (showBorder && enableSmoothCorners.current) {
     gap += AVATAR_BORDER_WIDTH * 2
   }

--- a/src/components/Avatars/Avatar/Avatar.test.tsx
+++ b/src/components/Avatars/Avatar/Avatar.test.tsx
@@ -88,15 +88,15 @@ describe('Avatar >', () => {
     expect(statusWrapper).toMatchSnapshot()
   })
 
-  it('should have right 4px, bottom 4px style on StatusWrapper when size grater then 90', () => {
-    const { getByTestId } = renderAvatar({ status: StatusType.Online, size: AvatarSize.Size90 })
+  it('should have right 4px, bottom 4px style on StatusWrapper when size grater then 72', () => {
+    const { getByTestId } = renderAvatar({ status: StatusType.Online, size: AvatarSize.Size72 })
     const statusWrapper = getByTestId(STATUS_WRAPPER_TEST_ID)
 
     expect(statusWrapper).toMatchSnapshot()
   })
 
-  it('should have right 8px, bottom 8px style on StatusWrapper when size grater then 90 and show border', () => {
-    const { getByTestId } = renderAvatar({ status: StatusType.Online, size: AvatarSize.Size90, showBorder: true })
+  it('should have right 8px, bottom 8px style on StatusWrapper when size grater then 72 and show border', () => {
+    const { getByTestId } = renderAvatar({ status: StatusType.Online, size: AvatarSize.Size72, showBorder: true })
     const statusWrapper = getByTestId(STATUS_WRAPPER_TEST_ID)
 
     expect(statusWrapper).toMatchSnapshot()

--- a/src/components/Avatars/Avatar/Avatar.test.tsx
+++ b/src/components/Avatars/Avatar/Avatar.test.tsx
@@ -101,4 +101,18 @@ describe('Avatar >', () => {
 
     expect(statusWrapper).toMatchSnapshot()
   })
+
+  it('should have right 4px, bottom 4px style on StatusWrapper when size grater then 90', () => {
+    const { getByTestId } = renderAvatar({ status: StatusType.Online, size: AvatarSize.Size90 })
+    const statusWrapper = getByTestId(STATUS_WRAPPER_TEST_ID)
+
+    expect(statusWrapper).toMatchSnapshot()
+  })
+
+  it('should have right 8px, bottom 8px style on StatusWrapper when size grater then 90 and show border', () => {
+    const { getByTestId } = renderAvatar({ status: StatusType.Online, size: AvatarSize.Size90, showBorder: true })
+    const statusWrapper = getByTestId(STATUS_WRAPPER_TEST_ID)
+
+    expect(statusWrapper).toMatchSnapshot()
+  })
 })

--- a/src/components/Avatars/Avatar/Avatar.tsx
+++ b/src/components/Avatars/Avatar/Avatar.tsx
@@ -62,7 +62,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
     return (
       <StatusWrapper
         data-testid={STATUS_WRAPPER_TEST_ID}
-        size={statusSize}
+        size={size}
         showBorder={showBorder}
       >
         { Contents }

--- a/src/components/Avatars/Avatar/Avatar.types.ts
+++ b/src/components/Avatars/Avatar/Avatar.types.ts
@@ -9,6 +9,7 @@ export enum AvatarSize {
   Size36 = 36,
   Size42 = 42,
   Size48 = 48,
+  Size72 = 72,
   Size90 = 90,
   Size120 = 120,
 }

--- a/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`Avatar > should have right -2px, bottom -2px style on StatusWrapper 1`]
 <div
   class="c0"
   data-testid="bezier-react-status-wrapper"
-  size="8"
+  size="24"
 >
   <div
     class="c1"
@@ -199,7 +199,7 @@ exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when 
 <div
   class="c0"
   data-testid="bezier-react-status-wrapper"
-  size="8"
+  size="24"
 >
   <div
     class="c1"
@@ -210,16 +210,16 @@ exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when 
 </div>
 `;
 
-exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when size grater then 90 1`] = `
+exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when size grater then 72 1`] = `
 .c1 {
   box-sizing: border-box;
   border-color: #FFFFFF;
   border-style: solid solid solid solid;
-  border-width: 3px;
+  border-width: 2px;
   position: relative;
   box-sizing: content-box;
-  width: 14px;
-  height: 14px;
+  width: 8px;
+  height: 8px;
   background-color: #FFFFFF;
   border-radius: 50%;
 }
@@ -229,8 +229,8 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
   top: 0;
   left: 0;
   display: block;
-  width: 14px;
-  height: 14px;
+  width: 8px;
+  height: 8px;
   content: '';
   background-color: #31A552;
   border-radius: 50%;
@@ -249,27 +249,27 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
 <div
   class="c0"
   data-testid="bezier-react-status-wrapper"
-  size="14"
+  size="72"
 >
   <div
     class="c1"
     color="bgtxt-green-normal"
     data-testid="bezier-react-status"
-    size="14"
+    size="8"
   />
 </div>
 `;
 
-exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when size grater then 90 and show border 1`] = `
+exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when size grater then 72 and show border 1`] = `
 .c1 {
   box-sizing: border-box;
   border-color: #FFFFFF;
   border-style: solid solid solid solid;
-  border-width: 3px;
+  border-width: 2px;
   position: relative;
   box-sizing: content-box;
-  width: 14px;
-  height: 14px;
+  width: 8px;
+  height: 8px;
   background-color: #FFFFFF;
   border-radius: 50%;
 }
@@ -279,8 +279,8 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
   top: 0;
   left: 0;
   display: block;
-  width: 14px;
-  height: 14px;
+  width: 8px;
+  height: 8px;
   content: '';
   background-color: #31A552;
   border-radius: 50%;
@@ -299,13 +299,13 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
 <div
   class="c0"
   data-testid="bezier-react-status-wrapper"
-  size="14"
+  size="72"
 >
   <div
     class="c1"
     color="bgtxt-green-normal"
     data-testid="bezier-react-status"
-    size="14"
+    size="8"
   />
 </div>
 `;

--- a/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -260,6 +260,56 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
 </div>
 `;
 
+exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when size grater then 90 1`] = `
+.c1 {
+  box-sizing: border-box;
+  border-color: #FFFFFF;
+  border-style: solid solid solid solid;
+  border-width: 3px;
+  position: relative;
+  box-sizing: content-box;
+  width: 14px;
+  height: 14px;
+  background-color: #FFFFFF;
+  border-radius: 50%;
+}
+
+.c1::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 14px;
+  height: 14px;
+  content: '';
+  background-color: #31A552;
+  border-radius: 50%;
+}
+
+.c0 {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+}
+
+@supports (background:paint(smooth-corners)) {
+
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-status-wrapper"
+  size="90"
+>
+  <div
+    class="c1"
+    color="bgtxt-green-normal"
+    data-testid="bezier-react-status"
+    size="14"
+  />
+</div>
+`;
+
 exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when size grater then 72 and show border 1`] = `
 .c1 {
   box-sizing: border-box;
@@ -306,6 +356,56 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
     color="bgtxt-green-normal"
     data-testid="bezier-react-status"
     size="8"
+  />
+</div>
+`;
+
+exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when size grater then 90 and show border 1`] = `
+.c1 {
+  box-sizing: border-box;
+  border-color: #FFFFFF;
+  border-style: solid solid solid solid;
+  border-width: 3px;
+  position: relative;
+  box-sizing: content-box;
+  width: 14px;
+  height: 14px;
+  background-color: #FFFFFF;
+  border-radius: 50%;
+}
+
+.c1::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 14px;
+  height: 14px;
+  content: '';
+  background-color: #31A552;
+  border-radius: 50%;
+}
+
+.c0 {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+}
+
+@supports (background:paint(smooth-corners)) {
+
+}
+
+<div
+  class="c0"
+  data-testid="bezier-react-status-wrapper"
+  size="90"
+>
+  <div
+    class="c1"
+    color="bgtxt-green-normal"
+    data-testid="bezier-react-status"
+    size="14"
   />
 </div>
 `;


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
**Avatar**에  **AvatarSize 72**를 추가합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
<img width="260" alt="스크린샷 2022-04-22 오후 8 21 30" src="https://user-images.githubusercontent.com/52924202/164705042-027db287-2233-488e-b196-783a96fb07a1.png">

- 72 size는 `StatusSize.M`을 가집니다.
- Avatar와 StatusWrapper가 가지게되는 gap은 StatusSize에 따라 계산되었지만, 72 size가 StatusSize.M을 보게되면서 **gap이 달라지는 기준을** `AvatarSize.Size72`로 변경합니다.
- StatusSize 사이즈 매칭은 AvatarSize.Size90으로 기존과 동일합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
