### PR TITLE
Enhance FormControl and FormLabel style to avoid text-overflow

### DIFF
--- a/.changeset/flat-ghosts-poke.md
+++ b/.changeset/flat-ghosts-poke.md
@@ -1,0 +1,7 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+- For avoiding text overflow, Change FormControl grid label cell size from flex to fixed.
+- For avoiding text overflow, Add 'work-break: break-word' style to FormLabel.
+- For avoiding text overflow, Add flex-shrink style to StackItem which is wrapping FormLabel when there is 'help'.

--- a/.changeset/strange-readers-grab.md
+++ b/.changeset/strange-readers-grab.md
@@ -1,7 +1,0 @@
----
-"@channel.io/bezier-react": patch
----
-
-- For avoiding text overflow, Change FormControl grid label cell size from flex to fixed.
-- For avoiding text overflow, Add 'work-break: break-all' style to FormLabel.
-- For avoiding text overflow, Add flex-shrink style to StackItem which is wrapping FormLabel when there is 'help'.

--- a/.changeset/strange-readers-grab.md
+++ b/.changeset/strange-readers-grab.md
@@ -1,0 +1,7 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+- For avoiding text overflow, Change FormControl grid label cell size from flex to fixed.
+- For avoiding text overflow, Add 'work-break: break-all' style to FormLabel.
+- For avoiding text overflow, Add flex-shrink style to StackItem which is wrapping FormLabel when there is 'help'.

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.styled.ts
@@ -23,7 +23,7 @@ export const TopHelperTextWrapper = styled(Box)`
 export const Grid = styled(Box)`
   display: grid;
   grid-template-rows: repeat(2, auto);
-  grid-template-columns: minmax(${LEFT_LABEL_MIN_WIDTH}px, auto) 1fr;
+  grid-template-columns: ${LEFT_LABEL_MIN_WIDTH}px 1fr;
   grid-column-gap: 12px;
   align-items: center;
 `

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 .c3 {
   display: block;
   text-align: left;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .c8 {
@@ -448,7 +448,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 .c4 {
   display: block;
   text-align: left;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .c11 {
@@ -713,7 +713,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 .c3 {
   display: block;
   text-align: left;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .c5 {
@@ -903,7 +903,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
 .c4 {
   display: block;
   text-align: left;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .c6 {

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -93,6 +93,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 .c3 {
   display: block;
   text-align: left;
+  word-break: break-all;
 }
 
 .c8 {
@@ -322,7 +323,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 .c1 {
   display: grid;
   grid-template-rows: repeat(2,auto);
-  grid-template-columns: minmax(150px,auto) 1fr;
+  grid-template-columns: 150px 1fr;
   grid-column-gap: 12px;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -447,6 +448,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 .c4 {
   display: block;
   text-align: left;
+  word-break: break-all;
 }
 
 .c11 {
@@ -711,6 +713,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 .c3 {
   display: block;
   text-align: left;
+  word-break: break-all;
 }
 
 .c5 {
@@ -833,7 +836,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
 .c1 {
   display: grid;
   grid-template-rows: repeat(2,auto);
-  grid-template-columns: minmax(150px,auto) 1fr;
+  grid-template-columns: 150px 1fr;
   grid-column-gap: 12px;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -900,6 +903,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
 .c4 {
   display: block;
   text-align: left;
+  word-break: break-all;
 }
 
 .c6 {

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.styled.ts
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.styled.ts
@@ -5,5 +5,5 @@ import { Text } from 'Components/Text'
 export const Label = styled(Text)`
   display: block;
   text-align: left;
-  word-break: break-all;
+  word-break: break-word;
 `

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.styled.ts
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.styled.ts
@@ -5,4 +5,5 @@ import { Text } from 'Components/Text'
 export const Label = styled(Text)`
   display: block;
   text-align: left;
+  word-break: break-all;
 `

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -78,7 +78,7 @@ forwardedRef: React.Ref<HTMLLabelElement>,
         ? LabelComponent
         : (
           <HStack align="center" spacing={6}>
-            <StackItem>
+            <StackItem shrink weight={1}>
               { LabelComponent }
             </StackItem>
             <StackItem>

--- a/packages/bezier-react/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`FormLabel > Snapshot > 1`] = `
 .c1 {
   display: block;
   text-align: left;
+  word-break: break-all;
 }
 
 <label

--- a/packages/bezier-react/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`FormLabel > Snapshot > 1`] = `
 .c1 {
   display: block;
   text-align: left;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 <label


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] I wrote **a unit test** about the implementation.
- [ ] I wrote **a storybook document** about the implementation.
- [x] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox ❌
  - macOS: Chrome, Edge, Safari, (Optional) Firefox ✅

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->

- 폼 유즈 케이스에서 라벨 컴포넌트의 영역이 150px로 고정되어있는걸 확인했습니다. `FormControl` 의 불필요한 `minmax` 스타일을 제거하고 고정 너비로 변경합니다.
- `FormLabel` 컴포넌트의 text-overflow를 방지하기 위해 `word-break: break-word` 스타일을 추가하고, Help 컴포넌트와 함께 사용될 경우도 마찬가지로 `flex-shrink` 속성을 추가합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

라벨이 길 경우 아래와 같이 줄넘김 처리가 됩니다.

### AS-IS

<img width="534" alt="스크린샷 2022-10-20 오후 9 17 19" src="https://user-images.githubusercontent.com/58209009/196949866-4a6126bd-61bf-463a-8507-c89cce11c52e.png">

### TO-BE

<img width="531" alt="스크린샷 2022-10-21 오후 12 06 30" src="https://user-images.githubusercontent.com/58209009/197102048-ec5b38d2-63f1-4032-ba6f-e3da0b55843c.png">

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- [Bezier Figma](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=1164%3A14992)
