### PR TITLE
fix(build-icon): 빌드 스크립트에서 로컬 svgr 커맨드를 사용하도록 수정

### DIFF
--- a/apps/bezier-react/scripts/build-icon.sh
+++ b/apps/bezier-react/scripts/build-icon.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-npx @svgr/cli \
+svgr \
   -d ./src/components/Icon/generated \
   --template ./scripts/icon-template.js \
   --index-template ./scripts/icon-index-template.js \


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

`npx` 커맨드 사용 시 ci 환경에서 [`svgr@next-v1` 패키지를 찾는 에러](https://app.circleci.com/pipelines/github/channel-io/bezier-react/2107/workflows/7686826d-f958-4dfa-9b07-009e9665f89d/jobs/6805?invite=true#step-102-373)가 발생합니다. (원인 파악 필요)
로컬에 설치되어 있는 `svgr` cli를 사용하도록 설정을 변경합니다. 

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

없음
