### PR TITLE
[WIP] Improve `ProgressBar` Storybook docs to be more readable

### DIFF
--- a/packages/bezier-react/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/bezier-react/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -62,6 +62,12 @@ Playground.args = {
   width: '36',
   value: 0.5,
 }
+Playground.parameters = {
+  viewMode: 'story',
+  options: {
+    showPanel: true,
+  },
+}
 
 export const Overview: Story<{}> = () => {
   const [values, setValues] = useState<number[]>([0.25, 0.5, 0.75, 1])
@@ -117,6 +123,15 @@ export const Overview: Story<{}> = () => {
     </VStack>
   )
 }
+Overview.parameters = {
+  viewMode: 'docs',
+  previewTabs: {
+    canvas: { hidden: true },
+  },
+  options: {
+    showPanel: false,
+  },
+}
 
 export const UsageWidth: Story<{}> = () => (
   <VStack spacing={6} align="stretch">
@@ -160,8 +175,16 @@ export const UsageWidth: Story<{}> = () => (
     </StackItem>
   </VStack>
 )
-
 UsageWidth.storyName = 'Usage (width)'
+UsageWidth.parameters = {
+  viewMode: 'docs',
+  previewTabs: {
+    canvas: { hidden: true },
+  },
+  options: {
+    showPanel: false,
+  },
+}
 
 export const UsageValue: Story<{}> = () => (
   <VStack spacing={6} align="stretch">
@@ -257,8 +280,16 @@ export const UsageValue: Story<{}> = () => (
     </StackItem>
   </VStack>
 )
-
 UsageValue.storyName = 'Usage (value)'
+UsageValue.parameters = {
+  viewMode: 'docs',
+  previewTabs: {
+    canvas: { hidden: true },
+  },
+  options: {
+    showPanel: false,
+  },
+}
 
 export const SizeVariant: Story<{}> = () => (
   <VStack spacing={16} align="stretch">
@@ -296,8 +327,16 @@ export const SizeVariant: Story<{}> = () => (
     </StackItem>
   </VStack>
 )
-
 SizeVariant.storyName = 'Variant (size)'
+SizeVariant.parameters = {
+  viewMode: 'docs',
+  previewTabs: {
+    canvas: { hidden: true },
+  },
+  options: {
+    showPanel: false,
+  },
+}
 
 export const Variant: Story<{}> = () => (
   <VStack spacing={16} align="stretch">
@@ -335,5 +374,13 @@ export const Variant: Story<{}> = () => (
     </StackItem>
   </VStack>
 )
-
 Variant.storyName = 'Variant (color)'
+Variant.parameters = {
+  viewMode: 'docs',
+  previewTabs: {
+    canvas: { hidden: true },
+  },
+  options: {
+    showPanel: false,
+  },
+}

--- a/packages/bezier-react/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/bezier-react/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,7 +1,7 @@
 /* External dependencies */
 import React, { useState } from 'react'
 import base from 'paths.macro'
-import type { Story, Meta } from '@storybook/react'
+import type { ComponentStory, ComponentMeta } from '@storybook/react'
 
 /* Internal dependencies */
 import { getTitle, getObjectFromEnum } from 'Utils/storyUtils'
@@ -14,7 +14,6 @@ import {
 import { Text } from 'Components/Text'
 import { Button } from 'Components/Button'
 import { ProgressBar } from './ProgressBar'
-import type ProgressBarProps from './ProgressBar.types'
 import { ProgressBarSize, ProgressBarVariant } from './ProgressBar.types'
 import mdx from './ProgressBar.mdx'
 
@@ -26,9 +25,11 @@ export default {
       page: mdx,
     },
   },
-} as Meta<ProgressBarProps>
+} as ComponentMeta<typeof ProgressBar>
 
-export const Playground: Story<ProgressBarProps> = (props) => <ProgressBar {...props} />
+export const Playground: ComponentStory<typeof ProgressBar> = (props) => (
+  <ProgressBar {...props} />
+)
 Playground.argTypes = {
   size: {
     control: {
@@ -69,7 +70,7 @@ Playground.parameters = {
   },
 }
 
-export const Overview: Story<{}> = () => {
+export const Overview: ComponentStory<typeof ProgressBar> = () => {
   const [values, setValues] = useState<number[]>([0.25, 0.5, 0.75, 1])
 
   const handleSetRandomValues = () => {
@@ -133,7 +134,7 @@ Overview.parameters = {
   },
 }
 
-export const UsageWidth: Story<{}> = () => (
+export const UsageWidth: ComponentStory<typeof ProgressBar> = () => (
   <VStack spacing={6} align="stretch">
     <StackItem>
       <HStack spacing={8} align="center">
@@ -186,7 +187,7 @@ UsageWidth.parameters = {
   },
 }
 
-export const UsageValue: Story<{}> = () => (
+export const UsageValue: ComponentStory<typeof ProgressBar> = () => (
   <VStack spacing={6} align="stretch">
     <StackItem>
       <HStack spacing={8} align="center">
@@ -291,7 +292,7 @@ UsageValue.parameters = {
   },
 }
 
-export const SizeVariant: Story<{}> = () => (
+export const SizeVariant: ComponentStory<typeof ProgressBar> = () => (
   <VStack spacing={16} align="stretch">
     <StackItem>
       <HStack spacing={8} align="center">
@@ -338,7 +339,7 @@ SizeVariant.parameters = {
   },
 }
 
-export const Variant: Story<{}> = () => (
+export const Variant: ComponentStory<typeof ProgressBar> = () => (
   <VStack spacing={16} align="stretch">
     <StackItem>
       <HStack spacing={8} align="center">

--- a/packages/bezier-react/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/bezier-react/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -26,36 +26,36 @@ export default {
       page: mdx,
     },
   },
-  argTypes: {
-    size: {
-      control: {
-        type: 'radio',
-        options: getObjectFromEnum(ProgressBarSize),
-      },
-    },
-    variant: {
-      control: {
-        type: 'radio',
-        options: getObjectFromEnum(ProgressBarVariant),
-      },
-    },
-    width: {
-      control: {
-        type: 'text',
-      },
-    },
-    value: {
-      control: {
-        type: 'range',
-        min: 0,
-        max: 1,
-        step: 0.01,
-      },
-    },
-  },
 } as Meta<ProgressBarProps>
 
 export const Playground: Story<ProgressBarProps> = (props) => <ProgressBar {...props} />
+Playground.argTypes = {
+  size: {
+    control: {
+      type: 'radio',
+      options: getObjectFromEnum(ProgressBarSize),
+    },
+  },
+  variant: {
+    control: {
+      type: 'radio',
+      options: getObjectFromEnum(ProgressBarVariant),
+    },
+  },
+  width: {
+    control: {
+      type: 'text',
+    },
+  },
+  value: {
+    control: {
+      type: 'range',
+      min: 0,
+      max: 1,
+      step: 0.01,
+    },
+  },
+}
 Playground.args = {
   size: ProgressBarSize.M,
   variant: ProgressBarVariant.Green,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None.

## Summary
<!-- Please add a summary of the modification. -->

- `ProgressBar` Storybook 및 MDX 문서가 documentation의 기능에 집중할 수 있도록 개선합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

https://user-images.githubusercontent.com/6940439/209123934-356c49ad-8dbf-4317-ab9f-3051ef7ff90c.mp4

- Argument controls에 대한 정보(`argTypes`)를 `Meta`(`ProgressBar.stories.tsx`의 default export)에서 `Playground` Story의 property로 옮깁니다.
  - Argument control이 필요한 곳(+ 컨트롤을 의도한 곳)은 `Playground` 스토리 하나입니다.
- `Playground` 이외의 다른 스토리(`Overview`, `Usage*`, `*Variant` 등)의 `viewMode`를 docs로 지정하고, Argument controls를 기본으로 숨깁니다.
  - 이 스토리들은 MDX 문서 내에서만 보도록 의도되었으며, Argument control을 의도하지 않았습니다.
- 타입 수정
  - Storybook 6.3에서 새로 추가된 타입을 사용합니다.
  - `Meta` -> `ComponentMeta`
  - `Story` -> `ComponentStory`
  > **Note** Storybook 6.4(CSF 3.0 도입)부터는 모든 Story가 object가 될 예정입니다. 이에 따라 Storybook 7부터는 `Story` 타입은 `StoryFn`으로 이름이 변경되며, `ComponentStory`는 `ComponentStoryFn`이 아닌 `ComponentStoryObj`를 가리키게 됩니다. 향후 마이그레이션을 유의해 두어야 할 것 같습니다.
  ```ts
  /**
   * For the common case where a component's stories are simple components that receives args as props:
   *
   * ```tsx
   * export default { ... } as ComponentMeta<typeof Button>;
   * ```
   */
  export declare type ComponentMeta<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> = Meta<ComponentProps<T>>;
  /**
   * For the common case where a (CSFv2) story is a simple component that receives args as props:
   *
   * ```tsx
   * const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />
   * ```
   */
  export declare type ComponentStoryFn<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> = StoryFn<ComponentProps<T>>;
  /**
   * For the common case where a (CSFv3) story is a simple component that receives args as props:
   *
   * ```tsx
   * const MyStory: ComponentStory<typeof Button> = {
   *   args: { buttonArg1: 'val' },
   * }
   * ```
   */
  export declare type ComponentStoryObj<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> = StoryObj<ComponentProps<T>>;
  /**
   * For the common case where a (CSFv2) story is a simple component that receives args as props:
   *
   * ```tsx
   * const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />
   * ```
   *
   * NOTE: this is an alias for `ComponentStoryFn`.
   * In Storybook v7, `ComponentStory` will alias `ComponentStoryObj`
   */
  export declare type ComponentStory<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> = Story<ComponentProps<T>>;
  ```

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No.

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- #1083
- https://storybook.js.org/blog/component-story-format-3-0/
