### PR TITLE
Deploy bezier-react storybook when the package is published

### DIFF
--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -33,7 +33,8 @@
     "build:storybook": "build-storybook",
     "build:icon": "./scripts/build-icon.sh",
     "prepublishOnly": "npm run build",
-    "deploy:storybook": "storybook-to-ghpages --remote=upstream",
+    "postpublish": "npm run deploy:storybook",
+    "deploy:storybook": "storybook-to-ghpages",
     "semantic-release": "semantic-release",
     "update-snapshot": "jest --updateSnapshot"
   },


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

`@channel.io/bezier-react` package publish 시, storybook을 빌드하여 GitHub Pages로 배포합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- `postpublish` script에 지정하여, package publish 이후 `deploy:storybook` script 진행 (스토리북 자동 publish를 위한 최소한만 진행)

### Points

- 이후 prelease에서 벗어나면, semantic-release와 맞춰서 가야 함. (즉, **버전별로 documentation이 따로따로 존재해야 함**)
- Monorepo 대응 필요함 (package마다 스토리북이 존재하고, 단일 GitHub Page에서 라우팅하여 보여줘야 함)
- Storybook에서 release note를 쌓아 보여주는 feature가 있었으면 좋겠음.

## ~Browser Compatibility~

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- #218 에서 automated deployment가 제거되었으나, 다시 복원