### PR TITLE
fix(Text): add handling code for unhandled interpolation prop

### DIFF
--- a/.changeset/serious-bags-buy.md
+++ b/.changeset/serious-bags-buy.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+fix(Text): add handling code for unhandled interpolation prop

--- a/packages/bezier-react/src/components/Text/Text.styled.ts
+++ b/packages/bezier-react/src/components/Text/Text.styled.ts
@@ -21,6 +21,7 @@ function getMargin({
 
 const Text = styled.span<TextProps & TextStyledProps>`
   ${props => props.typo};
+  ${props => props.interpolation};
   margin: ${getMargin};
   font-style: ${props => (props.italic ? 'italic' : 'normal')};
   font-weight: ${props => (props.bold ? 'bold' : 'normal')};


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

Fixes #1016

## Summary
`Text` component should support CSS interpolation but currently not. So I had add code to handling this `interpolation` prop.

## Details
`interpolation` prop which is declared in `StylableComponentProps` is injectable but not working because there is no handling code currently in `Text.styled.ts` style file.

![201611494-7ba4dd32-d3b7-4311-b082-8fe6032d051f](https://user-images.githubusercontent.com/6138662/201616341-7f94c3b2-4be6-4e0c-ae02-9b789ef70b85.png)

So I had add some handling code to `Text.styled.ts` style file.

```typescript
const Text = styled.span<TextProps & TextStyledProps>`
  ${props => props.typo};
  ${props => props.interpolation};  /* → added */
  ...
`
```

I thought that it should be placed after `props.typo` because 'used-place' level injected style is worth than 'code-level' of component.

## Breaking change or not (Yes/No)
No

## References
N/A
