### PR TITLE
Switch 컴포넌트 구현이 Figma 명세를 따르도록 수정

### DIFF
--- a/.changeset/old-students-raise.md
+++ b/.changeset/old-students-raise.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix Switch component implementation to follow Bezier Figma spec

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.stories.tsx
@@ -4,15 +4,34 @@ import base from 'paths.macro'
 import { Meta, Story } from '@storybook/react'
 
 /* Internal dependencies */
-import { getTitle } from 'Utils/storyUtils'
+import { getObjectFromEnum, getTitle } from 'Utils/storyUtils'
 import Switch from './Switch'
-import SwitchProps from './Switch.types'
+import type SwitchProps from './Switch.types'
+import { SwitchSize } from './Switch.types'
 
 export default {
   title: getTitle(base),
   component: Switch,
   argTypes: {
-    onClick: { action: 'onClick' },
+    size: {
+      control: {
+        type: 'radio',
+        options: getObjectFromEnum(SwitchSize),
+      },
+    },
+    checked: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    onClick: {
+      action: 'onClick',
+    },
   },
 } as Meta
 
@@ -20,7 +39,7 @@ const Template: Story<SwitchProps> = ({ ...otherSwitchProps }) => <Switch {...ot
 
 export const Primary = Template.bind({})
 Primary.args = {
-  size: 16,
+  size: SwitchSize.M,
   checked: true,
   disabled: false,
 }

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
@@ -1,5 +1,6 @@
 /* Internal dependencies */
 import { styled } from 'Foundation'
+import DisabledOpacity from 'Constants/DisabledOpacity'
 import type SwitchProps from './Switch.types'
 import { SwitchSize } from './Switch.types'
 
@@ -38,7 +39,7 @@ export const Wrapper = styled.div<WrapperProps>`
   )};
 
   ${({ foundation }) => foundation?.rounding?.round12}
-  opacity: ${props => (props.disabled ? '.2' : 'initial')};
+  opacity: ${({ disabled }) => (disabled ? DisabledOpacity : 'initial')};
 
   &:hover {
     background-color: ${props => (

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
@@ -1,46 +1,78 @@
 /* Internal dependencies */
 import { styled } from 'Foundation'
-import { WrapperProps, ContentProps } from './Switch.types'
+import type SwitchProps from './Switch.types'
+import { SwitchSize } from './Switch.types'
 
-const PADDING = 4
+const PADDING = 3
+
+const SWITCH_WIDTH: Record<SwitchSize, number> = {
+  [SwitchSize.M]: 36,
+  [SwitchSize.S]: 30,
+}
+
+const SWITCH_HEIGHT: Record<SwitchSize, number> = {
+  [SwitchSize.M]: 24,
+  [SwitchSize.S]: 20,
+}
+
+const SWITCH_HANDLE_WIDTH_HEIGHT: Record<SwitchSize, number> = {
+  [SwitchSize.M]: 18,
+  [SwitchSize.S]: 14,
+}
+
+interface WrapperProps extends Required<SwitchProps> {}
 
 /* eslint-disable @typescript-eslint/indent */
 export const Wrapper = styled.div<WrapperProps>`
   position: relative;
-  width: ${props => props.size * 2}px;
-  height: ${props => props.size + PADDING}px;
+
+  width: ${({ size }) => SWITCH_WIDTH[size]}px;
+  height: ${({ size }) => SWITCH_HEIGHT[size]}px;
+
   cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
-  background-color:
-    ${props => (
-      props.checked
-        ? props.foundation?.theme?.['bgtxt-green-normal']
-        : props.foundation?.theme?.['bg-black-dark']
-    )};
-  border-radius: ${props => (props.size + PADDING) / 2}px;
+
+  background-color: ${props => (
+    props.checked
+      ? props.foundation?.theme?.['bgtxt-green-normal']
+      : props.foundation?.theme?.['bg-black-dark']
+  )};
+
+  ${({ foundation }) => foundation?.rounding?.round12}
   opacity: ${props => (props.disabled ? '.2' : 'initial')};
-  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'opacity'])};
 
   &:hover {
-    background-color:
-      ${props => (
-        props.checked
-          ? props.foundation?.theme?.['bgtxt-green-dark']
-          : props.foundation?.theme?.['bg-black-dark']
-      )};
+    background-color: ${props => (
+      props.checked
+        ? props.foundation?.theme?.['bgtxt-green-dark']
+        : props.foundation?.theme?.['bg-black-dark']
+    )};
   }
