### PR TITLE
fix(modal): modal title ellipsis style을 제거

### DIFF
--- a/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
@@ -26,8 +26,6 @@ export const TitleText = styled(Text).attrs(() => ({
 }))`
   box-sizing: border-box;
   width: 100%;
-
-  ${ellipsis()}
 `
 
 export const SubTitleText = styled(Text).attrs(() => ({

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.test.tsx
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.test.tsx
@@ -184,9 +184,6 @@ describe('Modal', () => {
               expect(target).toHaveStyle('box-sizing: border-box;')
               expect(target).toHaveStyle('display: block;')
               expect(target).toHaveStyle('width: 100%;')
-              expect(target).toHaveStyle('overflow: hidden;')
-              expect(target).toHaveStyle('text-overflow: ellipsis;')
-              expect(target).toHaveStyle('white-space: nowrap;')
             })
           })
 


### PR DESCRIPTION
# Summary
- Modal Title에서의 ellipsis 처리를 제거합니다.

# Details
- Modal Title에서의 줄임말 처리는 의도되지 않은 디자인이라는 피드백이 있어서 이를 제거합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)


# References

- [Modal Figma](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=1427%3A229)
- [팀 기능 QA 시 Modal 리포트](https://www.notion.so/channelio/f2b71cbe8781481eb62cd032c1a8548b)
