### PR TITLE
refactor(components): key-value-list-item을 single/multiLine component로 분리

### DIFF
--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.common.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.common.styled.ts
@@ -1,0 +1,29 @@
+/* Internal dependencies */
+import React from 'react'
+import { css, styled } from 'Foundation'
+import { InterpolationProps } from 'Types/Foundation'
+
+export const KeyValueListItemWrapper = styled.div<InterpolationProps>`
+  ${({ foundation }) => foundation?.rounding?.round6}
+  ${({ foundation }) => foundation?.transition.getTransitionsCSS(['background-color', 'color'])}
+  ${({ interpolation }) => interpolation}
+`
+
+export interface KeyValueListItemContainerProps {
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void
+}
+
+export const KeyValueListItemContainer = styled.div<KeyValueListItemContainerProps>`
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  padding: 4px 6px;
+
+  ${({ foundation }) => foundation?.rounding?.round6};
+  ${({ onClick }) => onClick && css`
+    cursor: pointer;
+    &:hover {
+      background-color: ${({ foundation }) => foundation?.theme?.['bg-black-lighter']};
+    }
+  `};
+`

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.const.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.const.ts
@@ -1,0 +1,7 @@
+export const TEST_ID_MAP = {
+  ROOT: 'bezier-react-key-value-list-item',
+  MULTILINE_ROOT: 'bezier-react-key-value-list-item-multiline',
+  KEY_ITEM: 'bezier-react-key-value-list-item-key-item',
+  VALUE_ITEM: 'bezier-react-key-value-list-item-value-item',
+  ACTIONS_ITEM: 'bezier-react-key-value-list-item-actions-item',
+}

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.stories.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* External dependencies */
 import React from 'react'
 import base from 'paths.macro'
@@ -6,6 +7,7 @@ import { Meta, Story } from '@storybook/react'
 /* Internal dependencies */
 import { getTitle } from 'Utils/storyUtils'
 import KeyValueListItem from './KeyValueListItem'
