### PR TITLE
Reduce bundle size (apply minify for styled-components)

### DIFF
--- a/.changeset/good-keys-serve.md
+++ b/.changeset/good-keys-serve.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Reduce bundle size (apply minify for styled-components)

--- a/packages/bezier-react/babel.config.js
+++ b/packages/bezier-react/babel.config.js
@@ -22,6 +22,11 @@ module.exports = {
         '@babel/plugin-transform-runtime',
         ['@babel/plugin-proposal-private-property-in-object', { loose: false }],
         ['@babel/plugin-proposal-class-properties', { loose: false }],
+        ['babel-plugin-styled-components', {
+          minify: true,
+          pure: true,
+          topLevelImportPaths: ['Foundation'],
+        }],
       ],
     },
   },

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "run-s 'build:*'",
     "build:icon": "./scripts/build-icon.sh",
-    "build:rollup": "cross-env BABEL_ENV=build rollup -c",
+    "build:rollup": "cross-env BABEL_ENV=production rollup -c",
     "dev": "yarn storybook",
     "lint": "run-p 'lint:*'",
     "lint:js": "TIMING=1 eslint --cache 'src/**/*.+(js|ts)?(x)'",
@@ -85,6 +85,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^29.3.0",
     "babel-loader": "^9.1.0",
+    "babel-plugin-styled-components": "^2.0.7",
     "babel-preset-react-app": "^10.0.0",
     "chromatic": "^6.11.4",
     "core-js": "^3.8.1",
@@ -105,7 +106,6 @@
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "tslib": "^2.3.1",
     "ttypescript": "^1.5.13",
