### PR TITLE
Remove default value of event handler props in `Icon` component

### DIFF
--- a/.changeset/modern-pants-applaud.md
+++ b/.changeset/modern-pants-applaud.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Remove default value of event handler props in Icon component

--- a/packages/bezier-react/src/components/Icon/Icon.tsx
+++ b/packages/bezier-react/src/components/Icon/Icon.tsx
@@ -1,6 +1,5 @@
 /* External dependencies */
 import React, { memo } from 'react'
-import { noop } from 'lodash-es'
 
 /* Internal dependencies */
 import type IconProps from './Icon.types'
@@ -19,8 +18,8 @@ export const Icon = memo(function Icon({
   marginRight = 0,
   marginBottom = 0,
   marginLeft = 0,
-  onClick = noop,
-  onMouseDown = noop,
+  onClick,
+  onMouseDown,
 }: IconProps) {
   return (
     <Styled


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

#1123

## Summary
<!-- Please add a summary of the modification. -->
`Icon` 컴포넌트의 이벤트 핸들러 props에 default value를 할당하지 않도록 수정합니다.
- `onClick`
- `onMouseDown`

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->
`Icon`의 `onClick` prop에 default value(`noop`, `() => {}`)가 할당됨으로 인해 문제를 일으키는 경우가 있습니다.
아래의 조건을 만족할 경우 [a 태그의 telephone number link](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_telephone_numbers)(`tel:`)가 제대로 동작하지 않습니다.
1. iPad의 Safari 브라우저일 때
2. a 태그의 하위 엘리먼트 중 `onclick` attribute가 등록된 엘리먼트가 존재할 때

예를 들어 아래와 같은 usecase가 있습니다.
```html
<a href="tel:+49.157.0156">
    <div onclick="doSomething()"></div>
</a>
```

`Icon`을 활용하여 `tel:` link로 연결되는 버튼/링크를 만드는 경우 아래와 같은 구조를 가질 수 있습니다.
```jsx
<a href={telHref} target="_blank">
    <Icon source={CallIcon} size={IconSize.S} />
</a>
```

이때, iPad의 Safari 브라우저에서는 해당 링크가 동작하지 않게 됩니다.
- a 태그와 Icon 사이에 다른 엘리먼트를 중첩하는 경우에도 여전히 동작하지 않습니다.
- a 태그의 `target`을 `_self`, `_parent`, `_top` 등으로 변경해도 동작하지 않습니다.
- `Icon`이 내부적으로 svg 태그에 전달하고 있는 `onClick` prop을 제거할 경우 정상 동작합니다.

--
**참고: a 태그 구현의 파편화**

각 환경의 브라우저마다 a 태그의 구현이 제각기 다릅니다. 특히, a 태그의 `target` attribute에 대해 여러 동작을 가집니다.
예를 들어, 아래와 같은 케이스가 존재합니다.
- iOS의 Chrome 앱에서는 a 태그의 `target`이 `_blank`일 때 `tel:` link가 동작하지 않습니다. (다른 환경에서는 정상 동작)
- iOS의 Safari 앱에서는 a 태그의 `target`이 `_self`일 때 `tel:` link가 동작하지 않습니다. (다른 환경에서는 정상 동작)

--
**Workaround**

아래와 같은 방법으로 Bezier `Icon` 컴포넌트의 수정 없이 문제를 해결할 수 있습니다.
```jsx
<a
  onClick={() => window.open(`tel:${telLink}`, '_blank')}
>
    <Icon source={CallIcon} size={IconSize.S} />
</a>
```

단, 위와 같은 방법은 실행 환경에 따른 분기 처리를 복잡하게 만들고, iPad의 Safari 브라우저에 a 태그의 `tel:` link와 관련된 이슈가 있음을 개발자가 미리 알아채고 대응하기 어렵기 때문에 Bezier `Icon`의 수정을 통해 문제를 해결하기를 바랍니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
No

## References
<!-- External documents based on workarounds or reviewers should refer to -->
.
