### PR TITLE
Banner Story의 colorVariant를 variant로 수정

### DIFF
--- a/packages/bezier-react/src/components/Banner/Banner.stories.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.stories.tsx
@@ -2,13 +2,10 @@
 import React from 'react'
 import base from 'paths.macro'
 import type { Story } from '@storybook/react'
-import {
-  noop,
-  values,
-} from 'lodash-es'
+import { noop } from 'lodash-es'
 
 /* Internal dependencies */
-import { getTitle } from 'Utils/storyUtils'
+import { getTitle, getObjectFromEnum } from 'Utils/storyUtils'
 import Banner from './Banner'
 import {
   BannerVariant,
@@ -19,10 +16,10 @@ export default {
   title: getTitle(base),
   component: Banner,
   argTypes: {
-    colorVariant: {
+    variant: {
       control: {
         type: 'radio',
-        options: values(BannerVariant),
+        options: getObjectFromEnum(BannerVariant),
       },
     },
     dismissible: {

--- a/packages/bezier-react/src/components/Banner/Banner.stories.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.stories.tsx
@@ -1,7 +1,7 @@
 /* External dependencies */
 import React from 'react'
 import base from 'paths.macro'
-import type { Story } from '@storybook/react'
+import type { Meta, Story } from '@storybook/react'
 import { noop } from 'lodash-es'
 
 /* Internal dependencies */
@@ -43,7 +43,7 @@ export default {
       },
     },
   },
-}
+} as Meta<BannerProps>
 
 const Template: Story<BannerProps> = props => <Banner {...props} />
 


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
`Banner` 컴포넌트의 Storybook Story의 `colorVariant` args를 `variant`로 수정했습니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
- Closes #741

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
