### PR TITLE
arrayUtils.removeItem에 out of index를 넣으면 잘못 작동하는 버그 수정

### DIFF
--- a/packages/bezier-react/src/utils/arrayUtils.test.ts
+++ b/packages/bezier-react/src/utils/arrayUtils.test.ts
@@ -1,0 +1,20 @@
+/* Internal dependencies */
+import { removeItem } from './arrayUtils'
+
+describe('arrayUtils', () => {
+  describe('removeItem', () => {
+    it('should remove item of given index', () => {
+      const array = [1, 2, 3, 4, 5]
+
+      expect(removeItem(array, 0)).toEqual([2, 3, 4, 5])
+      expect(removeItem(array, 2)).toEqual([1, 2, 4, 5])
+    })
+
+    it('should return given array if index is out-of-bound', () => {
+      const array = [1, 2, 3, 4, 5]
+
+      expect(removeItem(array, -1)).toEqual(array)
+      expect(removeItem(array, 5)).toEqual(array)
+    })
+  })
+})

--- a/packages/bezier-react/src/utils/arrayUtils.ts
+++ b/packages/bezier-react/src/utils/arrayUtils.ts
@@ -7,6 +7,7 @@ export function insertItem<T>(array: T[], data: T, index: number = -1) {
 }
 
 export function removeItem(array: any[], index: number) {
+  if (index < 0 || index >= array.length) { return array }
   return [...array.slice(0, index), ...array.slice(index + 1)]
 }
 


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

`removeItem` 함수에 배열 범위를 벗어나는 index를 넣으면 잘못 작동하는 버그를 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- `LayoutReducer`에서 사용하는 `removeItem` 함수에 배열 범위를 벗어나는 index를 넣으면 잘못 작동할 가능성이 있었습니다.
  - `removeItem` 함수 내에서 index 범위를 체크하도록 하여 수정합니다.
  - 참고: `removeItem(arr, -1)`의 결과
    <img width="463" alt="image" src="https://user-images.githubusercontent.com/6940439/172827604-306c82fd-3752-4a99-a131-ffc4be69ffb0.png">

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
