### PR TITLE
Change return value of `getRootElement()` from element with specific id to `document.body` element

### DIFF
--- a/.changeset/lemon-steaks-decide.md
+++ b/.changeset/lemon-steaks-decide.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Change return value of `getRootElement()` from element with specific id to `document.body` element

--- a/packages/bezier-react/src/components/Modals/BaseModal/BaseModal.test.tsx
+++ b/packages/bezier-react/src/components/Modals/BaseModal/BaseModal.test.tsx
@@ -15,9 +15,6 @@ const DEFAULT_PROPS: BaseModalProps = {
   onHide: jest.fn(),
 }
 
-const main = document.createElement('div')
-main.setAttribute('id', 'main')
-
 describe('BaseModal', () => {
   let renderResult: RenderResult
 
@@ -26,7 +23,7 @@ describe('BaseModal', () => {
       renderResult = render(
         <BaseModal {...DEFAULT_PROPS} show={false} />,
         {
-          container: document.body.appendChild(main),
+          container: document.body,
         },
       )
     })
@@ -44,7 +41,7 @@ describe('BaseModal', () => {
       renderResult = render(
         <BaseModal {...DEFAULT_PROPS} />,
         {
-          container: document.body.appendChild(main),
+          container: document.body,
         },
       )
     })
@@ -87,7 +84,7 @@ describe('BaseModal', () => {
           autoFocus
         />,
         {
-          container: document.body.appendChild(main),
+          container: document.body,
         },
       )
     })
@@ -105,7 +102,7 @@ describe('BaseModal', () => {
       renderResult = render(
         <BaseModal {...DEFAULT_PROPS} />,
         {
-          container: document.body.appendChild(main),
+          container: document.body,
         },
       )
     })

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.test.tsx
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.test.tsx
@@ -51,9 +51,6 @@ const ModalTestRender = ({
   </Modal>
 )
 
-const main = document.createElement('div')
-main.setAttribute('id', 'main')
-
 describe('Modal', () => {
   let renderResult: RenderResult
 
@@ -65,7 +62,7 @@ describe('Modal', () => {
           show={false}
         />,
         {
-          container: document.body.appendChild(main),
+          container: document.body,
         },
       )
     })
@@ -86,7 +83,7 @@ describe('Modal', () => {
           className="Modal__Contests__Test"
         />,
         {
-          container: document.body.appendChild(main),
+          container: document.body,
         },
       )
     })
@@ -110,7 +107,7 @@ describe('Modal', () => {
             rightContent="Right content"
           />,
           {
-            container: document.body.appendChild(main),
+            container: document.body,
           },
         )
       })
@@ -136,7 +133,7 @@ describe('Modal', () => {
                 showCloseIcon
               />,
               {
-                container: document.body.appendChild(main),
+                container: document.body,
               },
             )
           })
@@ -158,7 +155,7 @@ describe('Modal', () => {
               rightContent="Right content"
             />,
             {
-              container: document.body.appendChild(main),
+              container: document.body,
             },
           )
         })
@@ -214,7 +211,7 @@ describe('Modal', () => {
                   showCloseIcon
                 />,
                 {
-                  container: document.body.appendChild(main),
+                  container: document.body,
                 },
               )
             })
@@ -254,7 +251,7 @@ describe('Modal', () => {
               showCloseIcon
             />,
             {
-              container: document.body.appendChild(main),
+              container: document.body,
             },
           )
         })
