### PR TITLE
Enhance `RadioGroup` component

### DIFF
--- a/.changeset/grumpy-islands-sit.md
+++ b/.changeset/grumpy-islands-sit.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Enhance the interface of `Radio` and `RadioGroup` components. Change `Radio` to render children when their value is evaluated as true.

--- a/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.tsx
+++ b/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.tsx
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React, { forwardRef, useEffect } from 'react'
+import React, { forwardRef, useEffect, isValidElement } from 'react'
 
 /* Internal dependencies */
 import { StackItem } from 'Components/Stack'
@@ -48,7 +48,7 @@ forwardedRef: React.Ref<HTMLDivElement>,
       role={role}
     >
       { React.Children.map(children, (child, index) => (
-        <StackItem key={(child as React.ReactElement)?.key ?? index}>
+        <StackItem key={isValidElement(child) ? child.key : index}>
           { child }
         </StackItem>
       )) }

--- a/packages/bezier-react/src/components/Forms/Radio/Radio.tsx
+++ b/packages/bezier-react/src/components/Forms/Radio/Radio.tsx
@@ -19,6 +19,9 @@ import RadioProps from './Radio.types'
 export const RADIO_TEST_ID = 'bezier-react-radio'
 export const RADIO_HANDLE_TEST_ID = 'bezier-react-radio-handle'
 
