### PR TITLE
SectionLabel의 help Tooltip의 allowHover를 true로 설정

### DIFF
--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
@@ -157,7 +157,10 @@ function SectionLabel({
   ])
 
   const helpContent = useMemo(() => !isNil(help) && (
-    <Tooltip content={help.tooltipContent}>
+    <Tooltip
+      content={help.tooltipContent}
+      allowHover
+    >
       <Styled.HelpIconWrapper data-testid={SECTION_LABEL_TEST_HELP_CONTENT_ID}>
         <Icon
           name={help.icon ?? 'help-filled'}


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

~~`SectionLabel` 컴포넌트의 `help` 프롭 타입에 `allowTooltipHover: boolean`을 추가하여, `SectionLabel`을 사용할 때 Help tooltip의 `allowHover` 여부를 정할 수 있게 합니다.~~

`SectionLabel` 컴포넌트의 `help` 툴팁의 `allowHover`를 항상 true로 변경합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

> 관련 Desk 이슈: https://github.com/channel-io/ch-desk-web/issues/10023

Help tooltip 내에 Clickable한 요소가 있는 경우 등에는 Tooltip이 호버 가능해야 하며, 이를 ~~`SectionLabel.help`의 props에 추가하여 해결합니다.~~ `SectionLabel.help`를 렌더링하는 툴팁의 `allowHover`를 true로 설정하여 해결합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
