### PR TITLE
add toast update feature for past toasts

### DIFF
--- a/.changeset/strong-ducks-complain.md
+++ b/.changeset/strong-ducks-complain.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+add toast update feature

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -74,6 +74,7 @@
     "@svgr/cli": "^6.2.1",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^13.1.1",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.1.1",
     "@types/jest": "^25.2.3",
     "@types/lodash-es": "^4.17.4",

--- a/packages/bezier-react/src/components/Toast/Toast.stories.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.stories.tsx
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { noop } from 'lodash-es'
 import { base } from 'paths.macro'
 import { Story, Meta } from '@storybook/react'
@@ -256,6 +256,86 @@ export const CustomContent: Story<ToastProps> = () => (
   <Container id="story-wrapper">
     <ToastProvider>
       <CustomContentToastController />
+    </ToastProvider>
+  </Container>
+)
+
+function UpdateContentToastController() {
+  const toast = useToast()
+  const toastId = useRef('')
+
+  const onClickCustomButtonInToast = useCallback(() => {
+    toast.removeAllToasts()
+  }, [toast])
+
+  const handleOpenToast = useCallback((option?: ToastOptions) => {
+    toastId.current = toast.addToast((
+      <VStack spacing={6} align="stretch">
+        <StackItem>
+          <Button
+            text="Close All Toasts"
+            styleVariant={ButtonStyleVariant.Primary}
+            colorVariant={ButtonColorVariant.Blue}
+            onClick={onClickCustomButtonInToast}
+          />
+        </StackItem>
+        <StackItem>
+          <ProgressBar
+            width="100%"
+            value={Math.random()}
+          />
+        </StackItem>
+      </VStack>
+    ), {
+      preset: ToastPreset.Default,
+      ...option,
+    })
+  }, [
+    toast,
+    onClickCustomButtonInToast,
+  ])
+
+  const handleUpdateToast = useCallback((option?: ToastOptions) => {
+    if (toastId.current) {
+      toast.updateToast(toastId.current, (
+        <VStack spacing={6} align="stretch">
+          <StackItem>
+            <Button
+              text="Close All Toasts"
+              styleVariant={ButtonStyleVariant.Primary}
+              colorVariant={ButtonColorVariant.Blue}
+              onClick={onClickCustomButtonInToast}
+            />
+          </StackItem>
+          <StackItem>
+            <ProgressBar
+              width="100%"
+              value={Math.random()}
+            />
+          </StackItem>
+        </VStack>
+      ), {
+        preset: ToastPreset.Default,
+        ...option,
+      })
+    }
+  }, [
+    toast,
+    onClickCustomButtonInToast,
+  ])
+
+  return (
+    <div>
+      <button type="button" onClick={() => handleOpenToast({ autoDismiss: false })}>Add</button>
+      <button type="button" onClick={() => handleUpdateToast({ autoDismiss: true })}>Update</button>
+    </div>
+  )
+}
+
+export const UpdateContentToast: Story<ToastProps> = () => (
+  <Container id="story-wrapper">
+    <ToastProvider>
+      <UpdateContentToastController />
     </ToastProvider>
   </Container>
 )

--- a/packages/bezier-react/src/components/Toast/Toast.types.ts
+++ b/packages/bezier-react/src/components/Toast/Toast.types.ts
@@ -92,10 +92,19 @@ export const defaultOptions: ToastOptions = {
   rightSide: false,
 }
 
