### PR TITLE
Status 컴포넌트에서 Legacy Icon 제거

### DIFF
--- a/src/components/Status/Status.styled.ts
+++ b/src/components/Status/Status.styled.ts
@@ -1,6 +1,6 @@
 /* Internal dependencies */
 import { styled, absoluteCenter, SemanticNames } from 'Foundation'
-import { Icon } from 'Components/Icon'
+import { LockIcon as BaseLockIcon } from 'Components/Icon/generated'
 import { StatusSize } from './Status.types'
 
 function getStatusCircleBorderSize(size: StatusSize) {
@@ -39,7 +39,7 @@ export const StatusCircle = styled.div<StatusCircleProps>`
   }
 `
 
-export const LockIcon = styled(Icon)`
+export const LockIcon = styled(BaseLockIcon)`
   ${absoluteCenter('')}
   z-index: 1;
 `

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -21,7 +21,6 @@ function Status({
         size={size}
       >
         <LockIcon
-          name="lock"
           size={IconSize.XXS}
           color="txt-black-darker"
         />


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
Avatar에서 쓰이는 Status에서 사용되는 Legacy 아이콘을 대체하여 빌드시 번들에 다른 아이콘이 포함되지 않도록 합니다.
![스크린샷 2022-04-28 오후 5 40 45](https://user-images.githubusercontent.com/16368822/165771588-a6e81674-eb7d-42d5-8505-6bb33ca65578.png)

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
프론트 번들 경량화의 일환입니다.
Avatar의 bundle size가 비정상적으로 크게 잡히는 문제를 해결합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [x] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- #762