### PR TITLE
Fix bug that first `StackItem` has `marginBefore` when preceding node is not JSX.Element

### DIFF
--- a/.changeset/real-vans-tie.md
+++ b/.changeset/real-vans-tie.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix bug that first StackItem has marginBefore when the preceding node is not valid element such as null or false

--- a/packages/bezier-react/src/components/Stack/Stack/Stack.test.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack/Stack.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 /* Internal dependencies */
 import { css } from 'Foundation'
 import { render } from 'Utils/testUtils'
+import { StackItem } from 'Components/Stack/StackItem'
 import { Stack } from './Stack'
 
 describe('Stack', () => {
@@ -51,5 +52,40 @@ describe('Stack', () => {
 
       expect(getByTestId('stack')).toHaveStyle({ 'background-color': 'red' })
     })
+  })
+
+  it('gives marginBefore attribute to second stackItem if it is given some spacing', () => {
+    const spacing = 10
+
+    const { getByTestId } = render(
+      <Stack direction="horizontal" spacing={spacing}>
+        <StackItem testId="one" />
+        <StackItem testId="two" />
+        <StackItem testId="three" />
+      </Stack>,
+    )
+
+    expect(getByTestId('one')).not.toHaveStyle('--margin-before: 10px')
+    expect(getByTestId('two')).toHaveStyle('--margin-before: 10px')
+    expect(getByTestId('three')).toHaveStyle('--margin-before: 10px')
+  })
+
+  it('does not give marginBefore attribute to first stackItem even if first node is not a valid JSXElement', () => {
+    const spacing = 10
+
+    const { getByTestId } = render(
+      <Stack direction="horizontal" spacing={spacing}>
+        { false }
+        { null }
+        abc
+        <StackItem testId="one" />
+        <StackItem testId="two" />
+        <StackItem testId="three" />
+      </Stack>,
+    )
+
+    expect(getByTestId('one')).not.toHaveStyle('--margin-before: 10px')
+    expect(getByTestId('two')).toHaveStyle('--margin-before: 10px')
+    expect(getByTestId('three')).toHaveStyle('--margin-before: 10px')
   })
 })

--- a/packages/bezier-react/src/components/Stack/Stack/Stack.test.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack/Stack.test.tsx
@@ -70,7 +70,7 @@ describe('Stack', () => {
     expect(getByTestId('three')).toHaveStyle('--margin-before: 10px')
   })
 
-  it('does not give marginBefore attribute to first stackItem even if first node is not a valid JSXElement', () => {
+  it('does not give marginBefore attribute to first stackItem if first node is not a valid ReactNode', () => {
     const spacing = 10
 
     const { getByTestId } = render(

--- a/packages/bezier-react/src/components/Stack/Stack/Stack.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack/Stack.tsx
@@ -4,6 +4,7 @@ import React, {
   cloneElement,
   forwardRef,
   isValidElement,
+  useRef,
 } from 'react'
 import type { Ref } from 'react'
 
@@ -45,6 +46,8 @@ export const Stack = forwardRef(function Stack(
   }: StackProps,
   forwardedRef: Ref<HTMLElement>,
 ) {
+  const firstValidElementIdx = useRef(-1)
+
   return (
     <Styled.Container
       ref={forwardedRef}
@@ -60,24 +63,26 @@ export const Stack = forwardRef(function Stack(
     >
       { Children.map(
         children,
-        (element, index) => (
-          isValidElement(element)
-            /**
+        (element, index) => {
+          if (!isValidElement(element)) { return element }
+
+          /**
              * NOTE: this assumes that this element is `StackItem`.
              *
              * Even if the child is not a `StackItem` component,
              * it could forward the prop to `StackItem` deeper in the tree,
              * or implement a custom behavior compatible with `StackItemProps`.
              */
-            ? cloneElement(element, {
-              ...element.props,
-              direction,
-              marginBefore:
+          if (firstValidElementIdx.current === -1) { firstValidElementIdx.current = index }
+          return cloneElement(element, {
+            ...element.props,
+            direction,
+            marginBefore:
                 element.props.marginBefore ??
-                (index > 0 ? spacing : 0),
-            })
-            : element
-        ),
+                (index > firstValidElementIdx.current ? spacing : 0),
+          })
+        },
+
       ) }
     </Styled.Container>
   )


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [x] [Component] I wrote **a unit test** about the implementation.
- [ ] ~~[Component] I wrote **a storybook document** about the implementation.~~
- [ ] ~~[Component] I tested the implementation in **various browsers**.~~
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

Fixes #1116 

## Summary
<!-- Please add a summary of the modification. -->
- 첫 번째 `StackItem` 이 원하지 않는 `marginBefore` 를 갖는 버그를 수정합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- 기존 코드에서는 valid element (=`ReactElement`. 참고로 `string`, `boolean`, `null` 등은 `ReactElement` 가 아닌 `ReactNode` 입니다) 라면 `index > 0` 만 검사하였기 때문에 아래와 같은 상황에서 원치 않은 `marginBefore` 가 들어갔습니다.

```typescript
<Stack spacing={10}>
  { false && <FirstComponent /> }

  <SecondComponent /> //  marginBefore is set to 10
<Stack>
```

- 이제 가장 첫번째 **valid** element 다음에 나오는 element 에 대해서만 `marginBefore` 를 줍니다.
- 처음으로 했던 시도는 `React.Children.toArray(children).findIndex(...)` 과 같이 `children` 을 미리 검사하는 방법으로 첫번째 valid한 element 의 index 를 찾으려고 했으나, `toArray` 자체가 valid 한 element 만 filter 하기 때문에 사용하지 못했습니다. 따라서 `useRef` 를 사용하여 로직을 만들었습니다.
 
## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
- No

## References
<!-- External documents based on workarounds or reviewers should refer to -->
- [`ReactElement vs ReactNode`](https://stackoverflow.com/questions/58123398/when-to-use-jsx-element-vs-reactnode-vs-reactelement)
- #1116 
