### PR TITLE
Change word-break style of Modal content from break-all to break-word

### DIFF
--- a/.changeset/rich-starfishes-notice.md
+++ b/.changeset/rich-starfishes-notice.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Change word-break property of Modal content

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
@@ -45,7 +45,7 @@ export const CloseIconButton = styled(Button)`
 export const Description = styled.div`
   box-sizing: border-box;
   width: 100%;
-  word-break: break-all;
+  word-break: break-word;
 
   /* stylelint-disable declaration-block-semicolon-newline-after, rule-empty-line-before, no-duplicate-selectors */
   ${Title} + & {
@@ -58,7 +58,7 @@ export const ChildrenContent = styled.div`
   box-sizing: border-box;
   width: 100%;
   padding-top: 12px;
-  word-break: break-all;
+  word-break: break-word;
 `
 
 export const DescriptionText = styled(Text).attrs(() => ({


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] I wrote **a unit test** about the implementation.
- [ ] I wrote **a storybook document** about the implementation.
- [x] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

Fixes #922 <!-- Please link to issue if one exists -->

## Summary
<!-- Please add a summary of the modification. -->
- Change word-break property to `break-word` in Modal component

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
- No

## References
<!-- External documents based on workarounds or reviewers should refer to -->
