### PR TITLE
style: Remove `margin-left: 8px` in `<KeyText />`

### DIFF
--- a/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.styled.ts
@@ -3,6 +3,10 @@ import { ellipsis, styled } from 'Foundation'
 import { InterpolationProps } from 'Types/Foundation'
 import { Text } from 'Components/Text'
 
+export const KeyIconWrapper = styled.div`
+  margin-right: 8px;
+`
+
 export const KeyContent = styled.div<InterpolationProps>`
   display: flex;
   align-items: center;
@@ -14,6 +18,5 @@ export const KeyText = styled(Text).attrs({
   forwardedAs: 'div',
   color: 'txt-black-dark',
 })`
-  margin-left: 8px;
   ${ellipsis()};
 `

--- a/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.tsx
@@ -51,7 +51,7 @@ function KeyItem(
       ref={forwardedRef}
       interpolation={interpolation}
     >
-      { KeyIcon }
+      <Styled.KeyIconWrapper>{ KeyIcon }</Styled.KeyIconWrapper>
       { KeyText }
     </Styled.KeyContent>
   )


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [ ] I wrote a commit message in **English**.
- [ ] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

Fixes #0000 <!-- Please link to issue if one exists -->

## Summary

KeyValueListItem 하위에 있는 KeyText의 margin 위치를 KeyIcon으로 변경하였습니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

## References
<!-- External documents based on workarounds or reviewers should refer to -->
