### PR TITLE
chore(github): fix dependabot yml parsing error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,6 @@ version: 2
 updates:
   # Maintain dependencies for root of repository
   - package-ecosystem: "npm"
-    # Raise pull requests to update vendored dependencies that are checked in to the repository
-    vendor: true
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] I wrote **a unit test** about the implementation.
- [ ] I wrote **a storybook document** about the implementation.
- [ ] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->

```
The property '#/updates/0/' contains additional properties ["vendor"] outside of the schema when none are allowed
```

dependabot의 위 에러를 해결합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

[vendor](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#vendor) 옵션의 Package manager에 `npm` 은 없으나, [package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) 옵션의 표로 미루어보건데 yarn v2는 지원을 하는 것으로 판단하여 옵션을 추가했는데, 지원하지 않는 거 같아 제거합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

없음
