### PR TITLE
refactor(form-group): change implementation to use Stack internally

### DIFF
--- a/.changeset/fresh-lamps-remain.md
+++ b/.changeset/fresh-lamps-remain.md
@@ -1,0 +1,10 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Change FormGroup implementation to use Stack internally
+
+BREAKING CHANGE
+
+- Change 'gap' prop to 'spacing' prop
+- Change the allowable value of 'direction' prop to be the same as Stack

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.stories.tsx
@@ -82,7 +82,7 @@ const WithMultiFormTemplate: Story<FormControlProps> = (args) => (
 
     <FormControl {...args}>
       <FormLabel help="Lorem Ipsum">Label</FormLabel>
-      <FormGroup direction="row" gap={10}>
+      <FormGroup direction="horizontal" spacing={10}>
         <Checkbox>Option</Checkbox>
         <Checkbox>Option</Checkbox>
         <Checkbox>Option</Checkbox>
@@ -94,7 +94,7 @@ const WithMultiFormTemplate: Story<FormControlProps> = (args) => (
 
     <FormControl {...args}>
       <FormLabel help="Lorem Ipsum">Label</FormLabel>
-      <FormGroup direction="row" gap={20}>
+      <FormGroup direction="horizontal" spacing={20}>
         <div
           style={{
             display: 'flex',

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   margin-bottom: 4px;
 }
 
-.c8 {
+.c10 {
   padding: 0 2px;
   margin-top: 4px;
 }
@@ -20,13 +20,40 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  width: 100%;
+  height: 100%;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c6 {
+  -webkit-flex-basis: var(--main-axis-size);
+  -ms-flex-preferred-size: var(--main-axis-size);
+  flex-basis: var(--main-axis-size);
+  -webkit-box-flex: var(--grow-weight);
+  -webkit-flex-grow: var(--grow-weight);
+  -ms-flex-positive: var(--grow-weight);
+  flex-grow: var(--grow-weight);
+  -webkit-flex-shrink: var(--shrink-weight);
+  -ms-flex-negative: var(--shrink-weight);
+  flex-shrink: var(--shrink-weight);
+  margin-top: var(--margin-before);
+  margin-bottom: var(--margin-after);
+}
+
+.c5 {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: 6px;
 }
 
 .c2 {
@@ -46,7 +73,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   transition-property: color;
 }
 
-.c9 {
+.c11 {
   font-size: 1.3rem;
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
@@ -68,7 +95,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   text-align: left;
 }
 
-.c6 {
+.c8 {
   width: 100%;
   height: 100%;
   padding: 0;
@@ -81,23 +108,23 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   color: #000000D9;
 }
 
-.c6::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #00000066;
 }
 
-.c6::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #00000066;
 }
 
-.c6:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #00000066;
 }
 
-.c6::placeholder {
+.c8::placeholder {
   color: #00000066;
 }
 
-.c5 {
+.c7 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -124,7 +151,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   transition-property: border-color,box-shadow;
 }
 
-.c7 {
+.c9 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -152,21 +179,9 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   transition-property: border-color,box-shadow;
 }
 
-.c10 {
+.c12 {
   display: block;
   text-align: left;
-}
-
-@supports not(gap:6px) {
-  .c4 {
-    margin-top: -6px;
-    margin-left: -6px;
-  }
-
-  .c4 > * {
-    margin-top: 6px;
-    margin-left: 6px;
-  }
 }
 
 <div>
@@ -189,81 +204,95 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
     <div
       aria-describedby="form-help-text"
       aria-labelledby="form-label"
-      class="c4"
+      class="c4 c5"
       data-testid="bezier-react-form-group"
-      direction="column"
+      direction="vertical"
       id="form-group"
       role="group"
     >
       <div
-        class="c0"
-        data-testid="bezier-react-form-control"
+        class="c6"
+        data-testid="bezier-react-stack-item"
+        direction="vertical"
+        style="--main-axis-size: initial; --grow-weight: 0; --shrink-weight: 0; --margin-before: 0px; --margin-after: 0px;"
       >
         <div
-          class="c0 c1"
+          class="c0"
+          data-testid="bezier-react-form-control"
         >
-          <label
-            class="c2 c3"
-            color="txt-black-darkest"
-            data-testid="bezier-react-form-label"
-            for="field-:r3:"
-            id="field-:r3:-label"
+          <div
+            class="c0 c1"
           >
-            First Inner Label
-          </label>
-        </div>
-        <div
-          class="c5"
-          data-testid="bezier-react-text-input"
-          size="36"
-        >
-          <input
-            autocomplete="off"
-            class="c6"
-            id="field-:r3:"
+            <label
+              class="c2 c3"
+              color="txt-black-darkest"
+              data-testid="bezier-react-form-label"
+              for="field-:r3:"
+              id="field-:r3:-label"
+            >
+              First Inner Label
+            </label>
+          </div>
+          <div
+            class="c7"
+            data-testid="bezier-react-text-input"
             size="36"
-            value=""
-          />
+          >
+            <input
+              autocomplete="off"
+              class="c8"
+              id="field-:r3:"
+              size="36"
+              value=""
+            />
+          </div>
         </div>
       </div>
       <div
-        class="c0"
-        data-testid="bezier-react-form-control"
+        class="c6"
+        data-testid="bezier-react-stack-item"
+        direction="vertical"
+        style="--main-axis-size: initial; --grow-weight: 0; --shrink-weight: 0; --margin-before: 6px; --margin-after: 0px;"
       >
         <div
-          class="c0 c1"
+          class="c0"
+          data-testid="bezier-react-form-control"
         >
-          <label
-            class="c2 c3"
-            color="txt-black-darkest"
-            data-testid="bezier-react-form-label"
-            for="field-:r4:"
-            id="field-:r4:-label"
+          <div
+            class="c0 c1"
           >
-            Second Inner Label
-          </label>
-        </div>
-        <div
-          class="c7"
-          data-testid="bezier-react-text-input"
-          size="36"
-        >
-          <input
-            aria-invalid="true"
-            autocomplete="off"
-            class="c6"
-            id="field-:r4:"
+            <label
+              class="c2 c3"
+              color="txt-black-darkest"
+              data-testid="bezier-react-form-label"
+              for="field-:r4:"
+              id="field-:r4:-label"
+            >
+              Second Inner Label
+            </label>
+          </div>
+          <div
+            class="c9"
+            data-testid="bezier-react-text-input"
             size="36"
-            value=""
-          />
+          >
+            <input
+              aria-invalid="true"
+              autocomplete="off"
+              class="c8"
+              id="field-:r4:"
+              size="36"
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>
     <div
-      class="c0 c8"
+      class="c0 c10"
     >
       <p
-        class="c9 c10"
+        class="c11 c12"
         color="txt-black-dark"
         data-testid="bezier-react-form-helper-text"
         id="form-help-text"
@@ -280,12 +309,12 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   position: relative;
 }
 
-.c6 {
+.c8 {
   padding: 0 2px;
   margin-bottom: 4px;
 }
 
-.c11 {
+.c13 {
   padding: 0 2px;
   margin-top: 4px;
 }
@@ -318,7 +347,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   height: 36px;
 }
 
-.c12 {
+.c14 {
   grid-row: 2 / 2;
   grid-column: 2;
 }
@@ -328,13 +357,40 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  width: 100%;
+  height: 100%;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c7 {
+  -webkit-flex-basis: var(--main-axis-size);
+  -ms-flex-preferred-size: var(--main-axis-size);
+  flex-basis: var(--main-axis-size);
+  -webkit-box-flex: var(--grow-weight);
+  -webkit-flex-grow: var(--grow-weight);
+  -ms-flex-positive: var(--grow-weight);
+  flex-grow: var(--grow-weight);
+  -webkit-flex-shrink: var(--shrink-weight);
+  -ms-flex-negative: var(--shrink-weight);
+  flex-shrink: var(--shrink-weight);
+  margin-top: var(--margin-before);
+  margin-bottom: var(--margin-after);
+}
+
+.c6 {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: 6px;
 }
 
 .c3 {
@@ -354,7 +410,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   transition-property: color;
 }
 
-.c7 {
+.c9 {
   font-size: 1.3rem;
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
@@ -371,7 +427,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   transition-property: color;
 }
 
-.c13 {
+.c15 {
   font-size: 1.3rem;
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
@@ -393,7 +449,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   text-align: left;
 }
 
-.c9 {
+.c11 {
   width: 100%;
   height: 100%;
   padding: 0;
@@ -406,23 +462,23 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   color: #000000D9;
 }
 
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #00000066;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #00000066;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #00000066;
 }
 
-.c9::placeholder {
+.c11::placeholder {
   color: #00000066;
 }
 
-.c8 {
+.c10 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -449,7 +505,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   transition-property: border-color,box-shadow;
 }
 
-.c10 {
+.c12 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -477,21 +533,9 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   transition-property: border-color,box-shadow;
 }
 
-.c14 {
+.c16 {
   display: block;
   text-align: left;
-}
-
-@supports not(gap:6px) {
-  .c5 {
-    margin-top: -6px;
-    margin-left: -6px;
-  }
-
-  .c5 > * {
-    margin-top: 6px;
-    margin-left: 6px;
-  }
 }
 
 <div>
@@ -515,81 +559,95 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
     <div
       aria-describedby="form-help-text"
       aria-labelledby="form-label"
-      class="c5"
+      class="c5 c6"
       data-testid="bezier-react-form-group"
-      direction="column"
+      direction="vertical"
       id="form-group"
       role="group"
     >
       <div
-        class="c0"
-        data-testid="bezier-react-form-control"
+        class="c7"
+        data-testid="bezier-react-stack-item"
+        direction="vertical"
+        style="--main-axis-size: initial; --grow-weight: 0; --shrink-weight: 0; --margin-before: 0px; --margin-after: 0px;"
       >
         <div
-          class="c0 c6"
+          class="c0"
+          data-testid="bezier-react-form-control"
         >
-          <label
-            class="c7 c4"
-            color="txt-black-darkest"
-            data-testid="bezier-react-form-label"
-            for="field-:r6:"
-            id="field-:r6:-label"
+          <div
+            class="c0 c8"
           >
-            First Inner Label
-          </label>
-        </div>
-        <div
-          class="c8"
-          data-testid="bezier-react-text-input"
-          size="36"
-        >
-          <input
-            autocomplete="off"
-            class="c9"
-            id="field-:r6:"
+            <label
+              class="c9 c4"
+              color="txt-black-darkest"
+              data-testid="bezier-react-form-label"
+              for="field-:r6:"
+              id="field-:r6:-label"
+            >
+              First Inner Label
+            </label>
+          </div>
+          <div
+            class="c10"
+            data-testid="bezier-react-text-input"
             size="36"
-            value=""
-          />
+          >
+            <input
+              autocomplete="off"
+              class="c11"
+              id="field-:r6:"
+              size="36"
+              value=""
+            />
+          </div>
         </div>
       </div>
       <div
-        class="c0"
-        data-testid="bezier-react-form-control"
+        class="c7"
+        data-testid="bezier-react-stack-item"
+        direction="vertical"
+        style="--main-axis-size: initial; --grow-weight: 0; --shrink-weight: 0; --margin-before: 6px; --margin-after: 0px;"
       >
         <div
-          class="c0 c6"
+          class="c0"
+          data-testid="bezier-react-form-control"
         >
-          <label
-            class="c7 c4"
-            color="txt-black-darkest"
-            data-testid="bezier-react-form-label"
-            for="field-:r7:"
-            id="field-:r7:-label"
+          <div
+            class="c0 c8"
           >
-            Second Inner Label
-          </label>
-        </div>
-        <div
-          class="c10"
-          data-testid="bezier-react-text-input"
-          size="36"
-        >
-          <input
-            aria-invalid="true"
-            autocomplete="off"
-            class="c9"
-            id="field-:r7:"
+            <label
+              class="c9 c4"
+              color="txt-black-darkest"
+              data-testid="bezier-react-form-label"
+              for="field-:r7:"
+              id="field-:r7:-label"
+            >
+              Second Inner Label
+            </label>
+          </div>
+          <div
+            class="c12"
+            data-testid="bezier-react-text-input"
             size="36"
-            value=""
-          />
+          >
+            <input
+              aria-invalid="true"
+              autocomplete="off"
+              class="c11"
+              id="field-:r7:"
+              size="36"
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>
     <div
-      class="c0 c11 c12"
+      class="c0 c13 c14"
     >
       <p
-        class="c13 c14"
+        class="c15 c16"
         color="txt-black-dark"
         data-testid="bezier-react-form-helper-text"
         id="form-help-text"

--- a/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.stories.tsx
@@ -13,7 +13,7 @@ export default {
   title: getTitle(base),
   component: FormGroup,
   argTypes: {
-    gap: {
+    spacing: {
       control: {
         type: 'number',
       },
@@ -21,7 +21,10 @@ export default {
     direction: {
       control: {
         type: 'radio',
-        options: ['column', 'row'],
+        options: [
+          'horizontal',
+          'vertical',
+        ],
       },
     },
   },
@@ -38,6 +41,6 @@ const Template: Story<FormGroupProps> = props => (
 
 export const Primary: Story<FormGroupProps> = Template.bind({})
 Primary.args = {
-  gap: 6,
-  direction: 'column',
+  spacing: 6,
+  direction: 'vertical',
 }

--- a/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.styled.ts
+++ b/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.styled.ts
@@ -1,15 +1,7 @@
 /* Internal dependencies */
 import { styled } from 'Foundation'
-import { gap } from 'Utils/styleUtils'
-import type FormGroupProps from './FormGroup.types'
+import { Stack as BaseStack } from 'Components/Stack'
 
-type StackProps = Required<Pick<FormGroupProps, 'gap' | 'direction' | 'interpolation'>>
-
-// TODO: Stack 컴포넌트로 교체
-export const Stack = styled.div<StackProps>`
-  display: flex;
-  flex-direction: ${({ direction }) => direction};
+export const Stack = styled(BaseStack)`
   flex-wrap: wrap;
-  ${({ gap: spacing }) => gap(spacing)}
-  ${({ interpolation }) => interpolation}
 `

--- a/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.test.tsx
+++ b/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 /* Internal dependencies */
 import { render } from 'Utils/testUtils'
-import FormGroup, { FORM_GROUP_TEST_ID } from './FormGroup'
+import FormGroup from './FormGroup'
 import type FormGroupProps from './FormGroup.types'
 
 describe('FormGroup >', () => {
@@ -11,16 +11,16 @@ describe('FormGroup >', () => {
 
   beforeEach(() => {
     props = {
-      gap: 6,
-      direction: 'column',
+      spacing: 6,
+      direction: 'vertical',
     }
   })
 
   const renderComponent = () => render(<FormGroup {...props} />)
 
   it('Snapshot >', () => {
-    const { getByTestId } = renderComponent()
-    const rendered = getByTestId(FORM_GROUP_TEST_ID)
+    const { getByRole } = renderComponent()
+    const rendered = getByRole('group')
 
     expect(rendered).toMatchSnapshot()
   })

--- a/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.tsx
+++ b/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.tsx
@@ -2,16 +2,17 @@
 import React, { forwardRef, useEffect } from 'react'
 
 /* Internal dependencies */
+import { StackItem } from 'Components/Stack'
 import useFormControlContext from 'Components/Forms/useFormControlContext'
 import type FormGroupProps from './FormGroup.types'
 import * as Styled from './FormGroup.styled'
 
-export const FORM_GROUP_TEST_ID = 'bezier-react-form-group'
+const FORM_GROUP_TEST_ID = 'bezier-react-form-group'
 
 function FormGroup({
   testId = FORM_GROUP_TEST_ID,
-  gap = 6,
-  direction = 'column',
+  spacing = 6,
+  direction = 'vertical',
   role = 'group',
   children,
   ...rest
@@ -40,11 +41,15 @@ forwardedRef: React.Ref<HTMLDivElement>,
       {...ownProps}
       data-testid={testId}
       ref={forwardedRef}
-      gap={gap}
+      spacing={spacing}
       direction={direction}
       role={role}
     >
-      { children }
+      { React.Children.map(children, (child, index) => (
+        <StackItem key={(child as React.ReactElement)?.key ?? index}>
+          { child }
+        </StackItem>
+      )) }
     </Styled.Stack>
   )
 }

--- a/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.types.ts
@@ -1,15 +1,16 @@
 /* Internal dependencies */
 import type { BezierComponentProps, ChildrenProps } from 'Types/ComponentProps'
+import type { StackProps } from 'Components/Stack'
 
 interface FormGroupOptions {
-  gap?: number
-  direction?: 'column' | 'row'
+  direction?: StackProps['direction']
   role?: string
 }
 
 interface FormGroupProps extends
   BezierComponentProps,
   ChildrenProps,
+  Omit<StackProps, 'direction'>,
   FormGroupOptions {}
 
 export default FormGroupProps

--- a/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.types.ts
@@ -3,14 +3,13 @@ import type { BezierComponentProps, ChildrenProps } from 'Types/ComponentProps'
 import type { StackProps } from 'Components/Stack'
 
 interface FormGroupOptions {
-  direction?: StackProps['direction']
   role?: string
 }
 
 interface FormGroupProps extends
   BezierComponentProps,
   ChildrenProps,
-  Omit<StackProps, 'direction'>,
+  Partial<Pick<StackProps, 'direction' | 'spacing'>>,
   FormGroupOptions {}
 
 export default FormGroupProps

--- a/packages/bezier-react/src/components/Forms/FormGroup/__snapshots__/FormGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormGroup/__snapshots__/FormGroup.test.tsx.snap
@@ -6,31 +6,31 @@ exports[`FormGroup > Snapshot > 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  width: 100%;
+  height: 100%;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c1 {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: 6px;
-}
-
-@supports not(gap:6px) {
-  .c0 {
-    margin-top: -6px;
-    margin-left: -6px;
-  }
-
-  .c0 > * {
-    margin-top: 6px;
-    margin-left: 6px;
-  }
 }
 
 <div
-  class="c0"
+  class="c0 c1"
   data-testid="bezier-react-form-group"
-  direction="column"
+  direction="vertical"
   role="group"
 />
 `;

--- a/packages/bezier-react/src/components/Stack/Stack/Stack.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack/Stack.tsx
@@ -41,7 +41,7 @@ function Stack(
     justify = 'start',
     align = 'start',
     spacing = 0,
-    role,
+    ...rest
   }: StackProps,
   forwardedRef: Ref<HTMLElement>,
 ) {
@@ -56,7 +56,7 @@ function Stack(
       direction={direction}
       justify={justify}
       align={align}
-      role={role}
+      {...rest}
     >
       { Children.map(
         children,

--- a/packages/bezier-react/src/components/Stack/Stack/Stack.types.ts
+++ b/packages/bezier-react/src/components/Stack/Stack/Stack.types.ts
@@ -61,4 +61,5 @@ interface StackOptions {
 export default interface StackProps extends
   BezierComponentProps,
   ChildrenProps,
+  React.HTMLAttributes<HTMLElement>,
   StackOptions {}

--- a/packages/bezier-react/src/components/Stack/Stack/Stack.types.ts
+++ b/packages/bezier-react/src/components/Stack/Stack/Stack.types.ts
@@ -49,13 +49,6 @@ interface StackOptions {
    * @default 0
    */
   spacing?: number
-
-  /**
-   * Role attribute for accessibility
-   *
-   * @default undefined
-   */
-  role?: string
 }
 
 export default interface StackProps extends


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

`FormGroup` 의 내부 구현을 `Stack` 을 사용하는 방향으로 변경합니다. (TODO Resolve)

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

## BREAKING CHANGE

- `gap` 프로퍼티 명이 `Stack` 과 동일하게 `spacing` 으로 변경됩니다.
- `direction` 프로퍼티에 가능한 값이 `Stack` 과 동일하게 `'horizontal' | 'vertical'` 로 변경됩니다.

## 그 외

- `Stack` 이 aria attribute를 전달받지 못하는 문제가 있어, rest parameter를 추가하는 방향으로 우선 해결했습니다.
- `flex: wrap` 같은 속성의 경우 `Stack` 에서 처리하지 못하는 문제가 있어, `Stack` 상위에 `Flex` 컴포넌트가 구현되어서 이를 내부적으로 상속하는 형태가 되면 스타일 오버라이드를 더 줄일 수 있겠다는 생각이 들었습니다. 
(ex: https://ui.docs.amplify.aws/react/components/flex, https://chakra-ui.com/docs/components/flex/usage)

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

없음
