### PR TITLE
Add `truncated` prop to Text component

### DIFF
--- a/.changeset/dull-phones-invent.md
+++ b/.changeset/dull-phones-invent.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Add truncated prop to Text component

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.styled.ts
@@ -1,9 +1,8 @@
 /* Internal dependencies */
-import { styled, css, ellipsis } from 'Foundation'
+import { styled, css } from 'Foundation'
 import DisabledOpacity from 'Constants/DisabledOpacity'
 import type { InterpolationProps } from 'Types/Foundation'
 import { Overlay } from 'Components/Overlay'
-import { Text } from 'Components/Text'
 import {
   inputTextStyle,
   inputWrapperStyle,
@@ -81,10 +80,6 @@ export const MainContentWrapper = styled.div`
   display: flex;
   align-items: center;
   overflow: hidden;
-`
-
-export const TextContainer = styled(Text)`
-  ${ellipsis()}
 `
 
 interface DropdownProps extends InterpolationProps {

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
@@ -15,6 +15,7 @@ import { isEmpty, noop } from 'lodash-es'
 import { Typography } from 'Foundation'
 import { LegacyIcon, Icon, IconSize, isIconName, ChevronUpIcon, ChevronDownIcon } from 'Components/Icon'
 import { OverlayPosition } from 'Components/Overlay'
+import { Text } from 'Components/Text'
 import useFormFieldProps from 'Components/Forms/useFormFieldProps'
 
 import SelectProps, { SelectRef, SelectSize } from './Select.types'
@@ -170,13 +171,14 @@ forwardedRef: Ref<SelectRef>,
       >
         <Styled.MainContentWrapper>
           { LeftComponent }
-          <Styled.TextContainer
+          <Text
             testId={triggerTextTestId}
             typo={Typography.Size14}
+            truncated
             color={hasContent ? textColor : 'txt-black-dark'}
           >
             { hasContent ? text : placeholder }
-          </Styled.TextContainer>
+          </Text>
           { RightComponent }
         </Styled.MainContentWrapper>
         { !withoutChevron && (

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select Test > Default Style > Snapshot > 1`] = `
-.c5 {
+.c4 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -20,6 +20,10 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
 .c3 {
   font-size: 1.4rem;
   line-height: 1.8rem;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -102,12 +106,6 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
   overflow: hidden;
 }
 
-.c4 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 <div
   class="c0"
   data-testid="bezier-react-select-container"
@@ -122,7 +120,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
       class="c2"
     >
       <span
-        class="c3 c4"
+        class="c3"
         color="txt-black-darkest"
         data-testid="bezier-react-select-trigger-text"
       >
@@ -130,7 +128,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
       </span>
     </div>
     <svg
-      class="c5"
+      class="c4"
       color="txt-black-darker"
       data-testid="bezier-react-icon"
       fill="none"
@@ -156,7 +154,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
 `;
 
 exports[`Select Test > rightContent > Snapshot > 1`] = `
-.c5 {
+.c4 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -175,6 +173,10 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
 .c3 {
   font-size: 1.4rem;
   line-height: 1.8rem;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -257,12 +259,6 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
   overflow: hidden;
 }
 
-.c4 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 <div
   class="c0"
   data-testid="bezier-react-select-container"
@@ -277,7 +273,7 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
       class="c2"
     >
       <span
-        class="c3 c4"
+        class="c3"
         color="txt-black-darkest"
         data-testid="bezier-react-select-trigger-text"
       >
@@ -288,7 +284,7 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
       </div>
     </div>
     <svg
-      class="c5"
+      class="c4"
       color="txt-black-darker"
       data-testid="bezier-react-icon"
       fill="none"

--- a/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
+++ b/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
@@ -4,6 +4,10 @@ exports[`KeyValueListItem Snapshot > 1`] = `
 .c6 {
   font-size: 1.2rem;
   line-height: 1.6rem;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: bold;
@@ -50,9 +54,6 @@ exports[`KeyValueListItem Snapshot > 1`] = `
 
 .c7 {
   margin-left: 8px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c9 {

--- a/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.styled.ts
@@ -15,5 +15,4 @@ export const KeyText = styled(Text).attrs({
   color: 'txt-black-dark',
 })`
   margin-left: 8px;
-  ${ellipsis()};
 `

--- a/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.tsx
@@ -36,7 +36,7 @@ function KeyItem(
   const KeyText = useMemo(() => {
     if (isString(children)) {
       return (
-        <Styled.KeyText bold typo={Typography.Size12}>
+        <Styled.KeyText bold typo={Typography.Size12} truncated>
           { children }
         </Styled.KeyText>
       )

--- a/packages/bezier-react/src/components/Modals/LegacyModal/Modal.styled.ts
+++ b/packages/bezier-react/src/components/Modals/LegacyModal/Modal.styled.ts
@@ -1,7 +1,6 @@
 /* Internal dependencies */
 import {
   styled,
-  ellipsis,
 } from 'Foundation'
 import { Text } from 'Components/Text'
 import { Button } from 'Components/Button'
@@ -33,8 +32,6 @@ export const SubTitleText = styled(Text).attrs(() => ({
 }))`
   box-sizing: border-box;
   width: 100%;
-
-  ${ellipsis()}
 `
 
 export const CloseIconButton = styled(Button)`

--- a/packages/bezier-react/src/components/Modals/LegacyModal/ModalContent.tsx
+++ b/packages/bezier-react/src/components/Modals/LegacyModal/ModalContent.tsx
@@ -68,6 +68,7 @@ const ModalContent = (
               <Styled.SubTitleText
                 testId="Modal__Contents__SubTitle__Text"
                 typo={Typography.Size13}
+                truncated
                 color="txt-black-dark"
               >
                 { subTitle }

--- a/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.styled.ts
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.styled.ts
@@ -1,7 +1,6 @@
 /* Internal dependencies */
-import { styled, css, ellipsis } from 'Foundation'
+import { styled, css } from 'Foundation'
 import type { InterpolationProps } from 'Types/Foundation'
-import { Text } from 'Components/Text'
 
 interface WrapperProps extends InterpolationProps {
   active: boolean
@@ -13,10 +12,6 @@ export const LeftIconWrapper = styled.div`
   min-width: 20px;
   max-width: 20px;
   margin-right: 8px;
-`
-
-export const ContentWrapper = styled(Text)`
-  ${ellipsis()}
 `
 
 export const ChevronWrapper = styled.div`

--- a/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.tsx
@@ -5,6 +5,7 @@ import { noop, isNil } from 'lodash-es'
 /* Internal dependencies */
 import { Typography } from 'Foundation'
 import { LegacyIcon, Icon, IconSize, isIconName, ChevronSmallDownIcon, ChevronSmallRightIcon } from 'Components/Icon'
+import { Text } from 'Components/Text'
 import type NavGroupProps from './NavGroup.types'
 import {
   Item,
@@ -12,7 +13,6 @@ import {
   ChildrenWrapper,
   LeftIconWrapper,
   ChevronWrapper,
-  ContentWrapper,
   RightContentWrapper,
 } from './NavGroup.styled'
 
@@ -72,9 +72,9 @@ function NavGroup({
           ) }
         </LeftIconWrapper>
 
-        <ContentWrapper typo={Typography.Size14}>
+        <Text typo={Typography.Size14} truncated>
           { content }
-        </ContentWrapper>
+        </Text>
 
         { hasChildren && (
           <ChevronWrapper>

--- a/packages/bezier-react/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`NavGroup Test > Snapshot > Active 1`] = `
   transition-property: color;
 }
 
-.c6 {
+.c5 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -36,6 +36,10 @@ exports[`NavGroup Test > Snapshot > Active 1`] = `
 .c3 {
   font-size: 1.4rem;
   line-height: 1.8rem;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -65,12 +69,6 @@ exports[`NavGroup Test > Snapshot > Active 1`] = `
 }
 
 .c4 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -145,16 +143,16 @@ exports[`NavGroup Test > Snapshot > Active 1`] = `
     </svg>
   </div>
   <span
-    class="c3 c4"
+    class="c3"
     data-testid="bezier-react-text"
   >
     test-content
   </span>
   <div
-    class="c5"
+    class="c4"
   >
     <svg
-      class="c6"
+      class="c5"
       color="bgtxt-orange-normal"
       data-testid="bezier-react-icon"
       fill="none"
@@ -196,7 +194,7 @@ exports[`NavGroup Test > Snapshot > Not active 1`] = `
   transition-property: color;
 }
 
-.c6 {
+.c5 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -215,6 +213,10 @@ exports[`NavGroup Test > Snapshot > Not active 1`] = `
 .c3 {
   font-size: 1.4rem;
   line-height: 1.8rem;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -244,12 +246,6 @@ exports[`NavGroup Test > Snapshot > Not active 1`] = `
 }
 
 .c4 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -331,16 +327,16 @@ exports[`NavGroup Test > Snapshot > Not active 1`] = `
     </svg>
   </div>
   <span
-    class="c3 c4"
+    class="c3"
     data-testid="bezier-react-text"
   >
     test-content
   </span>
   <div
-    class="c5"
+    class="c4"
   >
     <svg
-      class="c6"
+      class="c5"
       color="bgtxt-orange-normal"
       data-testid="bezier-react-icon"
       fill="none"

--- a/packages/bezier-react/src/components/Navigator/NavItem/NavItem.styled.ts
+++ b/packages/bezier-react/src/components/Navigator/NavItem/NavItem.styled.ts
@@ -1,7 +1,6 @@
 /* Internal dependencies */
-import { styled, css, ellipsis } from 'Foundation'
+import { styled, css } from 'Foundation'
 import type { InterpolationProps } from 'Types/Foundation'
-import { Text } from 'Components/Text'
 
 interface WrapperProps extends InterpolationProps {
   active: boolean
@@ -13,10 +12,6 @@ export const LeftIconWrapper = styled.div`
   min-width: 20px;
   max-width: 20px;
   margin-right: 8px;
-`
-
-export const ContentWrapper = styled(Text)`
-  ${ellipsis()}
 `
 
 export const RightContentWrapper = styled.div`

--- a/packages/bezier-react/src/components/Navigator/NavItem/NavItem.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavItem/NavItem.tsx
@@ -5,11 +5,11 @@ import { noop } from 'lodash-es'
 /* Internal dependencies */
 import { Typography } from 'Foundation'
 import { LegacyIcon, IconSize, isIconName } from 'Components/Icon'
+import { Text } from 'Components/Text'
 import type NavItemProps from './NavItem.types'
 import {
   Item,
   Wrapper,
-  ContentWrapper,
   RightContentWrapper,
   LeftIconWrapper,
 } from './NavItem.styled'
@@ -66,9 +66,9 @@ function NavItem({
           ) }
         </LeftIconWrapper>
 
-        <ContentWrapper typo={Typography.Size14}>
+        <Text typo={Typography.Size14} truncated>
           { content }
-        </ContentWrapper>
+        </Text>
 
         { rightContent && (
           <RightContentWrapper>

--- a/packages/bezier-react/src/components/Navigator/NavItem/__snapshots__/NavItem.test.tsx.snap
+++ b/packages/bezier-react/src/components/Navigator/NavItem/__snapshots__/NavItem.test.tsx.snap
@@ -20,6 +20,10 @@ exports[`NavItem Test > Snapshot > Active 1`] = `
 .c3 {
   font-size: 1.4rem;
   line-height: 1.8rem;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -46,12 +50,6 @@ exports[`NavItem Test > Snapshot > Active 1`] = `
   min-width: 20px;
   max-width: 20px;
   margin-right: 8px;
-}
-
-.c4 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 {
@@ -107,7 +105,7 @@ exports[`NavItem Test > Snapshot > Active 1`] = `
     </svg>
   </div>
   <span
-    class="c3 c4"
+    class="c3"
     data-testid="bezier-react-text"
   >
     test-content
@@ -135,6 +133,10 @@ exports[`NavItem Test > Snapshot > Not active 1`] = `
 .c3 {
   font-size: 1.4rem;
   line-height: 1.8rem;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   margin: 0px 0px 0px 0px;
   font-style: normal;
   font-weight: normal;
@@ -161,12 +163,6 @@ exports[`NavItem Test > Snapshot > Not active 1`] = `
   min-width: 20px;
   max-width: 20px;
   margin-right: 8px;
-}
-
-.c4 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 {
@@ -229,7 +225,7 @@ exports[`NavItem Test > Snapshot > Not active 1`] = `
     </svg>
   </div>
   <span
-    class="c3 c4"
+    class="c3"
     data-testid="bezier-react-text"
   >
     test-content

--- a/packages/bezier-react/src/components/Text/Text.stories.tsx
+++ b/packages/bezier-react/src/components/Text/Text.stories.tsx
@@ -46,6 +46,7 @@ Primary.args = {
   as: undefined,
   bold: false,
   italic: false,
+  truncated: false,
   style: { color: 'gray' },
   children: 'hello',
   marginTop: 0,
@@ -56,3 +57,21 @@ Primary.args = {
   marginHorizontal: 0,
   marginAll: 0,
 }
+
+const Truncated: Story<TextProps & { width: string }> = ({ children, width, ...otherTextProps }) => (
+  <div style={{ width }}>
+    <Text {...otherTextProps}>
+      { children }
+    </Text>
+  </div>
+)
+
+export const Secondary = Truncated.bind({})
+Secondary.args = {
+  width: '100px',
+  truncated: true,
+  style: { color: 'gray' },
+  children: 'test truncated long text',
+}
+
+Secondary.storyName = 'Usage (truncated)'

--- a/packages/bezier-react/src/components/Text/Text.styled.ts
+++ b/packages/bezier-react/src/components/Text/Text.styled.ts
@@ -1,5 +1,5 @@
 /* Internal dependencies */
-import { styled } from 'Foundation'
+import { styled, css, ellipsis } from 'Foundation'
 import { ColorProps } from 'Types/ComponentProps'
 import TextProps from './Text.types'
 
@@ -21,6 +21,10 @@ function getMargin({
 
 const Text = styled.span<TextProps & TextStyledProps>`
   ${props => props.typo};
+  ${props => props.truncated && css`
+    display: block;
+    ${ellipsis()}
+  `}
   ${props => props.interpolation};
   margin: ${getMargin};
   font-style: ${props => (props.italic ? 'italic' : 'normal')};

--- a/packages/bezier-react/src/components/Text/Text.test.tsx
+++ b/packages/bezier-react/src/components/Text/Text.test.tsx
@@ -37,12 +37,23 @@ describe('Text test >', () => {
     expect(renderedText).toHaveStyle('font-weight: bold;')
   })
 
-  it('Text receives bold style', () => {
+  it('Text receives italic style', () => {
     const { getByTestId } = renderComponent({ italic: true })
 
     const renderedText = getByTestId(TEXT_TEST_ID)
 
     expect(renderedText).toHaveStyle('font-style: italic;')
+  })
+
+  it('Text receives truncated style', () => {
+    const { getByTestId } = renderComponent({ truncated: true })
+
+    const renderedText = getByTestId(TEXT_TEST_ID)
+
+    expect(renderedText).toHaveStyle('display: block;')
+    expect(renderedText).toHaveStyle('overflow: hidden;')
+    expect(renderedText).toHaveStyle('text-overflow: ellipsis;')
+    expect(renderedText).toHaveStyle('white-space: nowrap;')
   })
 
   it('Text receives style object', () => {

--- a/packages/bezier-react/src/components/Text/Text.tsx
+++ b/packages/bezier-react/src/components/Text/Text.tsx
@@ -17,6 +17,7 @@ function Text(
     italic = false,
     color,
     typo = Typography.Size15,
+    truncated = false,
     marginTop = 0,
     marginRight = 0,
     marginBottom = 0,
@@ -46,6 +47,7 @@ function Text(
       italic={italic}
       color={color}
       typo={typo}
+      truncated={truncated}
       data-testid={testId}
       margintop={marginTop || marginVertical || marginAll}
       marginright={marginRight || marginHorizontal || marginAll}

--- a/packages/bezier-react/src/components/Text/Text.types.ts
+++ b/packages/bezier-react/src/components/Text/Text.types.ts
@@ -8,6 +8,7 @@ interface TextOptions {
   bold?: boolean
   italic?: boolean
   typo?: ReturnType<typeof css>
+  truncated?: boolean
   marginTop?: number
   marginRight?: number
   marginBottom?: number


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [x] [Component] I wrote **a unit test** about the implementation.
- [x] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

Fixes #629  <!-- Please link to issue if one exists -->

## Summary
<!-- Please add a summary of the modification. -->
- `Text` 컴포넌트에 `truncated` 속성을 추가합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->
- 현재 베지어 Text 컴포넌트는 `span`(inline 엘리먼트)을 사용하고 있습니다. inline 엘리먼트에서는 `text-overflow` 속성을 제대로 적용할 수 없습니다.(inline 엘리먼트는 너비를 가지지 않고 컨텐츠 크기만큼 공간을 차지함)

  > The text-overflow property only affects content that is overflowing a **block container element** in its inline progression direction
  
  따라서, `truncated` 옵션을 주었을 때 `text-overflow`가 제대로 적용될 수 있도록 `display: block` 속성도 추가하였습니다.
- (고민되는 부분) `display: block` 속성을 추가하는 것에 있어 `block`이라는 prop을 하나 더 열어주고, 말줄임 속성을 적용하고 싶으면 `block`, `truncated`를 둘 다 적용하는 방식이 더 명확하게 display 속성이 block으로 변화되는 것을 알 수 있다는 생각이 들었습니다.
 (#487 에서 예기치 못하게 inline -> block 속성으로 변경되어서 문제가 된 적이 있기 때문에)
하지만 사용처에서 항상 `block`, `trucated`를 같이 적용해야한다는 불편함과, `truncated` 단독으로 옵션을 주었을 때는 말줄임이 제대로 적용되지 않기 때문에 같이 스타일링 하는 것으로 작성하였습니다.
  1. 리서치 결과 `span`(inline 엘리먼트)과 함께 `truncated` 속성을 사용하는 경우에는 `display: block` or `inline-block`이 포함된 경우가 많음
  2. 말줄임 속성이 적용되는 곳은 inline -> block 속성으로 바뀌어도 문제가 없을 것으로 예상됨

  다만, 현재 Text props 중 `marginTop`, `marginBottom`, `marginVertical` 속성은 별도의 `display: block` or `inline-block`스타일링을 주고있지 않다면 margin이 제대로 적용되지 않고 있기 때문에, `block` prop을 하나 더 열어주고 필요할 때 사용해도 좋을것 같다는 생각입니다.
- **truncated 스타일에 `display: block` 이 포함되지 않은 사례**
  - Airbnb Lunar [Text 컴포넌트](https://github.com/airbnb/lunar/blob/fe3ed9758675dc3deef0e06307b5d0bedce06952/packages/core/src/components/Text/styles.ts)(default가 `div` 태그), [Link 컴포넌트](https://github.com/airbnb/lunar/blob/fe3ed9758675dc3deef0e06307b5d0bedce06952/packages/core/src/components/Link/styles.ts)(default가 `a` 태그), [Link 사용처](https://github.com/airbnb/lunar/blob/fe3ed9758675dc3deef0e06307b5d0bedce06952/packages/core/src/components/Link/story.tsx#L121)
  - [Chakra UI](https://github.com/chakra-ui/chakra-ui/blob/37b7a130aaff0cbb97f206978315075eb06e5100/packages/core/styled-system/src/config/typography.ts)(Text 컴포넌트 `div` 태그)
  - [Bootstrap](https://github.com/twbs/bootstrap/blob/f61a0218b36d915db80dc23635a9078e98e2e3e0/scss/mixins/_text-truncate.scss)(단순 스타일 코드)
- **truncated 스타일에 `display: block` 이 포함된 사례**
  - [Carbon-design-system](https://github.com/carbon-design-system/carbon/blob/5825cb460bb147bc7580bda93845b80a66a8ba51/packages/styles/scss/utilities/_text-truncate.scss)(단순 스타일 코드)
  - Braid-design-system [Truncate 컴포넌트](https://github.com/seek-oss/braid-design-system/blob/master/packages/braid-design-system/lib/components/private/Truncate/Truncate.css.ts)(`span` 태그)
  - Twilio paste [Truncate 컴포넌트](https://github.com/twilio-labs/paste/blob/804fb9316aa473529920a269b204dbb2710abd1b/packages/paste-core/components/truncate/src/index.tsx)(`span` 태그)
- 데스크에 적용된 후에, 후속으로 데스크 Text ellipsis 관련 스타일링 코드를 마이그레이션 할 예정입니다. 

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
No

## References
<!-- External documents based on workarounds or reviewers should refer to -->
- [Chakra UI - Text / Truncated](https://chakra-ui.com/docs/typography/text#truncate-text)
- [Airbnb Lunar- Text](http://airbnb.io/lunar/?path=/story/core-text--a-basic-string-of-text)
- [Carbon-design-system - Overflow Content](https://v10.carbondesignsystem.com/patterns/overflow-content/)
- [MDN text-overflow](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow)
