### PR TITLE
fix(text): change the font-weight of bold text

### DIFF
--- a/.changeset/purple-shrimps-play.md
+++ b/.changeset/purple-shrimps-play.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+change the font-weight of bold text from 600 to 'bold'

--- a/packages/bezier-react/src/components/Banner/Banner.test.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.test.tsx
@@ -31,7 +31,7 @@ describe('Banner >', () => {
 
     expect(bannerLink.tagName).toBe('A')
     expect(bannerLink.children.item(0)).toHaveStyle('text-decoration: underline;')
-    expect(bannerLink.children.item(0)).toHaveStyle('font-weight: 600;')
+    expect(bannerLink.children.item(0)).toHaveStyle('font-weight: bold;')
     expect(bannerLink.children.item(0)).toHaveStyle('font-size: 1.4rem;')
   })
 

--- a/packages/bezier-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/bezier-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Button Test > Active Test > Active prop change Button to hover style 1`
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -105,7 +105,7 @@ exports[`Button Test > Disabled Test > Button can have disabled attribute 1`] = 
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -215,7 +215,7 @@ exports[`Button Test > Loading Test > Active prop change Button to hover style 1
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -342,7 +342,7 @@ exports[`Button Test > Reset CSS 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -444,7 +444,7 @@ exports[`Button Test > Size Test > with text > Size L - styleVariant: Floating 1
   letter-spacing: -0.1px;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -553,7 +553,7 @@ exports[`Button Test > Size Test > with text > Size L 1`] = `
   letter-spacing: -0.1px;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -651,7 +651,7 @@ exports[`Button Test > Size Test > with text > Size M - styleVariant: Floating 1
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -756,7 +756,7 @@ exports[`Button Test > Size Test > with text > Size M 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -854,7 +854,7 @@ exports[`Button Test > Size Test > with text > Size S - styleVariant: Floating 1
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -959,7 +959,7 @@ exports[`Button Test > Size Test > with text > Size S 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1057,7 +1057,7 @@ exports[`Button Test > Size Test > with text > Size XL - styleVariant: Floating 
   line-height: 2.4rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1162,7 +1162,7 @@ exports[`Button Test > Size Test > with text > Size XL 1`] = `
   line-height: 2.4rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1260,7 +1260,7 @@ exports[`Button Test > Size Test > with text > Size XS - styleVariant: Floating 
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1365,7 +1365,7 @@ exports[`Button Test > Size Test > with text > Size XS 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1463,7 +1463,7 @@ exports[`Button Test > Size Test > with text > size prop not given, default size
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -1911,7 +1911,7 @@ exports[`Button Test > StyleVariant Test > Floating 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -2016,7 +2016,7 @@ exports[`Button Test > StyleVariant Test > FloatingAlt 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -2121,7 +2121,7 @@ exports[`Button Test > StyleVariant Test > Primary 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -2219,7 +2219,7 @@ exports[`Button Test > StyleVariant Test > Secondary 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -2317,7 +2317,7 @@ exports[`Button Test > StyleVariant Test > Tertiary 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -399,7 +399,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -416,7 +416,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -681,7 +681,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
@@ -871,7 +871,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;

--- a/packages/bezier-react/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FormLabel > Snapshot > 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: #000000D9;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SegmentedControl Snapshot 1`] = `
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: inherit;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;

--- a/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
+++ b/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`KeyValueListItem Snapshot > 1`] = `
   line-height: 1.6rem;
   margin: 0px 0px 0px 0px;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
   color: #00000066;
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.test.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.test.tsx
@@ -28,7 +28,7 @@ describe('SectionLabel', () => {
     const content = getByTestId(SECTION_LABEL_TEST_CONTENT_ID)
 
     expect(content.children.length).toBe(1)
-    expect(content.children.item(0)).toHaveStyle('font-weight: 600;')
+    expect(content.children.item(0)).toHaveStyle('font-weight: bold;')
     expect(content.children.item(0)).toHaveStyle('font-size: 1.3rem;')
   })
 
@@ -37,7 +37,7 @@ describe('SectionLabel', () => {
     const content = getByTestId(SECTION_LABEL_TEST_CONTENT_ID)
 
     expect(content.children.length).toBe(1)
-    expect(content.children.item(0)).toHaveStyle('font-weight: 600;')
+    expect(content.children.item(0)).toHaveStyle('font-weight: bold;')
     expect(content.children.item(0)).toHaveStyle('font-size: 1.3rem;')
   })
 

--- a/packages/bezier-react/src/components/Text/Text.styled.ts
+++ b/packages/bezier-react/src/components/Text/Text.styled.ts
@@ -23,7 +23,7 @@ const Text = styled.span<TextProps & TextStyledProps>`
   ${props => props.typo};
   margin: ${getMargin};
   font-style: ${props => (props.italic ? 'italic' : 'normal')};
-  font-weight: ${props => (props.bold ? 600 : 'normal')};
+  font-weight: ${props => (props.bold ? 'bold' : 'normal')};
   color: ${({ foundation, color }) => (color && foundation?.theme?.[color]) || 'inherit'};
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS('color')}

--- a/packages/bezier-react/src/components/Text/Text.test.tsx
+++ b/packages/bezier-react/src/components/Text/Text.test.tsx
@@ -34,7 +34,7 @@ describe('Text test >', () => {
 
     const renderedText = getByTestId(TEXT_TEST_ID)
 
-    expect(renderedText).toHaveStyle('font-weight: 600;')
+    expect(renderedText).toHaveStyle('font-weight: bold;')
   })
 
   it('Text receives bold style', () => {


### PR DESCRIPTION
change the font-weight of bold text from 600 to 'bold'

BREAKING CHANGE: every bold text is changed from 'font-weight:600' to 'font-weight: bold'

<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] I wrote **a unit test** about the implementation.
- [ ] I wrote **a storybook document** about the implementation.
- [ ] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please add a summary of the modification. -->
Text 컴포넌트 prop으로 `bold={true}` 를 받았을 때, font-weight를 `600`이 아닌 `bold`로 설정합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->
Bezier상 Typography의 스펙이 변경되어 대응합니다.

대표 사용처인 채널톡 Desk 어플리케이션과 이 bezier-react storybook에선 다음 폰트 정의을 가져다 쓰고 있습니다.
https://cf.channel.io/asset/font/Inter/inter.css

```css
@font-face {
  font-family: 'Inter';
  font-style:  normal;
  font-weight: 400;
  font-display: swap;
  src: url("Inter-Regular.woff2?v=3.13") format("woff2"),
       url("Inter-Regular.woff?v=3.13") format("woff");
}
@font-face {
  font-family: 'Inter';
  font-style:  italic;
  font-weight: 400;
  font-display: swap;
  src: url("Inter-Italic.woff2?v=3.13") format("woff2"),
       url("Inter-Italic.woff?v=3.13") format("woff");
}

@font-face {
  font-family: 'Inter';
  font-style:  normal;
  font-weight: 700;
  font-display: swap;
  src: url("Inter-Bold.woff2?v=3.13") format("woff2"),
       url("Inter-Bold.woff?v=3.13") format("woff");
}
@font-face {
  font-family: 'Inter';
  font-style:  italic;
  font-weight: 700;
  font-display: swap;
  src: url("Inter-BoldItalic.woff2?v=3.13") format("woff2"),
       url("Inter-BoldItalic.woff?v=3.13") format("woff");
}
```

이 css의 font-face를 보면 `font-weight: 600`을 지원하지 않습니다.
그래서 실제로는, 이 storybook이나 데스크 사용처에서 `font-weight: 600`으로 설정된 텍스트들이 Inter-BoldItalic.woff2 (700에 해당하는 폰트) 로 그려집니다.
(특정 [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-weight)가 존재하지 않으면 가까운 weight가 사용됩니다.)
> When a specified weight doesn't exist, a nearby weight is used.

즉, 기존에 beizer 스펙과 bezier-react Text component에 bold text는 semibold(600) 으로 정의되어 있었지만,
실제로 storybook이나 Desk 서비스에서는 700으로 렌더링 된 폰트를 보고 있었다는 겁니다.

그래서 bezier 스펙에서 bold text의 스펙을 semibold 에서 bold로 바꾸었고,
이에 따라 bezier-react의 Text 컴포넌트를 수정합니다.

## 사용처에서 변하는 부분
<!-- If Yes, please describe the impact and migration path for users -->
기존에 600으로 표시되던 텍스트들이 bold(700)으로 표시됩니다.
단, 기존 데스크 사용처는 변화가 없습니다.

## References
<!-- External documents based on workarounds or reviewers should refer to -->
- [Bezier font-weight 스펙 변경 히스토리](https://www.notion.so/channelio/Font-Weight-fa3e2138181f4d4aaa786d605fe3a644)