### PR TITLE
feat(banner): change the dismiss prop to actionIcon

### DIFF
--- a/packages/bezier-react/src/components/Banner/Banner.const.ts
+++ b/packages/bezier-react/src/components/Banner/Banner.const.ts
@@ -1,6 +1,7 @@
 /* Internal dependencies */
 import { css, SemanticNames } from 'Foundation'
 import type { InjectedInterpolation } from 'Types/Foundation'
+import { ButtonColorVariant } from 'Components/Button'
 import { BannerVariant } from './Banner.types'
 
 export const BACKGROUND_COLORS: Record<BannerVariant, SemanticNames> = {
@@ -21,6 +22,16 @@ export const DEFAULT_ICON_COLORS: Record<BannerVariant, SemanticNames> = {
   [BannerVariant.Orange]: 'bgtxt-orange-normal',
   [BannerVariant.Red]: 'bgtxt-red-normal',
   [BannerVariant.Alt]: 'bgtxt-red-normal',
+}
+
+export const ACTION_BUTTON_COLOR_VARIANTS: Record<BannerVariant, ButtonColorVariant> = {
+  [BannerVariant.Default]: ButtonColorVariant.MonochromeDark,
+  [BannerVariant.Blue]: ButtonColorVariant.Blue,
+  [BannerVariant.Cobalt]: ButtonColorVariant.Cobalt,
+  [BannerVariant.Green]: ButtonColorVariant.Green,
+  [BannerVariant.Orange]: ButtonColorVariant.Orange,
+  [BannerVariant.Red]: ButtonColorVariant.Red,
+  [BannerVariant.Alt]: ButtonColorVariant.MonochromeDark,
 }
 
 export const TEXT_COLORS: Record<BannerVariant, SemanticNames> = {

--- a/packages/bezier-react/src/components/Banner/Banner.stories.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.stories.tsx
@@ -52,6 +52,6 @@ Primary.args = {
   variant: BannerVariant.Default,
   icon: 'lightbulb',
   content: 'Information here.',
-  dismissible: true,
-  onDismiss: noop,
+  actionIcon: 'cancel-small',
+  onClickAction: noop,
 }

--- a/packages/bezier-react/src/components/Banner/Banner.styled.ts
+++ b/packages/bezier-react/src/components/Banner/Banner.styled.ts
@@ -1,7 +1,7 @@
 /* Internal dependencies */
 import { styled } from 'Foundation'
-import type { InterpolationProps } from 'Types/Foundation'
 import type { VariantProps } from 'Types/ComponentProps'
+import { HStack } from 'Components/Stack'
 import { Icon } from 'Components/Icon'
 import { Text } from 'Components/Text'
 import { BACKGROUND_COLORS, TEXT_COLORS, ELEVATIONS } from './Banner.const'
@@ -15,45 +15,19 @@ const ContentWrapper = styled.div<BannerVariantProps>`
   color: ${({ foundation, variant }) => foundation?.theme?.[TEXT_COLORS[variant]]};
 `
 
-const Dismiss = styled.div`
-  display: flex;
-  width: 20px;
-  height: 20px;
-  cursor: pointer;
-
-  > * {
-    margin: auto;
-  }
-`
-
 const Link = styled(Text)`
   margin-left: 2px;
   text-decoration: underline;
   cursor: pointer;
 `
 
-const Wrapper = styled.div<BannerVariantProps & InterpolationProps>`
-  display: flex;
+const Stack = styled(HStack)<BannerVariantProps>`
   min-width: 200px;
   padding: 12px;
   background-color: ${({ foundation, variant }) => foundation?.theme?.[BACKGROUND_COLORS[variant]]};
 
   ${({ foundation }) => foundation?.rounding?.round12}
   ${({ variant }) => ELEVATIONS[variant]}
-
-  ${({ interpolation }) => interpolation}
-
-  > ${ContentWrapper} {
-    flex: 1;
-  }
-
-  > ${BannerIcon} + ${ContentWrapper} {
-    margin-left: 6px;
-  }
-
-  > ${Dismiss} {
-    margin-left: 6px;
-  }
 
   & + & {
     margin-top: 6px;
@@ -63,7 +37,6 @@ const Wrapper = styled.div<BannerVariantProps & InterpolationProps>`
 export default {
   BannerIcon,
   ContentWrapper,
-  Dismiss,
   Link,
-  Wrapper,
+  Stack,
 }

--- a/packages/bezier-react/src/components/Banner/Banner.test.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.test.tsx
@@ -1,9 +1,10 @@
 /* External dependencies */
 import React from 'react'
+import { fireEvent } from '@testing-library/react'
 
 /* Internal dependencies */
 import { render } from 'Utils/testUtils'
-import Banner, { BANNER_DISMISS_TEST_ID, BANNER_LINK_TEST_ID } from './Banner'
+import Banner, { BANNER_LINK_TEST_ID } from './Banner'
 import type { BannerProps } from './Banner.types'
 
 describe('Banner >', () => {
@@ -14,7 +15,6 @@ describe('Banner >', () => {
       icon: 'info',
       content: 'Lorem ipsum dolor amet.',
       hasLink: false,
-      dismissible: false,
     }
   })
 
@@ -35,8 +35,19 @@ describe('Banner >', () => {
     expect(bannerLink.children.item(0)).toHaveStyle('font-size: 1.4rem;')
   })
 
-  it('does not render dismiss button if dismissible = false', () => {
-    const { queryByTestId } = renderBanner()
-    expect(queryByTestId(BANNER_DISMISS_TEST_ID)).toBeNull()
+  it('renders action button if actionIcon is correct value', () => {
+    const onClickAction = jest.fn()
+    const { getByRole } = renderBanner({ actionIcon: 'all', onClickAction })
+    const actionButton = getByRole('button')
+
+    fireEvent.click(actionButton)
+    expect(onClickAction).toHaveBeenCalled()
+  })
+
+  it('does not render action button if actionIcon is nil', () => {
+    const { queryByRole } = renderBanner()
+    const actionButton = queryByRole('button')
+
+    expect(actionButton).toBeNull()
   })
 })

--- a/packages/bezier-react/src/components/Banner/Banner.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.tsx
@@ -8,14 +8,15 @@ import {
 /* Internal dependencies */
 import { Typography } from 'Foundation'
 import { Text } from 'Components/Text'
-import { Icon, IconSize } from 'Components/Icon'
-import { DEFAULT_ICON_COLORS, TEXT_COLORS } from './Banner.const'
+import { IconSize } from 'Components/Icon'
+import { StackItem } from 'Components/Stack'
+import { Button, ButtonSize, ButtonStyleVariant } from 'Components/Button'
+import { DEFAULT_ICON_COLORS, TEXT_COLORS, ACTION_BUTTON_COLOR_VARIANTS } from './Banner.const'
 import { BannerVariant, BannerProps, RenderLinkFunc } from './Banner.types'
 import Styled from './Banner.styled'
 
 const BANNER_TEST_ID = 'bezier-react-banner'
 export const BANNER_LINK_TEST_ID = 'bezier-react-banner-link'
-export const BANNER_DISMISS_TEST_ID = 'bezier-react-banner-dismiss'
 
 const externalLinkRenderer: RenderLinkFunc = ({
   content,
@@ -54,28 +55,6 @@ function Link({
   })
 }
 
-function DismissButton({
-  variant = BannerVariant.Default,
-  dismissible,
-  onDismiss,
-}: BannerProps) {
-  if (!dismissible) { return null }
-
-  return (
-    <Styled.Dismiss
-      data-testid={BANNER_DISMISS_TEST_ID}
-      onClick={onDismiss}
-    >
-      <Icon
-        name="cancel"
-        size={IconSize.XS}
-        color={DEFAULT_ICON_COLORS[variant]}
-        onClick={onDismiss}
-      />
-    </Styled.Dismiss>
-  )
-}
-
 function Banner(
   props: BannerProps,
   forwardedRef: React.Ref<HTMLDivElement>,
@@ -87,39 +66,57 @@ function Banner(
     icon,
     iconColor,
     content,
+    actionIcon,
+    onClickAction,
     testId = BANNER_TEST_ID,
   } = props
 
   return (
-    <Styled.Wrapper
+    <Styled.Stack
       ref={forwardedRef}
       data-testid={testId}
       className={className}
-      variant={variant}
       interpolation={interpolation}
+      variant={variant}
+      spacing={6}
+      align="center"
     >
       { !isNil(icon) && (
-        <Styled.BannerIcon
-          name={icon}
-          color={iconColor ?? DEFAULT_ICON_COLORS[variant]}
-          size={IconSize.S}
-        />
+        <StackItem>
+          <Styled.BannerIcon
+            name={icon}
+            color={iconColor ?? DEFAULT_ICON_COLORS[variant]}
+            size={IconSize.S}
+          />
+        </StackItem>
       ) }
 
-      <Styled.ContentWrapper variant={variant}>
-        { isString(content) ? (
-          <Text
-            typo={Typography.Size14}
-            color={TEXT_COLORS[variant]}
-          >
-            { content }
-            <Link {...props} />
-          </Text>
-        ) : content }
-      </Styled.ContentWrapper>
+      <StackItem grow weight={1}>
+        <Styled.ContentWrapper variant={variant}>
+          { isString(content) ? (
+            <Text
+              typo={Typography.Size14}
+              color={TEXT_COLORS[variant]}
+            >
+              { content }
+              <Link {...props} />
+            </Text>
+          ) : content }
+        </Styled.ContentWrapper>
+      </StackItem>
 
-      <DismissButton {...props} />
-    </Styled.Wrapper>
+      { !isNil(actionIcon) && (
+        <StackItem>
+          <Button
+            size={ButtonSize.XS}
+            colorVariant={ACTION_BUTTON_COLOR_VARIANTS[variant]}
+            styleVariant={ButtonStyleVariant.Tertiary}
+            leftContent={actionIcon}
+            onClick={onClickAction}
+          />
+        </StackItem>
+      ) }
+    </Styled.Stack>
   )
 }
 

--- a/packages/bezier-react/src/components/Banner/Banner.types.ts
+++ b/packages/bezier-react/src/components/Banner/Banner.types.ts
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react'
 /* Internal dependencies */
 import type { BezierComponentProps, VariantProps, ContentProps, AdditionalColorProps } from 'Types/ComponentProps'
 import type { IconName } from 'Components/Icon'
+import type { ButtonProps } from 'Components/Button'
 
 export enum BannerVariant {
   Default = 'default',
@@ -28,8 +29,11 @@ interface BannerOptions {
   linkTo?: string
   renderLink?: RenderLinkFunc
 
-  dismissible?: boolean
-  onDismiss?: () => void
+  /**
+   * FIXME(@ed): 새로운 아이콘 방식으로 변경
+   */
+  actionIcon?: IconName
+  onClickAction?: ButtonProps['onClick']
 }
 
 export interface BannerProps extends


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

배너의 우측에 X 아이콘 외에도 다른 액션을 트리거하는 버튼이 들어갈 수 있도록 컴포넌트 스펙이 변경되었습니다.
`Banner` 컴포넌트의 `dismiss`, `onDismiss` prop을 `actionIcon`, `onClickAction` prop으로 변경합니다.

```diff
- dismiss: boolean
- onDismiss: () => void
+ actionIcon: IconName /* FIXME: 추후 IconSource로 변경 */
+ onClickAction: ButtonProps['onClick']
```

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

> **💥 BREAKING CHANGE: `dismiss`, `onDismiss` prop이 제거됩니다!**

- `Icon` 기반의 스타일링을 `Button` 을 사용하도록 변경
- 내부적으로 `Stack` 을 사용하여 스타일링하도록 리팩토링

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

- 피그마 참고
