### PR TITLE
ProgressBar에서 Size, Variant enum을 값까지 export하도록 수정

### DIFF
--- a/packages/bezier-react/src/components/ProgressBar/index.ts
+++ b/packages/bezier-react/src/components/ProgressBar/index.ts
@@ -1,10 +1,10 @@
 import ProgressBar from './ProgressBar'
 import type ProgressBarProps from './ProgressBar.types'
-import type { ProgressBarSize, ProgressBarVariant } from './ProgressBar.types'
+import { ProgressBarSize, ProgressBarVariant } from './ProgressBar.types'
 
 export {
   ProgressBar,
   type ProgressBarProps,
-  type ProgressBarSize,
-  type ProgressBarVariant,
+  ProgressBarSize,
+  ProgressBarVariant,
 }


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

- `ProgressBar`에 사용되는 Size, Variant enum을 type export가 아닌, 값까지 export하도록 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

> Closes #850

- As-is

```ts
import type { ProgressBarSize, ProgressBarVariant } from './ProgressBar.types'

export {
  ProgressBar,
  type ProgressBarProps,
  type ProgressBarSize,
  type ProgressBarVariant,
}
```

- To-be

```ts
import { ProgressBarSize, ProgressBarVariant } from './ProgressBar.types'

export {
  ProgressBar,
  type ProgressBarProps,
  ProgressBarSize,
  ProgressBarVariant,
}
```

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
