### PR TITLE
chore(modal): 모달 titleSize type exports index에 추가

### DIFF
--- a/apps/bezier-react/src/components/Modals/Modal/index.ts
+++ b/apps/bezier-react/src/components/Modals/Modal/index.ts
@@ -7,6 +7,7 @@ import type {
   ModalActionProps,
   ModalContentProps,
   ModalContextValue,
+  ModalTitleSize,
 } from './Modal.types'
 
 export type {
@@ -14,6 +15,7 @@ export type {
   ModalActionProps,
   ModalContentProps,
   ModalContextValue,
+  ModalTitleSize,
 }
 export {
   Modal,


### PR DESCRIPTION
# Summary
#727 에서 ModalTitleSize가 exports 되지 않았습니다.

# Details
ModalTitleSize가 exports 되게 수정합니다.

```tsx
// AS-is
import { ModalTitleSize } from '@channel.io/bezier-react/build/src/components/Modals/Modal/Modal.types'

// To-be
import { ModalTitleSize } from '@channel.io/bezier-react'
```

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
#727 
