### PR TITLE
Decrease horizontal padding of `ButtonSize.XS` size `Button` to 2px

### DIFF
--- a/.changeset/thick-zoos-clap.md
+++ b/.changeset/thick-zoos-clap.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Decrease horizontal padding of XS size button to 2px

--- a/packages/bezier-react/src/components/Button/Button.styled.ts
+++ b/packages/bezier-react/src/components/Button/Button.styled.ts
@@ -56,7 +56,7 @@ type ButtonPaddingVariantKey = 'default' | 'floating'
 // NOTE: floating 은 padding 이 버튼의 size value 의 절반에서 Text padding 값 만큼 빼줘야 스펙과 일치
 export const BUTTON_HORIZONTAL_PADDING_VALUE: Record<ButtonSize, Record<ButtonPaddingVariantKey, number>> = {
   [ButtonSize.XS]: {
-    default: 4,
+    default: 2,
     floating: (BUTTON_SIZE_VALUE[ButtonSize.XS] / 2) - TEXT_PADDING_VALUE[ButtonSize.XS],
   },
   [ButtonSize.S]: {

--- a/packages/bezier-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/bezier-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1411,7 +1411,7 @@ exports[`Button Test > Size Test > with text > Size XS 1`] = `
   transition-property: background-color,box-shadow;
   min-width: 20px;
   height: 20px;
-  padding: 0 4px 0 4px;
+  padding: 0 2px 0 2px;
   overflow: hidden;
   border-radius: 6px;
   color: #FFFFFF;


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] ~~[Component] I wrote **a unit test** about the implementation.~~
- [ ] ~~[Component] I wrote **a storybook document** about the implementation.~~
- [x] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

## Summary
<!-- Please add a summary of the modification. -->
- Decrease horizontal padding of `ButtonSize.XS` size `Button` to 2px

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
No

## References
<!-- External documents based on workarounds or reviewers should refer to -->
- [Figma](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=7463%3A70383&t=xMsOVdpIvqkQCguP-4)
