### PR TITLE
다크모드에서 Status 컴포넌트 배경 색상이 어색한 문제 수정

### DIFF
--- a/packages/bezier-react/src/components/Status/Status.tsx
+++ b/packages/bezier-react/src/components/Status/Status.tsx
@@ -34,7 +34,7 @@ function Status({
     return (
       <StatusCircle
         data-testid={STATUS_TEST_ID}
-        color="bg-white-normal"
+        color="bg-white-high"
         size={size}
       >
         { (type === StatusType.Lock) ? (


### PR DESCRIPTION
# Summary
Status 컴포넌트의 배경 색상이 잘못 지정되어 있어서 다크모드로 변경 했을 때 배경이 어색한 문제를 수정합니다.

# Details
### AS-IS
![June 9th 2022, 11_24_59 pm](https://user-images.githubusercontent.com/6138662/172872670-aefed78b-6419-4a89-af58-afd75db4bb44.png)

### TO-BE
![스크린샷 2022-06-09 오후 11 34 29](https://user-images.githubusercontent.com/6138662/172873083-99b91dfd-b62c-4808-8a2c-65dbf5ba4804.png)

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