+import KeyValueMultiLineListItem from './KeyValueMultiLineListItem'
 import { KeyValueListItemProps } from './KeyValueListItem.types'
 
 export default {
@@ -13,28 +15,63 @@ export default {
   component: KeyValueListItem,
 } as Meta
 
-const Template: Story<KeyValueListItemProps> = ({ ...otherProps }) => (
-  <>
+interface KeyValueListItemStorybookProps extends KeyValueListItemProps {
+  containerWidth: number
+}
+
+const DEFAULT_ARGS: KeyValueListItemStorybookProps = {
+  keyIcon: 'badge',
+  keyContent: 'I\'m the Long Long Key',
+  containerWidth: 300,
+  // eslint-disable-next-line max-len
+  children: 'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Perspiciatis eveniet minus nobis nemo quisquam ipsum ut. Iste molestiae sint, laboriosam minima, quaerat velit blanditiis natus quos non vel fugiat perspiciatis.',
+}
+
+function onClickKey() {
+  console.log('Key')
+}
+
+function onClickValue() {
+  console.log('Value')
+}
+
+const SingleLineTemplate: Story<KeyValueListItemStorybookProps> = ({ containerWidth, ...otherProps }) => (
+  <div
+    style={{
+      width: `${containerWidth}px`,
+    }}
+  >
+    <KeyValueListItem {...otherProps} />
     <KeyValueListItem
       {...otherProps}
-    >
-      value content
-    </KeyValueListItem>
-    <br />
-    <KeyValueListItem
-      multiline
-      {...otherProps}
-    >
-      multiline value content
-    </KeyValueListItem>
-  </>
+      actions={Array.from(Array(2)).map(() => ({ icon: 'edit', onClick: console.log, tooltip: '수정하기' }))}
+    />
+    <KeyValueListItem {...otherProps} onClickKey={onClickKey} onClickValue={onClickValue} />
+  </div>
 )
 
-export const Primary = Template.bind({})
+const MultiLineTemplate: Story<KeyValueListItemStorybookProps> = ({ containerWidth, ...otherProps }) => (
+  <div
+    style={{
+      width: `${containerWidth}px`,
+    }}
+  >
+    <KeyValueMultiLineListItem {...otherProps} />
+    <KeyValueMultiLineListItem
+      {...otherProps}
+      actions={Array.from(Array(2)).map(() => ({ icon: 'edit', onClick: console.log, tooltip: '수정하기' }))}
+    />
+    <KeyValueMultiLineListItem {...otherProps} onClickKey={onClickKey} onClickValue={onClickValue} />
+  </div>
+)
 
-Primary.args = {
-  keyIcon: 'trash',
-  keyContent: 'Key',
-  // eslint-disable-next-line no-console
+export const SingleLine = SingleLineTemplate.bind({})
+SingleLine.args = {
+  ...DEFAULT_ARGS,
   actions: { icon: 'edit', onClick: console.log, tooltip: '수정하기' },
+}
+
+export const MultiLine = MultiLineTemplate.bind({})
+MultiLine.args = {
+  ...DEFAULT_ARGS,
 }

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.test.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.test.tsx
@@ -1,43 +1,379 @@
 /* External dependencies */
 import React from 'react'
+import userEvent from '@testing-library/user-event'
+
+/* Internal dependencies */
 import { render } from 'Utils/testUtils'
+import { TOOLTIP_TEST_ID } from 'Components/Tooltip/Tooltip'
+import type { KeyValueListItemActionProps } from './common'
 import { KeyValueListItemProps } from './KeyValueListItem.types'
-import KeyValueListItem, { KEY_VALUE_LIST_ITEM_TEST_ID } from './KeyValueListItem'
+import { TEST_ID_MAP } from './KeyValueListItem.const'
+import KeyValueListItem from './KeyValueListItem'
+import KeyValueMultiLineListItem from './KeyValueMultiLineListItem'
+
+const DEFAULT_PROPS: KeyValueListItemProps = {
+  keyIcon: 'apple',
+  keyContent: 'Key',
+  children: 'Value',
+}
+
+const renderComponent = (optionProps?: Partial<KeyValueListItemProps>) => render(
+  <KeyValueListItem {...DEFAULT_PROPS} {...optionProps} />,
+)
+
+const renderMultilineComponent = (optionProps?: Partial<KeyValueListItemProps>) => render(
+  <KeyValueMultiLineListItem {...DEFAULT_PROPS} {...optionProps} />,
+)
 
 describe('KeyValueListItem', () => {
-  let props: KeyValueListItemProps
-
-  beforeEach(() => {
-    props = {
-      keyContent: 'key',
-      keyIcon: 'apple',
-    }
-  })
-
-  const renderedComponent = (optionProps?: Partial<KeyValueListItemProps>) => render(
-    <KeyValueListItem {...props} {...optionProps}>
-      thisiscontent
-    </KeyValueListItem>,
-  )
-
   it('Snapshot >', () => {
-    const { getByTestId } = renderedComponent()
-    const rendered = getByTestId(KEY_VALUE_LIST_ITEM_TEST_ID)
-
+    const { getByTestId } = renderComponent()
+    const rendered = getByTestId(TEST_ID_MAP.ROOT)
     expect(rendered).toMatchSnapshot()
   })
 
-  it('multiline이 아니면 하나의 div를 가진다', () => {
-    const { getByTestId } = renderedComponent()
-    const rendered = getByTestId(KEY_VALUE_LIST_ITEM_TEST_ID)
+  describe('Props', () => {
+    describe('keyIcon', () => {
+      it('keyIcon이 Bezier의 아이콘 한 종류면, icon으로 렌더링된다.', () => {
+        const keyIcon = 'badge'
+        const { getByTestId } = renderComponent({ keyIcon })
+        const rendered = getByTestId(TEST_ID_MAP.KEY_ITEM)
+        const keyItemIcon = rendered?.firstChild
+        expect(keyItemIcon?.nodeName).toEqual('svg')
+      })
 
-    expect(rendered.childElementCount).toBe(1)
+      it('keyIcon이 Bezier의 아이콘이 아니면, textContent로 렌더링된다.', () => {
+        const keyIcon = 'NoIcon'
+        const { getByTestId } = renderComponent({ keyIcon })
+        const rendered = getByTestId(TEST_ID_MAP.KEY_ITEM)
+        const keyItemIcon = rendered?.firstChild
+        expect(keyItemIcon?.nodeName).toEqual('#text')
+        expect(keyItemIcon?.textContent).toEqual(keyIcon)
+      })
+    })
+
+    describe('keyContent', () => {
+      it('keyContent가 string이면, Key의 text string으로서 렌더링된다.', () => {
+        const { getByTestId } = renderComponent()
+        const rendered = getByTestId(TEST_ID_MAP.KEY_ITEM)
+        const keyItemText = rendered?.lastChild
+        expect(keyItemText?.nodeName).toEqual('DIV')
+        expect(keyItemText?.textContent).toEqual(DEFAULT_PROPS.keyContent)
+      })
+
+      it('keyContent가 React.Node면, Key의 text가 node로서 렌더링된다.', () => {
+        const keyContent = (
+          <button type="button">
+            Button
+          </button>
+        )
+        const { getByTestId } = renderComponent({ keyContent })
+        const rendered = getByTestId(TEST_ID_MAP.KEY_ITEM)
+        const keyItemText = rendered?.lastChild
+        expect(keyItemText?.nodeName).toEqual('BUTTON')
+        expect(keyItemText?.textContent).toEqual('Button')
+      })
+    })
+
+    describe('children', () => {
+      it('children가 string이면, Value의 text string으로서 렌더링된다.', () => {
+        const { getByTestId } = renderComponent()
+        const rendered = getByTestId(TEST_ID_MAP.VALUE_ITEM)
+        expect(rendered?.nodeName).toEqual('DIV')
+        expect(rendered?.textContent).toEqual(DEFAULT_PROPS.children)
+      })
+
+      it('children가 React.Node면, Value의 text가 node로서 렌더링된다.', () => {
+        const children = (
+          <button type="button">
+            Button
+          </button>
+        )
+        const { getByTestId } = renderComponent({ children })
+        const rendered = getByTestId(TEST_ID_MAP.VALUE_ITEM)
+        const valueChildren = rendered?.firstChild
+        expect(valueChildren?.nodeName).toEqual('BUTTON')
+        expect(valueChildren?.textContent).toEqual('Button')
+      })
+    })
+
+    describe('actions', () => {
+      it('actions의 show가 true면, ActionIconWrapper display가 flex처리 된다.', () => {
+        const actions: KeyValueListItemActionProps = { icon: 'badge', show: true }
+        const { getByTestId } = renderComponent({ actions })
+        const rendered = getByTestId(TEST_ID_MAP.ACTIONS_ITEM)
+        const actionItemIconWrapper = rendered?.firstChild
+        expect(actionItemIconWrapper).toHaveStyle('display: flex;')
+      })
+
+      it('actions의 show가 false면, ActionIconWrapper display가 none처리 된다.', () => {
+        const actions: KeyValueListItemActionProps = { icon: 'badge', show: false }
+        const { getByTestId } = renderComponent({ actions })
+        const rendered = getByTestId(TEST_ID_MAP.ACTIONS_ITEM)
+        const actionItemIconWrapper = rendered?.firstChild
+        expect(actionItemIconWrapper).toHaveStyle('display: none;')
+      })
+
+      it('actions가 없으면, ItemAction은 렌더링되지 않는다.', async () => {
+        const { queryByTestId } = renderComponent({ })
+        const rendered = await queryByTestId(TEST_ID_MAP.ACTIONS_ITEM)
+        const actionItems = rendered
+        expect(actionItems).not.toBeInTheDocument()
+      })
+
+      it('actions가 Object면, 아이콘이 1개만 렌더링된다.', () => {
+        const actions: KeyValueListItemActionProps = { icon: 'badge' }
+        const { getByTestId } = renderComponent({ actions })
+        const rendered = getByTestId(TEST_ID_MAP.ACTIONS_ITEM)
+        const actionItemsCount = rendered?.childNodes.length
+        expect(actionItemsCount).toEqual(1)
+      })
+
+      it('actions가 Array면, 아이콘이 여러개 렌더링된다.', () => {
+        const actions: KeyValueListItemActionProps[] = (
+          Array.from(Array(2)).map(() => ({ icon: 'badge' }))
+        )
+        const { getByTestId } = renderComponent({ actions })
+        const rendered = getByTestId(TEST_ID_MAP.ACTIONS_ITEM)
+        const actionItemsCount = rendered?.childNodes.length
+        expect(actionItemsCount).toEqual(2)
+      })
+
+      it('actions의 icon이 렌더링된다.', () => {
+        const actions: KeyValueListItemActionProps = { icon: 'badge' }
+        const { getByTestId } = renderComponent({ actions })
+        const rendered = getByTestId(TEST_ID_MAP.ACTIONS_ITEM)
+        const actionItemIconWrapper = rendered?.firstChild
+        const actionItemIcon = actionItemIconWrapper?.firstChild
+        expect(actionItemIcon?.nodeName).toEqual('svg')
+      })
+
+      it('actions의 onClick 있으면, icon click event에서 호출된다.', async () => {
+        const user = userEvent.setup()
+
+        const actions: KeyValueListItemActionProps = { icon: 'badge', onClick: jest.fn() }
+        const { getByTestId } = renderComponent({ actions })
+        const rendered = getByTestId(TEST_ID_MAP.ACTIONS_ITEM)
+        const actionItemIconWrapper = rendered?.firstChild
+        const actionItemIcon = actionItemIconWrapper?.firstChild
+
+        await user.click(actionItemIcon as HTMLElement)
+        expect(actions.onClick).toBeCalledTimes(1)
+        await user.click(actionItemIcon as HTMLElement)
+        expect(actions.onClick).toBeCalledTimes(2)
+      })
+
+      it('actions의 tooltip이 있으면, tooltip이 렌더링된다.', () => {
+        const actions: KeyValueListItemActionProps = { icon: 'badge', tooltip: 'tooltip' }
+        const { getByTestId } = renderComponent({ actions })
+        const rendered = getByTestId(TOOLTIP_TEST_ID)
+        expect(rendered).toBeInTheDocument()
+      })
+    })
+
+    describe('onClickKey', () => {
+      it('onClickKey가 없으면, Key 영역의 hover/cursor 스타일이 없다.', async () => {
+        const user = userEvent.setup()
+
+        const { getByTestId } = renderComponent()
+        const rendered = getByTestId(TEST_ID_MAP.ROOT)
+        const keyItemContainer = rendered?.firstChild
+
+        await user.hover(keyItemContainer as Element)
+        expect(keyItemContainer).toHaveStyle('display: flex;')
+        expect(keyItemContainer).toHaveStyle('align-items: center;')
+        expect(keyItemContainer).toHaveStyle('padding: 4px 6px;')
+        expect(keyItemContainer).not.toHaveStyle('cursor: pointer;')
+        // NOTE(@sol): Hovered DOM style test is not working
+        // expect(keyItemContainer).not.toHaveStyle(`background-color: rgba(0, 0, 0, 0.051);`)
+      })
+
+      it('onClickKey가 있으면, Key 영역이 hover/cursor 스타일이 존재한다.', async () => {
+        const user = userEvent.setup()
+
+        const props: Partial<KeyValueListItemProps> = {
+          onClickKey: jest.fn(),
+        }
+        const { getByTestId } = renderComponent(props)
+        const rendered = getByTestId(TEST_ID_MAP.ROOT)
+        const keyItemContainer = rendered?.firstChild
+
+        await user.hover(keyItemContainer as Element)
+        expect(keyItemContainer).toHaveStyle('display: flex;')
+        expect(keyItemContainer).toHaveStyle('align-items: center;')
+        expect(keyItemContainer).toHaveStyle('padding: 4px 6px;')
+        expect(keyItemContainer).toHaveStyle('cursor: pointer;')
+        // NOTE(@sol): Hovered DOM style test is not working
+        // expect(keyItemContainer).toHaveStyle(`background-color: rgba(0, 0, 0, 0.051);`)
+      })
+
+      it('onClickKey가 있으면, Key 영역이 click event에서 호출된다.', async () => {
+        const user = userEvent.setup()
+
+        const props: Partial<KeyValueListItemProps> = {
+          onClickKey: jest.fn(),
+        }
+        const { getByTestId } = renderComponent(props)
+        const rendered = getByTestId(TEST_ID_MAP.ROOT)
+        const keyItemContainer = rendered?.firstChild
+
+        await user.click(keyItemContainer as Element)
+        expect(props.onClickKey).toBeCalledTimes(1)
+        await user.click(keyItemContainer as Element)
+        expect(props.onClickKey).toBeCalledTimes(2)
+      })
+    })
+
+    describe('onClickValue', () => {
+      it('onClickValue가 없으면, Value 영역의 hover/cursor 스타일이 없다.', async () => {
+        const user = userEvent.setup()
+
+        const { getByTestId } = renderComponent()
+        const rendered = getByTestId(TEST_ID_MAP.ROOT)
+        const valueItemContainer = rendered?.lastChild
+
+        await user.hover(valueItemContainer as Element)
+        expect(valueItemContainer).toHaveStyle('display: flex;')
+        expect(valueItemContainer).toHaveStyle('align-items: center;')
+        expect(valueItemContainer).toHaveStyle('padding: 4px 6px;')
+        expect(valueItemContainer).not.toHaveStyle('cursor: pointer;')
+        // NOTE(@sol): Hovered DOM style test is not working
+        // expect(valueItemContainer).not.toHaveStyle(`background-color: rgba(0, 0, 0, 0.051);`)
+      })
+
+      it('onClickValue가 있으면, Value 영역이 hover/cursor 스타일이 존재한다.', async () => {
+        const user = userEvent.setup()
+
+        const props: Partial<KeyValueListItemProps> = {
+          onClickValue: jest.fn(),
+        }
+        const { getByTestId } = renderComponent(props)
+        const rendered = getByTestId(TEST_ID_MAP.ROOT)
+        const valueItemContainer = rendered?.lastChild
+
+        await user.hover(valueItemContainer as Element)
+        expect(valueItemContainer).toHaveStyle('display: flex;')
+        expect(valueItemContainer).toHaveStyle('align-items: center;')
+        expect(valueItemContainer).toHaveStyle('padding: 4px 6px;')
+        expect(valueItemContainer).toHaveStyle('cursor: pointer;')
+        // NOTE(@sol): Hovered DOM style test is not working
+        // expect(valueItemContainer).toHaveStyle('background-color: rgba(0, 0, 0, 0.051);')
+      })
+
+      it('onClickValue가 있으면, Value 영역이 click event에서 호출된다.', async () => {
+        const user = userEvent.setup()
+
+        const props: Partial<KeyValueListItemProps> = {
+          onClickValue: jest.fn(),
+        }
+        const { getByTestId } = renderComponent(props)
+        const rendered = getByTestId(TEST_ID_MAP.ROOT)
+        const valueItemContainer = rendered?.lastChild
+
+        await user.click(valueItemContainer as Element)
+        expect(props.onClickValue).toBeCalledTimes(1)
+        await user.click(valueItemContainer as Element)
+        expect(props.onClickValue).toBeCalledTimes(2)
+      })
+    })
   })
 
-  it('multiline이라면 key 와 value가 다른 dom에 존재한다', () => {
-    const { getByTestId } = renderedComponent({ multiline: true })
-    const rendered = getByTestId(KEY_VALUE_LIST_ITEM_TEST_ID)
+  describe('Styles', () => {
+    describe('KeyValueListItem', () => {
+      it('Root', () => {
+        const { getByTestId } = renderComponent()
+        const rendered = getByTestId(TEST_ID_MAP.ROOT)
+        expect(rendered).toHaveStyle('display: flex;')
+        expect(rendered).toHaveStyle('align-items: center;')
+        expect(rendered).toHaveStyle('border-radius: 6px;')
+        expect(rendered).toHaveStyle('transition-delay: 0ms;')
+        expect(rendered).toHaveStyle('transition-timing-function: cubic-bezier(.3,0,0,1);')
+        expect(rendered).toHaveStyle('transition-duration: 150ms;')
+        expect(rendered).toHaveStyle('transition-property: background-color,color;')
 
-    expect(rendered.childElementCount).toBe(2)
+        const rootKeyContainer = rendered.firstChild
+        expect(rootKeyContainer).toHaveStyle('display: flex;')
+        expect(rootKeyContainer).toHaveStyle('flex: 1;')
+        expect(rootKeyContainer).toHaveStyle('height: 28px;')
+
+        const rootValueContainer = rendered.lastChild
+        expect(rootValueContainer).toHaveStyle('display: flex;')
+        expect(rootValueContainer).toHaveStyle('flex: 2;')
+        expect(rootValueContainer).toHaveStyle('justify-content: space-between;')
+        expect(rootValueContainer).toHaveStyle('height: 28px;')
+        expect(rootValueContainer).toHaveStyle('overflow: hidden;')
+        expect(rootValueContainer).toHaveStyle('text-overflow: ellipsis;')
+        expect(rootValueContainer).toHaveStyle('white-space: nowrap;')
+      })
+
+      it('Key, Value가 flex로서 1:2의 width 비율을 유지한다.', () => {
+        const { getByTestId } = renderComponent()
+        const rendered = getByTestId(TEST_ID_MAP.ROOT)
+
+        const rootKeyContainer = rendered.firstChild
+        expect(rootKeyContainer).toHaveStyle('display: flex;')
+        expect(rootKeyContainer).toHaveStyle('flex: 1;')
+
+        const rootValueContainer = rendered.lastChild
+        expect(rootValueContainer).toHaveStyle('display: flex;')
+        expect(rootValueContainer).toHaveStyle('flex: 2;')
+        expect(rootValueContainer).toHaveStyle('justify-content: space-between;')
+      })
+
+      it('KeyValueListItem > KeyItem', () => {
+        const { getByTestId } = renderComponent()
+        const rendered = getByTestId(TEST_ID_MAP.KEY_ITEM)
+        expect(rendered).toHaveStyle('display: flex;')
+        expect(rendered).toHaveStyle('align-items: center;')
+        expect(rendered).toHaveStyle('min-width: 100px;')
+
+        const keyItemText = rendered?.lastChild
+        expect(keyItemText).toHaveStyle('color: rgba(0, 0, 0, 0.4);')
+        expect(keyItemText).toHaveStyle('overflow: hidden;')
+        expect(keyItemText).toHaveStyle('text-overflow: ellipsis;')
+        expect(keyItemText).toHaveStyle('white-space: nowrap;')
+      })
+
+      it('KeyValueListItem > ValueItem', () => {
+        const { getByTestId } = renderComponent()
+        const rendered = getByTestId(TEST_ID_MAP.VALUE_ITEM)
+        expect(rendered).toHaveStyle('font-size: 1.4rem;')
+      })
+
+      it('KeyValueListItem > ItemActions', () => {
+        const actions: KeyValueListItemActionProps = { icon: 'badge' }
+        const { getByTestId } = renderComponent({ actions })
+        const rendered = getByTestId(TEST_ID_MAP.ACTIONS_ITEM)
+        expect(rendered).toHaveStyle('display: flex;')
+        expect(rendered).toHaveStyle('align-items: center;')
+      })
+    })
+
+    describe('KeyValueMultiLineListItem', () => {
+      it('Root', () => {
+        const { getByTestId } = renderMultilineComponent()
+        const rendered = getByTestId(TEST_ID_MAP.MULTILINE_ROOT)
+        expect(rendered).toHaveStyle('display: flex;')
+        expect(rendered).toHaveStyle('flex-direction: column;')
+        expect(rendered).toHaveStyle('justify-content: center;')
+        expect(rendered).toHaveStyle('border-radius: 6px;')
+        expect(rendered).toHaveStyle('transition-delay: 0ms;')
+        expect(rendered).toHaveStyle('transition-timing-function: cubic-bezier(.3,0,0,1);')
+        expect(rendered).toHaveStyle('transition-duration: 150ms;')
+        expect(rendered).toHaveStyle('transition-property: background-color,color;')
+
+        const rootKeyContainer = rendered.firstChild
+        expect(rootKeyContainer).toHaveStyle('display: flex;')
+        expect(rootKeyContainer).toHaveStyle('flex: 1;')
+        expect(rootKeyContainer).toHaveStyle('justify-content: space-between;')
+        expect(rootKeyContainer).toHaveStyle('height: 28px;')
+
+        const rootValueContainer = rendered.lastChild
+        expect(rootValueContainer).toHaveStyle('display: flex;')
+        expect(rootValueContainer).toHaveStyle('flex: 1;')
+        expect(rootValueContainer).toHaveStyle('padding: 0 6px;')
+        expect(rootValueContainer).toHaveStyle('min-height: 28px;')
+      })
+    })
   })
 })

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.types.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.types.ts
@@ -2,21 +2,14 @@
 import React from 'react'
 
 /* Internal dependencies */
-import type { BezierComponentProps, ChildrenProps, AdditionalStylableProps, AdditionalColorProps } from 'Types/ComponentProps'
+import type { BezierComponentProps, ChildrenProps, AdditionalStylableProps } from 'Types/ComponentProps'
 import type { IconName } from 'Components/Icon'
-
-export type KeyValueActionProps = {
-  icon: IconName
-  tooltip?: string
-  show?: boolean
-  onClick?: React.MouseEventHandler<HTMLDivElement>
-} & AdditionalColorProps<['icon', 'hoverBackground', 'hoverIcon']> | React.ReactElement
+import { KeyValueListItemActionProps } from './common'
 
 interface KeyValueListItemOptions {
-  multiline?: boolean
   keyIcon?: IconName | React.ReactNode
   keyContent?: React.ReactNode
-  actions?: KeyValueActionProps | KeyValueActionProps[]
+  actions?: KeyValueListItemActionProps | KeyValueListItemActionProps[]
 }
 
 export interface KeyValueListItemProps extends
@@ -24,4 +17,7 @@ export interface KeyValueListItemProps extends
   ChildrenProps,
   React.HTMLAttributes<HTMLDivElement>,
   AdditionalStylableProps<['valueWrapper', 'keyWrapper']>,
-  KeyValueListItemOptions {}
+  KeyValueListItemOptions {
+  onClickKey?: (e: React.MouseEvent<HTMLDivElement>) => void
+  onClickValue?: (e: React.MouseEvent<HTMLDivElement>) => void
+}

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueMultiLineListItem.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueMultiLineListItem.styled.ts
@@ -1,21 +1,21 @@
 /* Internal dependencies */
-import { ellipsis, styled } from 'Foundation'
+import { styled } from 'Foundation'
 import { KeyValueListItemWrapper, KeyValueListItemContainer } from './KeyValueListItem.common.styled'
 
 export const Wrapper = styled(KeyValueListItemWrapper)`
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  justify-content: center;
 `
 
 export const KeyItemContainer = styled(KeyValueListItemContainer)`
   flex: 1;
+  justify-content: space-between;
   height: 28px;
-  ${ellipsis()};
 `
 
 export const ValueItemContainer = styled(KeyValueListItemContainer)`
-  flex: 2;
-  justify-content: space-between;
-  height: 28px;
-  ${ellipsis()};
+  flex: 1;
+  min-height: 28px;
+  padding: 0 6px;
 `

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueMultiLineListItem.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueMultiLineListItem.tsx
@@ -2,12 +2,12 @@
 import React, { forwardRef, Ref } from 'react'
 
 /* Internal dependencies */
-import { ItemAction, KeyItem, ValueItem } from './common'
+import { ValueItem, ItemAction, KeyItem } from './common'
 import { TEST_ID_MAP } from './KeyValueListItem.const'
 import { KeyValueListItemProps } from './KeyValueListItem.types'
-import * as Styled from './KeyValueListItem.styled'
+import * as Styled from './KeyValueMultiLineListItem.styled'
 
-function KeyValueListItem(
+function KeyValueMultiLineListItem(
   {
     className,
     interpolation,
@@ -16,7 +16,7 @@ function KeyValueListItem(
     keyIcon,
     keyContent,
     actions,
-    testId = TEST_ID_MAP.ROOT,
+    testId = TEST_ID_MAP.MULTILINE_ROOT,
     children,
     onClickKey,
     onClickValue,
@@ -39,15 +39,15 @@ function KeyValueListItem(
         >
           { keyContent }
         </KeyItem>
+        <ItemAction actions={actions} />
       </Styled.KeyItemContainer>
       <Styled.ValueItemContainer onClick={onClickValue}>
-        <ValueItem interpolation={valueWrapperInterpolation}>
+        <ValueItem interpolation={valueWrapperInterpolation} multiline>
           { children }
         </ValueItem>
-        <ItemAction actions={actions} />
       </Styled.ValueItemContainer>
     </Styled.Wrapper>
   )
 }
 
-export default forwardRef(KeyValueListItem)
+export default forwardRef(KeyValueMultiLineListItem)

--- a/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
+++ b/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
@@ -1,7 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KeyValueListItem Snapshot > 1`] = `
-.c2 {
+.c7 {
+  font-size: 1.2rem;
+  line-height: 1.6rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: 600;
+  color: #00000066;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c6 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -17,35 +34,49 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   transition-property: color;
 }
 
-.c5 {
-  font-size: 1.2rem;
-  line-height: 1.6rem;
-  margin: 0px 0px 0px 0px;
-  font-style: normal;
-  font-weight: 600;
-  color: inherit;
-  -webkit-transition-delay: 0ms;
-  transition-delay: 0ms;
-  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
-  transition-timing-function: cubic-bezier(.3,0,0,1);
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-property: color;
-  transition-property: color;
-}
-
-.c0 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  width: 100%;
+  height: 100%;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  min-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c8 {
+  margin-left: 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c10 {
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c0 {
   overflow: hidden;
   border-radius: 6px;
   -webkit-transition-delay: 0ms;
@@ -58,18 +89,8 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   transition-property: background-color,color;
 }
 
-.c0:hover {
-  background-color: #0000000D;
-}
-
-.c6 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: #00000066;
-}
-
-.c4 {
+.c2 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -78,16 +99,9 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  max-width: 118px;
-  padding-left: 8px;
-}
-
-.c8 {
-  min-width: 0;
-}
-
-.c3 ~ .c7 {
-  margin-left: 8px;
+  padding: 4px 6px;
+  overflow: hidden;
+  border-radius: 6px;
 }
 
 .c1 {
@@ -99,52 +113,84 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  padding: 4px 6px;
+}
+
+.c3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  height: 28px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c9 {
+  -webkit-flex: 2;
+  -ms-flex: 2;
+  flex: 2;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  height: 28px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
   data-testid="bezier-react-key-value-list-item"
 >
   <div
-    class="c1"
+    class="c2 c3"
   >
-    <svg
-      class="c2"
-      color="txt-black-dark"
-      data-testid="bezier-react-icon"
-      fill="none"
-      foundation="[object Object]"
-      height="20"
-      marginbottom="0"
-      marginleft="0"
-      marginright="0"
-      margintop="0"
-      viewBox="0 0 24 24"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clip-rule="evenodd"
-        d="M15.832 1s.272 1.628-1.033 3.197c-1.394 1.675-2.979 1.4-2.979 1.4s-.297-1.317.872-2.857C14.006 1.01 15.832 1 15.832 1Zm3.637 6.81s-2.163 1.105-2.163 3.789c0 3.027 2.694 4.07 2.694 4.07s-1.883 5.302-4.427 5.302c-.577 0-1.09-.192-1.611-.387-.534-.2-1.075-.401-1.698-.401-.695 0-1.388.25-2.005.475-.497.18-.945.342-1.306.342-2.322 0-5.257-5.03-5.257-9.071 0-3.977 2.484-6.063 4.814-6.063.88 0 1.646.295 2.288.542.462.178.86.33 1.19.33.264 0 .618-.142 1.047-.315.669-.27 1.522-.613 2.517-.613 2.81 0 3.917 2 3.917 2Z"
-        fill="currentColor"
-        fill-rule="evenodd"
-      />
-    </svg>
     <div
-      class="c3 c4"
+      class="c4 c5"
+      data-testid="bezier-react-key-value-list-item-key-item"
+      direction="horizontal"
     >
-      <span
-        class="c5 c6"
-        data-testid="bezier-react-text"
+      <svg
+        class="c6"
+        color="txt-black-dark"
+        data-testid="bezier-react-icon"
+        fill="none"
+        foundation="[object Object]"
+        height="20"
+        marginbottom="0"
+        marginleft="0"
+        marginright="0"
+        margintop="0"
+        viewBox="0 0 24 24"
+        width="20"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        key
-      </span>
+        <path
+          clip-rule="evenodd"
+          d="M15.832 1s.272 1.628-1.033 3.197c-1.394 1.675-2.979 1.4-2.979 1.4s-.297-1.317.872-2.857C14.006 1.01 15.832 1 15.832 1Zm3.637 6.81s-2.163 1.105-2.163 3.789c0 3.027 2.694 4.07 2.694 4.07s-1.883 5.302-4.427 5.302c-.577 0-1.09-.192-1.611-.387-.534-.2-1.075-.401-1.698-.401-.695 0-1.388.25-2.005.475-.497.18-.945.342-1.306.342-2.322 0-5.257-5.03-5.257-9.071 0-3.977 2.484-6.063 4.814-6.063.88 0 1.646.295 2.288.542.462.178.86.33 1.19.33.264 0 .618-.142 1.047-.315.669-.27 1.522-.613 2.517-.613 2.81 0 3.917 2 3.917 2Z"
+          fill="currentColor"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <div
+        class="c7 c8"
+        color="txt-black-dark"
+        data-testid="bezier-react-text"
+        direction="horizontal"
+      >
+        Key
+      </div>
     </div>
+  </div>
+  <div
+    class="c2 c9"
+  >
     <div
-      class="c7 c8"
+      class="c10"
+      data-testid="bezier-react-key-value-list-item-value-item"
     >
-      thisiscontent
+      Value
     </div>
   </div>
 </div>

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.styled.ts
@@ -1,0 +1,45 @@
+/* External dependencies */
+import { isNil } from 'lodash-es'
+
+/* Internal dependencies */
+import { css, styled } from 'Foundation'
+import { AdditionalColorProps } from 'Types/ComponentProps'
+import { Icon } from 'Components/Icon'
+import { Tooltip } from 'Components/Tooltip'
+
+export const ItemActionWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`
+interface ActionWrapperProps extends AdditionalColorProps<['hoverBackground', 'hoverIcon']> {
+  show: boolean
+}
+
+export const ActionIcon = styled(Icon)``
+
+export const ActionIconWrapper = styled.div<ActionWrapperProps>`
+  display: ${({ show }) => (show ? 'flex' : 'none')};
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  margin-left: auto;
+  cursor: pointer;
+
+  ${({ foundation }) => foundation?.rounding?.round6}
+
+  &:hover {
+    ${({ foundation, hoverBackgroundColor }) => !isNil(hoverBackgroundColor) && css`
+      background-color: ${foundation?.theme?.[hoverBackgroundColor]};
+    `}
+
+    ${ActionIcon} {
+      ${({ foundation, hoverIconColor }) => !isNil(hoverIconColor) && css`
+        color: ${foundation?.theme?.[hoverIconColor]};
+      `}
+    }
+  }
+`
+
+export const ActionIconTooltip = styled(Tooltip)`
+  margin-left: auto;
+`

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.tsx
@@ -1,0 +1,79 @@
+/* External dependencies */
+import React, { forwardRef, memo, Ref, useCallback, useMemo } from 'react'
+import { noop, isNil, isEmpty, isArray, isBoolean } from 'lodash-es'
+import { v4 as uuid } from 'uuid'
+
+/* Internal dependencies */
+import { IconSize } from 'Components/Icon'
+import { TEST_ID_MAP } from 'Components/KeyValueListItem/KeyValueListItem.const'
+import { ItemActionProps, KeyValueListItemActionProps } from './ItemAction.types'
+import * as Styled from './ItemAction.styled'
+
+function ItemAction(
+  {
+    actions,
+    testId = TEST_ID_MAP.ACTIONS_ITEM,
+    ...props
+  }: ItemActionProps,
+  forwardedRef: Ref<HTMLDivElement>,
+) {
+  const renderAction = useCallback((action: KeyValueListItemActionProps, key?: string) => {
+    if ('icon' in action) {
+      const iconElement = (
+        <Styled.ActionIconWrapper
+          key={key}
+          hoverBackgroundColor={action.hoverBackgroundColor ?? 'bg-black-lighter'}
+          hoverIconColor={action.hoverIconColor ?? 'txt-black-darkest'}
+          show={isBoolean(action.show) ? action.show : true}
+          onClick={action.onClick ?? noop}
+        >
+          <Styled.ActionIcon
+            name={action.icon}
+            color={action.iconColor ?? 'txt-black-dark'}
+            size={IconSize.XS}
+          />
+        </Styled.ActionIconWrapper>
+      )
+      if (!isEmpty(action.tooltip)) {
+        return (
+          <Styled.ActionIconTooltip key={key} content={action.tooltip}>
+            { iconElement }
+          </Styled.ActionIconTooltip>
+        )
+      }
+      return iconElement
+    }
+    return React.cloneElement(action, { key })
+  }, [])
+
+  const ActionsComponent = useMemo(() => {
+    if (isNil(actions) || isEmpty(actions)) {
+      return null
+    }
+
+    const item = isArray(actions)
+      ? actions.map((action) => renderAction(action, uuid()))
+      : renderAction(actions)
+
+    return item
+  }, [
+    actions,
+    renderAction,
+  ])
+
+  if (isNil(actions) || isEmpty(actions)) {
+    return null
+  }
+
+  return (
+    <Styled.ItemActionWrapper
+      data-testid={testId}
+      {...props}
+      ref={forwardedRef}
+    >
+      { ActionsComponent }
+    </Styled.ItemActionWrapper>
+  )
+}
+
+export default memo(forwardRef(ItemAction))

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.types.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.types.ts
@@ -1,0 +1,23 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import type { BezierComponentProps, ChildrenProps, AdditionalColorProps } from 'Types/ComponentProps'
+import type { IconName } from 'Components/Icon'
+
+export type KeyValueListItemActionProps = {
+  icon: IconName
+  tooltip?: string
+  show?: boolean
+  onClick?: React.MouseEventHandler<HTMLDivElement>
+} & AdditionalColorProps<['icon', 'hoverBackground', 'hoverIcon']> | React.ReactElement
+
+interface ItemActionOptions {
+  actions?: KeyValueListItemActionProps | KeyValueListItemActionProps[]
+}
+
+export interface ItemActionProps extends
+  BezierComponentProps,
+  ChildrenProps,
+  React.HTMLAttributes<HTMLDivElement>,
+  ItemActionOptions {}

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/index.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/index.ts
@@ -1,0 +1,11 @@
+/* Internal dependencies */
+import ItemAction from './ItemAction'
+import type { KeyValueListItemActionProps } from './ItemAction.types'
+
+export type {
+  KeyValueListItemActionProps,
+}
+
+export {
+  ItemAction,
+}

--- a/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.styled.ts
@@ -1,0 +1,20 @@
+/* Internal dependencies */
+import { ellipsis, styled } from 'Foundation'
+import { Text } from 'Components/Text'
+import { Stack } from 'Components/Stack'
+
+export const KeyContentStack = styled(Stack).attrs({
+  direction: 'horizontal',
+  align: 'center',
+})`
+  min-width: 100px;
+  ${ellipsis()};
+`
+
+export const KeyText = styled(Text).attrs({
+  forwardedAs: 'div',
+  color: 'txt-black-dark',
+})`
+  margin-left: 8px;
+  ${ellipsis()};
+`

--- a/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.tsx
@@ -1,0 +1,60 @@
+/* External dependencies */
+import React, { forwardRef, memo, Ref, useMemo } from 'react'
+import { isString } from 'lodash-es'
+
+/* Internal dependencies */
+import { Typography } from 'Foundation'
+import { Icon, IconSize, isIconName } from 'Components/Icon'
+import { TEST_ID_MAP } from 'Components/KeyValueListItem/KeyValueListItem.const'
+import { KeyItemProps } from './KeyItem.types'
+import * as Styled from './KeyItem.styled'
+
+function KeyItem(
+  {
+    className,
+    interpolation,
+    keyIcon,
+    testId = TEST_ID_MAP.KEY_ITEM,
+    children,
+    ...props
+  }: KeyItemProps,
+  forwardedRef: Ref<HTMLDivElement>,
+) {
+  const KeyIcon = useMemo(() => {
+    if (isIconName(keyIcon)) {
+      return (
+        <Icon
+          name={keyIcon}
+          size={IconSize.S}
+          color="txt-black-dark"
+        />
+      )
+    }
+    return keyIcon
+  }, [keyIcon])
+
+  const KeyText = useMemo(() => {
+    if (isString(children)) {
+      return (
+        <Styled.KeyText bold typo={Typography.Size12}>
+          { children }
+        </Styled.KeyText>
+      )
+    }
+    return children
+  }, [children])
+
+  return (
+    <Styled.KeyContentStack
+      testId={testId}
+      {...props}
+      ref={forwardedRef}
+      interpolation={interpolation}
+    >
+      { KeyIcon }
+      { KeyText }
+    </Styled.KeyContentStack>
+  )
+}
+
+export default memo(forwardRef(KeyItem))

--- a/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.types.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.types.ts
@@ -1,0 +1,16 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import type { BezierComponentProps, ChildrenProps } from 'Types/ComponentProps'
+import type { IconName } from 'Components/Icon'
+
+interface KeyItemOptions {
+  keyIcon?: IconName | React.ReactNode
+}
+
+export interface KeyItemProps extends
+  BezierComponentProps,
+  ChildrenProps,
+  React.HTMLAttributes<HTMLDivElement>,
+  KeyItemOptions {}

--- a/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/index.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/index.ts
@@ -1,0 +1,6 @@
+/* Internal dependencies */
+import KeyItem from './KeyItem'
+
+export {
+  KeyItem,
+}

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ValueItem/ValueItem.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ValueItem/ValueItem.styled.ts
@@ -1,0 +1,13 @@
+/* Internal dependencies */
+import { ellipsis, styled, Typography } from 'Foundation'
+import { InterpolationProps } from 'Types/Foundation'
+
+interface ValueWrapperProps extends InterpolationProps {
+  multiline?: boolean
+}
+
+export const ValueWrapper = styled.div<ValueWrapperProps>`
+  ${Typography.Size14};
+  ${({ multiline }) => !multiline && ellipsis()};
+  ${({ interpolation }) => interpolation}
+`

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ValueItem/ValueItem.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ValueItem/ValueItem.tsx
@@ -1,0 +1,30 @@
+/* External dependencies */
+import React, { forwardRef, memo, Ref } from 'react'
+
+/* Internal dependencies */
+import { TEST_ID_MAP } from 'Components/KeyValueListItem/KeyValueListItem.const'
+import { ValueItemProps } from './ValueItem.types'
+import * as Styled from './ValueItem.styled'
+
+function ValueItem(
+  {
+    testId = TEST_ID_MAP.VALUE_ITEM,
+    interpolation,
+    children,
+    ...props
+  }: ValueItemProps,
+  forwardedRef: Ref<HTMLDivElement>,
+) {
+  return (
+    <Styled.ValueWrapper
+      data-testid={testId}
+      {...props}
+      ref={forwardedRef}
+      interpolation={interpolation}
+    >
+      { children }
+    </Styled.ValueWrapper>
+  )
+}
+
+export default memo(forwardRef(ValueItem))

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ValueItem/ValueItem.types.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ValueItem/ValueItem.types.ts
@@ -1,0 +1,16 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import type { BezierComponentProps, ChildrenProps } from 'Types/ComponentProps'
+
+interface ValueItemOptions {
+  multiline?: boolean
+}
+
+export interface ValueItemProps extends
+  BezierComponentProps,
+  ChildrenProps,
+  React.HTMLAttributes<HTMLDivElement>,
+  ValueItemOptions {}
+

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ValueItem/index.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ValueItem/index.ts
@@ -1,0 +1,6 @@
+/* Internal dependencies */
+import ValueItem from './ValueItem'
+
+export {
+  ValueItem,
+}

--- a/packages/bezier-react/src/components/KeyValueListItem/common/index.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/index.ts
@@ -1,0 +1,3 @@
+export * from './ItemActions'
+export * from './KeyItem'
+export * from './ValueItem'

--- a/packages/bezier-react/src/components/KeyValueListItem/index.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/index.ts
@@ -1,12 +1,17 @@
 /* Internal dependencies */
+import type { KeyValueListItemActionProps } from './common'
+import type { KeyValueListItemProps } from './KeyValueListItem.types'
+import type { KeyValueListItemContainerProps } from './KeyValueListItem.common.styled'
 import KeyValueListItem from './KeyValueListItem'
-import type { KeyValueActionProps, KeyValueListItemProps } from './KeyValueListItem.types'
+import KeyValueMultiLineListItem from './KeyValueMultiLineListItem'
 
 export type {
-  KeyValueActionProps,
+  KeyValueListItemContainerProps,
+  KeyValueListItemActionProps,
   KeyValueListItemProps,
 }
 
 export {
   KeyValueListItem,
+  KeyValueMultiLineListItem,
 }


### PR DESCRIPTION
# Summary
- KeyValueListItem의 공통 Component를 분리하고, RenderComponent를 Props가 아닌 Component 단위로 분리합니다.

## To-Be
### Single
![1](https://user-images.githubusercontent.com/16330024/169163458-db0cda0d-c30c-41fe-9771-a9fc3029f343.png)
![2](https://user-images.githubusercontent.com/16330024/169163457-faa24b5f-6b13-44d8-879f-b0dc0fb53238.png)
![3](https://user-images.githubusercontent.com/16330024/169163618-2fb9a334-0dce-4d3a-9410-6cf1f734dccb.png)

### Multi
![4](https://user-images.githubusercontent.com/16330024/169163454-b7e58fd9-d7f6-4e14-8902-4142c157ad9f.png)
![5](https://user-images.githubusercontent.com/16330024/169163451-cac1b79d-f78e-423e-997c-73e99a64f516.png)
![6](https://user-images.githubusercontent.com/16330024/169163439-826617f9-c5fb-49b2-90f3-1e81470f2ce9.png)

# Details
- Key, Value, Action으로 Component를 나눕니다.
  - common
- SingleLine과 MultiLine은 같은 Component를 공유하되 세부적인 Style은 Component와 styled 파일로 나눕니다.
  - KeyValueListItem.common.styled
  - KeyValueListItem + KeyValueListItem.styled
  - KeyValueMultiLineListItem + KeyValueMultiLineListItem.styled
- onClickKey, onClickValue가 추가되고, 각 영역의 Hover/Cursor 스타일이 ClickEvent를 기반으로 동작합니다.
  - KeyValueListItem.types
- SingleLine에서 min-width 100px이 추가되고, Key와 Value의 1:2 비율을 추가합니다.
- Test를 강화합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# References
- [KeyValueListItem Figma](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=1164%3A12605)
