### PR TITLE
Revert "ci(chromatic): change trigger event to repository_dispatch"

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,9 +1,6 @@
 name: Chromatic
 
-on:
-  push:
-  repository_dispatch:
-    types: [deploy-chromatic]
+on: push
 
 jobs:
   chromatic-deployment:


### PR DESCRIPTION
- Reverts channel-io/bezier-react#885
- https://github.com/channel-io/bezier-react/actions/runs/2712576956
- Chromatic 액션은 `repository_dispatch` 액션을 지원하지 않아 리버트합니다.