### PR TITLE
Change the default value of the `Stack`'s `align` prop from `start` to `stretch`

### DIFF
--- a/.changeset/violet-ravens-help.md
+++ b/.changeset/violet-ravens-help.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Change the default value of the `Stack`'s `align` prop from `start` to `stretch`

--- a/packages/bezier-react/src/components/Stack/Stack/Stack.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack/Stack.tsx
@@ -39,7 +39,7 @@ function Stack(
     children,
     direction,
     justify = 'start',
-    align = 'start',
+    align = 'stretch',
     spacing = 0,
     ...rest
   }: StackProps,

--- a/packages/bezier-react/src/components/Stack/Stack/Stack.types.ts
+++ b/packages/bezier-react/src/components/Stack/Stack/Stack.types.ts
@@ -32,7 +32,7 @@ interface StackOptions {
    * The `align` prop given to child `StackItem` component
    * overrides the default alignment.
    *
-   * @default start
+   * @default stretch
    */
   align?: AxisAlignment
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

Fixes #996

## Summary
<!-- Please add a summary of the modification. -->

`Stack` 의 `align` prop의 기본값을 `start` 에서 `stretch` 로 변경합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

#996 참고. [CSS Flexible Box Layout Module Level 1](https://drafts.csswg.org/css-flexbox-1/#align-items-property)의 스펙에 따르면, `align-items` 속성의 기본값은 `stretch` 입니다. 라이브러리를 사용하는 엔지니어들이 의도한대로 컴포넌트가 동작할 수 있도록, 기본값을 표준에 맞게 변경했습니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

Yes

> 애플리케이션에서 대부분은 `stretch` 로 설정되어있으나, **기본값을 사용하고 있는 사용처가 몇 있어 마이그레이션이 필요합니다.**

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- [CSS Flexible Box Layout Module Level 1](https://drafts.csswg.org/css-flexbox-1/#align-items-property)
