### PR TITLE
style(key-value-list=item): key-value-list-item에서 key에 min-width 스타일을 제거

### DIFF
--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.test.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.test.tsx
@@ -325,7 +325,6 @@ describe('KeyValueListItem', () => {
         const rendered = getByTestId(TEST_ID_MAP.KEY_ITEM)
         expect(rendered).toHaveStyle('display: flex;')
         expect(rendered).toHaveStyle('align-items: center;')
-        expect(rendered).toHaveStyle('min-width: 100px;')
 
         const keyItemText = rendered?.lastChild
         expect(keyItemText).toHaveStyle('color: rgba(0, 0, 0, 0.4);')

--- a/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
+++ b/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
@@ -43,7 +43,6 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  min-width: 100px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.styled.ts
@@ -6,7 +6,6 @@ import { Text } from 'Components/Text'
 export const KeyContent = styled.div<InterpolationProps>`
   display: flex;
   align-items: center;
-  min-width: 100px;
   ${ellipsis()};
   ${({ interpolation }) => interpolation}
 `


### PR DESCRIPTION
# Summary
KeyValueListItem에 key min-width 제거

# Details
KeyValueListItem에 key min-width 100px이 1:2 비율을 유지하는 flex와 중첩되어 key에 ellipsis가 100px보다 작아질 때 동작하지 않는 문제가 있습니다. 이를 해결합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
[채널톡 그룹쳇](https://desk.channel.io/root/threads/groups/(TF)BezierReactV1-124831/62a6f5430d62c58b5534/62a6f5430d62c58b5534)
