### PR TITLE
Enhance the `Status` component

### DIFF
--- a/.changeset/tame-trainers-chew.md
+++ b/.changeset/tame-trainers-chew.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Change the `Status` component to use CSS Variable internally

--- a/packages/bezier-react/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/bezier-react/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -112,15 +112,12 @@ exports[`Avatar > renders border style 1`] = `
 
 exports[`Avatar > should have right -2px, bottom -2px style on StatusWrapper 1`] = `
 .c1 {
-  box-sizing: border-box;
-  border-color: #FFFFFF;
-  border-style: solid solid solid solid;
-  border-width: 2px;
   position: relative;
   box-sizing: content-box;
-  width: 8px;
-  height: 8px;
-  background-color: #FFFFFF;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
+  background-color: var(--bg-white-high);
+  border: var(--bezier-status-border-width) solid var(--bg-white-high);
   border-radius: 50%;
 }
 
@@ -129,10 +126,10 @@ exports[`Avatar > should have right -2px, bottom -2px style on StatusWrapper 1`]
   top: 0;
   left: 0;
   display: block;
-  width: 8px;
-  height: 8px;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
   content: '';
-  background-color: #31A552;
+  background-color: var(--bezier-status-bg-color);
   border-radius: 50%;
 }
 
@@ -153,24 +150,20 @@ exports[`Avatar > should have right -2px, bottom -2px style on StatusWrapper 1`]
 >
   <div
     class="c1"
-    color="bgtxt-green-normal"
     data-testid="bezier-react-status"
-    size="8"
+    style="--bezier-status-size: 8px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 2px;"
   />
 </div>
 `;
 
 exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when show border 1`] = `
 .c1 {
-  box-sizing: border-box;
-  border-color: #FFFFFF;
-  border-style: solid solid solid solid;
-  border-width: 2px;
   position: relative;
   box-sizing: content-box;
-  width: 8px;
-  height: 8px;
-  background-color: #FFFFFF;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
+  background-color: var(--bg-white-high);
+  border: var(--bezier-status-border-width) solid var(--bg-white-high);
   border-radius: 50%;
 }
 
@@ -179,10 +172,10 @@ exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when 
   top: 0;
   left: 0;
   display: block;
-  width: 8px;
-  height: 8px;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
   content: '';
-  background-color: #31A552;
+  background-color: var(--bezier-status-bg-color);
   border-radius: 50%;
 }
 
@@ -203,24 +196,20 @@ exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when 
 >
   <div
     class="c1"
-    color="bgtxt-green-normal"
     data-testid="bezier-react-status"
-    size="8"
+    style="--bezier-status-size: 8px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 2px;"
   />
 </div>
 `;
 
 exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when size grater then 72 1`] = `
 .c1 {
-  box-sizing: border-box;
-  border-color: #FFFFFF;
-  border-style: solid solid solid solid;
-  border-width: 2px;
   position: relative;
   box-sizing: content-box;
-  width: 8px;
-  height: 8px;
-  background-color: #FFFFFF;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
+  background-color: var(--bg-white-high);
+  border: var(--bezier-status-border-width) solid var(--bg-white-high);
   border-radius: 50%;
 }
 
@@ -229,10 +218,10 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
   top: 0;
   left: 0;
   display: block;
-  width: 8px;
-  height: 8px;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
   content: '';
-  background-color: #31A552;
+  background-color: var(--bezier-status-bg-color);
   border-radius: 50%;
 }
 
@@ -253,24 +242,20 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
 >
   <div
     class="c1"
-    color="bgtxt-green-normal"
     data-testid="bezier-react-status"
-    size="8"
+    style="--bezier-status-size: 8px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 2px;"
   />
 </div>
 `;
 
 exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when size grater then 90 1`] = `
 .c1 {
-  box-sizing: border-box;
-  border-color: #FFFFFF;
-  border-style: solid solid solid solid;
-  border-width: 3px;
   position: relative;
   box-sizing: content-box;
-  width: 14px;
-  height: 14px;
-  background-color: #FFFFFF;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
+  background-color: var(--bg-white-high);
+  border: var(--bezier-status-border-width) solid var(--bg-white-high);
   border-radius: 50%;
 }
 
@@ -279,10 +264,10 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
   top: 0;
   left: 0;
   display: block;
-  width: 14px;
-  height: 14px;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
   content: '';
-  background-color: #31A552;
+  background-color: var(--bezier-status-bg-color);
   border-radius: 50%;
 }
 
@@ -303,24 +288,20 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
 >
   <div
     class="c1"
-    color="bgtxt-green-normal"
     data-testid="bezier-react-status"
-    size="14"
+    style="--bezier-status-size: 14px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 3px;"
   />
 </div>
 `;
 
 exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when size grater then 72 and show border 1`] = `
 .c1 {
-  box-sizing: border-box;
-  border-color: #FFFFFF;
-  border-style: solid solid solid solid;
-  border-width: 2px;
   position: relative;
   box-sizing: content-box;
-  width: 8px;
-  height: 8px;
-  background-color: #FFFFFF;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
+  background-color: var(--bg-white-high);
+  border: var(--bezier-status-border-width) solid var(--bg-white-high);
   border-radius: 50%;
 }
 
