### PR TITLE
[WIP] fix(stack): modify the align-self property of StackItem to work properly

### DIFF
--- a/.changeset/late-buckets-share.md
+++ b/.changeset/late-buckets-share.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Modify the 'align-self' property of `StackItem` to work properly. `StackItem` is now flexbox.

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -36,6 +36,10 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 }
 
 .c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-flex-basis: var(--main-axis-size);
   -ms-flex-preferred-size: var(--main-axis-size);
   flex-basis: var(--main-axis-size);
@@ -384,6 +388,10 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 }
 
 .c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-flex-basis: var(--main-axis-size);
   -ms-flex-preferred-size: var(--main-axis-size);
   flex-basis: var(--main-axis-size);

--- a/packages/bezier-react/src/components/Stack/StackItem/StackItem.styled.ts
+++ b/packages/bezier-react/src/components/Stack/StackItem/StackItem.styled.ts
@@ -18,6 +18,8 @@ interface ContainerProps extends
   | 'interpolation'>> {}
 
 export const Container = styled.div<ContainerProps>`
+  display: flex;
+
   ${({ justify }) => !isNil(justify) && css`
     justify-self: ${flex(justify)};
   `}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [x] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->

`StackItem` 의 align-self 속성이 올바르게 동작하도록 수정합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

> The [align-self](https://developer.mozilla.org/en-US/docs/Web/CSS/align-self) property does not apply to block-level boxes (including floats), because there is more than one item in the block axis. It also does not apply to table cells. ([MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Alignment/Box_Alignment_In_Block_Abspos_Tables#align-self))

Block level box에선 `align-self` 속성이 잘 적용되지 않는 문제가 있었습니다. flexbox로 변경해 이를 해결합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Alignment/Box_Alignment_In_Block_Abspos_Tables#align-self
- https://developer.mozilla.org/en-US/docs/Web/CSS/align-self
