### PR TITLE
SegmentedControl이 외부 box-sizing property에 관계없이 올바른 padding을 가지도록 수정

### DIFF
--- a/apps/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.const.ts
+++ b/apps/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.const.ts
@@ -3,10 +3,10 @@ import { css, Typography } from 'Foundation'
 import { SegmentedControlSize } from './SegmentedControl.types'
 
 export const SIZE_TO_HEIGHT: Record<SegmentedControlSize, number> = {
-  [SegmentedControlSize.XS]: 22,
-  [SegmentedControlSize.S]: 24,
-  [SegmentedControlSize.M]: 32,
-  [SegmentedControlSize.L]: 36,
+  [SegmentedControlSize.XS]: 24,
+  [SegmentedControlSize.S]: 28,
+  [SegmentedControlSize.M]: 36,
+  [SegmentedControlSize.L]: 44,
 }
 
 export const SIZE_TO_PADDING: Record<SegmentedControlSize, number> = {

--- a/apps/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/apps/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -34,6 +34,10 @@ const heightStyle = css<{ size: SegmentedControlSize }>`
   height: ${({ size }) => SIZE_TO_HEIGHT[size]}px;
 `
 
+const indicatorHeightStyle = css<{ size: SegmentedControlSize }>`
+  height: ${({ size }) => SIZE_TO_HEIGHT[size] - (SIZE_TO_PADDING[size] * 2)}px;
+`
+
 const verticalPaddingStyle = css<{ size: SegmentedControlSize }>`
   padding: ${({ size }) => SIZE_TO_PADDING[size]}px 0;
 `
@@ -67,6 +71,7 @@ const indicatorRoundingStyle = css<{ size: SegmentedControlSize }>`
 
 export const Wrapper = styled.div<StyledWrapperProps>`
   position: relative;
+  box-sizing: border-box;
   display: inline-flex;
   flex-direction: row;
   align-items: center;
@@ -86,7 +91,6 @@ export const Wrapper = styled.div<StyledWrapperProps>`
 
 export const OptionItemWrapper = styled.div<StyledOptionItemWrapperProps>`
   position: absolute;
-  box-sizing: border-box;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -117,7 +121,6 @@ export const OptionItemWrapper = styled.div<StyledOptionItemWrapperProps>`
 
 export const Indicator = styled.div<StyledIndicatorProps>`
   position: absolute;
-  box-sizing: border-box;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -128,7 +131,7 @@ export const Indicator = styled.div<StyledIndicatorProps>`
   )};
   will-change: transform;
 
-  ${heightStyle}
+  ${indicatorHeightStyle}
   ${indicatorRoundingStyle}
 `
 

--- a/apps/bezier-react/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/apps/bezier-react/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`SegmentedControl Snapshot 1`] = `
 
 .c0 {
   position: relative;
+  box-sizing: border-box;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -77,7 +78,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   transition-duration: 150ms;
   -webkit-transition-property: background-color;
   transition-property: background-color;
-  height: 32px;
+  height: 36px;
   overflow: hidden;
   border-radius: 8px;
   padding: 2px 0;
@@ -85,7 +86,6 @@ exports[`SegmentedControl Snapshot 1`] = `
 
 .c3 {
   position: absolute;
-  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -116,7 +116,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  height: 32px;
+  height: 36px;
   overflow: hidden;
   border-radius: 6px;
 }
@@ -127,7 +127,6 @@ exports[`SegmentedControl Snapshot 1`] = `
 
 .c6 {
   position: absolute;
-  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -158,14 +157,13 @@ exports[`SegmentedControl Snapshot 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  height: 32px;
+  height: 36px;
   overflow: hidden;
   border-radius: 6px;
 }
 
 .c1 {
   position: absolute;
-  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

#759 에서 renewal 한 style이 box-sizing: border-box 를 가지는 어플리케이션에서 올바르게 나타나지 않는 현상을 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

컴포넌트의 box-sizing property를 명시하고 padding을 적절하게 조정합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- #759