+/**
+ * @deprecated Use `RadioGroup` instead.
+ */
 function Radio(
   {
     as,
@@ -85,4 +88,7 @@ function Radio(
   )
 }
 
+/**
+ * @deprecated Use `RadioGroup` instead.
+ */
 export default forwardRef(Radio)

--- a/packages/bezier-react/src/components/Forms/Radio/Radio.types.ts
+++ b/packages/bezier-react/src/components/Forms/Radio/Radio.types.ts
@@ -17,6 +17,9 @@ interface RadioOptions {
   onClick?: (value: any, e: MouseEvent) => void
 }
 
+/**
+ * @deprecated Use `RadioGroup` instead.
+ */
 export default interface RadioProps extends
   BezierComponentProps,
   ChildrenProps,

--- a/packages/bezier-react/src/components/Forms/RadioGroup/Radio.tsx
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/Radio.tsx
@@ -19,10 +19,12 @@ function RadioImpl<Value extends string>({
       id={id}
       {...rest}
     >
-      { /* @ts-ignore FIXME(@ed): Delete after applying polymorphic props */ }
-      <Styled.Label htmlFor={id}>
-        { children }
-      </Styled.Label>
+      { children && (
+        /* @ts-ignore FIXME(@ed): Delete after applying polymorphic props */
+        <Styled.Label htmlFor={id}>
+          { children }
+        </Styled.Label>
+      ) }
     </Styled.RadioGroupPrimitiveItem>
   )
 }

--- a/packages/bezier-react/src/components/Forms/RadioGroup/Radio.tsx
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/Radio.tsx
@@ -31,7 +31,7 @@ function RadioImpl<Value extends string>({
 
 /**
  * `Radio` is a checkable button, known as a radio button.
- * It is must be a child of `RadioGroup`.
+ * It should be a child of `RadioGroup`.
  */
 export const Radio = forwardRef(RadioImpl) as <Value extends string>(
   props: RadioProps<Value> & { ref?: React.ForwardedRef<HTMLButtonElement> }

--- a/packages/bezier-react/src/components/Forms/RadioGroup/Radio.tsx
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/Radio.tsx
@@ -6,15 +6,11 @@ import useId from 'Hooks/useId'
 import { RadioProps } from './RadioGroup.types'
 import * as Styled from './RadioGroup.styled'
 
-/**
- * `Radio` is a checkable button, known as a radio button.
- * It is must be a child of `RadioGroup`.
- */
-export const Radio = forwardRef(function Radio({
+function RadioImpl<Value extends string>({
   children,
   id: idProp,
   ...rest
-}: RadioProps, forwardedRef: React.Ref<HTMLButtonElement>) {
+}: RadioProps<Value>, forwardedRef: React.Ref<HTMLButtonElement>) {
   const id = useId(idProp, 'bezier-radio')
 
   return (
@@ -29,4 +25,12 @@ export const Radio = forwardRef(function Radio({
       </Styled.Label>
     </Styled.RadioGroupPrimitiveItem>
   )
-})
+}
+
+/**
+ * `Radio` is a checkable button, known as a radio button.
+ * It is must be a child of `RadioGroup`.
+ */
+export const Radio = forwardRef(RadioImpl) as <Value extends string>(
+  props: RadioProps<Value> & { ref?: React.ForwardedRef<HTMLButtonElement> }
+) => ReturnType<typeof RadioImpl<Value>>

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.tsx
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.tsx
@@ -28,7 +28,7 @@ function RadioGroupImpl<Value extends string>({
         direction={direction}
       >
         { React.Children.map(children, (child, index) => (
-          <StackItem key={child?.key ?? index}>
+          <StackItem key={(child as React.ReactElement)?.key ?? index}>
             { child }
           </StackItem>
         )) }

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.tsx
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.tsx
@@ -7,27 +7,12 @@ import { Stack, StackItem } from 'Components/Stack'
 import useFormFieldProps from 'Components/Forms/useFormFieldProps'
 import { RadioGroupProps } from './RadioGroup.types'
 
-/**
- * `RadioGroup` is a set of checkable buttons, known as radio buttons.
- *
- * `RadioGroup` is a context of the `Radio` components. also, it renders an element which has the 'radiogroup' role.
- * It controls all the parts of a radio group.
- *
- * @example
- *
- * ```tsx
- * // Anatomy of the RadioGroup
- * <RadioGroup>
- *  <Radio />
- * </RadioGroup>
- * ```
- */
-export const RadioGroup = forwardRef(function RadioGroup({
+function RadioGroupImpl<Value extends string>({
   children,
   spacing = 0,
   direction = 'vertical',
   ...rest
-}: RadioGroupProps, forwardedRef: React.Ref<HTMLDivElement>) {
+}: RadioGroupProps<Value>, forwardedRef: React.Ref<HTMLDivElement>) {
   const formFieldProps = useFormFieldProps(rest)
 
   return (
@@ -50,4 +35,23 @@ export const RadioGroup = forwardRef(function RadioGroup({
       </Stack>
     </RadioGroupPrimitive.Root>
   )
-})
+}
+
+/**
+ * `RadioGroup` is a set of checkable buttons, known as radio buttons.
+ *
+ * `RadioGroup` is a context of the `Radio` components. also, it renders an element which has the 'radiogroup' role.
+ * It controls all the parts of a radio group.
+ *
+ * @example
+ *
+ * ```tsx
+ * // Anatomy of the RadioGroup
+ * <RadioGroup>
+ *  <Radio />
+ * </RadioGroup>
+ * ```
+ */
+export const RadioGroup = forwardRef(RadioGroupImpl) as <Value extends string>(
+  props: RadioGroupProps<Value> & { ref?: React.ForwardedRef<HTMLDivElement> }
+) => ReturnType<typeof RadioGroupImpl<Value>>

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.tsx
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.tsx
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React, { forwardRef } from 'react'
+import React, { forwardRef, isValidElement } from 'react'
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 
 /* Internal dependencies */
@@ -28,7 +28,7 @@ function RadioGroupImpl<Value extends string>({
         direction={direction}
       >
         { React.Children.map(children, (child, index) => (
-          <StackItem key={(child as React.ReactElement)?.key ?? index}>
+          <StackItem key={isValidElement(child) ? child.key : index}>
             { child }
           </StackItem>
         )) }

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.types.ts
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.types.ts
@@ -54,7 +54,7 @@ type RadioFormComponentProps = Pick<FormComponentProps, 'disabled' | 'required'>
 
 export interface RadioGroupProps<Value extends string = string> extends
   BezierComponentProps,
-  ChildrenProps<React.ReactElement[] | React.ReactElement>,
+  ChildrenProps,
   RadioFormComponentProps,
   Omit<React.HTMLAttributes<HTMLDivElement>, keyof RadioGroupOptions<Value> | keyof RadioGroupPrimitive.RadioGroupProps>,
   RadioGroupOptions<Value> {}

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.types.ts
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.types.ts
@@ -6,17 +6,17 @@ import { BezierComponentProps, ChildrenProps } from 'Types/ComponentProps'
 import { FormComponentProps } from 'Components/Forms'
 import { StackProps } from 'Components/Stack'
 
-interface RadioGroupOptions {
+interface RadioGroupOptions<Value extends string = string> {
   /**
    * The controlled value of the radio item to check.
    * Should be used in conjunction with `onValueChange`.
    */
-  value?: string
+  value?: Value
   /**
    * The value of the radio item that should be checked when initially rendered.
    * Use when you do not need to control the state of the radio items.
    */
-  defaultValue?: string
+  defaultValue?: Value
   /**
    * The name of the group.
    * Submitted with its owning form as part of a name/value pair.
@@ -35,14 +35,14 @@ interface RadioGroupOptions {
   /**
    * Event handler called when the value changes.
    */
-  onValueChange?: (value: string) => void
+  onValueChange?: (value: Value) => void
 }
 
-interface RadioOptions {
+interface RadioOptions<Value extends string = string> {
   /**
    * The value given as data when submitted with a `RadioGroupProps.name`.
    */
-  value: string
+  value: Value
   /**
    * The unique id of the radio item. It is created automatically by default.
    * It used by the label element in the radio item.
@@ -52,16 +52,16 @@ interface RadioOptions {
 
 type RadioFormComponentProps = Pick<FormComponentProps, 'disabled' | 'required'>
 
-export interface RadioGroupProps extends
+export interface RadioGroupProps<Value extends string = string> extends
   BezierComponentProps,
   ChildrenProps<React.ReactElement[] | React.ReactElement>,
   RadioFormComponentProps,
-  Omit<React.HTMLAttributes<HTMLDivElement>, keyof RadioGroupOptions | keyof RadioGroupPrimitive.RadioGroupProps>,
-  RadioGroupOptions {}
+  Omit<React.HTMLAttributes<HTMLDivElement>, keyof RadioGroupOptions<Value> | keyof RadioGroupPrimitive.RadioGroupProps>,
+  RadioGroupOptions<Value> {}
 
-export interface RadioProps extends
+export interface RadioProps<Value extends string = string> extends
   BezierComponentProps,
   ChildrenProps,
   RadioFormComponentProps,
-  Omit<React.HTMLAttributes<HTMLButtonElement>, keyof RadioOptions>,
-  RadioOptions {}
+  Omit<React.HTMLAttributes<HTMLButtonElement>, keyof RadioOptions<Value>>,
+  RadioOptions<Value> {}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->

`RadioGroup`, `Radio` 컴포넌트를 개선합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- 컴포넌트 타입에 제네릭을 적용합니다. `string` 외 `enum` 등의 케이스에서도 타입 에러 없이 사용할 수 있도록 합니다.
- `RadioGroup` 의 `children` 타입을 `React.ReactNode` 로 변경합니다. 다양한 유즈케이스에서도 타입 에러 없이 잘 동작하도록 변경합니다. 
- `Radio` 에 children이 존재하는 케이스에만 내부 라벨을 렌더하도록 변경합니다. 라벨이 없는 유즈케이스를 커버하기 위한 변경입니다.
- chore: 레거시 라디오 컴포넌트에 deprecated 주석을 추가합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

없음
