### PR TITLE
Enhance the `Modal` component

### DIFF
--- a/.changeset/big-penguins-compare.md
+++ b/.changeset/big-penguins-compare.md
@@ -1,0 +1,6 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+- Make the `Modal` overlay scrollable and enhance styling to work well when the `ModalBody` is used stand-alone.
+- Delete hide animation of the `Modal`.

--- a/packages/bezier-react/.storybook/preview.js
+++ b/packages/bezier-react/.storybook/preview.js
@@ -5,6 +5,7 @@ import React from 'react'
 import {
   LightFoundation,
   DarkFoundation,
+  createGlobalStyle,
 } from 'Foundation'
 import BezierProvider from 'Providers/BezierProvider'
 import { Text } from 'Components/Text'
@@ -52,14 +53,11 @@ function getFoundation(keyword) {
   }
 }
 
-const customGlobalStyle = {
-  // You can inject custom global CSS
-  global: {
-    html: {
-      fontFamily: 'Inter',
-    }
+const GlobalStyle = createGlobalStyle`
+  :root {
+    font-family: Inter, sans-serif;
   }
-}
+`
 
 const wrapperStyle = {
   display: 'flex',
@@ -90,8 +88,8 @@ const innerWrapperStyle = {
 function withFoundationProvider(Story, context) {
   const {
     isDarkFoundation,
-    foundation: Foundation,
-    invertedFoundation: InvertedFoundation,
+    foundation,
+    invertedFoundation,
    } = getFoundation(context.globals.Foundation)
 
   const [backgroundColor, invertedBackgroundColor, themeName, invertedThemeName] = (() => {
@@ -105,45 +103,42 @@ function withFoundationProvider(Story, context) {
       : [lightBackgroundColor, darkBackgroundColor, lightThemeName, darkThemeName]
   })()
 
-  const foundation = {
-    ...Foundation,
-    ...customGlobalStyle,
-  }
-
-  const invertedFoundation = {
-    ...InvertedFoundation,
-    ...customGlobalStyle,
-  }
-
   return (
-    <div style={wrapperStyle}>
-      <BezierProvider 
-        foundation={foundation}
-        themeVarsScope=".theme"
-      >
-        <div className="theme" style={storyWrapperStyle}>
-          <div style={{ ...innerWrapperStyle, backgroundColor }}>
-            { Story(context) }
-          </div>
-          <Text bold color="bgtxt-absolute-black-light">
-            { themeName }
-          </Text>
+    <>
+      <GlobalStyle />
+
+      <BezierProvider foundation={foundation}>
+        <div style={wrapperStyle}>
+          <BezierProvider 
+            foundation={foundation}
+            themeVarsScope=".theme"
+          >
+            <div className="theme" style={storyWrapperStyle}>
+              <div style={{ ...innerWrapperStyle, backgroundColor }}>
+                { Story(context) }
+              </div>
+              <Text bold color="bgtxt-absolute-black-light">
+                { themeName }
+              </Text>
+            </div>
+          </BezierProvider>
+
+          <BezierProvider
+            foundation={invertedFoundation}
+            themeVarsScope=".inverted-theme"
+          >
+            <div className="inverted-theme" style={storyWrapperStyle}>
+              <div style={{ ...innerWrapperStyle, backgroundColor: invertedBackgroundColor }}>
+                { Story(context) }
+              </div>
+              <Text bold color="bgtxt-absolute-black-light">
+                { invertedThemeName }
+              </Text>
+            </div>
+          </BezierProvider>
         </div>
       </BezierProvider>
-      <BezierProvider
-        foundation={invertedFoundation}
-        themeVarsScope=".inverted-theme"
-      >
-        <div className="inverted-theme" style={storyWrapperStyle}>
-          <div style={{ ...innerWrapperStyle, backgroundColor: invertedBackgroundColor }}>
-            { Story(context) }
-          </div>
-          <Text bold color="bgtxt-absolute-black-light">
-            { invertedThemeName }
-          </Text>
-        </div>
-      </BezierProvider>
-    </div>
+    </>
   )
 }
 

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.stories.tsx
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.stories.tsx
@@ -8,7 +8,8 @@ import { Button, ButtonColorVariant, ButtonStyleVariant } from 'Components/Butto
 import { ButtonGroup } from 'Components/ButtonGroup'
 import { FormControl } from 'Components/Forms/FormControl'
 import { FormLabel } from 'Components/Forms/FormLabel'
-import { TextField } from 'Components/Forms/Inputs/TextField'
+import { Select } from 'Components/Forms/Inputs/Select'
+import { ListItem } from 'Components/ListItem'
 import { Modal } from './Modal'
 import { ModalContent } from './ModalContent'
 import { ModalHeader } from './ModalHeader'
@@ -62,7 +63,14 @@ function ModalComposition({
         <ModalBody>
           <FormControl labelPosition="left">
             <FormLabel>Name</FormLabel>
-            <TextField />
+            <Select text="Lorem Ipsum">
+              { Array.from({ length: 20 }).map((_, index) => (
+                <ListItem
+                  key={index}
+                  content={`Item ${index}`}
+                />
+              )) }
+            </Select>
           </FormControl>
         </ModalBody>
 

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
@@ -84,7 +84,8 @@ export const Header = styled.header<ModalHeaderProps>`
 
   /* NOTE(@ed): Support when the ModalBody is used as stand-alone */
   ${({ hidden }) => !hidden && css`
-    & + ${Body} {
+    & + ${Body},
+    & + * ${Body} {
       padding-top: ${HEADER_BODY_GAP}px;
     }
   `}
@@ -98,7 +99,8 @@ export const Footer = styled.footer<ModalFooterProps>`
 
   /* NOTE(@ed): Support when the ModalBody is used as stand-alone */
   /* stylelint-disable declaration-block-semicolon-newline-after, rule-empty-line-before */
-  ${Body} + & {
+  ${Body} + &,
+  ${Body} + * & {
     padding-top: 0;
     margin-top: ${FOOTER_TOP_GAP - MODAL_PADDING}px;
   }

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
@@ -32,6 +32,7 @@ export const Content = styled.div<ModalContentProps>`
   ${({ foundation }) => foundation?.rounding.round20}
   ${({ foundation }) => foundation?.elevation.ev4()}
 
+  position: relative;
   box-sizing: border-box;
   width: var(--bezier-modal-width);
   min-width: 360px;

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
@@ -119,7 +119,9 @@ export const Title = styled(Text).attrs({
   forwardedAs: 'h2',
   bold: true,
   color: 'txt-black-darkest',
-})``
+})`
+  width: 100%;
+`
 
 const CLOSE_ICON_BUTTON_SIZE = ButtonSize.M
 const CLOSE_ICON_BUTTON_MARGIN_X = -6

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
@@ -12,6 +12,10 @@ import ModalAnimation from './ModalAnimation.styled'
 export const DialogPrimitiveOverlay = styled(DialogPrimitive.Overlay)`
   position: fixed;
   inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 40px 0;
+  overflow-y: auto;
   background-color: var(--bgtxt-absolute-black-lighter);
 
   &[data-state='open'] {
@@ -27,10 +31,6 @@ export const Content = styled.div<ModalContentProps>`
   ${({ foundation }) => foundation?.rounding.round20}
   ${({ foundation }) => foundation?.elevation.ev4()}
 
-  position: fixed;
-  inset: 0;
-  top: 50%;
-  left: 50%;
   z-index: var(--bezier-modal-z-index);
 
   box-sizing: border-box;
@@ -38,11 +38,10 @@ export const Content = styled.div<ModalContentProps>`
   min-width: 360px;
   max-width: 100vw;
   height: var(--bezier-modal-height);
-  max-height: calc(100vh - 80px);
-  overflow-y: auto;
+  max-height: 100%;
+  overflow: visible;
   color: var(--bg-grey-darkest);
   word-break: break-word;
-  transform: translate(-50%, -50%);
 
   &[data-state='open'] {
     ${ModalAnimation.contentShow}

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
@@ -12,6 +12,7 @@ import ModalAnimation from './ModalAnimation.styled'
 export const DialogPrimitiveOverlay = styled(DialogPrimitive.Overlay)`
   position: fixed;
   inset: 0;
+  z-index: var(--bezier-modal-z-index);
   display: grid;
   place-items: center;
   padding: 40px 0;
@@ -30,8 +31,6 @@ export const DialogPrimitiveOverlay = styled(DialogPrimitive.Overlay)`
 export const Content = styled.div<ModalContentProps>`
   ${({ foundation }) => foundation?.rounding.round20}
   ${({ foundation }) => foundation?.elevation.ev4()}
-
-  z-index: var(--bezier-modal-z-index);
 
   box-sizing: border-box;
   width: var(--bezier-modal-width);

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.styled.ts
@@ -22,10 +22,6 @@ export const DialogPrimitiveOverlay = styled(DialogPrimitive.Overlay)`
   &[data-state='open'] {
     ${ModalAnimation.overlayShow}
   }
-
-  &[data-state='closed'] {
-    ${ModalAnimation.overlayHide}
-  }
 `
 
 export const Content = styled.div<ModalContentProps>`
@@ -45,10 +41,6 @@ export const Content = styled.div<ModalContentProps>`
 
   &[data-state='open'] {
     ${ModalAnimation.contentShow}
-  }
-
-  &[data-state='closed'] {
-    ${ModalAnimation.contentHide}
   }
 
   &:focus {

--- a/packages/bezier-react/src/components/Modals/Modal/ModalAnimation.styled.ts
+++ b/packages/bezier-react/src/components/Modals/Modal/ModalAnimation.styled.ts
@@ -33,11 +33,11 @@ const overlayHide = keyframes`
 const contentStyles = {
   open: css`
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1);
+    transform: translate(0, 0) scale(1);
   `,
   closed: css`
     opacity: 0;
-    transform: translate(-50%, -48%) scale(0.95);
+    transform: translate(0, -2%) scale(0.95);
   `,
 }
 

--- a/packages/bezier-react/src/components/Modals/Modal/ModalContent.tsx
+++ b/packages/bezier-react/src/components/Modals/Modal/ModalContent.tsx
@@ -47,28 +47,29 @@ export const ModalContent = forwardRef(function ModalContent({
 
   return (
     <DialogPrimitive.Portal container={container}>
-      <Styled.DialogPrimitiveOverlay />
-      <DialogPrimitive.Content asChild>
-        <Styled.Content
-          aria-modal
-          ref={forwardedRef}
-          style={contentStyle}
-          {...rest}
-        >
-          <Styled.Section>
-            <ModalContentContext.Provider value={contextValue}>
-              { children }
-            </ModalContentContext.Provider>
+      <Styled.DialogPrimitiveOverlay>
+        <DialogPrimitive.Content asChild>
+          <Styled.Content
+            aria-modal
+            ref={forwardedRef}
+            style={contentStyle}
+            {...rest}
+          >
+            <Styled.Section>
+              <ModalContentContext.Provider value={contextValue}>
+                { children }
+              </ModalContentContext.Provider>
 
-            { /* NOTE: To prevent focusing first on the close button when opening the modal, place the close button behind. */ }
-            { showCloseIcon && (
-              <ModalClose>
-                <Styled.CloseIconButton />
-              </ModalClose>
-            ) }
-          </Styled.Section>
-        </Styled.Content>
-      </DialogPrimitive.Content>
+              { /* NOTE: To prevent focusing first on the close button when opening the modal, place the close button behind. */ }
+              { showCloseIcon && (
+                <ModalClose>
+                  <Styled.CloseIconButton />
+                </ModalClose>
+              ) }
+            </Styled.Section>
+          </Styled.Content>
+        </DialogPrimitive.Content>
+      </Styled.DialogPrimitiveOverlay>
     </DialogPrimitive.Portal>
   )
 })

--- a/packages/bezier-react/src/components/Modals/Modal/ModalContent.tsx
+++ b/packages/bezier-react/src/components/Modals/Modal/ModalContent.tsx
@@ -28,17 +28,14 @@ export const ModalContent = forwardRef(function ModalContent({
   const contentStyle = useMemo((): React.CSSProperties & {
     '--bezier-modal-width': ModalContentProps['width']
     '--bezier-modal-height': ModalContentProps['height']
-    '--bezier-modal-z-index': ModalContentProps['zIndex']
   } => ({
     ...style,
     '--bezier-modal-width': isNumber(width) ? `${width}px` : width,
     '--bezier-modal-height': isNumber(height) ? `${height}px` : height,
-    '--bezier-modal-z-index': zIndex,
   }), [
     style,
     width,
     height,
-    zIndex,
   ])
 
   const contextValue = useMemo((): ModalContentContextValue => ({
@@ -47,7 +44,7 @@ export const ModalContent = forwardRef(function ModalContent({
 
   return (
     <DialogPrimitive.Portal container={container}>
-      <Styled.DialogPrimitiveOverlay>
+      <Styled.DialogPrimitiveOverlay style={{ '--bezier-modal-z-index': zIndex } as React.CSSProperties}>
         <DialogPrimitive.Content asChild>
           <Styled.Content
             aria-modal

--- a/packages/bezier-react/src/components/Modals/Modal/ModalContent.tsx
+++ b/packages/bezier-react/src/components/Modals/Modal/ModalContent.tsx
@@ -25,6 +25,12 @@ export const ModalContent = forwardRef(function ModalContent({
   zIndex = 0,
   ...rest
 }: ModalContentProps, forwardedRef: React.Ref<HTMLDivElement>) {
+  const overlayStyle = useMemo((): React.CSSProperties & {
+    '--bezier-modal-z-index': ModalContentProps['zIndex']
+  } => ({
+    '--bezier-modal-z-index': zIndex,
+  }), [zIndex])
+
   const contentStyle = useMemo((): React.CSSProperties & {
     '--bezier-modal-width': ModalContentProps['width']
     '--bezier-modal-height': ModalContentProps['height']
@@ -44,7 +50,7 @@ export const ModalContent = forwardRef(function ModalContent({
 
   return (
     <DialogPrimitive.Portal container={container}>
-      <Styled.DialogPrimitiveOverlay style={{ '--bezier-modal-z-index': zIndex } as React.CSSProperties}>
+      <Styled.DialogPrimitiveOverlay style={overlayStyle}>
         <DialogPrimitive.Content asChild>
           <Styled.Content
             aria-modal


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [x] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->

`Modal` 컴포넌트를 애플리케이션에 적용하면서, 부족한 부분들을 개선합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

### 오버레이가 스크롤 가능하도록 개선

- `Modal` 내부에 Overlay 컴포넌트가 포함될 경우, Portal을 통해 동일하게 rootElement(body) 아래 렌더하는 케이스에서 Overlay 컴포넌트에 클릭이 불가능한 문제가 있었습니다. `Modal` 이 `modal={true}` 속성을 가져 외부에 이벤트가 전달되지 않기 때문입니다. 이를 해결하고자 overflow hidden 속성을 제거하고 오버레이 영역 전체가 스크롤 가능하게 변경했습니다. 애플리케이션에서는 Overlay container 속성 지정을 통해 `Modal` 내부에 그리는 방식으로 구현하게 됩니다.
- 관련해서 UI를 테스트해볼 수 있도록 스토리를 개선합니다.

### `Modal` hide 애니메이션 제거

어플리케이션에서 `onHide` 콜백 호출 시, 즉시 특정 상태가 변경되며 UI가 바뀌는 케이스가 있습니다. 애니메이션이 있을 경우 의도치 않은 UI가 애니메이션 실행 시간동안 노출되는 문제가 있어 우선 제거합니다.

### `ModalBody` 스타일 개선

`ModalBody` 가 다른 엘리먼트의 자식이 된 경우에도 스타일링이 잘 적용될 수 있도록 CSS 선택자를 개선합니다.

### chore: 스토리북 개선

root에 css variable을 추가하여 오버레이 색상이 잘 표시되도록 합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- https://www.radix-ui.com/docs/primitives/components/dialog#scrollable-overlay
