### PR TITLE
ci(chromatic-report): fix download artifact step script

### DIFF
--- a/.github/workflows/chromatic-report.yml
+++ b/.github/workflows/chromatic-report.yml
@@ -21,7 +21,7 @@ jobs:
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
+               run_id: ${{ github.event.workflow_run.id }},
             });
 
             const matchArtifact = artifacts.data.artifacts.filter((artifact) => {


### PR DESCRIPTION
<!-- Pull Request 를 작성하기 전, 충분히 로컬 환경에서 테스트 했는지 확인하세요. -->
# Summary
<!-- 수정 내용에 대한 요약  -->

Chromatic report 워크플로우가 작동하지 않던 부분을 수정합니다.

# Details
<!-- 수정 내역과 연관되는 문제의 자세한 설명 혹은 설명되어 있는 Issue  -->

- [예제](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)에서 예상하던 동작과 다르게 run id가 제대로 전달되지 않아 동작하지 않던 오류를 수정합니다.
- [이전 워크플로우](https://github.com/channel-io/bezier-react/runs/7456067119?check_suite_focus=true)에선 이 PR의 내용으로 Download artifact 스탭이 잘 실행되었기에 이 PR이 적용되면 문제가 수정될 거로 생각합니다.

## ~~Browser Compatibility~~

# References
<!-- - 해결 방법이 근거하고 있거나 리뷰어가 참고해야 하는 외부 문서 -->

없음
