### PR TITLE
Correct icon color of alt variant in Banner component

### DIFF
--- a/packages/bezier-react/src/components/Banner/Banner.const.ts
+++ b/packages/bezier-react/src/components/Banner/Banner.const.ts
@@ -20,7 +20,7 @@ export const DEFAULT_ICON_COLORS: Record<BannerVariant, SemanticNames> = {
   [BannerVariant.Green]: 'bgtxt-green-normal',
   [BannerVariant.Orange]: 'bgtxt-orange-normal',
   [BannerVariant.Red]: 'bgtxt-red-normal',
-  [BannerVariant.Alt]: 'txt-black-darker',
+  [BannerVariant.Alt]: 'bgtxt-red-normal',
 }
 
 export const TEXT_COLORS: Record<BannerVariant, SemanticNames> = {


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

`Banner` 컴포넌트의 variant에 따른 색상 중, alt variant의 아이콘 색상이 스펙과 일치하지 않아 이를 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

<img width="547" alt="스크린샷 2022-05-31 오후 12 04 51" src="https://user-images.githubusercontent.com/25701854/171084703-3fe53545-0d7a-4c65-b61e-dbd083ba3f48.png">

- `BannerVariant.Alt`의 올바른 icon color인 `bgtxt-red-normal` 로 수정합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
없음.