### PR TITLE
ci: enhance the chromatic workflow

### DIFF
--- a/.github/comment_template.md
+++ b/.github/comment_template.md
@@ -1,0 +1,6 @@
+# Chromatic Report
+
+🚀 Congratulations! Your build was successful!
+
+- [Storybook Preview]({{ .storybookUrl }})
+- [Chromatic Build]({{ .buildUrl }})

--- a/.github/workflows/chromatic-report.yml
+++ b/.github/workflows/chromatic-report.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Unzip artifact
         run: unzip pr.zip
         
-      - name: Get PR Number
+      - name: Get PR number
         uses: actions/github-script@v6
         id: pr-number
         with:
@@ -59,7 +59,7 @@ jobs:
             return fs.readFileSync('./storybookUrl');
           result-encoding: string
 
-      - name: Get Chromatic Build URL
+      - name: Get Chromatic build URL
         uses: actions/github-script@v6
         id: build-url
         with:
@@ -77,7 +77,7 @@ jobs:
             storybookUrl: ${{ steps.storybook-url.outputs.result }}
             buildUrl: ${{ steps.build-url.outputs.result }}
 
-      - name: Find Comment
+      - name: Find comment
         uses: peter-evans/find-comment@v2
         id: find-comment
         with:

--- a/.github/workflows/chromatic-report.yml
+++ b/.github/workflows/chromatic-report.yml
@@ -1,0 +1,94 @@
+name: Chromatic Report
+
+on:
+  workflow_run:
+    workflows: ["Chromatic"]
+    types:
+      - completed
+
+jobs:
+  chromatic-report:
+    name: Chromatic Report
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+
+            const download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+
+            const fs = require('fs');
+            fs.writeFileSync('${process.env.GITHUB_WORKSPACE}/pr.zip', Buffer.from(download.data));
+
+      - name: Unzip artifact
+        run: unzip pr.zip
+        
+      - name: Get PR Number
+        uses: actions/github-script@v6
+        id: pr-number
+        with:
+          script: |
+            const fs = require('fs');
+            return Number(fs.readFileSync('./prNumber'));
+          result-encoding: string
+
+      - name: Get Storybook URL
+        uses: actions/github-script@v6
+        id: storybook-url
+        with:
+          script: |
+            const fs = require('fs');
+            return fs.readFileSync('./storybookUrl');
+          result-encoding: string
+
+      - name: Get Chromatic Build URL
+        uses: actions/github-script@v6
+        id: build-url
+        with:
+          script: |
+            const fs = require('fs');
+            return fs.readFileSync('./buildUrl');
+          result-encoding: string
+
+      - name: Render template
+        id: template
+        uses: chuhlomin/render-template@v1.4
+        with:
+          template: .github/comment_template.md
+          vars: |
+            storybookUrl: ${{ steps.storybook-url.outputs.result }}
+            buildUrl: ${{ steps.build-url.outputs.result }}
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: find-comment
+        with:
+          issue-number: ${{ steps.pr-number.outputs.result }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Chromatic Report
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.pr-number.outputs.result }}
+          body: ${{ steps.template.outputs.result }}
+          edit-mode: replace

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,9 +5,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
     paths:
