### PR TITLE
Enhance the `Slider` Component

### DIFF
--- a/.changeset/beige-rice-shout.md
+++ b/.changeset/beige-rice-shout.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Enhance the Slider component

--- a/packages/bezier-react/jest.setup.ts
+++ b/packages/bezier-react/jest.setup.ts
@@ -20,6 +20,13 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 }
 
+/**
+ * Radix-ui uses the APIs below, but the DOM in jest (JSDOM) hasn't implemented them.
+ * @see https://github.com/radix-ui/primitives/issues/1822
+ */
+window.HTMLElement.prototype.hasPointerCapture = jest.fn()
+window.HTMLElement.prototype.setPointerCapture = jest.fn()
+
 beforeEach(() => {
   // @ts-ignore
   jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb())

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.stories.tsx
@@ -53,8 +53,9 @@ const Template: Story<SliderProps> = (args) => <Slider {...args} />
 
 export const Primary = Template.bind({})
 Primary.args = {
-  width: '36',
+  width: '285',
   defaultValue: [5],
+  value: [2],
   min: 0,
   max: 10,
   step: 1,
@@ -64,6 +65,7 @@ export const Uncontrolled = Template.bind({})
 Uncontrolled.args = {
   width: '285',
   defaultValue: [5],
+  value: [2],
   min: 0,
   max: 10,
   step: 1,
@@ -73,6 +75,7 @@ export const Disabled = Template.bind({})
 Disabled.args = {
   width: '285',
   defaultValue: [5],
+  value: [2],
   min: 0,
   max: 10,
   step: 1,
@@ -83,6 +86,7 @@ export const WithGuide = Template.bind({})
 WithGuide.args = {
   width: '285',
   defaultValue: [5],
+  value: [2],
   guide: [0, 1, 2, 3, 4, 5, 10],
   min: 0,
   max: 10,
@@ -93,6 +97,7 @@ export const MultipleThumbs = Template.bind({})
 MultipleThumbs.args = {
   width: '285',
   defaultValue: [3, 7],
+  value: [2, 4],
   min: 0,
   max: 10,
   step: 1,

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
@@ -160,9 +160,8 @@ describe('Slider', () => {
   })
 
   describe('onValueChange', () => {
-    const onValueChange = jest.fn()
-
     it('should be executed when the `value` prop changes', () => {
+      const onValueChange = jest.fn()
       let value = [3]
       const { rerender } = renderSlider({ value, onValueChange })
       expect(onValueChange).toHaveBeenCalledTimes(1)
@@ -172,12 +171,19 @@ describe('Slider', () => {
       rerender(<Slider {...{ value, onValueChange }} />)
 
       expect(onValueChange).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not be executed when the `value` prop has the same reference', () => {
+      const onValueChange = jest.fn()
+      const value = [3]
+      const { rerender } = renderSlider({ value, onValueChange })
+      expect(onValueChange).toHaveBeenCalledTimes(1)
 
       // change value with the same reference
       value.splice(0, 1, 3)
       rerender(<Slider {...{ value, onValueChange }} />)
 
-      expect(onValueChange).toHaveBeenCalledTimes(2)
+      expect(onValueChange).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
@@ -158,4 +158,26 @@ describe('Slider', () => {
       })
     })
   })
+
+  describe('onValueChange', () => {
+    const onValueChange = jest.fn()
+
+    it('should be executed when the `value` prop changes', () => {
+      let value = [3]
+      const { rerender } = renderSlider({ value, onValueChange })
+      expect(onValueChange).toHaveBeenCalledTimes(1)
+
+      // change value with a new array
+      value = [5]
+      rerender(<Slider {...{ value, onValueChange }} />)
+
+      expect(onValueChange).toHaveBeenCalledTimes(2)
+
+      // change value with the same reference
+      value.splice(0, 1, 3)
+      rerender(<Slider {...{ value, onValueChange }} />)
+
+      expect(onValueChange).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
@@ -1,5 +1,6 @@
 /* External dependencies */
 import React from 'react'
+import userEvent from '@testing-library/user-event'
 
 /* Internal dependencies */
 import { LightFoundation } from 'Foundation'
@@ -184,6 +185,27 @@ describe('Slider', () => {
       rerender(<Slider {...{ value, onValueChange }} />)
 
       expect(onValueChange).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('user interactions', () => {
+    it('Click and ArrowLeft key', async () => {
+      const user = userEvent.setup()
+      const { getAllByTestId } = renderSlider({
+        value: [4, 6],
+      })
+
+      const sliderThumbs = getAllByTestId(SLIDER_THUMB_TEST_ID)
+
+      expect(sliderThumbs).toHaveLength(2)
+      expect(sliderThumbs[0]).toHaveAttribute('aria-valuenow', '4')
+      expect(sliderThumbs[1]).toHaveAttribute('aria-valuenow', '6')
+
+      await user.click(sliderThumbs[0])
+      await user.keyboard('[ArrowLeft]')
+
+      expect(sliderThumbs[0]).toHaveAttribute('aria-valuenow', '3')
+      expect(sliderThumbs[1]).toHaveAttribute('aria-valuenow', '6')
     })
   })
 })

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -104,10 +104,10 @@ export const Slider = forwardRef(function Slider(
             guideValue={guideValue}
           />
         )) }
-        { currentValue.map((v) => (
+        { currentValue.map((v, i) => (
           <SliderPrimitive.Thumb
             asChild
-            key={`slider-thumb-${v}`}
+            key={`slider-thumb-${i}`}
             onPointerDown={handlePointerDown}
             onPointerUp={handlePointerUp}
           >

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -5,7 +5,7 @@ import React, {
   useCallback,
   useEffect,
 } from 'react'
-import { isFunction } from 'lodash-es'
+import { noop } from 'lodash-es'
 import * as SliderPrimitive from '@radix-ui/react-slider'
 
 /* Internal dependencies */
@@ -19,15 +19,15 @@ export const Slider = forwardRef(function Slider(
   {
     width = 36,
     guide,
-    onThumbPointerDown,
-    onThumbPointerUp,
+    onThumbPointerDown = noop,
+    onThumbPointerUp = noop,
     defaultValue = [5],
     value,
     disabled = false,
     min = 0,
     max = 10,
     step = 1,
-    onValueChange,
+    onValueChange = noop,
     minStepsBetweenThumbs = 0,
     ...rest
   }: SliderProps,
@@ -38,10 +38,7 @@ export const Slider = forwardRef(function Slider(
   useEffect(function updateCurrentValue() {
     if (value) {
       setCurrentValue(value)
-
-      if (isFunction(onValueChange)) {
-        onValueChange(value)
-      }
+      onValueChange(value)
     }
   }, [
     value,
@@ -50,12 +47,11 @@ export const Slider = forwardRef(function Slider(
 
   const handleValueChange: (value: number[]) => void = useCallback((_value) => {
     setCurrentValue(_value)
-    if (isFunction(onValueChange)) {
-      onValueChange(_value)
-    }
+    onValueChange(_value)
   }, [onValueChange])
+
   const handlePointerDown: React.PointerEventHandler<HTMLElement> = useCallback(() => {
-    if (!disabled && isFunction(onThumbPointerDown)) {
+    if (!disabled) {
       onThumbPointerDown(currentValue)
     }
   }, [
@@ -63,8 +59,9 @@ export const Slider = forwardRef(function Slider(
     onThumbPointerDown,
     currentValue,
   ])
+
   const handlePointerUp: React.PointerEventHandler<HTMLElement> = useCallback(() => {
-    if (!disabled && isFunction(onThumbPointerUp)) {
+    if (!disabled) {
       onThumbPointerUp(currentValue)
     }
   }, [

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -107,7 +107,7 @@ export const Slider = forwardRef(function Slider(
             guideValue={guideValue}
           />
         )) }
-        { defaultValue.map((v) => (
+        { currentValue.map((v) => (
           <SliderPrimitive.Thumb
             asChild
             key={`slider-thumb-${v}`}

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -35,7 +35,7 @@ export const Slider = forwardRef(function Slider(
 ) {
   const [currentValue, setCurrentValue] = useState<number[]>(value ?? defaultValue)
 
-  useEffect(() => {
+  useEffect(function updateCurrentValue() {
     if (value) {
       setCurrentValue(value)
 

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -1,5 +1,10 @@
 /* External dependencies */
-import React, { forwardRef, useState, useCallback } from 'react'
+import React, {
+  forwardRef,
+  useState,
+  useCallback,
+  useEffect,
+} from 'react'
 import { isFunction } from 'lodash-es'
 import * as SliderPrimitive from '@radix-ui/react-slider'
 
@@ -29,6 +34,19 @@ export const Slider = forwardRef(function Slider(
   forwardedRef: React.Ref<HTMLElement>,
 ) {
   const [currentValue, setCurrentValue] = useState<number[]>(value ?? defaultValue)
+
+  useEffect(() => {
+    if (value) {
+      setCurrentValue(value)
+
+      if (isFunction(onValueChange)) {
+        onValueChange(value)
+      }
+    }
+  }, [
+    value,
+    onValueChange,
+  ])
 
   const handleValueChange: (value: number[]) => void = useCallback((_value) => {
     setCurrentValue(_value)

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -31,7 +31,7 @@ export const Slider = forwardRef(function Slider(
     minStepsBetweenThumbs = 0,
     ...rest
   }: SliderProps,
-  forwardedRef: React.Ref<HTMLElement>,
+  forwardedRef: React.Ref<HTMLDivElement>,
 ) {
   const [currentValue, setCurrentValue] = useState<number[]>(value ?? defaultValue)
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [x] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Summary
<!-- Please add a summary of the modification. -->
Enhance/fix the `Slider` component

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->
Enhancement
- It now observes the `value` prop and change the `currentValue` state.

Fix
- Render the thumbs through `currentValue` state instead of `defaultValue` prop.
- Fix: Always rerender when the `currentValue` is changed

https://user-images.githubusercontent.com/14245930/206171410-8d312826-9572-4d55-9330-407bc5d2a963.mov

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
No

## References
<!-- External documents based on workarounds or reviewers should refer to -->
None
