### PR TITLE
Switch handle의 색상이 다크모드에서 잘못 표시되는 버그 수정

### DIFF
--- a/.changeset/old-olives-trade.md
+++ b/.changeset/old-olives-trade.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix style bug: background color of switch handle is overridden by elevation css

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
@@ -31,13 +31,13 @@ export const Wrapper = styled.div<WrapperProps>`
 
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 
+  ${({ foundation }) => foundation?.rounding?.round12}
   background-color: ${({ checked, foundation }) => (
     checked
       ? foundation?.theme?.['bgtxt-green-normal']
       : foundation?.theme?.['bg-black-dark']
   )};
 
-  ${({ foundation }) => foundation?.rounding?.round12}
   opacity: ${({ disabled }) => (disabled ? DisabledOpacity : 'initial')};
 
   &:hover {
@@ -63,9 +63,9 @@ export const Content = styled.div<ContentProps>`
 
   width: ${({ size }) => SWITCH_HANDLE_WIDTH_HEIGHT[size]}px;
   height: ${({ size }) => SWITCH_HANDLE_WIDTH_HEIGHT[size]}px;
-  background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-absolute-white-dark']};
   ${({ foundation }) => foundation?.rounding?.round12}
   ${({ foundation }) => foundation?.elevation?.ev2()};
+  background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-absolute-white-dark']};
   
   transform: ${({ checked, size }) => (
     checked


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

- [x] Switch handle의 색상이 다크모드에서 잘못 표시되는 버그를 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- handle의 bgColor를 `bgtxt-absolute-white-dark`로 옳게 지정하였으나, elevation의 css에 bgColor 속성이 override되어 absolute color가 제대로 적용되지 않고 있었습니다.
  - elevation 설정을 위로 올려 해결합니다.

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [ ] Edge - Blink
- [ ] Safari - WebKit
- [ ] Firefox - Gecko (Option)


# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