-    "typescript-plugin-styled-components": "^2.0.0",
     "typescript-transform-paths": "^3.3.1"
   },
   "peerDependencies": {

--- a/packages/bezier-react/rollup.config.js
+++ b/packages/bezier-react/rollup.config.js
@@ -6,15 +6,10 @@ import commonjs from '@rollup/plugin-commonjs'
 import babel from '@rollup/plugin-babel'
 import { visualizer } from 'rollup-plugin-visualizer'
 import typescript from 'rollup-plugin-typescript2'
-import createStyledComponentsTransformer from 'typescript-plugin-styled-components'
 
 import packageJson from './package.json'
 
 const extensions = DEFAULT_EXTENSIONS.concat(['.ts', '.tsx'])
-
-const styledComponentsTransformer = createStyledComponentsTransformer({
-  displayName: true,
-})
 
 // Order Matters, must after rollup-plugin-node-resolve
 // See Also: https://www.npmjs.com/package/rollup-plugin-typescript2
@@ -22,11 +17,6 @@ const typescriptPlugin = typescript({
   typescript: require('ttypescript'),
   tsconfig: './tsconfig.json',
   useTsconfigDeclarationDir: true,
-  transformers: [
-    () => ({
-      before: [styledComponentsTransformer],
-    }),
-  ],
   tsconfigDefaults: {
     noEmit: false,
     emitDeclarationOnly: true,
@@ -52,6 +42,7 @@ const commonPlugins = [
   commonjs(),
   babel({
     babelHelpers: 'runtime',
+    skipPreflightCheck: true,
     exclude: 'node_modules/**',
     extensions,
   }),

--- a/packages/bezier-react/src/components/Avatars/CheckableAvatar/CheckableAvatar.styled.ts
+++ b/packages/bezier-react/src/components/Avatars/CheckableAvatar/CheckableAvatar.styled.ts
@@ -59,11 +59,11 @@ export const getAvatarImageStyle = (
       height: 100%;
       content: '';
       opacity: ${isChecked ? 1 : 0};
-      /**
-       * NOTE: (@ed) smooth-corners가 적용된 상태에선 background 색상을 background-color 속성을 통해 그리지 않으므로 (background: paint(smooth-corners))
-       * smooth-corners가 사용 가능한 브라우저에선 background-color 트랜지션또한 불가능합니다.
-       * 발생하지 않는 트랜지션에 will-change 속성을 주는 건 불필요하므로, will-change 속성에서 background-color를 제거합니다.
-       */
+      ${'' /**
+         * NOTE: (@ed) smooth corner가 적용된 상태에선 background 색상을 background-color 속성을 통해 그리지 않으므로 (background: paint(smooth-corners))
+         * smooth-corners가 사용 가능한 브라우저에선 background-color 트랜지션또한 불가능합니다.
+         * 발생하지 않는 트랜지션에 will-change 속성을 주는 건 불필요하므로, will-change 속성에서 background-color를 제거합니다.
+      */}
       will-change: ${enableSmoothCorners.current ? 'opacity' : 'opacity, background-color'};
 
       ${({ foundation }) => foundation?.transition.getTransitionsCSS(['opacity', 'background-color'])}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,6 +2091,7 @@ __metadata:
     babel-eslint: ^10.1.0
     babel-jest: ^29.3.0
     babel-loader: ^9.1.0
+    babel-plugin-styled-components: ^2.0.7
     babel-preset-react-app: ^10.0.0
     chromatic: ^6.11.4
     core-js: ^3.8.1
@@ -2116,7 +2117,6 @@ __metadata:
     tslib: ^2.3.1
     ttypescript: ^1.5.13
     typesafe-actions: ^5.1.0
-    typescript-plugin-styled-components: ^2.0.0
     typescript-transform-paths: ^3.3.1
     uuid: ^9.0.0
   peerDependencies:
@@ -7720,7 +7720,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-styled-components@npm:>= 1.12.0":
+"babel-plugin-styled-components@npm:>= 1.12.0, babel-plugin-styled-components@npm:^2.0.7":
   version: 2.0.7
   resolution: "babel-plugin-styled-components@npm:2.0.7"
   dependencies:
@@ -21214,15 +21214,6 @@ __metadata:
   version: 5.1.0
   resolution: "typesafe-actions@npm:5.1.0"
   checksum: 63f973ca93fcd2a037bf994ec6b173a5bf2fe2eba04ea64d8ddc49f3fcac5506d4209d61e020ab07dd39a21539d9f03fbf7c9ed7a22244c3c6c0758e438f6ef5
-  languageName: node
-  linkType: hard
-
-"typescript-plugin-styled-components@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "typescript-plugin-styled-components@npm:2.0.0"
-  peerDependencies:
-    typescript: ^4.0
-  checksum: b4048b45e576ef01e0439f2f7fd6bddd96d83eb6fd91956b0952f56cfcbe952ab2a1330f1c46851b78f5bdf71821f43123145c0be1db6bb578257913a70ddd0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] ~~I wrote **a unit test** about the implementation.~~
- [ ] ~~I wrote **a storybook document** about the implementation.~~
- [ ] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

## Summary
It reduce many whitespace of component style code in compiled source like this:
| as-is | to-be |
|:---:|:---:|
<img width="633" alt="스크린샷 2022-10-17 오후 6 58 25" src="https://user-images.githubusercontent.com/33291896/196148840-5b6c4a5a-21d4-4662-a02d-2168d5aeadbc.png"> | <img width="634" alt="스크린샷 2022-10-17 오후 6 42 35" src="https://user-images.githubusercontent.com/33291896/196148722-404787be-beb1-450b-bb8b-ac731aa31dce.png">

Size diff:
| as-is | to-be |
|:---:|:---:|
<img width="265" alt="스크린샷 2022-10-17 오후 4 18 19" src="https://user-images.githubusercontent.com/33291896/196148655-15f8787f-7d5d-403d-ad19-ff9344bc6fac.png"> | <img width="264" alt="스크린샷 2022-10-17 오후 6 53 20" src="https://user-images.githubusercontent.com/33291896/196148681-62f7d878-cff7-4d5e-9931-6a92316ef81b.png">
<img width="265" alt="스크린샷 2022-10-17 오후 3 52 09" src="https://user-images.githubusercontent.com/33291896/196148634-ca729985-fe37-4f23-9530-7b995b6968ae.png"> | <img width="264" alt="스크린샷 2022-10-17 오후 6 47 09" src="https://user-images.githubusercontent.com/33291896/196148675-c845d14e-946b-4b51-99c0-91764d0bd208.png">

## Details
- Migrate typescript-plugin-styled-components to babel-plugin-styled-components for apply minify(for remove extra whitespace), pure(for remove dead code).
  > There is minify option at typescript-plugin-styled-components, but that's not work for me. (maybe influence of FoundationStyledComponent's override)
- Hide comment on style code that's not removed automatically by minify

## Breaking change or not (Yes/No)
- No breaking change.

## References
<!-- External documents based on workarounds or reviewers should refer to -->
