### PR TITLE
Suppress unnecessary layout effect in NavigationArea

### DIFF
--- a/packages/bezier-react/src/layout/components/Navigations/NavigationArea/NavigationArea.tsx
+++ b/packages/bezier-react/src/layout/components/Navigations/NavigationArea/NavigationArea.tsx
@@ -37,26 +37,23 @@ function NavigationArea(
 ) {
   const dispatch = useLayoutDispatch()
   const { columnStates, orderedColumnKeys } = useLayoutState()
+  const columnState = columnStates[currentKey]
 
   const { handleResizeStart, handleResizing } = useResizingHandlers()
 
   const hidable = useMemo(() => (
-    columnStates[currentKey]
-      ? columnStates[currentKey].hidable
+    columnState
+      ? columnState.hidable
       : false
-  ), [
-    columnStates,
-    currentKey,
-  ])
+  ), [columnState])
 
   const disableResize = useMemo(() => (
     !showNavigation ||
-    columnStates[currentKey]?.disableResize ||
+    columnState?.disableResize ||
     false
   ), [
     showNavigation,
-    columnStates,
-    currentKey,
+    columnState,
   ])
 
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -125,15 +122,15 @@ function NavigationArea(
 
   useLayoutEffect(() => {
     if (presenterRef.current) {
-      presenterRef.current.style.width = `${columnStates[currentKey]?.initialWidth}px`
+      presenterRef.current.style.width = `${columnState?.initialWidth}px`
 
       const payload = {
         key: currentKey,
         ref: {
           target: presenterRef.current,
-          minWidth: columnStates[currentKey]?.minWidth,
-          maxWidth: columnStates[currentKey]?.maxWidth,
-          initialWidth: columnStates[currentKey]?.initialWidth,
+          minWidth: columnState?.minWidth,
+          maxWidth: columnState?.maxWidth,
+          initialWidth: columnState?.initialWidth,
         },
         columnType: ColumnType.Nav,
       }
@@ -151,7 +148,7 @@ function NavigationArea(
   }, [
     dispatch,
     currentKey,
-    columnStates,
+    columnState,
   ])
 
   useLayoutEffect(() => {

--- a/packages/bezier-react/src/layout/components/Navigations/NavigationArea/NavigationArea.tsx
+++ b/packages/bezier-react/src/layout/components/Navigations/NavigationArea/NavigationArea.tsx
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React, { forwardRef, useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo } from 'react'
+import React, { forwardRef, useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react'
 
 /* Internal dependencies */
 import useEventHandler from 'Hooks/useEventHandler'
@@ -41,20 +41,17 @@ function NavigationArea(
 
   const { handleResizeStart, handleResizing } = useResizingHandlers()
 
-  const hidable = useMemo(() => (
+  const hidable = (
     columnState
       ? columnState.hidable
       : false
-  ), [columnState])
+  )
 
-  const disableResize = useMemo(() => (
+  const disableResize = (
     !showNavigation ||
     columnState?.disableResize ||
     false
-  ), [
-    showNavigation,
-    columnState,
-  ])
+  )
 
   const containerRef = useRef<HTMLDivElement | null>(null)
   const presenterRef = useRef<HTMLDivElement | null>(null)

--- a/packages/bezier-react/src/layout/components/Navigations/NavigationArea/NavigationArea.tsx
+++ b/packages/bezier-react/src/layout/components/Navigations/NavigationArea/NavigationArea.tsx
@@ -133,15 +133,13 @@ function NavigationArea(
       }
 
       dispatch(LayoutActions.addColumnRef(payload))
-    }
 
-    return function cleanUp() {
-      const payload = {
-        key: currentKey,
+      return function cleanUp() {
+        dispatch(LayoutActions.removeColumnRef({ key: currentKey }))
       }
-
-      dispatch(LayoutActions.removeColumnRef(payload))
     }
+
+    return function noop() {}
   }, [
     dispatch,
     currentKey,


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

어플리케이션에서 report된 현상으로, NavigationArea 컴포넌트로부터 발생하는 "Maximum update depth exceeded" 오류를 해결합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

React v18은 v17과 비교했을 때 layout effect의 dispatch 시점에 차이가 있습니다. (Fiber 구현의 차이)

한 NavigationArea 컴포넌트가 unmount되고 다른 NavigationArea 컴포넌트가 mount되는 상황에서, (주로 route 이동 시 발생) fiber의 task scheduling에 의해 layout effect의 dispatch 순서가 특정하게 배열되면 trigger 조건이 꼬여버려버려 infinite loop로 떨어지는 현상을 관찰했습니다.

이를 해결하기 위해, layout effect의 trigger 조건을 더 좁힙니다. 이 수정 후 위에서 서술한 현상이 발생하지 않는 것을 관찰했습니다.
(NavigationArea는 자신의 `currentKey`에 해당하는 state에만 관심을 가지면 됩니다.)

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
(없음)