### PR TITLE
VStack 컴포넌트 direction 오류 수정

### DIFF
--- a/src/components/Stack/HStack/HStack.test.tsx
+++ b/src/components/Stack/HStack/HStack.test.tsx
@@ -1,0 +1,15 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { render } from 'Utils/testUtils'
+import HStack from './HStack'
+
+describe('HStack', () => {
+  it('creates a horizontal flexbox', () => {
+    const { getByTestId } = render(<HStack testId="h-stack" />)
+
+    expect(getByTestId('h-stack')).toHaveStyle('display: flex')
+    expect(getByTestId('h-stack')).toHaveStyle('flex-direction: row')
+  })
+})

--- a/src/components/Stack/VStack/VStack.test.tsx
+++ b/src/components/Stack/VStack/VStack.test.tsx
@@ -1,0 +1,15 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { render } from 'Utils/testUtils'
+import VStack from './VStack'
+
+describe('VStack', () => {
+  it('creates a vertical flexbox', () => {
+    const { getByTestId } = render(<VStack testId="v-stack" />)
+
+    expect(getByTestId('v-stack')).toHaveStyle('display: flex')
+    expect(getByTestId('v-stack')).toHaveStyle('flex-direction: column')
+  })
+})

--- a/src/components/Stack/VStack/VStack.tsx
+++ b/src/components/Stack/VStack/VStack.tsx
@@ -13,7 +13,7 @@ function VStack(
   props: VStackProps,
   forwardedRef: Ref<HTMLElement>,
 ) {
-  return (<Stack ref={forwardedRef} direction="horizontal" {...props} />)
+  return (<Stack ref={forwardedRef} direction="vertical" {...props} />)
 }
 
 export default forwardRef(VStack)


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

#739 의 오류 수정.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- [x] VStack에서 사용하는 Stack의 direction prop 오류 수정
- [x] 테스트케이스 추가

셀프리뷰와 테스트케이스 작성을 강조했으나, 나부터 지켜야 할 듯 😅 

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- #739