### PR TITLE
feat: add Do-Not-Disturb status prop to Status and Avatar component

### DIFF
--- a/packages/bezier-react/src/components/Status/Status.styled.ts
+++ b/packages/bezier-react/src/components/Status/Status.styled.ts
@@ -1,6 +1,6 @@
 /* Internal dependencies */
 import { styled, absoluteCenter, SemanticNames } from 'Foundation'
-import { LockIcon as BaseLockIcon } from 'Components/Icon/generated'
+import { LockIcon as BaseLockIcon, MoonFilledIcon as BaseMoonFilledIcon } from 'Components/Icon/generated'
 import { StatusSize } from './Status.types'
 
 function getStatusCircleBorderSize(size: StatusSize) {
@@ -40,6 +40,11 @@ export const StatusCircle = styled.div<StatusCircleProps>`
 `
 
 export const LockIcon = styled(BaseLockIcon)`
+  ${absoluteCenter('')}
+  z-index: 1;
+`
+
+export const MoonFilledIcon = styled(BaseMoonFilledIcon)`
   ${absoluteCenter('')}
   z-index: 1;
 `

--- a/packages/bezier-react/src/components/Status/Status.tsx
+++ b/packages/bezier-react/src/components/Status/Status.tsx
@@ -2,6 +2,7 @@
 import React, { memo } from 'react'
 
 /* Internal dependencies */
+import type { SemanticNames } from 'Foundation'
 import { IconSize } from 'Components/Icon'
 import { StatusProps, StatusSize, StatusType } from './Status.types'
 import { LockIcon, MoonFilledIcon, StatusCircle } from './Status.styled'
@@ -14,6 +15,14 @@ const statusWithIcon: Readonly<StatusType[]> = [
   StatusType.OfflineCrescent,
   StatusType.Lock,
 ]
+
+const statusColor: Readonly<Record<StatusType, SemanticNames>> = {
+  [StatusType.Online]: 'bgtxt-green-normal',
+  [StatusType.Offline]: 'bg-black-dark',
+  [StatusType.OnlineCrescent]: 'bgtxt-green-normal',
+  [StatusType.OfflineCrescent]: 'bgtxt-orange-normal',
+  [StatusType.Lock]: 'txt-black-darker',
+}
 
 function Status({
   type,
@@ -28,22 +37,17 @@ function Status({
         color="bg-white-normal"
         size={size}
       >
-        { (() => {
-          if (type === StatusType.Lock) {
-            return (
-              <LockIcon
-                size={iconSize}
-                color="txt-black-darker"
-              />
-            )
-          }
-          return (
-            <MoonFilledIcon
-              size={iconSize}
-              color={type === StatusType.OnlineCrescent ? 'bgtxt-green-normal' : 'bgtxt-orange-normal'}
-            />
-          )
-        })() }
+        { (type === StatusType.Lock) ? (
+          <LockIcon
+            size={iconSize}
+            color={statusColor[type]}
+          />
+        ) : (
+          <MoonFilledIcon
+            size={iconSize}
+            color={statusColor[type]}
+          />
+        ) }
       </StatusCircle>
     )
   }
@@ -51,7 +55,7 @@ function Status({
   return (
     <StatusCircle
       data-testid={STATUS_TEST_ID}
-      color={type === StatusType.Online ? 'bgtxt-green-normal' : 'bg-black-dark'}
+      color={statusColor[type] ?? 'bg-black-dark'}
       size={size}
     />
   )

--- a/packages/bezier-react/src/components/Status/Status.tsx
+++ b/packages/bezier-react/src/components/Status/Status.tsx
@@ -1,29 +1,49 @@
 /* External dependencies */
-import React from 'react'
+import React, { memo } from 'react'
 
-/* Internal denpendencies */
+/* Internal dependencies */
 import { IconSize } from 'Components/Icon'
-import { StatusType, StatusSize, StatusProps } from './Status.types'
-import { StatusCircle, LockIcon } from './Status.styled'
+import { StatusProps, StatusSize, StatusType } from './Status.types'
+import { LockIcon, MoonFilledIcon, StatusCircle } from './Status.styled'
 
 // TODO: 테스트 코드 작성
 const STATUS_TEST_ID = 'bezier-react-status'
+
+const statusWithIcon: Readonly<StatusType[]> = [
+  StatusType.OnlineCrescent,
+  StatusType.OfflineCrescent,
+  StatusType.Lock,
+]
 
 function Status({
   type,
   size = StatusSize.M,
 }: StatusProps) {
-  if (type === StatusType.Lock) {
+  if (statusWithIcon.includes(type)) {
+    const iconSize = (size <= StatusSize.M) ? IconSize.XXS : IconSize.XS
+
     return (
       <StatusCircle
         data-testid={STATUS_TEST_ID}
         color="bg-white-normal"
         size={size}
       >
-        <LockIcon
-          size={IconSize.XXS}
-          color="txt-black-darker"
-        />
+        { (() => {
+          if (type === StatusType.Lock) {
+            return (
+              <LockIcon
+                size={iconSize}
+                color="txt-black-darker"
+              />
+            )
+          }
+          return (
+            <MoonFilledIcon
+              size={iconSize}
+              color={type === StatusType.OnlineCrescent ? 'bgtxt-green-normal' : 'bgtxt-orange-normal'}
+            />
+          )
+        })() }
       </StatusCircle>
     )
   }
@@ -37,4 +57,4 @@ function Status({
   )
 }
 
-export default Status
+export default memo(Status)

--- a/packages/bezier-react/src/components/Status/Status.types.ts
+++ b/packages/bezier-react/src/components/Status/Status.types.ts
@@ -2,6 +2,8 @@ export enum StatusType {
   Online = 'Online',
   Offline = 'Offline',
   Lock = 'Lock',
+  OnlineCrescent = 'OnlineCrescent',
+  OfflineCrescent = 'OfflineCrescent',
 }
 
 export enum StatusSize {


### PR DESCRIPTION
# Summary
`Status` 컴포넌트에 초승달 이미지가 표시될 수 있도록 `StatusType` enum에 두가지 값을 추가합니다.
또한 추가 된 두가지 값일 경우와 기존에 존재하던 `Lock`의 경우의 렌더링 로직을 개선합니다.

![스크린샷 2022-05-30 오후 4 13 17](https://user-images.githubusercontent.com/6138662/170937320-50e59507-040e-43ec-8d8a-dfd4d68117be.png)

# Details
```diff
export enum StatusType {
  Online = 'Online',
  Offline = 'Offline',
  Lock = 'Lock',
+ OnlineCrescent = 'OnlineCrescent',
+ OfflineCrescent = 'OfflineCrescent',
}
```

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.

### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)

### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