@@ -276,7 +273,7 @@ describe('Modal', () => {
             rightContent="Right content"
           />,
           {
-            container: document.body.appendChild(main),
+            container: document.body,
 
           },
         )

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.test.tsx
@@ -9,14 +9,10 @@ import { render } from 'Utils/testUtils'
 import Tooltip, { TOOLTIP_TEST_ID, TOOLTIP_CONTENT_TEST_ID } from './Tooltip'
 import TooltipProps from './Tooltip.types'
 
-const ROOT_TESTID = 'container'
-
 const RootTooltip: React.FC<TooltipProps> = ({ children, ...rests }) => (
-  <div id="main" data-testid={ROOT_TESTID}>
-    <Tooltip {...rests}>
-      { children }
-    </Tooltip>
-  </div>
+  <Tooltip {...rests}>
+    { children }
+  </Tooltip>
 )
 
 describe('Tooltip test >', () => {
@@ -42,8 +38,7 @@ describe('Tooltip test >', () => {
   )
 
   it('Tooltip with default props', () => {
-    const { getByTestId } = renderTooltip()
-    const rendered = getByTestId(ROOT_TESTID)
+    const { baseElement, getByTestId } = renderTooltip()
 
     act(() => {
       fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
@@ -51,14 +46,13 @@ describe('Tooltip test >', () => {
       jest.runAllTimers()
     })
 
-    expect(rendered).toMatchSnapshot()
+    expect(baseElement).toMatchSnapshot()
   })
 
   it('Tooltip with contentInterpolation prop', async () => {
-    const { getByTestId } = renderTooltip({
+    const { baseElement, getByTestId } = renderTooltip({
       contentInterpolation: css`background-color: black;`,
     })
-    const rendered = getByTestId(ROOT_TESTID)
 
     act(() => {
       fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
@@ -66,7 +60,7 @@ describe('Tooltip test >', () => {
       jest.runAllTimers()
     })
 
-    expect(rendered).toMatchSnapshot()
+    expect(baseElement).toMatchSnapshot()
   })
 
   it('TooltipContent not rendered at first', async () => {

--- a/packages/bezier-react/src/components/Tooltip/TooltipContent.test.tsx
+++ b/packages/bezier-react/src/components/Tooltip/TooltipContent.test.tsx
@@ -5,17 +5,13 @@ import { fireEvent } from '@testing-library/dom'
 
 /* Internal dependencies */
 import { render } from 'Utils/testUtils'
-import Tooltip, { TOOLTIP_TEST_ID } from './Tooltip'
+import Tooltip, { TOOLTIP_TEST_ID, TOOLTIP_CONTENT_TEST_ID } from './Tooltip'
 import TooltipProps from './Tooltip.types'
 
-const ROOT_TESTID = 'container'
-
 const RootTooltip: React.FC<TooltipProps> = ({ children, ...rests }) => (
-  <div id="main" data-testid={ROOT_TESTID}>
-    <Tooltip {...rests}>
-      { children }
-    </Tooltip>
-  </div>
+  <Tooltip {...rests}>
+    { children }
+  </Tooltip>
 )
 
 describe('TooltipContent test >', () => {
@@ -51,7 +47,6 @@ describe('TooltipContent test >', () => {
 
   it('TooltipContent with plain text content >', () => {
     const { getByTestId, queryByText } = renderTooltip({ content: PLAIN_TEXT_CONTENT })
-    const rendered = getByTestId(ROOT_TESTID)
 
     act(() => {
       fireEvent.mouseOver(getByTestId(TOOLTIP_TEST_ID))
@@ -59,7 +54,7 @@ describe('TooltipContent test >', () => {
       jest.runAllTimers()
     })
 
-    expect(rendered).toContainElement(queryByText(PLAIN_TEXT_CONTENT))
+    expect(getByTestId(TOOLTIP_CONTENT_TEST_ID)).toContainElement(queryByText(PLAIN_TEXT_CONTENT))
   })
 
   it('TooltipContent with array of text contents >', () => {

--- a/packages/bezier-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/bezier-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -59,15 +59,14 @@ exports[`Tooltip test > Tooltip with contentInterpolation prop 1`] = `
   -webkit-line-clamp: 20;
 }
 
-<div
-  data-testid="container"
-  id="main"
->
-  <div
-    class="c0"
-    data-testid="bezier-react-tooltip"
-  >
-    Text
+<body>
+  <div>
+    <div
+      class="c0"
+      data-testid="bezier-react-tooltip"
+    >
+      Text
+    </div>
   </div>
   <div
     class="c1"
@@ -89,7 +88,7 @@ exports[`Tooltip test > Tooltip with contentInterpolation prop 1`] = `
       </div>
     </div>
   </div>
-</div>
+</body>
 `;
 
 exports[`Tooltip test > Tooltip with default props 1`] = `
@@ -150,15 +149,14 @@ exports[`Tooltip test > Tooltip with default props 1`] = `
   -webkit-line-clamp: 20;
 }
 
-<div
-  data-testid="container"
-  id="main"
->
-  <div
-    class="c0"
-    data-testid="bezier-react-tooltip"
-  >
-    Text
+<body>
+  <div>
+    <div
+      class="c0"
+      data-testid="bezier-react-tooltip"
+    >
+      Text
+    </div>
   </div>
   <div
     class="c1"
@@ -180,5 +178,5 @@ exports[`Tooltip test > Tooltip with default props 1`] = `
       </div>
     </div>
   </div>
-</div>
+</body>
 `;

--- a/packages/bezier-react/src/utils/domUtils.test.ts
+++ b/packages/bezier-react/src/utils/domUtils.test.ts
@@ -5,61 +5,24 @@ import {
   getRootElement,
 } from './domUtils'
 
-describe('domUtils Test >', () => {
-  describe('document Test >', () => {
-    it('document has base methods', () => {
+describe('domUtils', () => {
+  describe('document', () => {
+    it('should have base methods', () => {
       expect(document).toHaveProperty('getElementById')
       expect(document).toHaveProperty('addEventListener')
       expect(document).toHaveProperty('removeEventListener')
     })
   })
 
-  describe('window Test >', () => {
-    it("window has 'requestAnimationFrame' method", () => {
+  describe('window', () => {
+    it("should have 'requestAnimationFrame' method", () => {
       expect(window).toHaveProperty('requestAnimationFrame')
     })
   })
 
-  describe('getRootElement Test >', () => {
-    beforeEach(() => {
-      const { body } = document
-      body.innerHTML = ''
-    })
-
-    it("Get dom with 'main' id", () => {
-      const target = document.createElement('span')
-      target.setAttribute('id', 'main')
-      const { body } = document
-      body.appendChild(target)
-
-      const rootElement = getRootElement()
-
-      expect(rootElement).toBeInstanceOf(HTMLSpanElement)
-      expect(rootElement).toHaveAttribute('id', 'main')
-    })
-
-    it("Get dom with 'root' id", () => {
-      const target = document.createElement('p')
-      target.setAttribute('id', 'root')
-      const { body } = document
-      body.appendChild(target)
-
-      const rootElement = getRootElement()
-
-      expect(rootElement).toBeInstanceOf(HTMLParagraphElement)
-      expect(rootElement).toHaveAttribute('id', 'root')
-    })
-
-    it("Get dom with '__next' id, for Next.js", () => {
-      const target = document.createElement('div')
-      target.setAttribute('id', '__next')
-      const { body } = document
-      body.appendChild(target)
-
-      const rootElement = getRootElement()
-
-      expect(rootElement).toBeInstanceOf(HTMLDivElement)
-      expect(rootElement).toHaveAttribute('id', '__next')
+  describe('getRootElement()', () => {
+    it('should return document.body element', () => {
+      expect(getRootElement()).toEqual(document.body)
     })
   })
 })

--- a/packages/bezier-react/src/utils/domUtils.ts
+++ b/packages/bezier-react/src/utils/domUtils.ts
@@ -8,9 +8,6 @@ export const document = getDocument()
 
 export const window = getWindow()
 
-export const getRootElement = () =>
-  document.getElementById!('main') ||
-  document.getElementById!('root') ||
-  document.getElementById!('__next') as HTMLElement
+export const getRootElement = () => document.body
 
 export const ariaAttr = (condition?: boolean) => (condition ? true : undefined)


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [ ] I wrote a PR title in **English**.
- [ ] I added an appropriate **label** to the PR.
- [ ] I wrote a commit message in **English**.
- [ ] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

Fixes #1042, Fixed #773

## Summary
<!-- Please add a summary of the modification. -->

`getRootElement()` 함수의 반환값을 특정 id를 가진 엘리먼트(e.g. main)에서 `document.body` 엘리먼트로 변경합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

#1042 를 참고해주세요.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

Yes

## References
<!-- External documents based on workarounds or reviewers should refer to -->

없음
