### PR TITLE
fix(tagbadge): make xs tagbadge more smaller

### DIFF
--- a/.changeset/witty-planets-exist.md
+++ b/.changeset/witty-planets-exist.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+make xs tagbadge more smaller

--- a/packages/bezier-react/src/components/TagBadge/TagBadgeCommon/utils.ts
+++ b/packages/bezier-react/src/components/TagBadge/TagBadgeCommon/utils.ts
@@ -23,7 +23,7 @@ export function getProperTagBadgeRounding(size: TagBadgeSize) {
 
 export function getProperTagBadgeTypo(size: TagBadgeSize) {
   return {
-    [TagBadgeSize.XS]: Typography.Size12,
+    [TagBadgeSize.XS]: Typography.Size11,
     [TagBadgeSize.S]: Typography.Size13,
     [TagBadgeSize.M]: Typography.Size14,
     [TagBadgeSize.L]: Typography.Size15,


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] ~~I wrote **a unit test** about the implementation.~~
- [ ] ~~I wrote **a storybook document** about the implementation.~~
- [ ] ~~I tested the implementation in **various browsers**.~~
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

## Summary

## Details
- TagBadgeSize.XS font size is changed from Size12 to Size11

## Breaking change or not (No)
<!-- If Yes, please describe the impact and migration path for users -->

## References
<!-- External documents based on workarounds or reviewers should refer to -->
