### PR TITLE
Add mdx documentation for Avatars component group

### DIFF
--- a/packages/bezier-react/src/components/Avatars/Avatars.mdx
+++ b/packages/bezier-react/src/components/Avatars/Avatars.mdx
@@ -200,7 +200,6 @@ Avatar 각각에 property를 지정하기보다는 AvatarGroup 컴포넌트에 �
 
 Group 내 Avatar 간의 간격을 조절하기 위해서는 `spacing` prop을 사용하세요.
 `spacing`이 음수가 되는 경우 (즉, Avatar 간에 겹치는 경우) 또한 종종 사용되는 UX입니다.
-이 경우에는 Avatar의 `showBorder` prop을 활용하여 Avatar 간의 대비를 주는 것이 좋습니다.
 
 <Story id="components-avatars--usage-group-spacing" />
 

--- a/packages/bezier-react/src/components/Avatars/Avatars.mdx
+++ b/packages/bezier-react/src/components/Avatars/Avatars.mdx
@@ -1,0 +1,224 @@
+import {
+  Canvas,
+  Story,
+} from '@storybook/addon-docs'
+
+# Avatars
+
+## Overview
+
+프로필 이미지를 가지는 객체를 표현하기 위해 사용합니다.
+
+<Story id="components-avatars--overview" />
+
+### Smoothed corners
+
+눈썰미가 좋으신 분들은 알아보셨겠지만, **Avatar의 테두리는 완전한 원형이 아닙니다!**
+
+CSS의 `border-radius` property를 이용하면 이러한 테두리를 얻을 수 없습니다.
+[Worklet Web API](https://developer.mozilla.org/en-US/docs/Web/API/Worklet)를 사용하여, Avatar 컴포넌트만의 테두리 곡선을 직접 그려냅니다!
+Worklet API를 지원하는 브라우저에서 단순한 원형 테두리가 아닌 bezier-react만의 Avatar 형태를 볼 수 있게 됩니다.
+
+구현 방법에 대해서는 `src/worklets` 안쪽 소스 코드를 확인해보세요 :)
+
+## Usage
+
+### Avatar
+
+Avatar를 사용하기 위한 최소한의 정보는 `name`과 `avatarUrl`입니다.
+`name`은 Avatar에 대한 label이 됩니다. `avatarUrl`은 Avatar 컴포넌트로 표현할 이미지의 리소스 URL입니다.
+
+<Story id="components-avatars--usage-basic" />
+
+```tsx
+<Avatar name="<name>" avatarUrl="<avatar-url>" />
+
+// Example
+<Avatar
+  name="Channel.io"
+  avatarUrl="https://cf.channel.io/thumb/200x200/pub-file/1/606d87d059a6093594c0/ch-symbol-filled-smiley-bg.png"
+/>
+```
+
+`avatarUrl` prop으로 주어진 resource URL의 이미지를 불러오는 동안에는, fallback 이미지를 보여줍니다.
+리소스 이미지를 불러오는 데 실패했을 때도 fallback 이미지를 보여줍니다.
+Fallback 이미지는 bezier-react에서 기본적으로 제공하나, `fallbackUrl` prop을 통해 직접 지정하는 것도 가능합니다.
+
+Avatar 컴포넌트에 대해 더 알아보려면 [스토리](/story/components-avatars-avatar--primary)를 살펴보세요.
+
+### Avatar with preset status
+
+Avatar 우측 하단에 컴포넌트를 추가하여, 아바타로 표현하고자 하는 객체의 상태를 보여줍니다.
+온라인, 오프라인, 방해금지 등의 상태를 보여줄 수 있습니다.
+
+Preset status를 사용할 때는 `status` prop에 `StatusType` enum의 값을 지정합니다.
+
+<Story id="components-avatars--usage-preset-status" />
+
+```tsx
+<Avatar
+  name="Channel.io"
+  avatarUrl="https://cf.channel.io/thumb/200x200/pub-file/1/606d87d059a6093594c0/ch-symbol-filled-smiley-bg.png"
+  status={StatusType.Online}
+/>
+```
+
+Avatar 크기가 달라져도 preset status 컴포넌트의 크기는 변하지 않습니다.
+커스텀 status 컴포넌트를 사용할 때도 유의해야 합니다.
+
+<Story id="components-avatars--usage-preset-status-with-size" />
+
+Preset status에 대해 더 알아보려면 [스토리](/story/components-status--primary)를 살펴보세요.
+
+### Avatar with custom status
+
+Preset status 이외에도, 원하는 컴포넌트를 status로 지정할 수 있습니다.
+외부 서비스와의 연동 상태를 표현하거나, 이모지를 사용하여 상태를 표현할 수 있습니다.
+
+커스텀 컴포넌트를 status로 사용할 때는, `<Avatar>` 컴포넌트의 **children**으로 지정합니다.
+
+<Story id="components-avatars--usage-custom-status" />
+
+```tsx
+<Avatar
+  name="Channel.io"
+  avatarUrl="https://cf.channel.io/thumb/200x200/pub-file/1/606d87d059a6093594c0/ch-symbol-filled-smiley-bg.png"
+>
+  <Emoji // <- status 자리에 들어갈 컴포넌트를 children으로 지정합니다.
+    name="smile"
+    avatarUrl="..."
+  />
+</Avatar>
+```
+
+다른 Avatar 컴포넌트를 status로 사용할 때는, `showBorder` prop을 `true`로 지정하여 원본 Avatar와의 대비를 주어야 합니다.
+
+<Story id="components-avatars--usage-custom-status-avatar" />
+
+```tsx
+<Avatar
+  name="Channel.io"
+  avatarUrl="https://cf.channel.io/thumb/200x200/pub-file/1/606d87d059a6093594c0/ch-symbol-filled-smiley-bg.png"
+>
+  <Avatar
+    name="status"
+    avatarUrl="https://bit.ly/code-beast"
+    showBorder // <-- showBorder prop을 지정하면, 원본 Avatar와의 대비가 보입니다.
+  />
+</Avatar>
+```
+
+### Disabled avatar
+
+`disabled` prop을 사용하여, 비활성화 상태의 Avatar를 표현합니다.
+
+<Story id="components-avatars--usage-disabled" />
+
+```tsx
+<Avatar
+  name="Channel.io"
+  avatarUrl="https://cf.channel.io/thumb/200x200/pub-file/1/606d87d059a6093594c0/ch-symbol-filled-smiley-bg.png"
+  disabled
+/>
+```
+
+### Checkable avatar
+
+Avatar 컴포넌트를 통해 표현되는 객체들이 있을 때, 객체들의 목록에서 선택하는 UX를 표현하기 위해 checkable avatar를 사용합니다.
+
+Checkable avatar는 선택 여부를 toggle할 수 있으며, 선택한 상태에서는 이미지 대신 체크 아이콘이 표시됩니다.
+
+<Story id="components-avatars--usage-checkable-avatar" />
+
+Avatar 컴포넌트와 유사하지만, `isChecked` 와 `isCheckable` prop을 통해 체크 상태를 표현할 수 있는 `CheckableAvatar` 컴포넌트를 사용하세요.
+
+```tsx
+<CheckableAvatar
+  name="Channel.io"
+  avatarUrl="https://cf.channel.io/thumb/200x200/pub-file/1/606d87d059a6093594c0/ch-symbol-filled-smiley-bg.png"
+  isChecked
+/>
+```
+
+Checkable avatar에 대해 더 알아보려면 [스토리](/story/components-avatars-checkableavatar--primary)를 살펴보세요.
+
+### Multiple avatars (AvatarGroup)
+
+Avatar 목록을 표현하기 위해서는 AvatarGroup 컴포넌트를 사용합니다.
+
+목록에 펼쳐놓을 최대 개수를 `max` prop으로 지정하고, 이보다 긴 목록은 두 가지 ellipsis 방식을 이용하여 표현합니다.
+Ellipsis 방법은 `ellipsisType` prop을 통해 지정합니다.
+AvatarGroup의 children으로 목록으로 표현할 Avatar 컴포넌트를 전달합니다.
+
+<Story id="components-avatars--usage-group-ellipsis" />
+
+```tsx
+<AvatarGroup
+  max={4}
+  ellipsisType={AvatarGroupEllipsisType.Icon}
+>
+  <Avatar ... />
+  <Avatar ... />
+  <Avatar ... />
+  <Avatar ... />
+  <Avatar ... />
+  <Avatar ... />
+</AvatarGroup>
+
+
+<AvatarGroup
+  max={4}
+  ellipsisType={AvatarGroupEllipsisType.Count}
+>
+  <Avatar ... />
+  <Avatar ... />
+  <Avatar ... />
+  <Avatar ... />
+  <Avatar ... />
+  <Avatar ... />
+</AvatarGroup>
+```
+
+AvatarGroup으로 표현하는 Avatar 목록은 같은 크기나 border property를 가져야 하기 때문에,
+Avatar 각각에 property를 지정하기보다는 AvatarGroup 컴포넌트에 한 번에 property를 지정하는 것이 best practice입니다.
+
+```tsx
+// DON'T ❌
+<AvatarGroup ... >
+  <Avatar size={AvatarSize.Size24} ... />
+  <Avatar size={AvatarSize.Size24} ... />
+  <Avatar size={AvatarSize.Size24} ... />
+</AvatarGroup>
+
+// DO ✅
+<AvatarGroup size={AvatarSize.Size24} ... >
+  <Avatar ... />
+  <Avatar ... />
+  <Avatar ... />
+</AvatarGroup>
+```
+
+Group 내 Avatar 간의 간격을 조절하기 위해서는 `spacing` prop을 사용하세요.
+`spacing`이 음수가 되는 경우 (즉, Avatar 간에 겹치는 경우) 또한 종종 사용되는 UX입니다.
+이 경우에는 Avatar의 `showBorder` prop을 활용하여 Avatar 간의 대비를 주는 것이 좋습니다.
+
+<Story id="components-avatars--usage-group-spacing" />
+
+Avatar group에 대해 더 알아보려면 [스토리](/story/components-avatars-avatargroup--primary)를 살펴보세요.
+
+## Variants
+
+### Size
+
+20x20 부터 120x120 까지, preset size가 존재합니다.
+기본 크기는 24x24 입니다.
+
+<Story id="components-avatars--variants-size" />
+
+## API
+
+> ✏️ TODO (`react-docgen-typescript-plugin` 적용 이후 작성)
+
+## Version
+
+- Available since 0.3.21

