### PR TITLE
Update icon size L from 34px to 36px

### DIFF
--- a/.changeset/shy-sloths-collect.md
+++ b/.changeset/shy-sloths-collect.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Update icon size L from 34 to 36

--- a/packages/bezier-react/src/components/Icon/Icon.types.ts
+++ b/packages/bezier-react/src/components/Icon/Icon.types.ts
@@ -6,7 +6,7 @@ import { BezierComponentProps, SizeProps, ColorProps } from 'Types/ComponentProp
 
 export enum IconSize {
   XL = 44,
-  L = 34,
+  L = 36,
   Normal = 24,
   S = 20,
   XS = 16,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] I wrote **a unit test** about the implementation.
- [ ] I wrote **a storybook document** about the implementation.
- [ ] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please add a summary of the modification. -->
- 피그마 상의 icon size와 실제 구현이 일치하도록 수정합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->
- IconSize.L: 34 => 36

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
- icon size가 변경됨에 따라 사용처의 레이아웃이 영향을 받게 됩니다. 따라서 각 사용처마다 확인이 필요합니다.

## References
<!-- External documents based on workarounds or reviewers should refer to -->
[피그마](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=966%3A4)