### PR TITLE
fix(ModalContent): invalid modal title size

### DIFF
--- a/.changeset/witty-starfishes-shake.md
+++ b/.changeset/witty-starfishes-shake.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+fix(ModalContent): invalid modal title size

--- a/packages/bezier-react/src/components/Modals/Modal/ModalContent.tsx
+++ b/packages/bezier-react/src/components/Modals/Modal/ModalContent.tsx
@@ -22,7 +22,7 @@ function ModalTitleText({ children, titleSize, ...rests }: ModalTitleTextProps) 
   const textTypo = useMemo(() => {
     switch (titleSize) {
       case ModalTitleSize.M: {
-        return Typography.Size15
+        return Typography.Size16
       }
       default: {
         return Typography.Size24


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

Fixes #1019

## Summary
Fix invalid value of `ModalTitleSize.M` from 15 to 16

## Details
`ModalTitleSize.M` should be `Typography.Size16`. Not ~`Typography.Size15`~

## Breaking change or not (Yes/No)
No

## References
N/A
