### PR TITLE
Revert the removed `size` property of the `TextField`'s internal `input` element

### DIFF
--- a/.changeset/tender-books-crash.md
+++ b/.changeset/tender-books-crash.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Revert the removed `size` property of the `TextField`'s internal `input` element.

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -253,6 +253,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
               autocomplete="off"
               class="c8 c9"
               id="field-:r3:"
+              size="36"
               value=""
             />
           </div>
@@ -291,6 +292,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
               autocomplete="off"
               class="c8 c9"
               id="field-:r4:"
+              size="36"
               value=""
             />
           </div>
@@ -617,6 +619,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
               autocomplete="off"
               class="c11 c12"
               id="field-:r6:"
+              size="36"
               value=""
             />
           </div>
@@ -655,6 +658,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
               autocomplete="off"
               class="c11 c12"
               id="field-:r7:"
+              size="36"
               value=""
             />
           </div>
@@ -825,6 +829,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
       autocomplete="off"
       class="c5 c6"
       id="form"
+      size="36"
       value=""
     />
   </div>
@@ -1020,6 +1025,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
       autocomplete="off"
       class="c6 c7"
       id="form"
+      size="36"
       value=""
     />
   </div>

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
@@ -362,6 +362,7 @@ forwardedRef: Ref<TextFieldRef>,
         ref={inputRef}
         value={normalizedValue}
         name={name}
+        size={size}
         autoComplete={autoComplete}
         readOnly={readOnly}
         disabled={disabled}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->

#1028 에서 함께 삭제한 `input` 의 `size` 속성을 되돌립니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

#1028 에서 TextField 컴포넌트의 사이즈별 폰트 사이즈를 업데이트하며, 내부 input 엘리먼트의 불필요한(하다고 생각한) size 속성을 제거했습니다. `TextFieldSize` enum은 input 엘리먼트를 감싸는 Wrapper(div) 스타일 컴포넌트에게 주입하여 텍스트 필드의 높이를 결정하는 데 사용하는 값이었기때문에, 잘못 설정된 속성이라고 생각해서 내린 결정이었습니다.

문제는 input 엘리먼트의 [size 속성](https://developer.mozilla.org/ko/docs/Web/HTML/Element/Input#attr-size)이 유효한 속성이라는 점입니다. 예를 들어 `TextFieldSize.M` 의 값은 36인데, 이 값을 size 에 주었을 경우 input 엘리먼트는 36개의 글자가 보일 수 있는 만큼의 너비로 설정됩니다. 이 너비는 폰트마다 달라서, Condensed 폰트의 경우와 일반적인 너비를 가진 폰트일 경우의 너비가 다르게 설정됩니다. 

이번에 데스크에 bezier-react 마이그레이션을 하면서 어플리케이션 전반적으로 일부 UI에서 input 엘리먼트의 size 속성을 통해 암묵적으로 정해진 너비(M 기준 302px)를 사용하고 있었다는 걸 알게 되었습니다. 이런 케이스가 꽤나 많아서(***Modal, ***Select, 기타 Flex layout), 당장 마이그레이션하기엔 리소스 부족으로 어렵다고 판단했습니다. 이후 Modal, Select 등 컴포넌트를 새로 구현하며 다시 살펴볼 예정입니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

없음
