### PR TITLE
Rounding에 round3 추가

### DIFF
--- a/packages/bezier-react/src/foundation/Rounding/Rounding.stories.tsx
+++ b/packages/bezier-react/src/foundation/Rounding/Rounding.stories.tsx
@@ -14,6 +14,7 @@ export default {
       control: {
         type: 'radio',
         options: [
+          'round3',
           'round4',
           'round6',
           'round8',

--- a/packages/bezier-react/src/foundation/Rounding/index.ts
+++ b/packages/bezier-react/src/foundation/Rounding/index.ts
@@ -7,6 +7,7 @@ const DefaultRoundStyle = css`
 `
 
 export enum RoundAbsoluteNumber {
+  R3 = 3,
   R4 = 4,
   R6 = 6,
   R8 = 8,
@@ -15,6 +16,11 @@ export enum RoundAbsoluteNumber {
   R20 = 20,
   R32 = 32,
 }
+
+const round3 = css`
+  ${DefaultRoundStyle};
+  border-radius: ${RoundAbsoluteNumber.R3}px;
+`
 
 const round4 = css`
   ${DefaultRoundStyle};
@@ -53,6 +59,7 @@ const round32 = css`
 
 export const Rounding = {
   DefaultRoundStyle,
+  round3,
   round4,
   round6,
   round8,


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
명세에 따라 `round3`을 추가합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
`border-radius: 3px;`에 해당하는 `round3`이 #803 에 필요하게 되어, 이를 `Rounding`에 추가합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- Figma: https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=24044%3A206093