### PR TITLE
Add Chromatic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
     <<: *defaults
     steps:
       - *attach_workspace
-      - run: yarn workspace @channel.io/bezier-react chromatic --skip 'dependabot/**'
+      - run: yarn workspace @channel.io/bezier-react chromatic --exit-zero-on-changes --skip 'dependabot/**'
 
   release:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,12 @@ jobs:
           file: './packages/bezier-react/coverage/lcov.info'
           token: $CODECOV_TOKEN
 
+  chromatic-deployment:
+    <<: *defaults
+    steps:
+      - *attach_workspace
+      - run: yarn workspace @channel.io/bezier-react chromatic --project-token={CHROMATIC_PROJECT_TOKEN} --skip 'dependabot/**'
+
   release:
     <<: *defaults
     steps:
@@ -85,8 +91,11 @@ workflows:
       - jest:
           requires:
             - install
-      - release:
+      - chromatic-deployment:
           requires:
             - lint
             - typecheck
             - jest
+      - release:
+          requires:
+            - chromatic-deployment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
     <<: *defaults
     steps:
       - *attach_workspace
-      - run: yarn workspace @channel.io/bezier-react chromatic --project-token={CHROMATIC_PROJECT_TOKEN} --skip 'dependabot/**'
+      - run: yarn workspace @channel.io/bezier-react chromatic --skip 'dependabot/**'
 
   release:
     <<: *defaults

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -35,7 +35,9 @@
     "build:icon": "./scripts/build-icon.sh",
     "prepublishOnly": "yarn build",
     "deploy:storybook": "storybook-to-ghpages --remote=upstream",
-    "update-snapshot": "jest --updateSnapshot"
+    "semantic-release": "semantic-release",
+    "update-snapshot": "jest --updateSnapshot",
+    "chromatic": "npx chromatic"
   },
   "lint-staged": {
     "src/**/*.styled.{js,ts}": [
@@ -95,6 +97,7 @@
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
     "babel-preset-react-app": "^10.0.0",
+    "chromatic": "^6.7.0",
     "core-js": "^3.8.1",
     "cross-env": "^7.0.3",
     "identity-obj-proxy": "^3.0.0",

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -37,7 +37,7 @@
     "deploy:storybook": "storybook-to-ghpages --remote=upstream",
     "semantic-release": "semantic-release",
     "update-snapshot": "jest --updateSnapshot",
-    "chromatic": "npx chromatic"
+    "chromatic": "chromatic"
   },
   "lint-staged": {
     "src/**/*.styled.{js,ts}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,6 +1767,7 @@ __metadata:
     babel-jest: ^26.6.3
     babel-loader: ^8.2.2
     babel-preset-react-app: ^10.0.0
+    chromatic: ^6.7.0
     core-js: ^3.8.1
     cross-env: ^7.0.3
     identity-obj-proxy: ^3.0.0
@@ -5199,7 +5200,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/webpack-env@npm:^1.16.0":
+"@types/webpack-env@npm:^1.16.0, @types/webpack-env@npm:^1.17.0":
   version: 1.17.0
   resolution: "@types/webpack-env@npm:1.17.0"
   checksum: 9ad4d208c4429c9427191d1f4c92e4c43e530384c17a6bc298acb89003fc47fcde1d8372e50acefa3061e9100e57fd9d616e96def875afd06c0c2afe508f298e
@@ -7703,6 +7704,19 @@ __metadata:
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
   checksum: c57cf9dd0791e2f18a5ee9c1a299ae6e801ff58fee96dc8bfd0dcb4738a6ce58dd252a3605b1c93c6418fe4f9d5093b28ffbf4d66648cb2a9c67eaef9679be2f
+  languageName: node
+  linkType: hard
+
+"chromatic@npm:^6.7.0":
+  version: 6.7.0
+  resolution: "chromatic@npm:6.7.0"
+  dependencies:
+    "@types/webpack-env": ^1.17.0
+  bin:
+    chroma: bin/main.cjs
+    chromatic: bin/main.cjs
+    chromatic-cli: bin/main.cjs
+  checksum: 0e5ebc9d8c4f4d54a0dd256f7c509b375d76bfec08a78ca5cb7a18cea04d8c88071768a7d108b21f620143f7381819d66c32b8cc3828f9a2a04c032e3a460b57
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

[Chromatic - bezier-react](https://www.chromatic.com/builds?appId=62bead1508281287d3c94d25)
Chromatic을 설치하고, CI pipeline에 Chromatic 배포(Storybook) 작업을 추가합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- circleci project 환경변수로 프로젝트 토큰을 추가했습니다.
- push할 때마다 각 브랜치별 Storybook이 배포되도록 합니다. 주소는 아래와 같습니다.

```bash
https://<branch>--62bead1508281287d3c94d25.chromatic.com
```

- `yarn workspace @channel.io/bezier-react chromatic --exit-zero-on-changes --skip 'dependabot/**'`
  - `--exit-zero-on-changes` : Chromatic에서 변경사항이 있다면 머지가 블로킹되는데, 이를 방지하는 옵션입니다. 
  비슷하게 `--auto-accept-changes` 옵션의 경우 Chromatic의 변경사항을 자동으로 확인해주기도 하는데, 이 옵션을 적용할지는 더 살펴볼 예정입니다.
  - `-skip 'dependabot/**'` : depandabot PR의 경우 스토리북 배포를 스킵합니다.
- 스토리북 배포 과정에서 테스트를 다시 한 번 실행합니다. `jest` 명령어와 충돌하는데, `jest` 명령어를 통해 코드 커버리지 파일을 생성하고 있고 Chromatic에서 테스트를 스킵할 수 있는 방법이 현재 없어 테스트 2번 실행은 불가피해보입니다.

## ~~Browser Compatibility~~
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

- Close #783 
