### PR TITLE
feat(text): add size17 option to Text typography

### DIFF
--- a/.changeset/cuddly-eagles-serve.md
+++ b/.changeset/cuddly-eagles-serve.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Add size17 option to Typography

--- a/.changeset/seven-planes-serve.md
+++ b/.changeset/seven-planes-serve.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": major
+---
+
+Add size17 option to Typography

--- a/.changeset/seven-planes-serve.md
+++ b/.changeset/seven-planes-serve.md
@@ -1,5 +1,0 @@
----
-"@channel.io/bezier-react": major
----
-
-Add size17 option to Typography

--- a/packages/bezier-react/src/foundation/Typography.ts
+++ b/packages/bezier-react/src/foundation/Typography.ts
@@ -8,6 +8,7 @@ export enum TypoAbsoluteNumber {
   Typo14 = 1.4,
   Typo15 = 1.5,
   Typo16 = 1.6,
+  Typo17 = 1.7,
   Typo18 = 1.8,
   Typo22 = 2.2,
   Typo24 = 2.4,
@@ -55,6 +56,12 @@ const Size16 = css`
   letter-spacing: -0.1px;
 `
 
+const Size17 = css`
+  font-size: ${TypoAbsoluteNumber.Typo17}rem;
+  line-height: ${LineHeightAbsoluteNumber.Lh22}rem;
+  letter-spacing: -0.1px;
+`
+
 const Size18 = css`
   font-size: ${TypoAbsoluteNumber.Typo18}rem;
   line-height: ${LineHeightAbsoluteNumber.Lh24}rem;
@@ -81,6 +88,7 @@ export const Typography = {
   Size14,
   Size15,
   Size16,
+  Size17,
   Size18,
   Size22,
   Size24,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] I wrote **a unit test** about the implementation.
- [ ] I wrote **a storybook document** about the implementation.
- [x] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

Fixes #912  <!-- Please link to issue if one exists -->

## Summary
<!-- Please add a summary of the modification. -->
This PR adds `Size17` option to Typography

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
No

## References
<!-- External documents based on workarounds or reviewers should refer to -->
[Figma](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=1161%3A1)
