### PR TITLE
feat(use-id): implement the useIdLegacy hook for legacy react version compatibility

### DIFF
--- a/apps/bezier-react/src/hooks/useId.test.ts
+++ b/apps/bezier-react/src/hooks/useId.test.ts
@@ -1,6 +1,6 @@
 /* Internal dependencies */
 import { renderHook } from 'Utils/testUtils'
-import useId from './useId'
+import useId, { useIdLegacy } from './useId'
 
 describe('useId >', () => {
   it('should return unique id', () => {
@@ -25,5 +25,31 @@ describe('useId >', () => {
     const { result } = renderHook(() => useId(undefined, 'prefix'))
 
     expect(result.current).toBe('prefix-:r3:')
+  })
+})
+
+describe('useIdLegacy >', () => {
+  it('should return unique id', () => {
+    const { result } = renderHook(() => useIdLegacy())
+
+    expect(result.current).toBe('1')
+  })
+
+  it('should return unique id with 1 added on the next call', () => {
+    const { result } = renderHook(() => useIdLegacy())
+
+    expect(result.current).toBe('2')
+  })
+
+  it('should return id prop when given id prop', () => {
+    const { result } = renderHook(() => useIdLegacy('test'))
+
+    expect(result.current).toBe('test')
+  })
+
+  it('should return unique id with a prefix when given prefix prop', () => {
+    const { result } = renderHook(() => useIdLegacy(undefined, 'prefix'))
+
+    expect(result.current).toBe('prefix-3')
   })
 })

--- a/apps/bezier-react/src/hooks/useId.ts
+++ b/apps/bezier-react/src/hooks/useId.ts
@@ -16,7 +16,7 @@ const generateId = () => {
 
 const joinId = (...args: unknown[]) => compact(args).join('-')
 
-function useIdLegacy(idProp?: string, prefix?: string) {
+export function useIdLegacy(idProp?: string, prefix?: string) {
   const [id, setId] = useState(idRef.current)
 
   useEffect(() => {

--- a/apps/bezier-react/src/hooks/useId.ts
+++ b/apps/bezier-react/src/hooks/useId.ts
@@ -1,12 +1,31 @@
 /* External dependencies */
-import { useId as useIdentifier, useMemo } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import { compact } from 'lodash-es'
 
-function useId(idProp?: string, prefix?: string) {
-  const id = useIdentifier()
+/* Internal dependencies */
+import { getReactVersion } from 'Utils/reactUtils'
+
+/* @see https://github.com/chakra-ui/chakra-ui/blob/fa474bea3dcbdd4bbf2a26925f938d6e75a50c6d/packages/hooks/src/use-id.ts */
+const idRef = Object.seal({ current: 1 })
+
+const generateId = () => {
+  const id = idRef.current
+  idRef.current += 1
+  return id
+}
+
+const joinId = (...args: unknown[]) => compact(args).join('-')
+
+function useIdLegacy(idProp?: string, prefix?: string) {
+  const [id, setId] = useState(idRef.current)
+
+  useEffect(() => {
+    if (idProp) { return }
+    setId(generateId())
+  }, [idProp])
 
   return useMemo(() => (
-    idProp || compact([prefix, id]).join('-')
+    idProp || joinId(prefix, id)
   ), [
     idProp,
     prefix,
@@ -14,4 +33,18 @@ function useId(idProp?: string, prefix?: string) {
   ])
 }
 
-export default useId
+function useId(idProp?: string, prefix?: string) {
+  const id = React.useId()
+
+  return useMemo(() => (
+    idProp || joinId(prefix, id)
+  ), [
+    idProp,
+    prefix,
+    id,
+  ])
+}
+
+const isReactUnderV18 = getReactVersion().major < 18
+
+export default isReactUnderV18 ? useIdLegacy : useId

--- a/apps/bezier-react/src/utils/reactUtils.ts
+++ b/apps/bezier-react/src/utils/reactUtils.ts
@@ -1,0 +1,7 @@
+/* External dependencies */
+import React from 'react'
+
+export const getReactVersion = () => {
+  const [major, minor, patch] = React.version.split('.').map(Number)
+  return { major, minor, patch }
+}


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

React 버전 하위 호환성(v16.8, v17)을 위해 `useId` 훅의 구현을 변경합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- `React.useId` 훅이 없이도 동작하도록 `useId` 훅의 이전 구현을 되돌렸습니다. 
- 버전을 체크하여 v18 이전 버전일 경우 이전 구현을 사용하도록 합니다.

## Browser Compatibility

- [x] 채널톡 데스크 앱에서 테스트

OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

없음