--- a/packages/bezier-react/src/components/Avatars/Avatars.stories.tsx
+++ b/packages/bezier-react/src/components/Avatars/Avatars.stories.tsx
@@ -442,7 +442,7 @@ export const UsageGroupSpacing: Story<{}> = () => (
 
     <StackItem>
       <AvatarGroup max={4} spacing={-8}>
-        { SAMPLE_AVATARS.map(meta => <Avatar showBorder {...meta} />) }
+        { SAMPLE_AVATARS.map(meta => <Avatar {...meta} />) }
       </AvatarGroup>
     </StackItem>
   </VStack>

--- a/packages/bezier-react/src/components/Avatars/Avatars.stories.tsx
+++ b/packages/bezier-react/src/components/Avatars/Avatars.stories.tsx
@@ -1,0 +1,486 @@
+/* External dependencies */
+import React from 'react'
+import {
+  type Meta,
+  type Story,
+} from '@storybook/react'
+import {
+  range,
+} from 'lodash-es'
+import base from 'paths.macro'
+
+/* Internal dependencies */
+import { styled } from 'Foundation'
+import { getTitle } from 'Utils/storyUtils'
+import {
+  Avatar,
+  AvatarSize,
+} from 'Components/Avatars/Avatar'
+import {
+  AvatarGroup,
+  AvatarGroupEllipsisType,
+} from 'Components/Avatars/AvatarGroup'
+import {
+  CheckableAvatar,
+} from 'Components/Avatars/CheckableAvatar'
+import {
+  Emoji,
+  EmojiSize,
+} from 'Components/Emoji'
+import {
+  HStack,
+  StackItem,
+  VStack,
+} from 'Components/Stack'
+import {
+  StatusType,
+} from 'Components/Status'
+import {
+  Text,
+} from 'Components/Text'
+import mdx from './Avatars.mdx'
+
+export default {
+  title: getTitle(base),
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+} as Meta
+
+const SAMPLE_AVATARS = [
+  {
+    name: 'Channel.io',
+    avatarUrl: 'https://cf.channel.io/thumb/200x200/pub-file/1/606d87d059a6093594c0/ch-symbol-filled-smiley-bg.png',
+  },
+  {
+    avatarUrl: 'https://bit.ly/code-beast',
+    name: 'Christian Nwamba',
+  },
+  {
+    avatarUrl: 'https://bit.ly/kent-c-dodds',
+    name: 'Kent Dodds',
+  },
+  {
+    avatarUrl: 'https://bit.ly/ryan-florence',
+    name: 'Ryan Florence',
+  },
+  {
+    avatarUrl: 'https://bit.ly/dan-abramov',
+    name: 'Dan Abrahmov',
+  },
+  {
+    avatarUrl: 'https://bit.ly/prosper-baba',
+    name: 'Prosper Otemuyiwa',
+  },
+  {
+    avatarUrl: 'https://bit.ly/sage-adebayo',
+    name: 'Segun Adebayo',
+  },
+]
+
+const KAKAO_AVATAR = {
+  name: 'kakao',
+  avatarUrl: 'https://cf.channel.io/asset/plugin/images/app-messenger-kakao.png',
+}
+
+const NAVER_TALK_AVATAR = {
+  name: 'naver-talk',
+  avatarUrl: 'https://cf.channel.io/asset/plugin/images/app-messenger-naver-talk.png',
+}
+
+export const Overview: Story<{}> = () => (
+  <VStack spacing={16}>
+    <StackItem>
+      <HStack spacing={16}>
+        { [AvatarSize.Size20, AvatarSize.Size36, AvatarSize.Size72, AvatarSize.Size120]
+          .map(size => (
+            <StackItem key={size}>
+              <Avatar
+                {...SAMPLE_AVATARS[0]}
+                size={size}
+              />
+            </StackItem>
+          )) }
+      </HStack>
+    </StackItem>
+
+    <StackItem>
+      <HStack spacing={16}>
+        { [StatusType.Online, StatusType.Offline, StatusType.Lock]
+          .map(status => (
+            <StackItem key={status}>
+              <Avatar
+                {...SAMPLE_AVATARS[0]}
+                status={status}
+                size={AvatarSize.Size36}
+              />
+            </StackItem>
+          )) }
+
+        <StackItem>
+          <Avatar
+            {...SAMPLE_AVATARS[0]}
+            size={AvatarSize.Size36}
+          >
+            <Avatar
+              {...KAKAO_AVATAR}
+              size={AvatarSize.Size20}
+              showBorder
+            />
+          </Avatar>
+        </StackItem>
+      </HStack>
+    </StackItem>
+
+    <StackItem>
+      <HStack spacing={16}>
+        { [AvatarSize.Size24, AvatarSize.Size36, AvatarSize.Size42, AvatarSize.Size48]
+          .map((size, i) => (
+            <StackItem key={size}>
+              <CheckableAvatar
+                {...SAMPLE_AVATARS[0]}
+                size={size}
+                isChecked={i % 2 === 0}
+                disabled={i % 3 === 1}
+              />
+            </StackItem>
+          )) }
+      </HStack>
+    </StackItem>
+
+    <StackItem>
+      <HStack spacing={16}>
+        <StackItem>
+          <AvatarGroup max={4} size={AvatarSize.Size36}>
+            { range(6).map(i => (
+              <Avatar
+                key={i}
+                {...SAMPLE_AVATARS[0]}
+              />
+            )) }
+          </AvatarGroup>
+        </StackItem>
+
+        <StackItem>
+          <AvatarGroup max={4} spacing={-8} size={AvatarSize.Size36}>
+            { range(6).map(i => (
+              <Avatar
+                key={i}
+                {...SAMPLE_AVATARS[0]}
+              />
+            )) }
+          </AvatarGroup>
+        </StackItem>
+
+        <StackItem>
+          <AvatarGroup max={4} spacing={-8} ellipsisType={AvatarGroupEllipsisType.Count} size={AvatarSize.Size36}>
+            { range(6).map(i => (
+              <Avatar
+                key={i}
+                {...SAMPLE_AVATARS[0]}
+              />
+            )) }
+          </AvatarGroup>
+        </StackItem>
+      </HStack>
+    </StackItem>
+  </VStack>
+)
+
+export const UsageBasic: Story<{}> = () => (
+  <HStack spacing={16}>
+    { SAMPLE_AVATARS.map(meta => (
+      <StackItem key={meta.name}>
+        <Avatar
+          {...meta}
+          size={AvatarSize.Size36}
+        />
+      </StackItem>
+    )) }
+  </HStack>
+)
+
+UsageBasic.storyName = 'Usage (basic)'
+
+export const UsagePresetStatus: Story<{}> = () => (
+  <HStack spacing={16}>
+    { [
+      StatusType.Online,
+      StatusType.Offline,
+      StatusType.Lock,
+      StatusType.OnlineCrescent,
+      StatusType.OfflineCrescent,
+    ]
+      .map(status => (
+        <StackItem key={status}>
+          <Avatar
+            {...SAMPLE_AVATARS[0]}
+            status={status}
+            size={AvatarSize.Size24}
+          />
+        </StackItem>
+      )) }
+  </HStack>
+)
+
+UsagePresetStatus.storyName = 'Usage (with preset status)'
+
+export const UsagePresetStatusWithSize: Story<{}> = () => (
+  <HStack spacing={16}>
+    { [AvatarSize.Size24, AvatarSize.Size36, AvatarSize.Size48]
+      .map(size => (
+        <StackItem key={size}>
+          <Avatar
+            {...SAMPLE_AVATARS[0]}
+            status={StatusType.Online}
+            size={size}
+          />
+        </StackItem>
+      )) }
+  </HStack>
+)
+
+UsagePresetStatusWithSize.storyName = 'Usage (with preset status and size)'
+
+const EmojiStatusWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 42%;
+  background-color: ${({ foundation }) => foundation?.theme['bg-white-high']};
+`
+
+export const UsageCustomStatus: Story<{}> = () => (
+  <HStack spacing={16}>
+    <StackItem>
+      <Avatar
+        {...SAMPLE_AVATARS[0]}
+        size={AvatarSize.Size36}
+      >
+        <Avatar
+          {...KAKAO_AVATAR}
+          size={AvatarSize.Size20}
+          showBorder
+        />
+      </Avatar>
+    </StackItem>
+
+    <StackItem>
+      <Avatar
+        {...SAMPLE_AVATARS[0]}
+        size={AvatarSize.Size36}
+      >
+        <Avatar
+          {...NAVER_TALK_AVATAR}
+          size={AvatarSize.Size20}
+          showBorder
+        />
+      </Avatar>
+    </StackItem>
+
+    <StackItem>
+      <Avatar
+        {...SAMPLE_AVATARS[0]}
+        size={AvatarSize.Size36}
+      >
+        <Avatar
+          {...SAMPLE_AVATARS[0]}
+          size={AvatarSize.Size20}
+          showBorder
+        />
+      </Avatar>
+    </StackItem>
+
+    <StackItem>
+      <Avatar
+        {...SAMPLE_AVATARS[0]}
+        size={AvatarSize.Size36}
+      >
+        <EmojiStatusWrapper>
+          <Emoji
+            name="smile"
+            imageUrl="https://cf.channel.io/asset/emoji/images/80/smile.png"
+            size={EmojiSize.Size20}
+          />
+        </EmojiStatusWrapper>
+      </Avatar>
+    </StackItem>
+  </HStack>
+)
+
+UsageCustomStatus.storyName = 'Usage (with custom status)'
+
+export const UsageCustomStatusAvatar: Story<{}> = () => (
+  <Avatar
+    {...SAMPLE_AVATARS[0]}
+    size={AvatarSize.Size48}
+  >
+    <Avatar
+      {...KAKAO_AVATAR}
+      size={AvatarSize.Size20}
+      showBorder
+    />
+  </Avatar>
+)
+
+UsageCustomStatusAvatar.storyName = 'Usage (avatar as custom status)'
+
+export const UsageDisabled: Story<{}> = () => (
+  <Avatar
+    {...SAMPLE_AVATARS[0]}
+    size={AvatarSize.Size36}
+    disabled
+  />
+)
+
+UsageDisabled.storyName = 'Usage (disabled)'
+
+export const UsageCheckableAvatar: Story<{}> = () => (
+  <VStack spacing={16}>
+    <StackItem>
+      <HStack align="center" spacing={24}>
+        <StackItem size={270}>
+          <Text color="txt-black-darkest">Checkable (checked=false)</Text>
+        </StackItem>
+
+        <StackItem>
+          <CheckableAvatar
+            {...SAMPLE_AVATARS[0]}
+            size={AvatarSize.Size36}
+          />
+        </StackItem>
+      </HStack>
+    </StackItem>
+
+    <StackItem>
+      <HStack align="center" spacing={24}>
+        <StackItem size={270}>
+          <Text color="txt-black-darkest">Checkable (checked=false, readonly)</Text>
+        </StackItem>
+
+        <StackItem>
+          <CheckableAvatar
+            {...SAMPLE_AVATARS[0]}
+            size={AvatarSize.Size36}
+            isCheckable={false}
+          />
+        </StackItem>
+      </HStack>
+    </StackItem>
+
+    <StackItem>
+      <HStack align="center" spacing={24}>
+        <StackItem size={270}>
+          <Text color="txt-black-darkest">Checkable (checked=true)</Text>
+        </StackItem>
+
+        <StackItem>
+          <CheckableAvatar
+            {...SAMPLE_AVATARS[0]}
+            size={AvatarSize.Size36}
+            isChecked
+          />
+        </StackItem>
+      </HStack>
+    </StackItem>
+  </VStack>
+)
+
+UsageCheckableAvatar.storyName = 'Usage (checkable avatars)'
+
+export const UsageGroupEllipsis: Story<{}> = () => (
+  <VStack spacing={16}>
+    <StackItem>
+      <HStack align="center" spacing={24}>
+        <StackItem size={150}>
+          <Text color="txt-black-darkest">Ellipsis type = Icon</Text>
+        </StackItem>
+
+        <StackItem>
+          <AvatarGroup max={4} size={AvatarSize.Size36}>
+            { SAMPLE_AVATARS.map(meta => <Avatar {...meta} />) }
+          </AvatarGroup>
+        </StackItem>
+      </HStack>
+    </StackItem>
+
+    <StackItem>
+      <HStack align="center" spacing={24}>
+        <StackItem size={150}>
+          <Text color="txt-black-darkest">Ellipsis type = Count</Text>
+        </StackItem>
+
+        <StackItem>
+          <AvatarGroup max={4} size={AvatarSize.Size36} ellipsisType={AvatarGroupEllipsisType.Count}>
+            { SAMPLE_AVATARS.map(meta => <Avatar {...meta} />) }
+          </AvatarGroup>
+        </StackItem>
+      </HStack>
+    </StackItem>
+  </VStack>
+)
+
+UsageGroupEllipsis.storyName = 'Usage (avatar group with ellipsis)'
+
+export const UsageGroupSpacing: Story<{}> = () => (
+  <VStack spacing={16}>
+    <StackItem>
+      <AvatarGroup max={4} spacing={8}>
+        { SAMPLE_AVATARS.map(meta => <Avatar {...meta} />) }
+      </AvatarGroup>
+    </StackItem>
+
+    <StackItem>
+      <AvatarGroup max={4} spacing={2}>
+        { SAMPLE_AVATARS.map(meta => <Avatar {...meta} />) }
+      </AvatarGroup>
+    </StackItem>
+
+    <StackItem>
+      <AvatarGroup max={4} spacing={-8}>
+        { SAMPLE_AVATARS.map(meta => <Avatar showBorder {...meta} />) }
+      </AvatarGroup>
+    </StackItem>
+  </VStack>
+)
+
+UsageGroupSpacing.storyName = 'Usage (avatar group with spacing)'
+
+export const VariantsSize: Story<{}> = () => (
+  <VStack spacing={16}>
+    {
+      [
+        AvatarSize.Size20,
+        AvatarSize.Size24,
+        AvatarSize.Size30,
+        AvatarSize.Size36,
+        AvatarSize.Size42,
+        AvatarSize.Size48,
+        AvatarSize.Size72,
+        AvatarSize.Size90,
+        AvatarSize.Size120,
+      ]
+        .map(size => (
+          <StackItem key={size}>
+            <HStack spacing={24}>
+              <StackItem>
+                <Text color="txt-black-darkest">{ `Size${size}` }</Text>
+              </StackItem>
+              <StackItem>
+                <Avatar
+                  {...SAMPLE_AVATARS[0]}
+                  size={size}
+                />
+              </StackItem>
+            </HStack>
+          </StackItem>
+        ))
+    }
+  </VStack>
+)
+
+VariantsSize.storyName = 'Variants (size)'

--- a/packages/bezier-react/src/stories/mdx.d.ts
+++ b/packages/bezier-react/src/stories/mdx.d.ts
@@ -1,0 +1,4 @@
+declare module '*.mdx' {
+  const content: string
+  export default content
+}


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

`Components/Avatars` 에 속하는 Avatar 컴포넌트군 (`Avatar`, `CheckableAvatar`, `AvatarGroup`) 에 대한 documentation을 작성합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- API 명세의 경우, `react-docgen-typescript-plugin` 적용 이후에 다시 살펴보도록 합니다.

스토리 확인 후 첨삭 부탁드립니다!

<img width="1089" alt="스크린샷 2022-07-20 오후 9 23 54" src="https://user-images.githubusercontent.com/25701854/179981455-80fb855c-b6ba-4523-a107-056a186a438f.png">
<img width="1073" alt="스크린샷 2022-07-20 오후 9 24 02" src="https://user-images.githubusercontent.com/25701854/179981481-51ed8692-353b-41c5-a109-97d35030555f.png">
<img width="1066" alt="스크린샷 2022-07-20 오후 9 24 11" src="https://user-images.githubusercontent.com/25701854/179981494-deee9081-1a4d-4e5c-8496-d2a87f73c6ad.png">
<img width="1054" alt="스크린샷 2022-07-20 오후 9 24 16" src="https://user-images.githubusercontent.com/25701854/179981500-e9a3dba3-29e5-4cae-a009-1fb4ea9fc637.png">
<img width="1052" alt="스크린샷 2022-07-20 오후 9 24 22" src="https://user-images.githubusercontent.com/25701854/179981507-0397c8cc-9c5f-432a-a4dd-fc5b71ff8226.png">
<img width="1061" alt="스크린샷 2022-07-20 오후 9 24 29" src="https://user-images.githubusercontent.com/25701854/179981520-189dcb08-5ccd-4ca4-a17a-bed52f0d551a.png">
<img width="1060" alt="스크린샷 2022-07-20 오후 9 24 34" src="https://user-images.githubusercontent.com/25701854/179981522-cbe31584-e6ae-441b-b167-ff12f300a4a5.png">

## ~Browser Compatibility~

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->
없음.