### PR TITLE
Change `BaseModal` animation to scale-based animation

### DIFF
--- a/.changeset/four-pugs-swim.md
+++ b/.changeset/four-pugs-swim.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Change `BaseModal` animation to scale-based animation

--- a/packages/bezier-react/src/components/Modals/BaseModal/BaseModal.styled.ts
+++ b/packages/bezier-react/src/components/Modals/BaseModal/BaseModal.styled.ts
@@ -19,11 +19,13 @@ const visibleAnimation = keyframes`
 
 const translateAnimation = keyframes`
   from {
-    transform: translate(0, -122px);
+    opacity: 0;
+    transform: scale(0.95);
   }
 
   to {
-    transform: translate(0, 0);
+    opacity: 1;
+    transform: scale(1);
   }
 `
 
@@ -43,6 +45,7 @@ export const BaseModalWrapper = styled.div<{ padded?: boolean }>`
 
   animation-name: ${() => visibleAnimation};
   animation-duration: ${TransitionDuration.M}ms;
+  animation-timing-function: cubic-bezier(0.3, 0, 0, 1);
 `
 
 export const BaseModalBackgroundOverlay = styled.div`
@@ -66,5 +69,7 @@ export const BaseModalChildrenScrollArea = styled.div`
 
   animation-name: ${() => translateAnimation};
   animation-duration: ${TransitionDuration.M}ms;
+  animation-timing-function: cubic-bezier(0.3, 0, 0, 1);
+
   ${({ foundation }) => foundation?.elevation.ev4()};
 `

--- a/packages/bezier-react/src/components/Modals/BaseModal/__snapshots__/BaseModal.test.tsx.snap
+++ b/packages/bezier-react/src/components/Modals/BaseModal/__snapshots__/BaseModal.test.tsx.snap
@@ -24,6 +24,8 @@ exports[`BaseModal When "show" is true should equal the snapshot 1`] = `
   animation-name: jgQpwH;
   -webkit-animation-duration: 300ms;
   animation-duration: 300ms;
+  -webkit-animation-timing-function: cubic-bezier(0.3,0,0,1);
+  animation-timing-function: cubic-bezier(0.3,0,0,1);
 }
 
 .c1 {
@@ -44,10 +46,12 @@ exports[`BaseModal When "show" is true should equal the snapshot 1`] = `
   color: #242428;
   background-color: #FFFFFF;
   border-radius: 20px;
-  -webkit-animation-name: gUeayS;
-  animation-name: gUeayS;
+  -webkit-animation-name: cYIBgc;
+  animation-name: cYIBgc;
   -webkit-animation-duration: 300ms;
   animation-duration: 300ms;
+  -webkit-animation-timing-function: cubic-bezier(0.3,0,0,1);
+  animation-timing-function: cubic-bezier(0.3,0,0,1);
   background-color: #FFFFFF;
   box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 20px #00000038;
 }

--- a/packages/bezier-react/src/components/Modals/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/bezier-react/src/components/Modals/Modal/__snapshots__/Modal.test.tsx.snap
@@ -24,6 +24,8 @@ exports[`Modal When "show" is true should equal the snapshot 1`] = `
   animation-name: jgQpwH;
   -webkit-animation-duration: 300ms;
   animation-duration: 300ms;
+  -webkit-animation-timing-function: cubic-bezier(0.3,0,0,1);
+  animation-timing-function: cubic-bezier(0.3,0,0,1);
 }
 
 .c1 {
@@ -44,10 +46,12 @@ exports[`Modal When "show" is true should equal the snapshot 1`] = `
   color: #242428;
   background-color: #FFFFFF;
   border-radius: 20px;
-  -webkit-animation-name: gUeayS;
-  animation-name: gUeayS;
+  -webkit-animation-name: cYIBgc;
+  animation-name: cYIBgc;
   -webkit-animation-duration: 300ms;
   animation-duration: 300ms;
+  -webkit-animation-timing-function: cubic-bezier(0.3,0,0,1);
+  animation-timing-function: cubic-bezier(0.3,0,0,1);
   background-color: #FFFFFF;
   box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 20px #00000038;
 }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- ~~[ ] [Component] I wrote **a unit test** about the implementation.~~
- ~~[ ] [Component] I wrote **a storybook document** about the implementation.~~
- ~~[ ] [Component] I tested the implementation in **various browsers**.~~
  - ~~Windows: Chrome, Edge, (Optional) Firefox~~
  - ~~macOS: Chrome, Edge, Safari, (Optional) Firefox~~
- ~~[ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.~~

## Related Issue

None.

## Summary
<!-- Please add a summary of the modification. -->

- 기존 모달(`BaseModal`)에 사용되는 appear 애니메이션을 애플리케이션의 사용성을 저해하지 않는 수준으로 개선합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

### As-is
- 기존 모달의 애니메이션 keyframe은 다음과 같습니다.
  ```ts
  const translateAnimation = keyframes`
    from {
      transform: translate(0, -122px);
    }

    to {
      transform: translate(0, 0);
    }
  `
  ```
- 위에서 내려오는 애니메이션이 다음과 같은 이유로 모달에 적합하지 않다고 생각하였습니다:
  - 컴포넌트 자체가 크게 이동하기 때문에 반복되는 모달 appear - disappear는 유저로 하여금 annoying하게 느껴질 수 있다고 생각했습니다.
  - 전체 화면 dimming과 함께 화면 중앙에 나타나는 컴포넌트이므로, 위에서 내려오는 식으로 컴포넌트를 크게 이동시킬 필요가 없습니다. 주변 dimming이 있으므로 충분히 해당 컴포넌트는 강조된다고 생각하고, 여기서 애니메이션은 컴포넌트가 중앙에 나타날 때 부드러운 인상을 주는 정도만 되어도 충분하다고 생각했습니다.
  - 이 코드에 한정된 이야기지만, `-122px`라는 수치 또한 모호한 면이 있습니다. 세로로 긴 화면에서는 화면 상단에 갑자기 모달이 나타나서 내려오는 모습이 되고, `-100%`와 같이 percentage 값으로 개선하여도 화면 크기에 따라 애니메이션이 너무 빠르거나 너무 느리게 느껴질 수 있습니다.

### To-be

- 컴포넌트의 y축 이동을 없애고, `opacity` 변화와 미세한 `scale` 조정 (95% → 100%)을 적용해 보았습니다.
  ```ts
  const translateAnimation = keyframes`
    from {
      opacity: 0;
      transform: scale(0.95);
    }

    to {
      opacity: 1;
      transform: scale(1);
    }
  `
  ```
- duration은 기존과 똑같이 300ms(`TransitionDuration.M`)이며, timing function 또한 Bezier에서 기존에 사용하던 `cubic-bezier(.3,0,0,1)`을 그대로 사용하였습니다.

https://user-images.githubusercontent.com/6940439/201808328-a1d37aea-39c7-49b6-a7e0-21d0c0967349.mp4

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No.

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- [Radix UI - Dialog](https://www.radix-ui.com/docs/primitives/components/dialog)
- [Headless UI - Dialog](https://headlessui.com/react/dialog)
