### PR TITLE
여러 Stack을 중첩하여 사용할 때 적용되는 스타일 오류 수정

### DIFF
--- a/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: bold;
+  font-weight: 600;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;

--- a/src/components/Stack/StackItem/StackItem.test.tsx
+++ b/src/components/Stack/StackItem/StackItem.test.tsx
@@ -113,4 +113,32 @@ describe('StackItem', () => {
     expect(getByTestId('item-end')).toHaveStyle({ 'align-self': 'flex-end' })
     expect(getByTestId('item-stretch')).toHaveStyle({ 'align-self': 'stretch' })
   })
+
+  describe('dimensions', () => {
+    it('should set all of customizable css variables', () => {
+      const REQUIRED_CSS_VARS = [
+        '--main-axis-size',
+        '--grow-weight',
+        '--shrink-weight',
+        '--margin-before',
+        '--margin-after',
+      ]
+
+      const TEST_IDS = ['one', 'two', 'three', 'four']
+
+      const { getByTestId } = render(
+        <Stack direction="horizontal">
+          <StackItem testId="one" />
+          <StackItem testId="two" grow shrink weight={1} />
+          <StackItem testId="three" marginBefore={16} shrink weight={2} />
+          <StackItem testId="four" style={{ color: 'red' }} marginAfter={20} size={32} />
+        </Stack>,
+      )
+
+      TEST_IDS
+        .map(id => getByTestId(id))
+        .forEach(el => REQUIRED_CSS_VARS
+          .forEach(field => expect(el.style.getPropertyValue(field)).not.toBe('')))
+    })
+  })
 })

--- a/src/components/Stack/StackItem/StackItem.tsx
+++ b/src/components/Stack/StackItem/StackItem.tsx
@@ -53,7 +53,7 @@ function StackItem(
       data-testid={testId}
       style={{
         ...style,
-        '--main-axis-size': isNil(size) ? undefined : `${size}px`,
+        '--main-axis-size': isNil(size) ? 'initial' : `${size}px`,
         '--grow-weight': grow ? sanitizeWeight(weight) : '0',
         '--shrink-weight': shrink ? sanitizeWeight(weight) : '0',
         '--margin-before': `${marginBefore}px`,


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

아래와 같이 Stack을 여러 번 중첩하여 사용하는 usecase에서 하위 레벨의 stack 스타일이 깨지는 이슈를 수정합니다.

```tsx
<HStack>
  <StackItem size={320}>
    <VStack>
      <StackItem>{ ... }</StackItem> /* <- here */
    </VStack>
  </StackItem>
  { ... }
</HStack>
```

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

원인은 StackItem의 `--main-axis-size` css variable이 undefined인 경우, 상위 element의 variable이 적용되기 때문에 의도하지 않은 값을 스타일링에 사용하기 때문입니다.

StackItem에서 사용하는 CSS Variable이 항상 overwritten 되도록 `--main-axis-size`의 fallback 값을 `undefined`가 아닌 `"initial"`로 합니다. (테스트 케이스를 통해 이를 검증합니다.)

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- #739