-export type ToastType = ToastOptions & { id: ToastId, content: ToastContent }
+export type ToastType = ToastOptions & {
+  id: ToastId
+  content: ToastContent
+  /**
+   * Updated version
+   * @default 0
+   */
+  version?: number
+}
 
 export interface ToastContextType {
-  add: (content: ToastContent, options: ToastOptions) => ToastId
+  add: (content: ToastContent, options?: ToastOptions) => ToastId
+  update: (toastId: ToastId, content: ToastContent, options?: ToastOptions) => ToastId
   remove: (id: ToastId) => void
   removeAll: () => void
   leftToasts: ToastType[]
@@ -111,4 +120,9 @@ export interface ToastControllerProps extends ToastElementProps {
   autoDismiss: boolean
   autoDismissTimeout: number
   component: ComponentType<ToastElementProps>
+  /**
+   * Updated toast version
+   * @default 0
+   */
+  version?: number
 }

--- a/packages/bezier-react/src/components/Toast/ToastContext.ts
+++ b/packages/bezier-react/src/components/Toast/ToastContext.ts
@@ -7,6 +7,7 @@ import { ToastContextType } from './Toast.types'
 
 const ToastContext = createContext<ToastContextType>({
   add: () => '',
+  update: () => '',
   remove: noop,
   removeAll: noop,
   leftToasts: [],

--- a/packages/bezier-react/src/components/Toast/ToastController.test.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastController.test.tsx
@@ -76,5 +76,35 @@ describe('ToastController >', () => {
         expect(onDismiss).toBeCalledTimes(1)
       })
     })
+
+    describe('version >', () => {
+      beforeEach(() => {
+        jest.useFakeTimers()
+        jest.spyOn(global, 'setTimeout')
+        jest.spyOn(global, 'clearTimeout')
+      })
+
+      it('autoDismiss reinitialized, when version is changed', () => {
+        const onDismiss = jest.fn()
+        const { rerender } = render((
+          <ToastController
+            {...props}
+            onDismiss={onDismiss}
+            autoDismiss
+          />
+        ))
+        expect(clearTimeout).toHaveBeenCalledTimes(0)
+        rerender((
+          <ToastController
+            {...props}
+            onDismiss={onDismiss}
+            autoDismiss={false}
+            version={1}
+          />
+        ))
+        // unmount + reinitialize = 2
+        expect(clearTimeout).toHaveBeenCalledTimes(2)
+      })
+    })
   })
 })

