### PR TITLE
refactor(key-value-list-item): change key and value component styles removed fixed height and given default color

### DIFF
--- a/.changeset/thick-dryers-deliver.md
+++ b/.changeset/thick-dryers-deliver.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+refactor(key-value-list-item): change key and value component styles removed fixed height and given default color

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.common.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.common.styled.ts
@@ -16,7 +16,7 @@ export interface KeyValueListItemContainerProps {
 export const KeyValueListItemContainer = styled.div<KeyValueListItemContainerProps>`
   box-sizing: border-box;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   padding: 4px 6px;
 
   ${({ foundation }) => foundation?.rounding?.round6};

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.stories.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.stories.tsx
@@ -6,6 +6,7 @@ import { Meta, Story } from '@storybook/react'
 
 /* Internal dependencies */
 import { getTitle } from 'Utils/storyUtils'
+import { Button, ButtonColorVariant, ButtonStyleVariant } from 'Components/Button'
 import KeyValueListItem from './KeyValueListItem'
 import KeyValueMultiLineListItem from './KeyValueMultiLineListItem'
 import { KeyValueListItemProps } from './KeyValueListItem.types'
@@ -47,6 +48,14 @@ const SingleLineTemplate: Story<KeyValueListItemStorybookProps> = ({ containerWi
       actions={Array.from(Array(2)).map(() => ({ icon: 'edit', onClick: console.log, tooltip: '수정하기' }))}
     />
     <KeyValueListItem {...otherProps} onClickKey={onClickKey} onClickValue={onClickValue} />
+    <KeyValueListItem {...otherProps}>
+      <Button
+        leftContent="play"
+        text="높이 테스트"
+        colorVariant={ButtonColorVariant.Green}
+        styleVariant={ButtonStyleVariant.Primary}
+      />
+    </KeyValueListItem>
   </div>
 )
 

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.styled.ts
@@ -4,18 +4,17 @@ import { KeyValueListItemWrapper, KeyValueListItemContainer } from './KeyValueLi
 
 export const Wrapper = styled(KeyValueListItemWrapper)`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
 `
 
 export const KeyItemContainer = styled(KeyValueListItemContainer)`
   flex: 1;
-  height: 28px;
   ${ellipsis()};
 `
 
 export const ValueItemContainer = styled(KeyValueListItemContainer)`
   flex: 2;
   justify-content: space-between;
-  height: 28px;
+  min-height: 28px;
   ${ellipsis()};
 `

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.test.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.test.tsx
@@ -181,7 +181,7 @@ describe('KeyValueListItem', () => {
 
         await user.hover(keyItemContainer as Element)
         expect(keyItemContainer).toHaveStyle('display: flex;')
-        expect(keyItemContainer).toHaveStyle('align-items: center;')
+        expect(keyItemContainer).toHaveStyle('align-items: flex-start;')
         expect(keyItemContainer).toHaveStyle('padding: 4px 6px;')
         expect(keyItemContainer).not.toHaveStyle('cursor: pointer;')
         // NOTE(@sol): Hovered DOM style test is not working
@@ -200,7 +200,7 @@ describe('KeyValueListItem', () => {
 
         await user.hover(keyItemContainer as Element)
         expect(keyItemContainer).toHaveStyle('display: flex;')
-        expect(keyItemContainer).toHaveStyle('align-items: center;')
+        expect(keyItemContainer).toHaveStyle('align-items: flex-start;')
         expect(keyItemContainer).toHaveStyle('padding: 4px 6px;')
         expect(keyItemContainer).toHaveStyle('cursor: pointer;')
         // NOTE(@sol): Hovered DOM style test is not working
@@ -234,7 +234,7 @@ describe('KeyValueListItem', () => {
 
         await user.hover(valueItemContainer as Element)
         expect(valueItemContainer).toHaveStyle('display: flex;')
-        expect(valueItemContainer).toHaveStyle('align-items: center;')
+        expect(valueItemContainer).toHaveStyle('align-items: flex-start;')
         expect(valueItemContainer).toHaveStyle('padding: 4px 6px;')
         expect(valueItemContainer).not.toHaveStyle('cursor: pointer;')
         // NOTE(@sol): Hovered DOM style test is not working
@@ -253,7 +253,7 @@ describe('KeyValueListItem', () => {
 
         await user.hover(valueItemContainer as Element)
         expect(valueItemContainer).toHaveStyle('display: flex;')
-        expect(valueItemContainer).toHaveStyle('align-items: center;')
+        expect(valueItemContainer).toHaveStyle('align-items: flex-start;')
         expect(valueItemContainer).toHaveStyle('padding: 4px 6px;')
         expect(valueItemContainer).toHaveStyle('cursor: pointer;')
         // NOTE(@sol): Hovered DOM style test is not working
@@ -284,7 +284,7 @@ describe('KeyValueListItem', () => {
         const { getByTestId } = renderComponent()
         const rendered = getByTestId(TEST_ID_MAP.ROOT)
         expect(rendered).toHaveStyle('display: flex;')
-        expect(rendered).toHaveStyle('align-items: center;')
+        expect(rendered).toHaveStyle('align-items: flex-start;')
         expect(rendered).toHaveStyle('border-radius: 6px;')
         expect(rendered).toHaveStyle('transition-delay: 0ms;')
         expect(rendered).toHaveStyle('transition-timing-function: cubic-bezier(.3,0,0,1);')
@@ -294,13 +294,11 @@ describe('KeyValueListItem', () => {
         const rootKeyContainer = rendered.firstChild
         expect(rootKeyContainer).toHaveStyle('display: flex;')
         expect(rootKeyContainer).toHaveStyle('flex: 1;')
-        expect(rootKeyContainer).toHaveStyle('height: 28px;')
 
         const rootValueContainer = rendered.lastChild
         expect(rootValueContainer).toHaveStyle('display: flex;')
         expect(rootValueContainer).toHaveStyle('flex: 2;')
         expect(rootValueContainer).toHaveStyle('justify-content: space-between;')
-        expect(rootValueContainer).toHaveStyle('height: 28px;')
         expect(rootValueContainer).toHaveStyle('overflow: hidden;')
         expect(rootValueContainer).toHaveStyle('text-overflow: ellipsis;')
         expect(rootValueContainer).toHaveStyle('white-space: nowrap;')

--- a/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
+++ b/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`KeyValueListItem Snapshot > 1`] = `
 }
 
 .c9 {
+  color: #000000D9;
   font-size: 1.4rem;
   line-height: 1.8rem;
   overflow: hidden;
@@ -82,10 +83,10 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   padding: 4px 6px;
   overflow: hidden;
   border-radius: 6px;
@@ -96,17 +97,16 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  height: 28px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -120,7 +120,7 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  height: 28px;
+  min-height: 28px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ValueItem/ValueItem.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ValueItem/ValueItem.styled.ts
@@ -7,6 +7,7 @@ interface ValueWrapperProps extends InterpolationProps {
 }
 
 export const ValueWrapper = styled.div<ValueWrapperProps>`
+  color: ${({ foundation }) => foundation?.theme['txt-black-darkest']};
   ${Typography.Size14};
   ${({ multiline }) => !multiline && ellipsis()};
   ${({ interpolation }) => interpolation}


### PR DESCRIPTION

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [x] I wrote **a unit test** about the implementation.
- [ ] I wrote **a storybook document** about the implementation.
- [ ] I tested the implementation in **various browsers**.
  - [ ] Windows: Chrome, Edge, (Optional) Firefox
  - [x] macOS: Chrome, Edge, Safari, (Optional) Firefox


# Summary

- remove fixed height(28px) styles 
- add default color to value component

# Details
- add color(txt/black/darkest) style to value component
- remove fixed height(28px) style
- change align-items "center" to "flex-start"

![Screen Shot 2022-07-25 at 11 51 18](https://user-images.githubusercontent.com/16330024/180692573-48a55b9c-40e0-4be2-ab8b-2041b9c0dae6.png)

## Browser Compatibility
OS / Engine 호환성을 반드시 확인해주세요.
### Windows
- [ ] Chrome - Blink
- [ ] Edge - Blink
- [ ] Firefox - Gecko (Option)
### macOS
- [x] Chrome - Blink
- [x] Edge - Blink
- [x] Safari - WebKit
- [x] Firefox - Gecko (Option)

# References
- [KeyValueListItem Figma](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=1164%3A12605)
- [ChannelTalk - GroupChat Bug](https://desk.channel.io/root/groups/Bug-10/62d6c137ad052a374c4a)