@@ -329,10 +310,10 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
   top: 0;
   left: 0;
   display: block;
-  width: 8px;
-  height: 8px;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
   content: '';
-  background-color: #31A552;
+  background-color: var(--bezier-status-bg-color);
   border-radius: 50%;
 }
 
@@ -353,24 +334,20 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
 >
   <div
     class="c1"
-    color="bgtxt-green-normal"
     data-testid="bezier-react-status"
-    size="8"
+    style="--bezier-status-size: 8px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 2px;"
   />
 </div>
 `;
 
 exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when size grater then 90 and show border 1`] = `
 .c1 {
-  box-sizing: border-box;
-  border-color: #FFFFFF;
-  border-style: solid solid solid solid;
-  border-width: 3px;
   position: relative;
   box-sizing: content-box;
-  width: 14px;
-  height: 14px;
-  background-color: #FFFFFF;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
+  background-color: var(--bg-white-high);
+  border: var(--bezier-status-border-width) solid var(--bg-white-high);
   border-radius: 50%;
 }
 
@@ -379,10 +356,10 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
   top: 0;
   left: 0;
   display: block;
-  width: 14px;
-  height: 14px;
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
   content: '';
-  background-color: #31A552;
+  background-color: var(--bezier-status-bg-color);
   border-radius: 50%;
 }
 
@@ -403,9 +380,8 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
 >
   <div
     class="c1"
-    color="bgtxt-green-normal"
     data-testid="bezier-react-status"
-    size="14"
+    style="--bezier-status-size: 14px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 3px;"
   />
 </div>
 `;

