### PR TITLE
Apply `font-family: 'Inter'` as Storybook global style

### DIFF
--- a/.changeset/green-camels-shop.md
+++ b/.changeset/green-camels-shop.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Apply `font-family: 'Inter'` as StoryBook global style

--- a/packages/bezier-react/.storybook/preview-head.html
+++ b/packages/bezier-react/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="https://cf.channel.io/asset/font/Inter/inter.css">
+<link rel="preload stylesheet" href="https://cf.channel.io/asset/font/Inter/inter.css">

--- a/packages/bezier-react/.storybook/preview.js
+++ b/packages/bezier-react/.storybook/preview.js
@@ -44,7 +44,7 @@ export const globalTypes = {
 };
 
 function getFoundation(keyword) {
-  const isDarkFoundation = keyword === FoundationKeyword.Dark 
+  const isDarkFoundation = keyword === FoundationKeyword.Dark
   return {
     isDarkFoundation,
     foundation: isDarkFoundation ? DarkFoundation : LightFoundation,
@@ -54,11 +54,11 @@ function getFoundation(keyword) {
 
 const customGlobalStyle = {
   // You can inject custom global CSS
-  // global: {
-  //   html: {
-  //     fontSize: '20px',
-  //   }
-  // }
+  global: {
+    html: {
+      fontFamily: 'Inter',
+    }
+  }
 }
 
 const wrapperStyle = {
@@ -70,7 +70,6 @@ const wrapperStyle = {
   gap: 20,
   width: '100%',
   height: '100%',
-  fontFamily: 'Inter',
 }
 
 const storyWrapperStyle = {
@@ -89,7 +88,7 @@ const innerWrapperStyle = {
 }
 
 function withFoundationProvider(Story, context) {
-  const { 
+  const {
     isDarkFoundation,
     foundation: Foundation,
     invertedFoundation: InvertedFoundation,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] ~~[Component] I wrote **a unit test** about the implementation.~~
- [ ] ~~[Component] I wrote **a storybook document** about the implementation.~~
- [ ] ~~[Component] I tested the implementation in **various browsers**.~~
  - ~~Windows: Chrome, Edge, (Optional) Firefox~~
  - ~~macOS: Chrome, Edge, Safari, (Optional) Firefox~~
- [ ] ~~[*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.~~

## Related Issue

None.

## Summary
<!-- Please add a summary of the modification. -->

- Storybook preview에 적용되는 웹 폰트 CSS(`font-family: 'Inter'`)를 iframe 전역에 적용되도록 합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- 기존에도 `.storybook/preview.js`에서 `fontFamily: 'Inter'`로 폰트를 명시하고 있었지만, FoundationProvider 상위의 wrapper에만 적용되어 해당 wrapper 바깥에 렌더링되는 컴포넌트(Modal, Toast 등)는 브라우저 기본 폰트로 렌더링되었습니다.
- 웹 폰트 스타일을 `customGlobalStyle`로 이동해 Storybook preview 전체에서 해당 폰트로 렌더링되도록 합니다.

### Examples - Modal

| as-is | to-be |
|:---:|:---:|
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/6940439/201595044-b1848e5f-4747-4eb5-90d5-00a080441c87.png"> | <img width="1087" alt="image" src="https://user-images.githubusercontent.com/6940439/201594816-a7a91afb-f6bd-4403-9610-07bc5f8a3a9d.png">

### Examples - Toast

| as-is | to-be |
|:---:|:---:|
<img width="1081" alt="image" src="https://user-images.githubusercontent.com/6940439/201595246-fb0bdb10-9091-45cc-ae85-a8f014f40c1b.png"> | <img width="1083" alt="image" src="https://user-images.githubusercontent.com/6940439/201595282-a38f826e-79df-4dbc-8514-16be8d79b375.png">

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No.

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- [Storybook - Story rendering](https://storybook.js.org/docs/react/configure/story-rendering)
