### PR TITLE
Banner의 아이콘과 버튼의 align을 교정

### DIFF
--- a/packages/bezier-react/src/components/Banner/Banner.styled.ts
+++ b/packages/bezier-react/src/components/Banner/Banner.styled.ts
@@ -1,7 +1,10 @@
 /* Internal dependencies */
 import { styled } from 'Foundation'
 import type { VariantProps } from 'Types/ComponentProps'
-import { HStack } from 'Components/Stack'
+import {
+  HStack,
+  StackItem as BaseStackItem,
+} from 'Components/Stack'
 import { Icon } from 'Components/Icon'
 import { Text } from 'Components/Text'
 import { BACKGROUND_COLORS, TEXT_COLORS, ELEVATIONS } from './Banner.const'
@@ -36,9 +39,14 @@ const Stack = styled(HStack)<BannerVariantProps>`
   }
 `
 
+const StackItem = styled(BaseStackItem)`
+  height: 20px;
+`
+
 export default {
   BannerIcon,
   ContentWrapper,
   Link,
   Stack,
+  StackItem,
 }

--- a/packages/bezier-react/src/components/Banner/Banner.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.tsx
@@ -82,13 +82,13 @@ function Banner(
       align="start"
     >
       { !isNil(icon) && (
-        <StackItem>
+        <Styled.StackItem>
           <Styled.BannerIcon
             name={icon}
             color={iconColor ?? DEFAULT_ICON_COLORS[variant]}
             size={IconSize.S}
           />
-        </StackItem>
+        </Styled.StackItem>
       ) }
 
       <StackItem
@@ -111,7 +111,7 @@ function Banner(
       </StackItem>
 
       { !isNil(actionIcon) && (
-        <StackItem>
+        <Styled.StackItem>
           <Button
             size={ButtonSize.XS}
             colorVariant={ACTION_BUTTON_COLOR_VARIANTS[variant]}
@@ -119,7 +119,7 @@ function Banner(
             leftContent={actionIcon}
             onClick={onClickAction}
           />
-        </StackItem>
+        </Styled.StackItem>
       ) }
     </Styled.Stack>
   )


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
- StackItem 사용으로 인해 height가 아이콘, 버튼보다 커져 align이 깨지던 문제를 해결합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->
- As-is
<img width="352" alt="스크린샷 2022-06-23 오후 4 25 34" src="https://user-images.githubusercontent.com/60692645/175252236-09e04e81-9528-4ea4-b8e3-469936fb5e48.png">

- To-be
<img width="353" alt="스크린샷 2022-06-23 오후 5 21 32" src="https://user-images.githubusercontent.com/60692645/175252250-53a74571-1be1-485a-a203-699d212944c0.png">

- StackItem의 SIze는 상위 Stack의 타입에 따라 width를 조절할지 height를 조절할지 결정됩니다. 이에 따라 Banner의 아이콘, 버튼의 Height를 별개로 조절할 수 없어서 StackItem을 오버라이드 한 후 height를 고정합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
