### PR TITLE
fix(form-group): apply default value of justify-content, align-items property

### DIFF
--- a/.changeset/cold-jars-clap.md
+++ b/.changeset/cold-jars-clap.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Apply CSS default value to the align, justify properties of FormGroup component.

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -29,10 +29,10 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
 }
 
 .c6 {
@@ -366,10 +366,10 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
 }
 
 .c7 {

--- a/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.tsx
+++ b/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.tsx
@@ -41,6 +41,8 @@ forwardedRef: React.Ref<HTMLDivElement>,
       {...ownProps}
       data-testid={testId}
       ref={forwardedRef}
+      justify="start"
+      align="stretch"
       spacing={spacing}
       direction={direction}
       role={role}

--- a/packages/bezier-react/src/components/Forms/FormGroup/__snapshots__/FormGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormGroup/__snapshots__/FormGroup.test.tsx.snap
@@ -15,10 +15,10 @@ exports[`FormGroup > Snapshot > 1`] = `
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
 }
 
 .c1 {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] I wrote **a unit test** about the implementation.
- [ ] I wrote **a storybook document** about the implementation.
- [ ] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->

`FormGroup` 컴포넌트의 동작을 #866 이전과 동일하게 맞추기 위해, CSS Flex 프로퍼티 기본 값과 동일하게 세팅합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

[What are the default values for justify-content & align content?](https://stackoverflow.com/questions/62350959/what-are-the-default-values-for-justify-content-align-content)

> The [first one related to flexbox](https://drafts.csswg.org/css-flexbox-1/#propdef-justify-content) (the one you have to follow) gives the initial value as flex-start for justify-content and stretch for align-items. This is the Flexbox Level 1 specification and it's widely supported.
>
> The second one is related [to future alignment techniques](https://drafts.csswg.org/css-align-3/#propdef-justify-content). This specification is still in Draft mode and will define new way to align items in different contexts (Flexbox/Grid/Block/multicol/.. containers). The default value is normal for both properties (justify-content and align-items)
>
> If you continue the reading you can see that normal will fallback to stretch in the flexbox context and for justify-content stretch behave as flex-start
>
> **So in all the cases, it's safe to assume that the initial value is flex-start for justify-content since normal will fallback to it (same for align-items where you can consider stretch as default)**

위를 참고하여, `justify-content` 의 경우 `flex-start` 를 기본값으로, `align-items` 의 경우 `stretch` 를 기본값으로 하도록 변경합니다.

- `Stack` 의 align 속성의 기본값을 마찬가지로 `flex-start` 에서 `justify-content` 로 변경하는 걸 제안해봅니다. 사용하다보니, 특히 `VStack` 의 경우  `justify="stretch"` 속성을 주는 경우가 굉장히 빈번했었습니다. 다른 분들의 의견도 궁금합니다. (FYI @inhibitor1217)

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- Details 참고