+
+  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'opacity'])};
 `
 /* eslint-enable @typescript-eslint/indent */
 
-export const Content = styled.div<ContentProps>`
-  ${({ foundation }) => foundation?.elevation?.ev2()};
-  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['transform'])};
+interface ContentProps extends SwitchProps {
+  size: NonNullable<SwitchProps['size']>
+  checked: NonNullable<SwitchProps['checked']>
+}
 
+export const Content = styled.div<ContentProps>`
   position: absolute;
-  top: ${PADDING / 2}px;
-  left: ${PADDING / 2}px;
-  width: ${props => props.size}px;
-  height: ${props => props.size}px;
+  top: ${PADDING}px;
+  left: ${PADDING}px;
+
+  width: ${({ size }) => SWITCH_HANDLE_WIDTH_HEIGHT[size]}px;
+  height: ${({ size }) => SWITCH_HANDLE_WIDTH_HEIGHT[size]}px;
   background-color: ${props => props.foundation?.theme?.['bgtxt-absolute-white-dark']};
-  border-radius: 50%;
-  transform: ${props => (props.checked ? `translateX(${props.size - PADDING}px)` : 'initial')};
+  ${({ foundation }) => foundation?.rounding?.round12}
+  ${({ foundation }) => foundation?.elevation?.ev2()};
+  
+  transform: ${props => (
+    props.checked
+      ? `translateX(${SWITCH_WIDTH[props.size] - SWITCH_HANDLE_WIDTH_HEIGHT[props.size] - (PADDING * 2)}px)`
+      : 'initial'
+  )};
+
+  ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['transform'])};
 `

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
@@ -23,35 +23,33 @@ const SWITCH_HANDLE_WIDTH_HEIGHT: Record<SwitchSize, number> = {
 
 interface WrapperProps extends Required<SwitchProps> {}
 
-/* eslint-disable @typescript-eslint/indent */
 export const Wrapper = styled.div<WrapperProps>`
   position: relative;
 
   width: ${({ size }) => SWITCH_WIDTH[size]}px;
   height: ${({ size }) => SWITCH_HEIGHT[size]}px;
 
-  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 
-  background-color: ${props => (
-    props.checked
-      ? props.foundation?.theme?.['bgtxt-green-normal']
-      : props.foundation?.theme?.['bg-black-dark']
+  background-color: ${({ checked, foundation }) => (
+    checked
+      ? foundation?.theme?.['bgtxt-green-normal']
+      : foundation?.theme?.['bg-black-dark']
   )};
 
   ${({ foundation }) => foundation?.rounding?.round12}
   opacity: ${({ disabled }) => (disabled ? DisabledOpacity : 'initial')};
 
   &:hover {
-    background-color: ${props => (
-      props.checked
-        ? props.foundation?.theme?.['bgtxt-green-dark']
-        : props.foundation?.theme?.['bg-black-dark']
-    )};
+    background-color: ${({ checked, foundation }) => (
+    checked
+      ? foundation?.theme?.['bgtxt-green-dark']
+      : foundation?.theme?.['bg-black-dark']
+  )};
   }
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color', 'opacity'])};
 `
-/* eslint-enable @typescript-eslint/indent */
 
 interface ContentProps extends SwitchProps {
   size: NonNullable<SwitchProps['size']>
@@ -65,13 +63,13 @@ export const Content = styled.div<ContentProps>`
 
   width: ${({ size }) => SWITCH_HANDLE_WIDTH_HEIGHT[size]}px;
   height: ${({ size }) => SWITCH_HANDLE_WIDTH_HEIGHT[size]}px;
-  background-color: ${props => props.foundation?.theme?.['bgtxt-absolute-white-dark']};
+  background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-absolute-white-dark']};
   ${({ foundation }) => foundation?.rounding?.round12}
   ${({ foundation }) => foundation?.elevation?.ev2()};
   
-  transform: ${props => (
-    props.checked
-      ? `translateX(${SWITCH_WIDTH[props.size] - SWITCH_HANDLE_WIDTH_HEIGHT[props.size] - (PADDING * 2)}px)`
+  transform: ${({ checked, size }) => (
+    checked
+      ? `translateX(${SWITCH_WIDTH[size] - SWITCH_HANDLE_WIDTH_HEIGHT[size] - (PADDING * 2)}px)`
       : 'initial'
   )};
 

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.test.tsx
@@ -7,6 +7,7 @@ import { LightFoundation } from 'Foundation'
 import { render } from 'Utils/testUtils'
 import Switch, { SWITCH_TEST_ID, SWITCH_HANDLE_TEST_ID } from './Switch'
 import type SwitchProps from './Switch.types'
+import { SwitchSize } from './Switch.types'
 
 describe('Switch', () => {
   const renderComponent = (props?: Partial<SwitchProps>) => render(
@@ -20,38 +21,48 @@ describe('Switch', () => {
       const switchHandleComponent = getByTestId(SWITCH_HANDLE_TEST_ID)
 
       expect(switchComponent).toHaveStyle('position: relative')
-      expect(switchComponent).toHaveStyle('width: 32px')
-      expect(switchComponent).toHaveStyle('height: 20px')
+      expect(switchComponent).toHaveStyle('width: 36px')
+      expect(switchComponent).toHaveStyle('height: 24px')
       expect(switchComponent).toHaveStyle('cursor: pointer')
       expect(switchComponent).toHaveStyle(`background-color: ${LightFoundation.theme['bg-black-dark']}`)
-      expect(switchComponent).toHaveStyle('border-radius: 10px')
+      expect(switchComponent).toHaveStyle('border-radius: 12px')
       expect(switchComponent).toHaveStyle('opacity: initial')
       expect(switchHandleComponent).toHaveStyle('position: absolute')
-      expect(switchHandleComponent).toHaveStyle('top: 2px')
-      expect(switchHandleComponent).toHaveStyle('left: 2px')
-      expect(switchHandleComponent).toHaveStyle('width: 16px')
-      expect(switchHandleComponent).toHaveStyle('height: 16px')
+      expect(switchHandleComponent).toHaveStyle('top: 3px')
+      expect(switchHandleComponent).toHaveStyle('left: 3px')
+      expect(switchHandleComponent).toHaveStyle('width: 18px')
+      expect(switchHandleComponent).toHaveStyle('height: 18px')
       expect(switchHandleComponent).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-absolute-white-dark']}`)
-      expect(switchHandleComponent).toHaveStyle('border-radius: 50%')
+      expect(switchHandleComponent).toHaveStyle('border-radius: 12px')
       expect(switchHandleComponent).toHaveStyle('transform: initial')
     })
   })
 
   describe('specify size props', () => {
-    it('should render Switch with given size', () => {
+    it('should render Switch with size M', () => {
       const { getByTestId } = renderComponent({
-        size: 16,
+        size: SwitchSize.M,
       })
       const switchComponent = getByTestId(SWITCH_TEST_ID)
       const switchHandleComponent = getByTestId(SWITCH_HANDLE_TEST_ID)
 
-      expect(switchComponent).toHaveStyle('width: 32px')
+      expect(switchComponent).toHaveStyle('width: 36px')
+      expect(switchComponent).toHaveStyle('height: 24px')
+      expect(switchHandleComponent).toHaveStyle('width: 18px')
+      expect(switchHandleComponent).toHaveStyle('height: 18px')
+    })
+
+    it('should render Switch with size S', () => {
+      const { getByTestId } = renderComponent({
+        size: SwitchSize.S,
+      })
+      const switchComponent = getByTestId(SWITCH_TEST_ID)
+      const switchHandleComponent = getByTestId(SWITCH_HANDLE_TEST_ID)
+
+      expect(switchComponent).toHaveStyle('width: 30px')
       expect(switchComponent).toHaveStyle('height: 20px')
-      expect(switchComponent).toHaveStyle('border-radius: 10px')
-      expect(switchHandleComponent).toHaveStyle('top: 2px')
-      expect(switchHandleComponent).toHaveStyle('left: 2px')
-      expect(switchHandleComponent).toHaveStyle('width: 16px')
-      expect(switchHandleComponent).toHaveStyle('height: 16px')
+      expect(switchHandleComponent).toHaveStyle('width: 14px')
+      expect(switchHandleComponent).toHaveStyle('height: 14px')
     })
   })
 

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent } from '@testing-library/react'
 
 /* Internal dependencies */
 import { LightFoundation } from 'Foundation'
+import DisabledOpacity from 'Constants/DisabledOpacity'
 import { render } from 'Utils/testUtils'
 import Switch, { SWITCH_TEST_ID, SWITCH_HANDLE_TEST_ID } from './Switch'
 import type SwitchProps from './Switch.types'
@@ -106,7 +107,7 @@ describe('Switch', () => {
       })
       const switchComponent = getByTestId(SWITCH_TEST_ID)
 
-      expect(switchComponent).toHaveStyle('opacity: .2')
+      expect(switchComponent).toHaveStyle(`opacity: ${DisabledOpacity}`)
     })
   })
 

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.tsx
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.tsx
@@ -9,7 +9,8 @@ import React, {
 
 /* Internal dependencies */
 import useFormFieldProps from 'Components/Forms/useFormFieldProps'
-import SwitchProps from './Switch.types'
+import type SwitchProps from './Switch.types'
+import { SwitchSize } from './Switch.types'
 import * as Styled from './Switch.styled'
 
 export const SWITCH_TEST_ID = 'bezier-react-switch'
@@ -20,7 +21,7 @@ function Switch(
     testId = SWITCH_TEST_ID,
     handleTestId = SWITCH_HANDLE_TEST_ID,
     checked = false,
-    size = 16,
+    size = SwitchSize.M,
     onClick,
     ...rest
   }: SwitchProps,

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.types.ts
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.types.ts
@@ -2,8 +2,13 @@
 import type { MouseEvent } from 'react'
 
 /* Internal dependencies */
-import type { BezierComponentProps, SizeProps, DisableProps, AdditionalTestIdProps } from 'Types/ComponentProps'
+import type { BezierComponentProps, SizeProps, AdditionalTestIdProps } from 'Types/ComponentProps'
 import type { FormComponentProps } from 'Components/Forms/Form.types'
+
+export enum SwitchSize {
+  M = 'm',
+  S = 's',
+}
 
 interface SwitchOptions {
   checked?: boolean
@@ -12,15 +17,7 @@ interface SwitchOptions {
 
 export default interface SwitchProps extends
   BezierComponentProps,
-  SizeProps<number>,
+  SizeProps<SwitchSize>,
   FormComponentProps,
   AdditionalTestIdProps<'handle'>,
   SwitchOptions {}
-
-type StyledSwitchProps = Required<SizeProps<number> & Omit<SwitchOptions, 'onClick'>>
-
-export interface WrapperProps extends
-  StyledSwitchProps,
-  Required<DisableProps> {}
-
-export interface ContentProps extends StyledSwitchProps {}

--- a/packages/bezier-react/src/components/Forms/Switch/index.ts
+++ b/packages/bezier-react/src/components/Forms/Switch/index.ts
@@ -1,10 +1,9 @@
 import Switch from './Switch'
 import type SwitchProps from './Switch.types'
-
-export type {
-  SwitchProps,
-}
+import type { SwitchSize } from './Switch.types'
 
 export {
   Switch,
+  type SwitchProps,
+  type SwitchSize,
 }

--- a/packages/bezier-react/src/components/Forms/Switch/index.ts
+++ b/packages/bezier-react/src/components/Forms/Switch/index.ts
@@ -1,9 +1,9 @@
 import Switch from './Switch'
 import type SwitchProps from './Switch.types'
-import type { SwitchSize } from './Switch.types'
+import { SwitchSize } from './Switch.types'
 
 export {
   Switch,
   type SwitchProps,
-  type SwitchSize,
+  SwitchSize,
 }


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

- Forms의 `Switch` 컴포넌트 구현이 Figma 명세를 따르도록 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

> Closes #840

- [x] BREAKING CHANGE: `size` prop은 더 이상 `number`형이 아닌, 새로 정의한 `SwitchSize` enum 타입을 사용합니다.
  ```ts
  export enum SwitchSize {
    M = 'm',
    S = 's',
  }
  ```
- [x] `Switch` 컴포넌트의 `width`, `height`, `disabled = true` 시의 `opacity`가 명세에 맞게 변경됩니다.
- [x] `border-radius`를 `foundation.rounding`을 사용합니다.
- [x] `Switch` 핸들 컴포넌트의 `width`, `height` 및 absolute 위치(padding)이 명세에 맞게(2px -> 3px) 변경됩니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

- [Figma Switch](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=3263%3A131)
