### PR TITLE
Ensure mdx documentation is shown instead of canvas

### DIFF
--- a/packages/bezier-react/src/components/Banner/Banner.mdx
+++ b/packages/bezier-react/src/components/Banner/Banner.mdx
@@ -1,9 +1,7 @@
 import {
   Canvas,
-  Meta,
   Story,
 } from '@storybook/addon-docs'
-import base from 'paths.macro'
 import {
   getTitle,
 } from 'Utils/storyUtils'
@@ -15,23 +13,6 @@ import {
   StackItem,
   VStack,
 } from 'Components/Stack'
-import {
-  Overview,
-  UsageConsecutive,
-  UsageFullWidth,
-  UsageLink,
-  UsageLinkTo,
-  UsageMinWidth,
-  UsageMaxWidth,
-  UsageNoIcon,
-} from './Banner.stories'
-
-<Meta
-  title={getTitle(base)}
-  parameters={{
-    viewMode: 'docs',
-  }}
-/>
 
 # Banner
 
@@ -40,7 +21,7 @@ import {
 안내, 경고, 추천 등의 다양한 정보를 잘 전달하고 싶을 때 사용합니다.
 
 <Canvas>
-  <Story story={Overview} />
+  <Story id="components-banner--overview" />
 </Canvas>
 
 ## Usage
@@ -48,31 +29,31 @@ import {
 - 최소 너비는 200px입니다.
 
 <Canvas>
-  <Story story={UsageMinWidth} />
+  <Story id="components-banner--usage-min-width" />
 </Canvas>
 
 - Parent의 너비를 가득 채웁니다.
 
 <Canvas>
-  <Story story={UsageFullWidth} />
+  <Story id="components-banner--usage-full-width" />
 </Canvas>
 
 - 최대 너비는 없으나, Banner의 텍스트 영역은 좌측 상단에 위치합니다.
 
 <Canvas>
-  <Story story={UsageMaxWidth} />
+  <Story id="components-banner--usage-max-width" />
 </Canvas>
 
 - 연속으로 보여줘야 하는 경우, Banner 간의 간격은 6px 입니다.
 
 <Canvas>
-  <Story story={UsageConsecutive} />
+  <Story id="components-banner--usage-consecutive" />
 </Canvas>
 
 - 아이콘을 제거하여 사용할 수 있습니다.
 
 <Canvas>
-  <Story story={UsageNoIcon} />
+  <Story id="components-banner--usage-no-icon" />
 </Canvas>
 
 ### Link
@@ -81,14 +62,14 @@ import {
 - `hasLink={true}` prop을 통해 링크를 enable하고, `linkText` prop으로 링크의 텍스트를 설정할 수 있습니다.
 
 <Canvas>
-  <Story story={UsageLink} />
+  <Story id="components-banner--usage-link" />
 </Canvas>
 
 - `linkTo` prop을 활용하면, 링크를 클릭했을 때 이동할 location을 지정할 수 있습니다.
 - 기본적으로, 링크를 클릭하면 새 탭으로 해당 location이 열리게 됩니다. (`<a>` 태그, `target="_blank"`, `rel="noopener noreferrer"` 를 기본으로 합니다.)
 
 <Canvas>
-  <Story story={UsageLinkTo} />
+  <Story id="components-banner--usage-link-to" />
 </Canvas>
 
 - Default로 제공되는 링크 메커니즘을 이용할 수 없는 경우가 있습니다. (대표적인 usecase는, SPA에서 `react-router`와 같은 라이브러리가 제공하는 링크 컴포넌를 활용하는 경우입니다.) 이 경우, `renderLink` prop을 지정하여 링크를 어떤 컴포넌트로 렌더링할지 결정할 수 있습니다.

--- a/packages/bezier-react/src/components/Banner/Banner.stories.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.stories.tsx
@@ -55,10 +55,9 @@ export default {
   },
 } as Meta<BannerProps>
 
-const Template: Story<BannerProps> = props => <Banner {...props} />
+export const Playground: Story<BannerProps> = props => <Banner {...props} />
 
-export const Primary: Story<BannerProps> = Template.bind({})
-Primary.args = {
+Playground.args = {
   variant: BannerVariant.Default,
   icon: 'lightbulb',
   content: 'Information here.',
@@ -133,6 +132,8 @@ export const UsageMinWidth: Story<{}> = () => (
   </VStack>
 )
 
+UsageMinWidth.storyName = 'Usage (min width)'
+
 export const UsageFullWidth: Story<{}> = () => (
   <VStack spacing={6} align="start">
     <StackItem style={{ width: 360, border: '1px solid red' }}>
@@ -159,6 +160,8 @@ export const UsageFullWidth: Story<{}> = () => (
   </VStack>
 )
 
+UsageFullWidth.storyName = 'Usage (full width)'
+
 export const UsageMaxWidth: Story<{}> = () => (
   <VStack spacing={6} align="start">
     <StackItem>
@@ -171,6 +174,8 @@ export const UsageMaxWidth: Story<{}> = () => (
     </StackItem>
   </VStack>
 )
+
+UsageMaxWidth.storyName = 'Usage (max width)'
 
 export const UsageConsecutive: Story<{}> = () => (
   <VStack spacing={6} align="stretch">
@@ -203,6 +208,8 @@ export const UsageConsecutive: Story<{}> = () => (
   </VStack>
 )
 
+UsageConsecutive.storyName = 'Usage (consecutive)'
+
 export const UsageNoIcon: Story<{}> = () => (
   <Banner
     icon={null}
@@ -212,6 +219,8 @@ export const UsageNoIcon: Story<{}> = () => (
     linkText="바로가기"
   />
 )
+
+UsageNoIcon.storyName = 'Usage (no icon)'
 
 export const UsageLink: Story<{}> = () => (
   <Banner
@@ -224,6 +233,8 @@ export const UsageLink: Story<{}> = () => (
   />
 )
 
+UsageLink.storyName = 'Usage (link)'
+
 export const UsageLinkTo: Story<{}> = () => (
   <Banner
     variant={BannerVariant.Cobalt}
@@ -235,3 +246,5 @@ export const UsageLinkTo: Story<{}> = () => (
     actionIcon="cancel"
   />
 )
+
+UsageLinkTo.storyName = 'Usage (link to external location)'

--- a/packages/bezier-react/src/components/Banner/Banner.stories.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.stories.tsx
@@ -15,10 +15,16 @@ import {
   BannerVariant,
   BannerProps,
 } from './Banner.types'
+import mdx from './Banner.mdx'
 
 export default {
   title: getTitle(base),
   component: Banner,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
   argTypes: {
     variant: {
       control: {

--- a/packages/bezier-react/src/components/Button/Button.mdx
+++ b/packages/bezier-react/src/components/Button/Button.mdx
@@ -3,13 +3,8 @@ import {
 } from 'react'
 import {
   Canvas,
-  Meta,
   Story,
 } from '@storybook/addon-docs'
-import base from 'paths.macro'
-import {
-  getTitle,
-} from 'Utils/storyUtils'
 import {
   Avatar,
 } from 'Components/Avatars/Avatar'
@@ -61,13 +56,6 @@ import {
   VariantsStyle,
 } from './Button.stories'
 
-<Meta
-  title={getTitle(base)}
-  parameters={{
-    viewMode: 'docs',
-  }}
-/>
-
 # Button
 
 ## Overview
@@ -77,11 +65,11 @@ import {
 버튼은 크게 4가지 사이즈로 나뉩니다. 그 중 M이 가장 보편적이며, 공간 절약을 위해 S가 쓰입니다. List나 Input 등 액션이 필요할 때는 XS도 사용할 수 있습니다. 가입, 초대 UX 등 굉장히 강조해야 할 버튼의 경우, L, XL 사이즈를 사용할 수 있습니다.
 
 <Canvas>
-  <Story story={OverviewCTA} />
+  <Story id="components-button--overview-cta" />
 </Canvas>
 
 <Canvas>
-  <Story story={OverviewFloating} />
+  <Story id="components-button--overview-floating" />
 </Canvas>
 
 ## Usage
@@ -92,12 +80,12 @@ import {
 - 버튼 사이의 간격은 0 또는 6으로 합니다.
 
 <Canvas>
-  <Story story={UsageCTA} />
+  <Story id="components-button--usage-cta" />
 </Canvas>
 
 
 <Canvas>
-  <Story story={UsageCTA2} />
+  <Story id="components-button--usage-cta2" />
 </Canvas>
 
 ### Recipe: Web links
@@ -105,33 +93,33 @@ import {
 - 보통의 경우, tertiary button을 적절한 icon과 함께 사용합니다.
 
 <Canvas>
-  <Story story={UsageWebLinks} />
+  <Story id="components-button--usage-web-links" />
 </Canvas>
 
 ### Recipe: Composite Usage
 
 - XS 크기의 버튼은 ListItem, SectionLabel 등 다른 컴포넌트에 함께 사용될 수 있습니다. 컴포넌트 좌우측에서 액션으로 사용됩니다.
 
-<Story story={UsageComposite} />
+<Story id="components-button--usage-composite" />
 
 ### Recipe: Button with various contents
 
 - 기본적으로 `leftContent`, `rightContent` prop에 icon name에 해당하는 string을 지정하여 좌우측에 아이콘이 들어가는 형태를 표현합니다.
 
 <Canvas>
-  <Story story={UsageVariousContentsComposite} />
+  <Story id="components-button--usage-various-contents-composite" />
 </Canvas>
 
 - 아이콘만 들어가는 버튼의 경우, `leftContent` prop만 사용합니다.
 
 <Canvas>
-  <Story story={UsageVariousContentsIconOnly} />
+  <Story id="components-button--usage-various-contents-icon-only" />
 </Canvas>
 
 - 아이콘 이외에 커스텀 컴포넌트가 들어가야 하는 상황에는, `leftContent`, `rightContent` prop에 `JSX.Element` 값을 지정할 수 있습니다.
 
 <Canvas>
-  <Story story={UsageVariousContentsCustom} />
+  <Story id="components-button--usage-various-contents-custom" />
 </Canvas>
 
 ### Recipe: Button with asynchronous actions
@@ -162,7 +150,7 @@ const AsyncActionButton = () => {
 ```
 
 <Canvas>
-  <Story story={UsageAsync} />
+  <Story id="components-button--usage-async" />
 </Canvas>
 
 ### Recipe: Button with dropdown
@@ -192,7 +180,7 @@ const OpenDropdownButton = () => {
 ```
 
 <Canvas>
-  <Story story={UsageDropdown} />
+  <Story id="components-button--usage-dropdown" />
 </Canvas>
 
 ## Variants
@@ -201,19 +189,19 @@ const OpenDropdownButton = () => {
 
 - `ButtonColorVariant` enum을 통해 정의되며, `colorVariant` prop으로 지정할 수 있습니다.
 
-<Story story={VariantsColor} />
+<Story id="components-button--variants-color" />
 
 ### Style Variants
 
 - `ButtonStyleVariant` enum을 통해 정의되며, `styleVariant` prop으로 지정할 수 있습니다.
 
-<Story story={VariantsStyle} />
+<Story  id="components-button--variants-style" />
 
 ### Size
 
 - `ButtonSize` enum을 통해 정의되며, `size` prop으로 지정할 수 있습니다.
 
-<Story story={VariantsSize} />
+<Story id="components-button--variants-size" />
 
 ## API
 

--- a/packages/bezier-react/src/components/Button/Button.mdx
+++ b/packages/bezier-react/src/components/Button/Button.mdx
@@ -85,7 +85,7 @@ import {
 
 
 <Canvas>
-  <Story id="components-button--usage-cta2" />
+  <Story id="components-button--usage-cta-2" />
 </Canvas>
 
 ### Recipe: Web links

--- a/packages/bezier-react/src/components/Button/Button.mdx
+++ b/packages/bezier-react/src/components/Button/Button.mdx
@@ -77,7 +77,7 @@ import {
 ### Recipe: Call to action
 
 - 한 화면 내에서 CTA 버튼은 가능한 한, 가장 중요한 버튼 1개만 primary로 지정합니다. 후순위로 colored button을 같이 넣어야 할 경우에는 secondary로 넣습니다. 그 외에는 secondary, tetiary button을 조합하여 넣습니다.
-- 버튼 사이의 간격은 0 또는 6으로 합니다.
+- 버튼 사이의 간격은 0 또는 6으로 합니다. 둘 이상의 버튼을 활용할 때는, `<ButtonGroup>` 컴포넌트를 활용하는 것을 권장합니다.
 
 <Canvas>
   <Story id="components-button--usage-cta" />
@@ -87,6 +87,8 @@ import {
 <Canvas>
   <Story id="components-button--usage-cta-2" />
 </Canvas>
+
+ButtonGroup에 대해 더 알아보려면 [스토리](/docs/components-buttongroup--playground)를 참조하세요.
 
 ### Recipe: Web links
 

--- a/packages/bezier-react/src/components/Button/Button.stories.tsx
+++ b/packages/bezier-react/src/components/Button/Button.stories.tsx
@@ -49,10 +49,16 @@ import ButtonProps, {
   ButtonColorVariant,
 } from './Button.types'
 import Button from './Button'
+import mdx from './Button.mdx'
 
 export default {
   title: getTitle(base),
   component: Button,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
   argTypes: {
     onClick: { action: 'onClick' },
     size: {

--- a/packages/bezier-react/src/components/Button/Button.stories.tsx
+++ b/packages/bezier-react/src/components/Button/Button.stories.tsx
@@ -23,6 +23,9 @@ import {
   Avatar,
 } from 'Components/Avatars/Avatar'
 import {
+  ButtonGroup,
+} from 'Components/ButtonGroup'
+import {
   ListItem,
 } from 'Components/ListItem'
 import {
@@ -161,60 +164,48 @@ export const OverviewFloating: Story<{}> = () => (
 OverviewFloating.storyName = 'Overview (as floating button)'
 
 export const UsageCTA: Story<{}> = () => (
-  <HStack justify="center" spacing={6}>
-    <StackItem>
-      <Button
-        text="취소"
-        colorVariant={ButtonColorVariant.MonochromeLight}
-        styleVariant={ButtonStyleVariant.Secondary}
-      />
-    </StackItem>
-    <StackItem>
-      <Button
-        leftContent="play"
-        text="퍼블리시"
-        colorVariant={ButtonColorVariant.Green}
-        styleVariant={ButtonStyleVariant.Primary}
-      />
-    </StackItem>
-  </HStack>
+  <ButtonGroup>
+    <Button
+      text="취소"
+      colorVariant={ButtonColorVariant.MonochromeLight}
+      styleVariant={ButtonStyleVariant.Secondary}
+    />
+    <Button
+      leftContent="play"
+      text="퍼블리시"
+      colorVariant={ButtonColorVariant.Green}
+      styleVariant={ButtonStyleVariant.Primary}
+    />
+  </ButtonGroup>
 )
 
 UsageCTA.storyName = 'Usage (as CTA)'
 
 export const UsageCTA2: Story<{}> = () => (
-  <HStack justify="center" spacing={6}>
-    <StackItem>
-      <Button
-        text="임시 저장 삭제"
-        disabled
-        colorVariant={ButtonColorVariant.MonochromeLight}
-        styleVariant={ButtonStyleVariant.Secondary}
-      />
-    </StackItem>
-    <StackItem>
-      <Button
-        text="임시 저장"
-        colorVariant={ButtonColorVariant.Blue}
-        styleVariant={ButtonStyleVariant.Secondary}
-      />
-    </StackItem>
-    <StackItem>
-      <Button
-        leftContent="play"
-        text="퍼블리시"
-        colorVariant={ButtonColorVariant.Green}
-        styleVariant={ButtonStyleVariant.Primary}
-      />
-    </StackItem>
-    <StackItem>
-      <Button
-        leftContent="cancel"
-        colorVariant={ButtonColorVariant.MonochromeLight}
-        styleVariant={ButtonStyleVariant.Tertiary}
-      />
-    </StackItem>
-  </HStack>
+  <ButtonGroup>
+    <Button
+      text="임시 저장 삭제"
+      disabled
+      colorVariant={ButtonColorVariant.MonochromeLight}
+      styleVariant={ButtonStyleVariant.Secondary}
+    />
+    <Button
+      text="임시 저장"
+      colorVariant={ButtonColorVariant.Blue}
+      styleVariant={ButtonStyleVariant.Secondary}
+    />
+    <Button
+      leftContent="play"
+      text="퍼블리시"
+      colorVariant={ButtonColorVariant.Green}
+      styleVariant={ButtonStyleVariant.Primary}
+    />
+    <Button
+      leftContent="cancel"
+      colorVariant={ButtonColorVariant.MonochromeLight}
+      styleVariant={ButtonStyleVariant.Tertiary}
+    />
+  </ButtonGroup>
 )
 
 UsageCTA2.storyName = 'Usage (as CTA 2)'

--- a/packages/bezier-react/src/components/Button/Button.stories.tsx
+++ b/packages/bezier-react/src/components/Button/Button.stories.tsx
@@ -217,7 +217,7 @@ export const UsageCTA2: Story<{}> = () => (
   </HStack>
 )
 
-UsageCTA2.storyName = 'Usage 2 (as CTA)'
+UsageCTA2.storyName = 'Usage (as CTA 2)'
 
 export const UsageWebLinks: Story<{}> = () => (
   <HStack justify="center" spacing={6}>

--- a/packages/bezier-react/src/components/Button/Button.stories.tsx
+++ b/packages/bezier-react/src/components/Button/Button.stories.tsx
@@ -90,8 +90,9 @@ export default {
 
 const Template: Story<ButtonProps> = (args) => <Button {...args} />
 
-export const Primary: Story<ButtonProps> = Template.bind({})
-Primary.args = {
+export const Playground: Story<ButtonProps> = Template.bind({})
+
+Playground.args = {
   text: 'Invite',
   disabled: false,
   active: false,
@@ -104,6 +105,7 @@ Primary.args = {
 }
 
 export const WithCustomComponent: Story<ButtonProps> = Template.bind({})
+
 WithCustomComponent.args = {
   text: 'Set Manager',
   leftContent: <Avatar name="test" avatarUrl="https://source.unsplash.com/random" />,
@@ -141,6 +143,8 @@ export const OverviewCTA: Story<{}> = () => (
   </HStack>
 )
 
+OverviewCTA.storyName = 'Overview (as CTA)'
+
 export const OverviewFloating: Story<{}> = () => (
   <HStack justify="center">
     <StackItem>
@@ -153,6 +157,8 @@ export const OverviewFloating: Story<{}> = () => (
     </StackItem>
   </HStack>
 )
+
+OverviewFloating.storyName = 'Overview (as floating button)'
 
 export const UsageCTA: Story<{}> = () => (
   <HStack justify="center" spacing={6}>
@@ -173,6 +179,8 @@ export const UsageCTA: Story<{}> = () => (
     </StackItem>
   </HStack>
 )
+
+UsageCTA.storyName = 'Usage (as CTA)'
 
 export const UsageCTA2: Story<{}> = () => (
   <HStack justify="center" spacing={6}>
@@ -209,6 +217,8 @@ export const UsageCTA2: Story<{}> = () => (
   </HStack>
 )
 
+UsageCTA2.storyName = 'Usage 2 (as CTA)'
+
 export const UsageWebLinks: Story<{}> = () => (
   <HStack justify="center" spacing={6}>
     <StackItem>
@@ -235,6 +245,8 @@ export const UsageWebLinks: Story<{}> = () => (
     </StackItem>
   </HStack>
 )
+
+UsageWebLinks.storyName = 'Usage (as web link)'
 
 const Card = styled.div`
   width: 360px;
@@ -320,6 +332,8 @@ export const UsageComposite: Story<{}> = () => (
   </HStack>
 )
 
+UsageComposite.storyName = 'Usage (in composite components)'
+
 export const UsageVariousContentsComposite: Story<{}> = () => (
   <HStack justify="center">
     <StackItem>
@@ -333,6 +347,8 @@ export const UsageVariousContentsComposite: Story<{}> = () => (
   </HStack>
 )
 
+UsageVariousContentsComposite.storyName = 'Usage (with left/right contents)'
+
 export const UsageVariousContentsIconOnly: Story<{}> = () => (
   <HStack justify="center">
     <StackItem>
@@ -344,6 +360,8 @@ export const UsageVariousContentsIconOnly: Story<{}> = () => (
     </StackItem>
   </HStack>
 )
+
+UsageVariousContentsIconOnly.storyName = 'Usage (icon only button)'
 
 const AlertBadge = styled.div`
   display: flex;
@@ -379,6 +397,8 @@ export const UsageVariousContentsCustom: Story<{}> = () => (
   </HStack>
 )
 
+UsageVariousContentsCustom.storyName = 'Usage (with custom contents)'
+
 const AsyncActionButton = () => {
   const [isFetching, setFetching] = useState(false)
   const handleClick = () => {
@@ -407,6 +427,8 @@ export const UsageAsync: Story<{}> = () => (
     </StackItem>
   </HStack>
 )
+
+UsageAsync.storyName = 'Usage (with asyncrhonous actions)'
 
 const Dropdown = styled.div`
   width: 200px;
@@ -453,6 +475,8 @@ export const UsageDropdown: Story<{}> = () => (
     </StackItem>
   </HStack>
 )
+
+UsageDropdown.storyName = 'Usage (with dropdown)'
 
 export const VariantsColor: Story<{}> = () => (
   <VStack spacing={16} align="start">
@@ -549,6 +573,8 @@ export const VariantsColor: Story<{}> = () => (
   </VStack>
 )
 
+VariantsColor.storyName = 'Color variants'
+
 export const VariantsStyle: Story<{}> = () => (
   <VStack spacing={16} align="start">
     { entries(ButtonStyleVariant)
@@ -573,6 +599,8 @@ export const VariantsStyle: Story<{}> = () => (
   </VStack>
 )
 
+VariantsStyle.storyName = 'Style variants'
+
 export const VariantsSize: Story<{}> = () => (
   <VStack spacing={16} align="start">
     { entries(ButtonSize)
@@ -596,3 +624,5 @@ export const VariantsSize: Story<{}> = () => (
       )) }
   </VStack>
 )
+
+VariantsSize.storyName = 'Size variants'

--- a/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.mdx
+++ b/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.mdx
@@ -3,17 +3,9 @@ import {
   Meta,
   Story,
 } from '@storybook/addon-docs'
-import base from 'paths.macro'
 import {
   Composition,
 } from './ButtonGroup.stories'
-
-<Meta
-  title={getTitle(base)}
-  parameters={{
-    viewMode: 'docs',
-  }}
-/>
 
 # ButtonGroup
 
@@ -24,7 +16,7 @@ import {
 버튼 사이의 간격은 0px 혹은 6px 이며, 디폴트값은 6px 입니다.
 
 <Canvas>
-  <Story story={Composition} />
+  <Story id="components-buttongroup--composition" />
 </Canvas>
 
 ## API

--- a/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -11,11 +11,15 @@ import { ButtonStyleVariant } from 'Components/Button/Button.types'
 import { Spacer, StackItem } from 'Components/Stack'
 import ButtonGroup from './ButtonGroup'
 import ButtonGroupProps from './ButtonGroup.types'
+import mdx from './ButtonGroup.mdx'
 
 export default {
   title: getTitle(base),
   component: ButtonGroup,
-  argTypes: {
+  parameters: {
+    docs: {
+      page: mdx,
+    },
   },
 } as Meta
 
@@ -45,8 +49,8 @@ const Template: Story<ButtonGroupProps> = (props) => (
   </Wrapper>
 )
 
-export const Primary: Story<ButtonGroupProps> = Template.bind({})
-Primary.args = {
+export const Playground: Story<ButtonGroupProps> = Template.bind({})
+Playground.args = {
   withoutSpacing: false,
 }
 

--- a/packages/bezier-react/src/components/Stack/Stack.mdx
+++ b/packages/bezier-react/src/components/Stack/Stack.mdx
@@ -1,9 +1,7 @@
 import {
   Canvas,
-  Meta,
   Story,
 } from '@storybook/addon-docs'
-import base from 'paths.macro'
 import {
   getTitle,
 } from 'Utils/storyUtils'
@@ -35,13 +33,6 @@ import {
   WeightSpacer,
 } from './Stack.stories'
 
-<Meta
-  title={getTitle(base)}
-  parameters={{
-    viewMode: 'docs',
-  }}
-/>
-
 # Stack
 
 ## Overview
@@ -53,7 +44,7 @@ Stack은 flex layout을 제공하는 컴포넌트입니다.
 Flexbox 내의 각 item을 `StackItem`으로 구성합니다. Flex layout 내에서 각 item의 weight, base size, item 간의 spacing을 컨트롤할 수 있습니다.
 
 <Canvas>
-  <Story story={Overview} />
+  <Story id="components-stack--overview" />
 </Canvas>
 
 ## Usage
@@ -78,12 +69,12 @@ Flexbox 내의 각 item을 `StackItem`으로 구성합니다. Flex layout 내에
 기본 컴포넌트인 `Stack`에 `direction` prop을 사용하여 방향을 결정할 수 있으나, 방향이 고정된 경우에는 `HStack`과 `VStack`을 바로 이용하는 것이 좋습니다.
 
 <Canvas>
-  <Story story={DirectionHorizontal} />
+  <Story id="components-stack--direction-horizontal" />
 </Canvas>
 
 
 <Canvas>
-  <Story story={DirectionVertical} />
+  <Story id="components-stack--direction-vertical" />
 </Canvas>
 
 ### Alignment
@@ -92,16 +83,16 @@ Flex container의 **주 방향** (`HStack`은 가로, `VStack`은 세로) 의 �
 
 기본적으로, `Stack` container에 지정하는 prop이 모든 child의 기본값이 됩니다. 각 `StackItem`에도 `justify`, `align` prop을 지정하여 parent `Stack`의 기본값을 overriding할 수 있습니다.
 
-<Story story={AlignmentJustify} />
+<Story id="components-stack--alignment-justify" />
 
-<Story story={AlignmentAlign} />
+<Story id="components-stack--alignment-align" />
 
 ### Spacing
 
 `Stack` 컴포넌트의 `spacing` prop으로 item 간의 기본 간격을 조정합니다. `StackItem`에 `marginBefore`, `marginAfter` prop으로 기본 간격을 오버라이딩할 수 있습니다.
 
 <Canvas>
-  <Story story={Spacing} />
+  <Story id="components-stack--spacing" />
 </Canvas>
 
 ### Weight
@@ -113,20 +104,20 @@ Flex layout의 특징은, container의 크기에 맞춰 item의 크기가 적절
 - Item 하나가 container의 여유 공간을 모두 차지하는 경우입니다. 이 경우, 해당 item에게 `grow shrink weight={1}` prop을 지정합니다.
 
 <Canvas>
-  <Story story={Expanded} />
+  <Story id="components-stack--expanded" />
 </Canvas>
 
 - CSS의 `justify-content: space-between`과 같이, item 사이에 공간을 두고자 하는 경우가 있습니다. 이 경우에는 `<Spacer />` 컴포넌트를 활용합니다. `Spacer`는 기본적으로 `grow shrink weight={1}` 을 가진 빈 `StackItem`입니다.
 
 <Canvas>
-  <Story story={WeightSpacer} />
+  <Story id="components-stack--weight-spacer" />
 </Canvas>
 
 - Item이 container의 크기와 무관하게 (특히, container 크기가 충분하지 않은 경우) 일정한 크기를 차지하고자 하는 경우, 기본값인 `grow={false} shrink={false} weight={0}` prop을 지정합니다. 그리고, 의도하는 크기를 `size` prop으로 지정합니다.
 
 
 <Canvas>
-  <Story story={WeightFixed} />
+  <Story id="components-stack--weight-fixed" />
 </Canvas>
 
 ## API

--- a/packages/bezier-react/src/components/Stack/Stack.stories.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack.stories.tsx
@@ -30,9 +30,15 @@ import { Stack } from './Stack'
 import { StackItem } from './StackItem'
 import { VStack } from './VStack'
 import type { AxisAlignment } from './types'
+import mdx from './Stack.mdx'
 
 export default {
   title: getTitle(base),
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
   argTypes: {
     containerSize: {
       control: {

--- a/packages/bezier-react/src/components/Stack/Stack.stories.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack.stories.tsx
@@ -275,6 +275,8 @@ export const DirectionHorizontal: Story<{}> = () => (
   </HStack>
 )
 
+DirectionHorizontal.storyName = 'Horizontal stack'
+
 export const DirectionVertical: Story<{}> = () => (
   <VStack
     style={{ width: '200px', height: '600px', border: '1px solid #ffc0c0' }}
@@ -306,6 +308,8 @@ export const DirectionVertical: Story<{}> = () => (
     </StackItem>
   </VStack>
 )
+
+DirectionVertical.storyName = 'Vertical stack'
 
 export const AlignmentJustify: Story<{}> = () => (
   <VStack align="stretch" spacing={8}>
@@ -422,6 +426,8 @@ export const AlignmentJustify: Story<{}> = () => (
     </StackItem>
   </VStack>
 )
+
+AlignmentJustify.storyName = 'Alignment (justify)'
 
 export const AlignmentAlign: Story<{}> = () => (
   <VStack align="stretch" spacing={8}>
@@ -576,6 +582,8 @@ export const AlignmentAlign: Story<{}> = () => (
   </VStack>
 )
 
+AlignmentAlign.storyName = 'Alignment (align)'
+
 export const Spacing: Story<{}> = () => (
   <HStack
     style={{ width: '720px', height: '80px', border: '1px solid #ffc0c0' }}
@@ -668,6 +676,8 @@ export const WeightSpacer: Story<{}> = () => (
   </HStack>
 )
 
+WeightSpacer.storyName = 'Spacer'
+
 export const WeightFixed: Story<{}> = () => (
   <HStack
     style={{ width: '100px', height: '80px', border: '1px solid #ffc0c0' }}
@@ -689,3 +699,5 @@ export const WeightFixed: Story<{}> = () => (
     </StackItem>
   </HStack>
 )
+
+WeightFixed.storyName = 'Fix-sized item'

--- a/packages/bezier-react/src/stories/mdx.d.ts
+++ b/packages/bezier-react/src/stories/mdx.d.ts
@@ -1,0 +1,4 @@
+declare module '*.mdx' {
+  const content: string
+  export default content
+}


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

TSX, MDX 파일에서 동일 컴포넌트에 대한 스토리를 모두 export하고 있어, mdx documentation이 가려지는 현상이 발생합니다.

<img width="1565" alt="스크린샷 2022-07-19 오후 3 58 41" src="https://user-images.githubusercontent.com/25701854/179686313-12ac57ad-85b2-43cb-9d20-7755a81c9c29.png">

이를 수정하여, Docs tab에서 mdx documentation이 올바르게 표시되도록 합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- mdx documentation 파일에서 metadata를 export하지 않고, tsx 파일에서 mdx 파일을 import하여 docs page로 지정합니다. 이로 인해 중복 export 문제가 해소됩니다.

```ts
// [Component].stories.tsx

import mdx from './[Component].mdx'

export default {
  ...
  parameters: {
    docs: {
      page: mdx,
    },
  },
}
```

- 스토리에 name을 더 적절하게 지정합니다.

<img width="309" alt="스크린샷 2022-07-19 오후 3 57 06" src="https://user-images.githubusercontent.com/25701854/179686620-cc788c14-6724-4169-b4d7-ef061c21b36d.png">

## ~Browser Compatibility~

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
- Carbon design system의 스토리 구현을 참고했습니다.