### PR TITLE
feat(storybook): improvements to show the inverted theme as well

### DIFF
--- a/packages/bezier-react/.storybook/preview.js
+++ b/packages/bezier-react/.storybook/preview.js
@@ -7,6 +7,7 @@ import {
   DarkFoundation,
 } from 'Foundation'
 import BezierProvider from 'Providers/BezierProvider'
+import { Text } from 'Components/Text'
 
 const FoundationKeyword = {
   Light: 'light',
@@ -43,36 +44,99 @@ export const globalTypes = {
 };
 
 function getFoundation(keyword) {
-  if (keyword === FoundationKeyword.Light) return LightFoundation
-  return DarkFoundation
+  const isDarkFoundation = keyword === FoundationKeyword.Dark 
+  return {
+    isDarkFoundation,
+    foundation: isDarkFoundation ? DarkFoundation : LightFoundation,
+    invertedFoundation: isDarkFoundation ? LightFoundation : DarkFoundation,
+  }
+}
+
+const customGlobalStyle = {
+  // You can inject custom global CSS
+  // global: {
+  //   html: {
+  //     fontSize: '20px',
+  //   }
+  // }
+}
+
+const wrapperStyle = {
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 20,
+  width: '100%',
+  height: '100%',
+  fontFamily: 'Inter',
+}
+
+const storyWrapperStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 20,
+  padding: 20,
+}
+
+const innerWrapperStyle = {
+  height: '100%',
+  padding: 40,
+  borderRadius: 20,
 }
 
 function withFoundationProvider(Story, context) {
-  const Foundation = getFoundation(context.globals.Foundation)
-  const backgroundColor = context.globals.Foundation === 'dark'
-    ? DarkFoundation.theme['bg-white-normal']
-    : LightFoundation.theme['bg-white-normal']
+  const { 
+    isDarkFoundation,
+    foundation: Foundation,
+    invertedFoundation: InvertedFoundation,
+   } = getFoundation(context.globals.Foundation)
+
+  const [backgroundColor, invertedBackgroundColor, themeName, invertedThemeName] = (() => {
+    const lightBackgroundColor = LightFoundation.theme['bg-white-normal']
+    const darkBackgroundColor = DarkFoundation.theme['bg-white-normal']
+    const lightThemeName = 'Light Theme'
+    const darkThemeName = 'Dark Theme'
+
+    return isDarkFoundation
+      ? [darkBackgroundColor, lightBackgroundColor, darkThemeName, lightThemeName]
+      : [lightBackgroundColor, darkBackgroundColor, lightThemeName, darkThemeName]
+  })()
 
   const foundation = {
     ...Foundation,
-    // You can inject custom global CSS
-    // global: {
-    //   html: {
-    //     fontSize: '20px',
-    //   }
-    // }
+    ...customGlobalStyle,
+  }
+
+  const invertedFoundation = {
+    ...InvertedFoundation,
+    ...customGlobalStyle,
   }
 
   return (
-    <div
-      style={{
-        backgroundColor,
-        padding: 16,
-        fontFamily: 'Inter',
-      }}
-    >
+    <div style={wrapperStyle}>
       <BezierProvider foundation={foundation}>
-        { Story(context) }
+        <div style={storyWrapperStyle}>
+          <div style={{ ...innerWrapperStyle, backgroundColor }}>
+            { Story(context) }
+          </div>
+          <Text bold color="bgtxt-absolute-black-light">
+            { themeName }
+          </Text>
+        </div>
+      </BezierProvider>
+      <BezierProvider foundation={invertedFoundation}>
+        <div style={storyWrapperStyle}>
+          <div style={{ ...innerWrapperStyle, backgroundColor: invertedBackgroundColor }}>
+            { Story(context) }
+          </div>
+          <Text bold color="bgtxt-absolute-black-light">
+            { invertedThemeName }
+          </Text>
+        </div>
       </BezierProvider>
     </div>
   )


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->
<img width="580" alt="스크린샷 2022-07-09 오전 12 40 51" src="https://user-images.githubusercontent.com/58209009/178025426-b4bcf854-2bfd-4607-9252-fe497468cc76.png">

<img width="580" alt="스크린샷 2022-07-09 오전 12 40 06" src="https://user-images.githubusercontent.com/58209009/178025432-8806c12c-2f42-4071-bc74-b5f3c70850f5.png">

> 뷰포트 사이즈에 따라 잘 줄바꿈 됩니다.

스토리북에서 별도의 설정 없이, 라이트 테마와 다크 테마를 함께 보여주도록 개선합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- 스토리북 상단의 툴바를 사용하여 테마를 전환할 수 있으나, 기본적으로 라이트 테마로 고정되어있어 작업자가 주의를 기울이지 않으면 다크 테마를 고려하지 못하고 실수를 저지르는 경우가 많았습니다. 이를 미연에 방지하고자 두 테마의 스토리를 동시에 띄우는 방식으로 개선합니다.
- Chromatic의 Snapshot diff에 어떤 영향이 있을지는 계속해서 지켜보아야 할 거 같습니다.
- `FIXME` : Layout playground 스토리가 제대로 안보이는 문제
- 가이드 문서에도 두가지 테마가 동시에 보여 어노잉할 수 있을 거 같습니다.

## ~~Browser Compatibility~~

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

없음
