### PR TITLE
ci(chromatic): move deploy chromatic job to github workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,15 +65,9 @@ jobs:
           file: './packages/bezier-react/coverage/lcov.info'
           token: $CODECOV_TOKEN
 
-  chromatic-deployment:
-    <<: *defaults
-    steps:
-      - *attach_workspace
-      - run: yarn workspace @channel.io/bezier-react chromatic --exit-zero-on-changes --skip 'dependabot/**'
-
 workflows:
   version: 2
-  test-n-deploy-chromatic:
+  lint_and_test:
     jobs:
       - install
       - lint:
@@ -85,7 +79,3 @@ workflows:
       - jest:
           requires:
             - install
-      - chromatic-deployment:
-          requires:
-            - lint
-            - typecheck

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,36 @@
+name: Chromatic
+
+on: push
+
+jobs:
+  chromatic-deployment:
+    name: Chromatic
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Yarn cache path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Load Yarn cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          workingDir: packages/bezier-react
+          exitZeroOnChanges: true
+          skip: dependabot/**
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

Chromatic 배포 job을 circle ci에서 github ci로 이동합니다.
[GitHub Action for Chromatic](https://github.com/chromaui/action)을 사용하여 진행상황을 더 자세히 보여주기 위한 변경입니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- circleci의 workflow명을 적절하게 변경
- secret 토큰 추가

## ~~Browser Compatibility~~

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

- https://storybook.js.org/tutorials/ui-testing-handbook/react/en/automate/