--- a/packages/bezier-react/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/bezier-react/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -113,6 +113,7 @@ exports[`Avatar > renders border style 1`] = `
 exports[`Avatar > should have right -2px, bottom -2px style on StatusWrapper 1`] = `
 .c1 {
   position: relative;
+  z-index: 0;
   box-sizing: content-box;
   width: var(--bezier-status-size);
   height: var(--bezier-status-size);
@@ -150,7 +151,6 @@ exports[`Avatar > should have right -2px, bottom -2px style on StatusWrapper 1`]
 >
   <div
     class="c1"
-    data-testid="bezier-react-status"
     style="--bezier-status-size: 8px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 2px;"
   />
 </div>
@@ -159,6 +159,7 @@ exports[`Avatar > should have right -2px, bottom -2px style on StatusWrapper 1`]
 exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when show border 1`] = `
 .c1 {
   position: relative;
+  z-index: 0;
   box-sizing: content-box;
   width: var(--bezier-status-size);
   height: var(--bezier-status-size);
@@ -196,7 +197,6 @@ exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when 
 >
   <div
     class="c1"
-    data-testid="bezier-react-status"
     style="--bezier-status-size: 8px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 2px;"
   />
 </div>
@@ -205,6 +205,7 @@ exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when 
 exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when size grater then 72 1`] = `
 .c1 {
   position: relative;
+  z-index: 0;
   box-sizing: content-box;
   width: var(--bezier-status-size);
   height: var(--bezier-status-size);
@@ -242,7 +243,6 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
 >
   <div
     class="c1"
-    data-testid="bezier-react-status"
     style="--bezier-status-size: 8px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 2px;"
   />
 </div>
@@ -251,6 +251,7 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
 exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when size grater then 90 1`] = `
 .c1 {
   position: relative;
+  z-index: 0;
   box-sizing: content-box;
   width: var(--bezier-status-size);
   height: var(--bezier-status-size);
@@ -288,7 +289,6 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
 >
   <div
     class="c1"
-    data-testid="bezier-react-status"
     style="--bezier-status-size: 14px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 3px;"
   />
 </div>
@@ -297,6 +297,7 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
 exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when size grater then 72 and show border 1`] = `
 .c1 {
   position: relative;
+  z-index: 0;
   box-sizing: content-box;
   width: var(--bezier-status-size);
   height: var(--bezier-status-size);
@@ -334,7 +335,6 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
 >
   <div
     class="c1"
-    data-testid="bezier-react-status"
     style="--bezier-status-size: 8px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 2px;"
   />
 </div>
@@ -343,6 +343,7 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
 exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when size grater then 90 and show border 1`] = `
 .c1 {
   position: relative;
+  z-index: 0;
   box-sizing: content-box;
   width: var(--bezier-status-size);
   height: var(--bezier-status-size);
@@ -380,7 +381,6 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
 >
   <div
     class="c1"
-    data-testid="bezier-react-status"
     style="--bezier-status-size: 14px; --bezier-status-bg-color: var(--bgtxt-green-normal); --bezier-status-border-width: 3px;"
   />
 </div>

--- a/packages/bezier-react/src/components/Status/Status.stories.tsx
+++ b/packages/bezier-react/src/components/Status/Status.stories.tsx
@@ -7,7 +7,7 @@ import { Story, Meta } from '@storybook/react'
 import { styled } from 'Foundation'
 import { getTitle } from 'Utils/storyUtils'
 import { StatusProps, StatusSize, StatusType } from './Status.types'
-import Status from './Status'
+import { Status } from './Status'
 
 export default {
   title: getTitle(base),

--- a/packages/bezier-react/src/components/Status/Status.styled.ts
+++ b/packages/bezier-react/src/components/Status/Status.styled.ts
@@ -4,6 +4,7 @@ import { Icon as BaseIcon } from 'Components/Icon'
 
 export const Circle = styled.div`
   position: relative;
+  z-index: 0;
   box-sizing: content-box;
   width: var(--bezier-status-size);
   height: var(--bezier-status-size);

--- a/packages/bezier-react/src/components/Status/Status.styled.ts
+++ b/packages/bezier-react/src/components/Status/Status.styled.ts
@@ -1,29 +1,14 @@
 /* Internal dependencies */
-import { styled, absoluteCenter, SemanticNames } from 'Foundation'
+import { styled, absoluteCenter } from 'Foundation'
 import { Icon as BaseIcon } from 'Components/Icon'
-import { StatusSize } from './Status.types'
 
-function getStatusCircleBorderSize(size: StatusSize) {
-  if (size >= StatusSize.L) { return 3 }
-  return 2
-}
-
-interface StatusCircleProps {
-  color: SemanticNames
-  size: StatusSize
-}
-
-export const StatusCircle = styled.div<StatusCircleProps>`
-  ${({ foundation, size }) => foundation?.border?.getBorder(
-    getStatusCircleBorderSize(size),
-    foundation?.theme?.['bg-white-high'],
-  )};
-
+export const Circle = styled.div`
   position: relative;
   box-sizing: content-box;
-  width: ${({ size }) => size}px;
-  height: ${({ size }) => size}px;
-  background-color: ${({ foundation }) => foundation?.theme?.['bg-white-high']};
+  width: var(--bezier-status-size);
+  height: var(--bezier-status-size);
+  background-color: var(--bg-white-high);
+  border: var(--bezier-status-border-width) solid var(--bg-white-high);
   border-radius: 50%;
 
   &::after {
@@ -31,10 +16,10 @@ export const StatusCircle = styled.div<StatusCircleProps>`
     top: 0;
     left: 0;
     display: block;
-    width: ${({ size }) => size}px;
-    height: ${({ size }) => size}px;
+    width: var(--bezier-status-size);
+    height: var(--bezier-status-size);
     content: '';
-    background-color: ${({ foundation, color = 'bg-white-high' }) => foundation?.theme?.[color]};
+    background-color: var(--bezier-status-bg-color);
     border-radius: 50%;
   }
 `

--- a/packages/bezier-react/src/components/Status/Status.tsx
+++ b/packages/bezier-react/src/components/Status/Status.tsx
@@ -7,9 +7,6 @@ import { IconSize, LockIcon, MoonFilledIcon } from 'Components/Icon'
 import { StatusProps, StatusSize, StatusType } from './Status.types'
 import * as Styled from './Status.styled'
 
-// TODO: 테스트 코드 작성
-const STATUS_TEST_ID = 'bezier-react-status'
-
 const statusTypesWithIcon: Readonly<StatusType[]> = [
   StatusType.OnlineCrescent,
   StatusType.OfflineCrescent,
@@ -40,7 +37,6 @@ export const Status = memo(forwardRef(function Status({
 
   return (
     <Styled.Circle
-      data-testid={STATUS_TEST_ID}
       ref={forwardedRef}
       style={{
         ...style,

--- a/packages/bezier-react/src/components/Status/Status.tsx
+++ b/packages/bezier-react/src/components/Status/Status.tsx
@@ -1,16 +1,16 @@
 /* External dependencies */
-import React, { memo } from 'react'
+import React, { memo, forwardRef } from 'react'
 
 /* Internal dependencies */
 import type { SemanticNames } from 'Foundation'
 import { IconSize, LockIcon, MoonFilledIcon } from 'Components/Icon'
 import { StatusProps, StatusSize, StatusType } from './Status.types'
-import { Icon, StatusCircle } from './Status.styled'
+import * as Styled from './Status.styled'
 
 // TODO: 테스트 코드 작성
 const STATUS_TEST_ID = 'bezier-react-status'
 
-const statusWithIcon: Readonly<StatusType[]> = [
+const statusTypesWithIcon: Readonly<StatusType[]> = [
   StatusType.OnlineCrescent,
   StatusType.OfflineCrescent,
   StatusType.Lock,
@@ -24,43 +24,39 @@ const statusColor: Readonly<Record<StatusType, SemanticNames>> = {
   [StatusType.Lock]: 'txt-black-darker',
 }
 
-function Status({
-  type,
-  size = StatusSize.M,
-}: StatusProps) {
-  if (statusWithIcon.includes(type)) {
-    const iconSize = (size <= StatusSize.M) ? IconSize.XXXS : IconSize.XS
-
-    return (
-      <StatusCircle
-        data-testid={STATUS_TEST_ID}
-        color="bg-white-high"
-        size={size}
-      >
-        { (type === StatusType.Lock) ? (
-          <Icon
-            source={LockIcon}
-            size={iconSize}
-            color={statusColor[type]}
-          />
-        ) : (
-          <Icon
-            source={MoonFilledIcon}
-            size={iconSize}
-            color={statusColor[type]}
-          />
-        ) }
-      </StatusCircle>
-    )
-  }
-
-  return (
-    <StatusCircle
-      data-testid={STATUS_TEST_ID}
-      color={statusColor[type] ?? 'bg-black-dark'}
-      size={size}
-    />
-  )
+function getStatusCircleBorderWidth(size: StatusSize) {
+  if (size >= StatusSize.L) { return 3 }
+  return 2
 }
 
-export default memo(Status)
+export const Status = memo(forwardRef(function Status({
+  type,
+  size = StatusSize.M,
+  style,
+  ...rest
+}: StatusProps, forwardedRef: React.Ref<HTMLDivElement>) {
+  const withIcon = statusTypesWithIcon.includes(type)
+  const backgroundColor = withIcon ? 'bg-white-high' : statusColor[type]
+
+  return (
+    <Styled.Circle
+      data-testid={STATUS_TEST_ID}
+      ref={forwardedRef}
+      style={{
+        ...style,
+        '--bezier-status-size': `${size}px`,
+        '--bezier-status-bg-color': `var(--${backgroundColor})`,
+        '--bezier-status-border-width': `${getStatusCircleBorderWidth(size)}px`,
+      }}
+      {...rest}
+    >
+      { withIcon && (
+        <Styled.Icon
+          source={type === StatusType.Lock ? LockIcon : MoonFilledIcon}
+          size={size <= StatusSize.M ? IconSize.XXXS : IconSize.XS}
+          color={statusColor[type]}
+        />
+      ) }
+    </Styled.Circle>
+  )
+}))

--- a/packages/bezier-react/src/components/Status/Status.types.ts
+++ b/packages/bezier-react/src/components/Status/Status.types.ts
@@ -1,3 +1,6 @@
+/* Internal dependencies */
+import type { BezierComponentProps, SizeProps } from 'Types/ComponentProps'
+
 export enum StatusType {
   Online = 'Online',
   Offline = 'Offline',
@@ -11,7 +14,12 @@ export enum StatusSize {
   L = 14,
 }
 
-export interface StatusProps {
+interface StatusOptions {
   type: StatusType
-  size?: StatusSize
 }
+
+export interface StatusProps extends
+  BezierComponentProps,
+  SizeProps<StatusSize>,
+  React.HTMLAttributes<HTMLDivElement>,
+  StatusOptions {}

--- a/packages/bezier-react/src/components/Status/index.ts
+++ b/packages/bezier-react/src/components/Status/index.ts
@@ -1,13 +1,2 @@
-import Status from './Status'
-import { StatusType, StatusSize } from './Status.types'
-import type { StatusProps } from './Status.types'
-
-export type {
-  StatusProps,
-}
-
-export {
-  Status,
-  StatusType,
-  StatusSize,
-}
+export * from './Status'
+export { StatusType, StatusSize, type StatusProps } from './Status.types'


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->

`Status` 컴포넌트에 대한 마이너 개선사항들이 포함됩니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- 래퍼 컴포넌트에 쌓임 맥락을 생성하여 내부의 z-index를 외부로 노출시키지 않도록 합니다.
- 내부 로직을 간결하게 리팩토링했습니다. 인터페이스 선언을 다른 베지어 컴포넌트들과 통일했습니다.
- 내부적으로 CSS Variable을 사용하여 불필요한 컴포넌트 컴포넌트 재생성을 막습니다.
- 불필요한 주석을 제거했습니다. Status 컴포넌트는 스토리북을 통해 테스트해야하지, 별도의 유닛 테스트 작성은 큰 의미가 없다고 판단했습니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

없음