--- a/packages/bezier-react/src/components/Toast/ToastController.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastController.tsx
@@ -13,14 +13,15 @@ function ToastController({
   placement,
   component: ToastElement,
   onDismiss,
+  version = 0,
   ...props
 }: ToastControllerProps) {
   const [transform, setTransform] = useState(showedToastTranslateXStyle)
-  const timer = useRef<ReturnType<Window['setTimeout']>>()
+  const dismissTimer = useRef<ReturnType<Window['setTimeout']>>()
 
   const handleDismiss = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     setTransform(initPosition(placement))
-    timer.current = window.setTimeout(() => {
+    dismissTimer.current = window.setTimeout(() => {
       onDismiss(e)
     }, transitionDuration)
   }, [
@@ -29,26 +30,30 @@ function ToastController({
     transitionDuration,
   ])
 
-  const startTimer = useCallback(() => {
-    timer.current = window.setTimeout(handleDismiss, autoDismissTimeout)
+  const startDismissTimer = useCallback(() => {
+    dismissTimer.current = window.setTimeout(handleDismiss, autoDismissTimeout)
   }, [
     autoDismissTimeout,
     handleDismiss,
   ])
 
-  const clearTimer = useCallback(() => {
-    if (autoDismiss) {
-      clearTimeout(timer.current)
+  const clearDismissTimer = useCallback(() => {
+    if (dismissTimer.current != null) {
+      clearTimeout(dismissTimer.current)
     }
-  }, [autoDismiss])
-
-  useEffect(() => {
-    if (autoDismiss) {
-      timer.current = window.setTimeout(startTimer, transitionDuration)
-    }
-    return clearTimer
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  useEffect(function initStartDismissTimer() {
+    clearDismissTimer()
+    if (autoDismiss) {
+      dismissTimer.current = window.setTimeout(startDismissTimer, transitionDuration)
+    }
+    return clearDismissTimer
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    autoDismiss,
+    version,
+  ])
 
   return (
     <ToastElement

--- a/packages/bezier-react/src/components/Toast/ToastProvider.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastProvider.tsx
@@ -1,26 +1,20 @@
 /* External dependencies */
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback } from 'react'
 import { createPortal } from 'react-dom'
-import { noop } from 'lodash-es'
 
 /* Internal dependencies */
 import { css, TransitionDuration } from 'Foundation'
 import { getRootElement } from 'Utils/domUtils'
 import ToastContext from './ToastContext'
 import {
-  OnDismissCallback,
-  defaultOptions,
-  ToastOptions,
   ToastPlacement,
-  ToastId,
   ToastProviderProps,
   ToastType,
-  ToastContent,
 } from './Toast.types'
 import ToastContainer from './ToastContainer'
 import ToastController from './ToastController'
 import ToastElement from './ToastElement'
-import ToastService from './ToastService'
+import useToastProviderValues from './useToastContextValues'
 
 const { Provider } = ToastContext
 
@@ -28,74 +22,12 @@ function ToastProvider({
   autoDismissTimeout = 3000,
   children = [],
 }: ToastProviderProps) {
-  const leftToastService = useMemo(() => new ToastService(), [])
-  const rightToastService = useMemo(() => new ToastService(), [])
-  const [leftToasts, setLeftToasts] = useState<ToastType[]>([])
-  const [rightToasts, setRightToasts] = useState<ToastType[]>([])
-
-  const add = useCallback((content: ToastContent, options: ToastOptions = defaultOptions) => {
-    let result = ''
-    if (options.rightSide) {
-      result = rightToastService.add(content, options)
-      setRightToasts(rightToastService.getToasts())
-    } else {
-      result = leftToastService.add(content, options)
-      setLeftToasts(leftToastService.getToasts())
-    }
-    return result
-  }, [
-    leftToastService,
-    rightToastService,
-  ])
-
-  const remove = useCallback((id: ToastId) => {
-    if (leftToastService.remove(id)) {
-      setLeftToasts(leftToastService.getToasts())
-    }
-    if (rightToastService.remove(id)) {
-      setRightToasts(rightToastService.getToasts())
-    }
-  }, [
-    leftToastService,
-    rightToastService,
-  ])
-
-  const removeAll = useCallback(() => {
-    leftToastService.removeAll()
-    rightToastService.removeAll()
-    setLeftToasts(leftToastService.getToasts())
-    setRightToasts(rightToastService.getToasts())
-  }, [
-    leftToastService,
-    rightToastService,
-  ])
-
-  const handleDismiss = useCallback((id: ToastId, callback: OnDismissCallback = noop) => {
-    callback(id)
-    remove(id)
-  }, [remove])
-
-  useEffect(() => {
-    setLeftToasts(leftToastService.getToasts())
-    setRightToasts(rightToastService.getToasts())
-  }, [
-    leftToastService,
-    rightToastService,
-  ])
-
-  const ToastContextValue = useMemo(() => ({
-    add,
-    remove,
-    removeAll,
+  const toastContextValue = useToastProviderValues()
+  const {
     leftToasts,
     rightToasts,
-  }), [
-    add,
-    remove,
-    removeAll,
-    leftToasts,
-    rightToasts,
-  ])
+    dismiss,
+  } = toastContextValue
 
   const createContainer = useCallback((placement: ToastPlacement, toasts: ToastType[]) => (
     <ToastContainer
@@ -113,6 +45,7 @@ function ToastProvider({
         id,
         onDismiss,
         zIndex,
+        version,
       }) => (
         <ToastController
           key={id}
@@ -127,19 +60,20 @@ function ToastProvider({
           content={content}
           iconName={iconName}
           component={ToastElement}
-          onDismiss={() => handleDismiss(id, onDismiss)}
+          onDismiss={() => dismiss(id, onDismiss)}
           transform={css``}
           zIndex={zIndex}
+          version={version}
         />
       )) }
     </ToastContainer>
   ), [
     autoDismissTimeout,
-    handleDismiss,
+    dismiss,
   ])
 
   return (
-    <Provider value={ToastContextValue}>
+    <Provider value={toastContextValue}>
       { children }
       { createPortal(
         [

--- a/packages/bezier-react/src/components/Toast/ToastService.test.ts
+++ b/packages/bezier-react/src/components/Toast/ToastService.test.ts
@@ -1,0 +1,89 @@
+/* Internal dependencies */
+import { ToastType } from './Toast.types'
+import ToastService from './ToastService'
+
+const UUID_V4_REGEX = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+
+function createToasts(size: number): ToastType[] {
+  return Array.from(Array(size)).map((_, i) => ({
+    id: `${i}`,
+    content: `${i}`,
+    version: 0,
+  }))
+}
+
+describe('ToastService', () => {
+  it('initialize', () => {
+    const toastService = new ToastService()
+
+    expect(toastService.toasts).toStrictEqual([])
+  })
+
+  describe('getToasts()', () => {
+    const toastService = new ToastService()
+
+    expect(toastService.toasts).toStrictEqual([])
+    expect(toastService.getToasts()).toStrictEqual([])
+  })
+
+  it('setToasts()', () => {
+    const toastService = new ToastService()
+
+    const nextToasts: ToastType[] = createToasts(2)
+    toastService.setToasts(nextToasts)
+    expect(toastService.getToasts()).toStrictEqual(nextToasts)
+  })
+
+  it('add()', () => {
+    const toastService = new ToastService()
+
+    toastService.add('0')
+    expect(toastService.getToasts()).toStrictEqual([
+      expect.objectContaining({
+        id: expect.stringMatching(UUID_V4_REGEX),
+        appearance: 'info',
+        autoDismiss: false,
+        content: '0',
+        iconName: 'info-filled',
+        rightSide: false,
+        version: 0,
+      }),
+    ])
+  })
+
+  describe('update()', () => {
+    it('not found', () => {
+      const toastService = new ToastService()
+      expect(toastService.update('0', 'Not found')).toBe('')
+    })
+
+    it('updated', () => {
+      const toastService = new ToastService()
+
+      const size = 2
+      const nextToasts: ToastType[] = createToasts(size)
+      toastService.setToasts(nextToasts)
+
+      const targetIndex = size - 1
+      const targetToast = toastService.getToasts()[targetIndex]
+      const updateTargetToast: ToastType = {
+        ...targetToast,
+        content: 'New Toast',
+      }
+      expect(toastService.update(updateTargetToast.id, updateTargetToast.content)).toBe(updateTargetToast.id)
+      expect(toastService.getToasts()[targetIndex]).toStrictEqual({
+        ...updateTargetToast,
+        version: 1,
+      })
+    })
+  })
+
+  it('remove()', () => {
+    const toastService = new ToastService()
+
+    const nextToasts: ToastType[] = createToasts(2)
+    toastService.setToasts(nextToasts)
+    toastService.remove('1')
+    expect(toastService.getToasts()).toStrictEqual(createToasts(1))
+  })
+})

--- a/packages/bezier-react/src/components/Toast/ToastService.ts
+++ b/packages/bezier-react/src/components/Toast/ToastService.ts
@@ -23,11 +23,11 @@ class ToastService {
     this.toasts = newToasts
   }
 
-  has = (id: string) => {
+  has = (toastId: ToastId) => {
     if (!this.toasts.length) {
       return false
     }
-    return this.toasts.reduce((flag, cur) => (cur.id === id ? true : flag), false)
+    return this.toasts.reduce((flag, toast) => (toast.id === toastId ? true : flag), false)
   }
 
   add = (content: ToastContent, options: ToastOptions = defaultOptions) => {
@@ -40,11 +40,32 @@ class ToastService {
     const newToast: ToastType = {
       id: newId,
       content,
+      version: 0,
       ...options,
     }
     const newToasts: ToastType[] = [...this.toasts, newToast]
     this.setToasts(newToasts)
     return newId
+  }
+
+  update = (toastId: ToastId, content: ToastContent, options: ToastOptions = {}) => {
+    if (!this.has(toastId)) {
+      return ''
+    }
+
+    const newToasts: ToastType[] = this.toasts.map((toast) => {
+      if (toast.id === toastId) {
+        return {
+          ...toast,
+          ...options,
+          version: toast?.version != null ? toast.version + 1 : 0,
+          content,
+        }
+      }
+      return toast
+    })
+    this.setToasts(newToasts)
+    return toastId
   }
 
   remove = (id: ToastId): boolean => {

--- a/packages/bezier-react/src/components/Toast/useToast.ts
+++ b/packages/bezier-react/src/components/Toast/useToast.ts
@@ -13,6 +13,7 @@ export default function useToast() {
 
   return {
     addToast: context.add,
+    updateToast: context.update,
     removeToast: context.remove,
     removeAllToasts: context.removeAll,
     leftToasts: context.leftToasts,

--- a/packages/bezier-react/src/components/Toast/useToastContextValues.test.tsx
+++ b/packages/bezier-react/src/components/Toast/useToastContextValues.test.tsx
@@ -1,0 +1,152 @@
+/* External dependencies */
+import { renderHook, act } from '@testing-library/react-hooks'
+
+/* Internal dependencies */
+import { ToastAppearance, ToastType } from './Toast.types'
+import useToastContextValues from './useToastContextValues'
+
+const UUID_V4_REGEX = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+
+describe('ToastService', () => {
+  it('leftToasts', () => {
+    const { result } = renderHook(() => useToastContextValues())
+
+    expect(result.current.leftToasts).toStrictEqual([])
+  })
+
+  it('rightToasts', () => {
+    const { result } = renderHook(() => useToastContextValues())
+
+    expect(result.current.rightToasts).toStrictEqual([])
+  })
+
+  it('add()', () => {
+    const { result } = renderHook(() => useToastContextValues())
+
+    act(() => {
+      result.current.add('0')
+    })
+
+    expect(result.current.leftToasts).toStrictEqual([
+      expect.objectContaining({
+        id: expect.stringMatching(UUID_V4_REGEX),
+        content: '0',
+        iconName: 'info-filled',
+        appearance: ToastAppearance.Info,
+        autoDismiss: false,
+        rightSide: false,
+        version: 0,
+      }),
+    ])
+  })
+
+  describe('update()', () => {
+    it('not found', () => {
+      const { result } = renderHook(() => useToastContextValues())
+
+      act(() => {
+        expect(result.current.update('0', 'Not found')).toBe('')
+      })
+    })
+
+    it('updated', () => {
+      const { result } = renderHook(() => useToastContextValues())
+
+      act(() => {
+        result.current.add('0')
+      })
+      const targetIndex = 0
+      const targetToast = result.current.leftToasts[targetIndex]
+      const updateTargetToast: ToastType = {
+        ...targetToast,
+        content: 'New Toast',
+      }
+      act(() => {
+        expect(result.current.update(updateTargetToast.id, updateTargetToast.content)).toBe(updateTargetToast.id)
+      })
+      expect(result.current.leftToasts[targetIndex]).toStrictEqual({
+        ...updateTargetToast,
+        version: 1,
+      })
+      expect(result.current.rightToasts).toStrictEqual([])
+    })
+  })
+
+  it('remove()', () => {
+    const { result } = renderHook(() => useToastContextValues())
+
+    let toastId
+    act(() => {
+      toastId = result.current.add('0')
+    })
+    expect(result.current.leftToasts).toStrictEqual([
+      expect.objectContaining({
+        id: expect.stringMatching(UUID_V4_REGEX),
+        content: '0',
+        iconName: 'info-filled',
+        appearance: ToastAppearance.Info,
+        autoDismiss: false,
+        rightSide: false,
+        version: 0,
+      }),
+    ])
+    act(() => {
+      result.current.remove(toastId)
+    })
+    expect(result.current.leftToasts).toStrictEqual([])
+    expect(result.current.rightToasts).toStrictEqual([])
+  })
+
+  it('removeAll()', () => {
+    const { result } = renderHook(() => useToastContextValues())
+
+    act(() => {
+      result.current.add('0')
+    })
+
+    expect(result.current.leftToasts).toStrictEqual([
+      expect.objectContaining({
+        id: expect.stringMatching(UUID_V4_REGEX),
+        content: '0',
+        iconName: 'info-filled',
+        appearance: ToastAppearance.Info,
+        autoDismiss: false,
+        rightSide: false,
+        version: 0,
+      }),
+    ])
+
+    act(() => {
+      result.current.removeAll()
+    })
+    expect(result.current.leftToasts).toStrictEqual([])
+    expect(result.current.rightToasts).toStrictEqual([])
+  })
+
+  it('dismiss()', () => {
+    const onDismiss = jest.fn()
+    const { result } = renderHook(() => useToastContextValues())
+
+    let toastId
+    act(() => {
+      toastId = result.current.add('0')
+    })
+    expect(result.current.leftToasts).toStrictEqual([
+      expect.objectContaining({
+        id: expect.stringMatching(UUID_V4_REGEX),
+        content: '0',
+        iconName: 'info-filled',
+        appearance: ToastAppearance.Info,
+        autoDismiss: false,
+        rightSide: false,
+        version: 0,
+      }),
+    ])
+    act(() => {
+      result.current.dismiss(toastId, onDismiss)
+    })
+    expect(onDismiss).toBeCalledTimes(1)
+    expect(result.current.leftToasts).toStrictEqual([])
+    expect(result.current.rightToasts).toStrictEqual([])
+  })
+})

--- a/packages/bezier-react/src/components/Toast/useToastContextValues.ts
+++ b/packages/bezier-react/src/components/Toast/useToastContextValues.ts
@@ -1,0 +1,114 @@
+/* External dependencies */
+import { useCallback, useMemo, useState } from 'react'
+import { noop } from 'lodash-es'
+
+/* Internal dependencies */
+import {
+  OnDismissCallback,
+  defaultOptions,
+  ToastOptions,
+  ToastId,
+  ToastType,
+  ToastContent,
+  ToastContextType,
+} from './Toast.types'
+import ToastService from './ToastService'
+
+interface UseToastContextValuesReturns extends ToastContextType {
+  leftToasts: ToastType[]
+  rightToasts: ToastType[]
+  dismiss: (id: ToastId, callback?: OnDismissCallback) => void
+}
+
+/**
+ * NOTE(@sol): The ToastService is enough to fulfill the responsibility of toast.
+ * However, wrapping this for ToastProvider to create new features does not need to be done in bezier-react.
+ * It would have been better to implement this function in service needed it of use.
+ * Therefore, it would be good to pay attention to this part in a future update.
+ */
+/**
+ * @deprecated Implement this in your service with ToastProvider, not here.
+ */
+function useToastContextValues(): UseToastContextValuesReturns {
+  const leftToastService = useMemo(() => new ToastService(), [])
+  const rightToastService = useMemo(() => new ToastService(), [])
+  const [leftToasts, setLeftToasts] = useState<ToastType[]>([])
+  const [rightToasts, setRightToasts] = useState<ToastType[]>([])
+
+  const add = useCallback((content: ToastContent, options: ToastOptions = defaultOptions) => {
+    let result = ''
+    if (options.rightSide) {
+      result = rightToastService.add(content, options)
+      setRightToasts(rightToastService.getToasts())
+    } else {
+      result = leftToastService.add(content, options)
+      setLeftToasts(leftToastService.getToasts())
+    }
+    return result
+  }, [
+    leftToastService,
+    rightToastService,
+  ])
+
+  const update = useCallback((toastId: ToastId, content: ToastContent, options: ToastOptions = defaultOptions) => {
+    let result = ''
+    if (options.rightSide) {
+      result = rightToastService.update(toastId, content, options)
+      setRightToasts(rightToastService.getToasts())
+    } else {
+      result = leftToastService.update(toastId, content, options)
+      setLeftToasts(leftToastService.getToasts())
+    }
+    return result
+  }, [
+    leftToastService,
+    rightToastService,
+  ])
+
+  const remove = useCallback((toastId: ToastId) => {
+    if (leftToastService.remove(toastId)) {
+      setLeftToasts(leftToastService.getToasts())
+    }
+    if (rightToastService.remove(toastId)) {
+      setRightToasts(rightToastService.getToasts())
+    }
+  }, [
+    leftToastService,
+    rightToastService,
+  ])
+
+  const removeAll = useCallback(() => {
+    leftToastService.removeAll()
+    rightToastService.removeAll()
+    setLeftToasts(leftToastService.getToasts())
+    setRightToasts(rightToastService.getToasts())
+  }, [
+    leftToastService,
+    rightToastService,
+  ])
+
+  const dismiss = useCallback((toastId: ToastId, callback: OnDismissCallback = noop) => {
+    callback(toastId)
+    remove(toastId)
+  }, [remove])
+
+  return useMemo<UseToastContextValuesReturns>(() => ({
+    add,
+    update,
+    remove,
+    removeAll,
+    leftToasts,
+    rightToasts,
+    dismiss,
+  }), [
+    add,
+    update,
+    remove,
+    removeAll,
+    leftToasts,
+    rightToasts,
+    dismiss,
+  ])
+}
+
+export default useToastContextValues

--- a/yarn.lock
+++ b/yarn.lock
@@ -1994,6 +1994,7 @@ __metadata:
     "@svgr/cli": ^6.2.1
     "@testing-library/jest-dom": ^5.11.6
     "@testing-library/react": ^13.1.1
+    "@testing-library/react-hooks": ^8.0.1
     "@testing-library/user-event": ^14.1.1
     "@types/jest": ^25.2.3
     "@types/lodash-es": ^4.17.4
@@ -4670,6 +4671,28 @@ __metadata:
     lodash: ^4.17.15
     redent: ^3.0.0
   checksum: 4240501223b72b97a44d4e3c669f39b208c49fb645d11d08d5f178d607265c5dfad07efbe027f41a0e2458178ff1fd5bf437fc05661b9109dcd013b95a37079e
+  languageName: node
+  linkType: hard
+
+"@testing-library/react-hooks@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@testing-library/react-hooks@npm:8.0.1"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    react-error-boundary: ^3.1.0
+  peerDependencies:
+    "@types/react": ^16.9.0 || ^17.0.0
+    react: ^16.9.0 || ^17.0.0
+    react-dom: ^16.9.0 || ^17.0.0
+    react-test-renderer: ^16.9.0 || ^17.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react-dom:
+      optional: true
+    react-test-renderer:
+      optional: true
+  checksum: 7fe44352e920deb5cb1876f80d64e48615232072c9d5382f1e0284b3aab46bb1c659a040b774c45cdf084a5257b8fe463f7e08695ad8480d8a15635d4d3d1f6d
   languageName: node
   linkType: hard
 
@@ -17117,6 +17140,17 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
   checksum: 42bcd4423f12e9ee21b2d3f0c2a28805ff4953bd82b6be4c1f5b5f9a371115aafa36a6f3d82726d43b4912179b79e99550c2b9a772c7fe6a5cd8f7e93ff34ceb
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^3.1.0":
+  version: 3.1.4
+  resolution: "react-error-boundary@npm:3.1.4"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: f36270a5d775a25c8920f854c0d91649ceea417b15b5bc51e270a959b0476647bb79abb4da3be7dd9a4597b029214e8fe43ea914a7f16fa7543c91f784977f1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [x] I wrote **a unit test** about the implementation.
- [ ] I wrote **a storybook document** about the implementation.
- [ ] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

#894 

## Summary

- add toast update feature for past toasts
- add version type in ToastType
- add update functions in ToastService
  - add ToastService test
- migration ToastProvider functions to useToastContextValues hooks
  - add useToastContextValues test, but this is deprecated.

## Details

https://user-images.githubusercontent.com/16330024/182978176-26b53b7b-9e19-4681-a1d1-1ef7d43fecb7.mov

## Breaking change or not (Yes/No)
No

## References

#894 

https://github.com/channel-io/ch-desk-web/issues/10597
- [Figma](https://www.figma.com/file/82ho83cCj4n1FbD9ErU825/Contacts?node-id=4210%3A150677)
- [Notion - Contacts Bulk Action](https://www.notion.so/channelio/DB-BulkAction-1668569383ae412abf2b3e2cd479f73d)
