### PR TITLE
fix(banner): fix invalid styling

### DIFF
--- a/packages/bezier-react/src/components/Banner/Banner.styled.ts
+++ b/packages/bezier-react/src/components/Banner/Banner.styled.ts
@@ -22,7 +22,9 @@ const Link = styled(Text)`
 `
 
 const Stack = styled(HStack)<BannerVariantProps>`
+  width: auto;
   min-width: 200px;
+  height: auto;
   padding: 12px;
   background-color: ${({ foundation, variant }) => foundation?.theme?.[BACKGROUND_COLORS[variant]]};
 

--- a/packages/bezier-react/src/components/Banner/Banner.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.tsx
@@ -79,7 +79,7 @@ function Banner(
       interpolation={interpolation}
       variant={variant}
       spacing={6}
-      align="center"
+      align="start"
     >
       { !isNil(icon) && (
         <StackItem>
@@ -91,7 +91,12 @@ function Banner(
         </StackItem>
       ) }
 
-      <StackItem grow weight={1}>
+      <StackItem
+        grow
+        shrink
+        weight={1}
+        align="center"
+      >
         <Styled.ContentWrapper variant={variant}>
           { isString(content) ? (
             <Text


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

`Banner` 컴포넌트의 잘못된 스타일을 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- `Banner` 가 부모 컨테이너의 width, height 100%를 차지하는 문제 수정
  - 이 부분은 `Stack` 의 기본 스타일을 수정하거나 width, height를 설정하는 인터페이스가 추가되어야 하지 않나는 생각이 듭니다. #817 에서도 그렇고 부모 컨테이너의 크기를 꽉 채운다는 속성때문에 범용적으로 사용하기가 어려운 부분이 있는 거 같습니다.
- 텍스트가 길 경우 액션 아이콘이 가려보이는 문제 수정
- 텍스트가 2줄 이상일 경우 요소간의 alignment를 디자인 시안에 맞도록 center에서 start로 수정

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

없음
