### PR TITLE
Use lodash-es instead of lodash

### DIFF
--- a/apps/bezier-react/scripts/icon-index-template.js
+++ b/apps/bezier-react/scripts/icon-index-template.js
@@ -1,4 +1,4 @@
-const _ = require('lodash')
+const _ = require('lodash-es')
 const path = require('path')
 
 const ICON_SUFFIX = "Icon"
@@ -44,7 +44,7 @@ export type IconName = keyof typeof icons
 
 export {
 ${exportEntries.join('\n')}
-} 
+}
 
 /* eslint-enable */
 export default icons

--- a/apps/bezier-react/src/components/Emoji/Emoji.tsx
+++ b/apps/bezier-react/src/components/Emoji/Emoji.tsx
@@ -1,6 +1,6 @@
 /* External dependencies */
 import React, { useMemo, forwardRef } from 'react'
-import { noop } from 'lodash'
+import { noop } from 'lodash-es'
 
 /* Internal dependencies */
 import { backgroundImageVariable } from 'Foundation'

--- a/apps/bezier-react/src/components/Toast/Toast.test.tsx
+++ b/apps/bezier-react/src/components/Toast/Toast.test.tsx
@@ -1,6 +1,6 @@
 /* External dependencies */
 import React from 'react'
-import _ from 'lodash'
+import _ from 'lodash-es'
 
 /* Internal dependencies */
 import { css, TransitionDuration } from 'Foundation'

--- a/apps/bezier-react/src/utils/storyUtils.test.ts
+++ b/apps/bezier-react/src/utils/storyUtils.test.ts
@@ -1,5 +1,5 @@
 /* External dependencies */
-import { isArray } from 'lodash'
+import { isArray } from 'lodash-es'
 
 /* Internal dependencies */
 import { IconName } from 'Components/Icon'


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

Tree shaking 및 CJS 처리가 원활한 `lodash-es` 를 사용해야 함
(`lodash-es`를 dependency에서 명시하고 있습니다)

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

<img width="464" alt="스크린샷 2022-05-23 오전 11 53 51" src="https://user-images.githubusercontent.com/25701854/169734499-ace93e86-4596-4aef-888f-2c790aeb00d3.png">

현재 빌드를 보면 `_virtual` 아래에 `lodash`에 의한 artifact가 생성되어 있는데, 이것을 제거하고자 하여 원인을 찾았음

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

(없음)