### PR TITLE
Fix typo in ButtonGroup mdx

### DIFF
--- a/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.mdx
+++ b/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.mdx
@@ -16,7 +16,7 @@ import {
 버튼 사이의 간격은 0px 혹은 6px 이며, 디폴트값은 6px 입니다.
 
 <Canvas>
-  <Story id="components-buttongroup--composition" />
+  <Story id="components-buttongroup--playground" />
 </Canvas>
 
 ## API
@@ -29,10 +29,10 @@ import {
 ```ts
 interface ButtonGroupOption {
   /**
-   * Determines whether there is a 6px gap between the buttons.
-   * @default true
+   * Determines whether there is no 6px gap between the buttons.
+   * @default false
    */
-  hasSpacing?: boolean
+  withoutSpacing?: boolean
 }
 ```
 </details>

--- a/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -25,6 +25,7 @@ export default {
 
 const Wrapper = styled.div`
   display: flex;
+  align-items: center;
   justify-content: center;
   width: 200px;
   height: 200px;
@@ -53,24 +54,3 @@ export const Playground: Story<ButtonGroupProps> = Template.bind({})
 Playground.args = {
   withoutSpacing: false,
 }
-
-const CompositionTemplate: Story<ButtonGroupProps> = (props) => (
-  <Wrapper>
-    <Spacer />
-    <StackItem>
-      <ButtonGroup {...props}>
-        <Button
-          text="취소"
-          styleVariant={ButtonStyleVariant.Secondary}
-        />
-        <Button
-          text="확인"
-          styleVariant={ButtonStyleVariant.Primary}
-        />
-      </ButtonGroup>
-    </StackItem>
-    <Spacer />
-  </Wrapper>
-)
-
-export const Composition: Story<ButtonGroupProps> = CompositionTemplate.bind({})


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

Fixes #984  <!-- Please link to issue if one exists -->

## Summary
<!-- Please add a summary of the modification. -->
- `ButtonGroup` 에 관한 mdx 가 잘못 작성되어 있는 부분을 수정합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
No

## References
<!-- External documents based on workarounds or reviewers should refer to -->