-      - packages/bezier-react/src/**.jsx?
-      - packages/bezier-react/src/**.tsx?
-      - packages/bezier-react/.storybook/**
+      - packages/bezier-react/**
 
 jobs:
   chromatic-deployment:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,9 @@
 name: Chromatic
 
-on: push
+on: 
+  push:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
 
 jobs:
   chromatic-deployment:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -36,4 +36,4 @@ jobs:
           workingDir: packages/bezier-react
           exitZeroOnChanges: true
           skip: dependabot/**
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: 06157a6fbe6f

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,6 @@
 name: Chromatic
 
-on: 
+on:
   push:
     branches:
       - 'next*'
@@ -34,8 +34,34 @@ jobs:
 
       - name: Publish to Chromatic
         uses: chromaui/action@v1
+        id: chromatic
         with:
           workingDir: packages/bezier-react
           exitZeroOnChanges: true
           skip: dependabot/**
           projectToken: 06157a6fbe6f
+
+      - name: Render template
+        id: template
+        uses: chuhlomin/render-template@v1.4
+        with:
+          template: .github/comment_template.md
+          vars: |
+            storybookUrl: ${{ steps.chromatic.outputs.storybookUrl }}
+            buildUrl: ${{ steps.chromatic.outputs.buildUrl }}
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Chromatic Report
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.template.outputs.result }}
+          edit-mode: replace

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,8 +2,10 @@ name: Chromatic
 
 on: 
   push:
+    branches:
+      - 'next*'
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   chromatic-deployment:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -41,27 +41,13 @@ jobs:
           skip: dependabot/**
           projectToken: 06157a6fbe6f
 
-      - name: Render template
-        id: template
-        uses: chuhlomin/render-template@v1.4
+      - name: Save PR number and Chromatic build outputs
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.pull_request.number }} > ./pr/prNumber
+          echo ${{ steps.chromatic.outputs.storybookUrl }} > ./pr/storybookUrl
+          echo ${{ steps.chromatic.outputs.buildUrl }} > ./pr/buildUrl
+      - uses: actions/upload-artifact@v2
         with:
-          template: .github/comment_template.md
-          vars: |
-            storybookUrl: ${{ steps.chromatic.outputs.storybookUrl }}
-            buildUrl: ${{ steps.chromatic.outputs.buildUrl }}
-
-      - name: Find Comment
-        uses: peter-evans/find-comment@v2
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Chromatic Report
-
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: ${{ steps.template.outputs.result }}
-          edit-mode: replace
+          name: pr
+          path: pr/

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,10 +2,12 @@ name: Chromatic
 
 on:
   push:
-    branches:
-      - 'next*'
   pull_request:
     types: [opened, reopened, synchronize]
+    paths:
+      - packages/bezier-react/src/**.jsx?
+      - packages/bezier-react/src/**.tsx?
+      - packages/bezier-react/.storybook/**
 
 jobs:
   chromatic-deployment:
@@ -47,7 +49,9 @@ jobs:
           echo ${{ github.event.pull_request.number }} > ./pr/prNumber
           echo ${{ steps.chromatic.outputs.storybookUrl }} > ./pr/storybookUrl
           echo ${{ steps.chromatic.outputs.buildUrl }} > ./pr/buildUrl
-      - uses: actions/upload-artifact@v2
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
         with:
           name: pr
           path: pr/

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -33,7 +33,7 @@
     "storybook": "start-storybook -p 4101",
     "deploy:storybook": "storybook-to-ghpages --remote=upstream",
     "build-storybook": "build-storybook",
-    "chromatic": "chromatic"
+    "chromatic": "chromatic --project-token=06157a6fbe6f"
   },
   "keywords": [
     "design",


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

- Close #877
- 크로마틱 워크플로우가 올바르게 작동하도록 수정하고, 개선합니다.
- 크로마틱 배포가 마무리되면 해당 PR에 배포 정보에 대한 코멘트를 남기는 워크플로우를 추가합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

기존 `Chromatic` 워크플로우는 `push` 이벤트가 발생할 때만 트리거되도록 설정되어 있었습니다. 하지만 Fork된 레포지토리의 브랜치에 커밋을 푸시하는 거로는 트리거되지 않아서, origin(upstream)의 `next-v1` 브랜치에 푸시하는 경우에만 동작하고 있었습니다. 

항상 최신 상태의 스토리북을 배포하고자 하는 목적도 있었으나, 작업자들의 개별 PR에서 자동 배포가 이루어져서 리뷰 과정을 원활하게 하고자 하는 이유도 있었기때문에 이전 CircleCI에서 동작하던 방식처럼 되돌릴 필요가 있었습니다.

## 1. 브랜치별 스토리북 배포 정상화

트리거 이벤트의 목록에 `push` 이벤트는 그대로 둔 채, `pull_request` 이벤트를 추가했습니다. 

```yml
# .github/workflows/chromatic.yml
on:
  push:
  pull_request:
    types: [opened, reopened, synchronize]
    paths:
      - packages/bezier-react/src/**.jsx?
      - packages/bezier-react/src/**.tsx?
      - packages/bezier-react/.storybook/**
```

PR이 열릴 때(`opened`), 다시 열릴 때(`reopend`), 그리고 PR의 head branch가 업데이트될 때(`synchronize`) 워크플로우가 트리거 되도록 했습니다. 아래 설명에 따르면, 커밋이 푸시되거나 base branch가 변경되거나 할 때도 함께 트리거 됩니다.

> Triggered when a pull request's head branch is updated. For example, when the head branch is updated from the base branch, when new commits are pushed to the head branch, or when the base branch is changed. [참고 링크](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request)

현재 bezier-react 패키지에 대한 스토리만 배포하고 있으므로, 연관있는 변경사항이 없는 PR에선 워크플로우가 동작하지 않도록 path 옵션을 추가했습니다. 해당하는 경로의 파일이 변경되었을 때만 워크플로우가 트리거 됩니다.

### Chromatic Project Token 퍼블릭화

`pull_request` 이벤트에 의해 원하는대로 동작은 됐으나, `pull_request` 이벤트에 의해 트리거되는 워크플로우는 읽기 전용에, 시크릿에 접근하지 못하기 때문에 크로마틱 토큰에 접근할 수가 없습니다. 따라서 토큰이 공개되는 리스크가 있으나, 코드를 그대로 삽입하는 방식으로 변경했습니다. [크로마틱에서도 오픈소스 프로젝트에서 해당 방식을 사용할 수 있다고 말하고 있습니다.](https://www.chromatic.com/docs/github-actions#run-chromatic-on-external-forks-of-open-source-projects) 

시크릿 접근 권한을 얻기 위해 `pull_request_target` 이벤트로 사용하는 방식도 있으나, 해당 이벤트는 target branch를 기준으로 실행되므로 최신 결과를 배포한다는 목적을 달성할 수 없었습니다. 해당 PR의 `head.sha` 에 접근하여 최신 커밋위에서 워크플로우를 실행시킬 수도 있으나, [보안상 아주 위험한 방법이라고하여 사용하지 않았습니다.](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

## 2. 코멘트 워크플로우 추가

배포 정보에 대해 해당 PR에 코멘트를 다는 워크플로우를 추가했습니다. `workflow_run` 이벤트에 의해 트리거되고, 앞서 말했던 `Chromatic` 워크플로우가 완료되면 트리거됩니다. `workflow_run` 이벤트로 트리거되는 워크플로우는 `pull_request` 와 다르게 쓰기 권한을 가지기 때문에, 코멘트를 작성하기 위해 이 방식으로 구현했습니다. [Github 공식 레퍼런스](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow)

```yml
# .github/workflows/chromatic-report.yml
name: Chromatic Report

on:
  workflow_run:
    workflows: ["Chromatic"]
    types:
      - completed
```

[링크](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)를 참고하여 아래처럼 조건문을 추가했는데, 테스트해보았을 때 `pull-request` 에 의해 `Chromatic` 워크플로우가 동작하지 않은 경우(`push`)에도 동작하는 것처럼 보여 추후 확인이 필요합니다.

```yml
# .github/workflows/chromatic-report.yml
jobs:
  chromatic-report:
    name: Chromatic Report
    runs-on: ubuntu-latest
    if: >
      ${{ github.event.workflow_run.event == 'pull_request' &&
      github.event.workflow_run.conclusion == 'success' }}
```

간략하게 워크플로우는 아래의 순서로 실행됩니다.

1. `Chromatic` 워크플로우에서 업로드한 아티팩트(`prNumber`, `storybookUrl`, `buildUrl`)을 다운로드 받습니다.
2. 해당 아티팩트(텍스트)를 가지고 마크다운 템플릿을 통해 코멘트 내용을 생성합니다.
3. PR 넘버를 통해 코멘트를 찾습니다. (봇 작성, 마크다운 템플릿의 제목을 포함하는)
4. 2의 코멘트 내용으로 코멘트가 없다면 생성하고, 있다면 내용을 덮어씌웁니다.

## Tests

워크플로우 테스트를 위해선 워크플로우 파일이 base branch에 존재해야만 했었기 때문에, 강제 머지를 통해 몇차례 테스트를 진행했습니다 (#891 참고)

- ✅ Chromatic Report 워크플로우가 잘 트리거되고, 아티팩트의 업로드/다운로드가 잘 이루어지는 걸 확인했습니다.
- ✅ 마크다운 템플릿에 storybook, chromatic build url이 잘 전달되는 걸 확인했습니다.
- ❌ 실제 코멘트가 달리는 동작은 현재 테스트가 안 된 상태입니다. 머지 후 테스트해볼 예정입니다.

## ~~Browser Compatibility~~

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

- [Github Actions Workflows - Using data from the triggering workflow](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow)
- [GitHub Actions의 pull_request_target과 workflow_run 이벤트](https://blog.outsider.ne.kr/1541)
- [Github Actions - Create or Update Comment](https://github.com/marketplace/actions/create-or-update-comment)
- [Github Actions - Render Template](https://github.com/marketplace/actions/render-template)
