### PR TITLE
chore(github): fix dependabot config to update yarn.lock file and support monorepo structure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Maintain dependencies for root of repository
+  # Maintain dependencies for npm packages
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -14,37 +14,6 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-
-  # Maintain dependencies for bezier-react package
-  - package-ecosystem: "npm"
-    directory: "/packages/bezier-react"
-    schedule:
-      interval: "daily"
-      time: "11:00"
-      timezone: "Asia/Seoul"
-    reviewers:
-      - "sungik-choi"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels:
-      - "dependencies"
-
-  # Maintain dependencies for bezier-figma-plugin package
-  - package-ecosystem: "npm"
-    directory: "/packages/bezier-figma-plugin"
-    schedule:
-      interval: "daily"
-      time: "11:00"
-      timezone: "Asia/Seoul"
-    reviewers:
-      - "sungik-choi"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels:
-      - "dependencies"
-      - "bezier-figma-plugin"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] I wrote **a unit test** about the implementation.
- [ ] I wrote **a storybook document** about the implementation.
- [ ] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

- https://github.com/dependabot/dependabot-core/issues/4993
- https://github.com/dependabot/dependabot-core/issues/5226

## Summary
<!-- Please add a summary of the modification. -->

Fix dependabot config to update yarn.lock file and support monorepo structure

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

See also: [comment](https://github.com/dependabot/dependabot-core/issues/4993#issuecomment-1289133027)

> For those still looking for a solution: The solution is described here: #5226
> 
> Short version:
> 
> * Do not set up the `dependabot.yml` as described above (by listing each package individually) but by just listing the npm root like so:
> 
> ```
> version: 2
> updates:
>   - package-ecosystem: "npm"
>     directory: "/"
> ```
> 
> * To trigger dependabot to also properly fix the `package-lock.json`, set `versioning-strategy: increase`

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

Skip
