### PR TITLE
refactor(forms): add FormFieldSize enum

### DIFF
--- a/apps/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/apps/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -6,7 +6,7 @@ import { isNil } from 'lodash-es'
 import { Typography } from 'Foundation'
 import useId from 'Hooks/useId'
 import { omitBezierComponentProps, pickBezierComponentProps } from 'Utils/propsUtils'
-import { TextFieldSize } from 'Components/Forms/Inputs/TextField'
+import { FormFieldSize } from 'Components/Forms'
 import FormControlContext from './FormControlContext'
 import FormControlProps, {
   GroupPropsGetter,
@@ -23,7 +23,7 @@ function FormControl({
   id: idProp,
   testId = FORM_CONTROL_TEST_ID,
   labelPosition = 'top',
-  leftLabelWrapperHeight = TextFieldSize.M,
+  leftLabelWrapperHeight = FormFieldSize.M,
   children,
   ...rest
 }: FormControlProps) {

--- a/apps/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/apps/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -6,7 +6,8 @@ import { isNil } from 'lodash-es'
 import { Typography } from 'Foundation'
 import useId from 'Hooks/useId'
 import { omitBezierComponentProps, pickBezierComponentProps } from 'Utils/propsUtils'
-import { FormFieldSize } from 'Components/Forms'
+// eslint-disable-next-line no-restricted-imports
+import FormFieldSize from '../FormFieldSize'
 import FormControlContext from './FormControlContext'
 import FormControlProps, {
   GroupPropsGetter,

--- a/apps/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
+++ b/apps/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
@@ -1,10 +1,10 @@
 /* Internal dependencies */
 import type { BezierComponentProps, ChildrenProps, IdentifierProps } from 'Types/ComponentProps'
-import type { FormComponentProps } from 'Components/Forms/Form.types'
+import type { FormComponentProps, FormFieldSize } from 'Components/Forms'
 
 interface FormControlOptions {
   labelPosition?: 'top' | 'left'
-  leftLabelWrapperHeight?: number
+  leftLabelWrapperHeight?: FormFieldSize
 }
 
 export interface FormControlContextCommonValue extends Partial<IdentifierProps> {}

--- a/apps/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/apps/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -1,6 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormControl > Snapshot > With multiple field 1`] = `
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  padding: 0 2px;
+  margin-bottom: 4px;
+}
+
+.c8 {
+  padding: 0 2px;
+  margin-top: 4px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.c2 {
+  font-size: 1.3rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: 600;
+  color: #000000D9;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c9 {
+  font-size: 1.3rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: #00000066;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c3 {
+  display: block;
+  text-align: left;
+}
+
 .c6 {
   width: 100%;
   height: 100%;
@@ -83,73 +150,6 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   transition-duration: 150ms;
   -webkit-transition-property: border-color,box-shadow;
   transition-property: border-color,box-shadow;
-}
-
-.c0 {
-  position: relative;
-}
-
-.c1 {
-  padding: 0 2px;
-  margin-bottom: 4px;
-}
-
-.c8 {
-  padding: 0 2px;
-  margin-top: 4px;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.c2 {
-  font-size: 1.3rem;
-  line-height: 1.8rem;
-  margin: 0px 0px 0px 0px;
-  font-style: normal;
-  font-weight: 600;
-  color: #000000D9;
-  -webkit-transition-delay: 0ms;
-  transition-delay: 0ms;
-  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
-  transition-timing-function: cubic-bezier(.3,0,0,1);
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-property: color;
-  transition-property: color;
-}
-
-.c9 {
-  font-size: 1.3rem;
-  line-height: 1.8rem;
-  margin: 0px 0px 0px 0px;
-  font-style: normal;
-  font-weight: normal;
-  color: #00000066;
-  -webkit-transition-delay: 0ms;
-  transition-delay: 0ms;
-  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
-  transition-timing-function: cubic-bezier(.3,0,0,1);
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-property: color;
-  transition-property: color;
-}
-
-.c3 {
-  display: block;
-  text-align: left;
 }
 
 .c10 {
@@ -276,90 +276,6 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 `;
 
 exports[`FormControl > Snapshot > With multiple field and left label position 1`] = `
-.c9 {
-  width: 100%;
-  height: 100%;
-  padding: 0;
-  cursor: auto;
-  background-color: transparent;
-  border: none;
-  outline: none;
-  font-size: 1.4rem;
-  line-height: 1.8rem;
-  color: #000000D9;
-}
-
-.c9::-webkit-input-placeholder {
-  color: #00000066;
-}
-
-.c9::-moz-placeholder {
-  color: #00000066;
-}
-
-.c9:-ms-input-placeholder {
-  color: #00000066;
-}
-
-.c9::placeholder {
-  color: #00000066;
-}
-
-.c8 {
-  position: relative;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 36px;
-  padding: 0 12px;
-  background-color: #FCFCFC;
-  overflow: hidden;
-  border-radius: 8px;
-  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
-  -webkit-transition-delay: 0ms;
-  transition-delay: 0ms;
-  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
-  transition-timing-function: cubic-bezier(.3,0,0,1);
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-property: border-color,box-shadow;
-  transition-property: border-color,box-shadow;
-}
-
-.c10 {
-  position: relative;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 36px;
-  padding: 0 12px;
-  background-color: #FFFFFF;
-  overflow: hidden;
-  border-radius: 8px;
-  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
-  box-shadow: 0 0 0 3px #F4800B4D, inset 0 0 0 1px #F4800B;
-  -webkit-transition-delay: 0ms;
-  transition-delay: 0ms;
-  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
-  transition-timing-function: cubic-bezier(.3,0,0,1);
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-property: border-color,box-shadow;
-  transition-property: border-color,box-shadow;
-}
-
 .c0 {
   position: relative;
 }
@@ -475,6 +391,90 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 .c4 {
   display: block;
   text-align: left;
+}
+
+.c9 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  cursor: auto;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  color: #000000D9;
+}
+
+.c9::-webkit-input-placeholder {
+  color: #00000066;
+}
+
+.c9::-moz-placeholder {
+  color: #00000066;
+}
+
+.c9:-ms-input-placeholder {
+  color: #00000066;
+}
+
+.c9::placeholder {
+  color: #00000066;
+}
+
+.c8 {
+  position: relative;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 36px;
+  padding: 0 12px;
+  background-color: #FCFCFC;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: border-color,box-shadow;
+  transition-property: border-color,box-shadow;
+}
+
+.c10 {
+  position: relative;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 36px;
+  padding: 0 12px;
+  background-color: #FFFFFF;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
+  box-shadow: 0 0 0 3px #F4800B4D, inset 0 0 0 1px #F4800B;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: border-color,box-shadow;
+  transition-property: border-color,box-shadow;
 }
 
 .c14 {
@@ -602,6 +602,59 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 `;
 
 exports[`FormControl > Snapshot > With single field 1`] = `
+.c0 {
+  position: relative;
+}
+
+.c1 {
+  padding: 0 2px;
+  margin-bottom: 4px;
+}
+
+.c6 {
+  padding: 0 2px;
+  margin-top: 4px;
+}
+
+.c2 {
+  font-size: 1.3rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: 600;
+  color: #000000D9;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c7 {
+  font-size: 1.3rem;
+  line-height: 1.8rem;
+  margin: 0px 0px 0px 0px;
+  font-style: normal;
+  font-weight: normal;
+  color: #00000066;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: color;
+  transition-property: color;
+}
+
+.c3 {
+  display: block;
+  text-align: left;
+}
+
 .c5 {
   width: 100%;
   height: 100%;
@@ -658,59 +711,6 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   transition-property: border-color,box-shadow;
 }
 
-.c0 {
-  position: relative;
-}
-
-.c1 {
-  padding: 0 2px;
-  margin-bottom: 4px;
-}
-
-.c6 {
-  padding: 0 2px;
-  margin-top: 4px;
-}
-
-.c2 {
-  font-size: 1.3rem;
-  line-height: 1.8rem;
-  margin: 0px 0px 0px 0px;
-  font-style: normal;
-  font-weight: 600;
-  color: #000000D9;
-  -webkit-transition-delay: 0ms;
-  transition-delay: 0ms;
-  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
-  transition-timing-function: cubic-bezier(.3,0,0,1);
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-property: color;
-  transition-property: color;
-}
-
-.c7 {
-  font-size: 1.3rem;
-  line-height: 1.8rem;
-  margin: 0px 0px 0px 0px;
-  font-style: normal;
-  font-weight: normal;
-  color: #00000066;
-  -webkit-transition-delay: 0ms;
-  transition-delay: 0ms;
-  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
-  transition-timing-function: cubic-bezier(.3,0,0,1);
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-property: color;
-  transition-property: color;
-}
-
-.c3 {
-  display: block;
-  text-align: left;
-}
-
 .c8 {
   display: block;
   text-align: left;
@@ -763,62 +763,6 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 `;
 
 exports[`FormControl > Snapshot > With single field and left label position 1`] = `
-.c6 {
-  width: 100%;
-  height: 100%;
-  padding: 0;
-  cursor: auto;
-  background-color: transparent;
-  border: none;
-  outline: none;
-  font-size: 1.4rem;
-  line-height: 1.8rem;
-  color: #000000D9;
-}
-
-.c6::-webkit-input-placeholder {
-  color: #00000066;
-}
-
-.c6::-moz-placeholder {
-  color: #00000066;
-}
-
-.c6:-ms-input-placeholder {
-  color: #00000066;
-}
-
-.c6::placeholder {
-  color: #00000066;
-}
-
-.c5 {
-  position: relative;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 36px;
-  padding: 0 12px;
-  background-color: #FCFCFC;
-  overflow: hidden;
-  border-radius: 8px;
-  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
-  -webkit-transition-delay: 0ms;
-  transition-delay: 0ms;
-  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
-  transition-timing-function: cubic-bezier(.3,0,0,1);
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-property: border-color,box-shadow;
-  transition-property: border-color,box-shadow;
-}
-
 .c0 {
   position: relative;
 }
@@ -898,6 +842,62 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
 .c4 {
   display: block;
   text-align: left;
+}
+
+.c6 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  cursor: auto;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
+  color: #000000D9;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #00000066;
+}
+
+.c6::-moz-placeholder {
+  color: #00000066;
+}
+
+.c6:-ms-input-placeholder {
+  color: #00000066;
+}
+
+.c6::placeholder {
+  color: #00000066;
+}
+
+.c5 {
+  position: relative;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 36px;
+  padding: 0 12px;
+  background-color: #FCFCFC;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: border-color,box-shadow;
+  transition-property: border-color,box-shadow;
 }
 
 .c10 {

--- a/apps/bezier-react/src/components/Forms/FormFieldSize.ts
+++ b/apps/bezier-react/src/components/Forms/FormFieldSize.ts
@@ -1,0 +1,8 @@
+enum FormFieldSize {
+  XL = 56,
+  L = 44,
+  M = 36,
+  XS = 28,
+}
+
+export default FormFieldSize

--- a/apps/bezier-react/src/components/Forms/FormFieldSize.ts
+++ b/apps/bezier-react/src/components/Forms/FormFieldSize.ts
@@ -1,5 +1,5 @@
 enum FormFieldSize {
-  XL = 56,
+  XL = 54,
   L = 44,
   M = 36,
   XS = 28,

--- a/apps/bezier-react/src/components/Forms/Inputs/Select/Select.styled.ts
+++ b/apps/bezier-react/src/components/Forms/Inputs/Select/Select.styled.ts
@@ -26,28 +26,6 @@ interface TriggerProps {
   size: SelectSize
 }
 
-function selectSizeConverter(size: SelectSize) {
-  switch (size) {
-    case SelectSize.XL:
-      return css`
-        height: 54px;
-      `
-    case SelectSize.L:
-      return css`
-        height: 44px;
-      `
-    case SelectSize.S:
-      return css`
-        height: 28px;
-      `
-    case SelectSize.M:
-    default:
-      return css`
-        height: 36px;
-      `
-  }
-}
-
 const focusedStyle = css`
   ${focusedInputWrapperStyle};
   background-color: ${({ foundation }) => foundation?.theme?.['bg-grey-lighter']};
@@ -60,6 +38,7 @@ export const Trigger = styled.button<TriggerProps>`
   align-items: center;
   justify-content: space-between;
   width: 100%;
+  height: ${({ size }) => size}px;
   padding: 8px 12px;
   cursor: pointer;
   user-select: none;
@@ -68,8 +47,6 @@ export const Trigger = styled.button<TriggerProps>`
   ${inputTextStyle}
 
   ${inputWrapperStyle}
-
-  ${({ size }) => selectSizeConverter(size)}
 
   ${({ foundation }) => foundation?.rounding?.round8}
 

--- a/apps/bezier-react/src/components/Forms/Inputs/Select/Select.types.ts
+++ b/apps/bezier-react/src/components/Forms/Inputs/Select/Select.types.ts
@@ -8,15 +8,16 @@ import type {
   AdditionalColorProps,
   AdditionalTestIdProps,
 } from 'Types/ComponentProps'
-import { FormComponentProps } from 'Components/Forms/Form.types'
+import type { FormComponentProps } from 'Components/Forms'
+import { FormFieldSize } from 'Components/Forms'
 import type { OverlayProps } from 'Components/Overlay'
 import type { IconName } from 'Components/Icon'
 
 export enum SelectSize {
-  XL = 'XL',
-  L = 'L',
-  M = 'M',
-  S = 'S',
+  XL = FormFieldSize.XL,
+  L = FormFieldSize.L,
+  M = FormFieldSize.M,
+  S = FormFieldSize.XS,
 }
 
 export interface SelectRef {

--- a/apps/bezier-react/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/apps/bezier-react/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
+  height: 36px;
   padding: 8px 12px;
   cursor: pointer;
   -webkit-user-select: none;
@@ -63,7 +64,6 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   background-color: #FCFCFC;
   color: #000000D9;
   box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
-  height: 36px;
   overflow: hidden;
   border-radius: 8px;
   -webkit-transition-delay: 0ms;
@@ -115,6 +115,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   <button
     class="c1"
     data-testid="bezier-react-select-trigger"
+    size="36"
     type="button"
   >
     <div
@@ -208,6 +209,7 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   width: 100%;
+  height: 36px;
   padding: 8px 12px;
   cursor: pointer;
   -webkit-user-select: none;
@@ -217,7 +219,6 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
   background-color: #FCFCFC;
   color: #000000D9;
   box-shadow: 0 1px 2px #0000000D, inset 0 0 0 1px #00000026;
-  height: 36px;
   overflow: hidden;
   border-radius: 8px;
   -webkit-transition-delay: 0ms;
@@ -269,6 +270,7 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
   <button
     class="c1"
     data-testid="bezier-react-select-trigger"
+    size="36"
     type="button"
   >
     <div

--- a/apps/bezier-react/src/components/Forms/Inputs/TextField/TextField.types.ts
+++ b/apps/bezier-react/src/components/Forms/Inputs/TextField/TextField.types.ts
@@ -10,7 +10,8 @@ import type {
   AdditionalStylableProps,
   AdditionalColorProps,
 } from 'Types/ComponentProps'
-import type { FormComponentProps } from 'Components/Forms/Form.types'
+import type { FormComponentProps } from 'Components/Forms'
+import { FormFieldSize } from 'Components/Forms'
 import type { IconName } from 'Components/Icon'
 
 export enum TextFieldType {
@@ -25,10 +26,10 @@ export enum TextFieldType {
 }
 
 export enum TextFieldSize {
-  XL = 56,
-  L = 44,
-  M = 36,
-  XS = 28,
+  XL = FormFieldSize.XL,
+  L = FormFieldSize.L,
+  M = FormFieldSize.M,
+  XS = FormFieldSize.XS,
 }
 
 export type SelectionRangeDirections = 'forward' | 'backward' | 'none'

--- a/apps/bezier-react/src/components/Forms/index.ts
+++ b/apps/bezier-react/src/components/Forms/index.ts
@@ -1,6 +1,7 @@
 import type { FormComponentProps } from './Form.types'
+import FormFieldSize from './FormFieldSize'
 import useFormControlContext from './useFormControlContext'
 import useFormFieldProps from './useFormFieldProps'
 
 export type { FormComponentProps }
-export { useFormControlContext, useFormFieldProps }
+export { FormFieldSize, useFormControlContext, useFormFieldProps }


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

`SelectSize` , `TextFieldSize` 와 동일한 사이즈를 가진 `FormFieldSize` enum을 추가합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

## What's changed

- `FormControlProps` 의 `leftLabelWrapperHeight` 타입을 `FormFieldSize` 로 변경하고, 기존 `TextFieldSize` 를 참조하던 것을 `FormFieldSize` 를 참조하도록 변경합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

- Fix #728 . 상위 디렉토리의 enum을 사용하면서 해결됩니다.
