### PR TITLE
Delete `RadioGroup`'s default generic parameter to fix type inferencing

### DIFF
--- a/.changeset/afraid-kids-do.md
+++ b/.changeset/afraid-kids-do.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Delete `RadioGroup`'s default generic parameter to fix type inferencing.

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.stories.tsx
@@ -9,6 +9,12 @@ import { RadioGroup } from './RadioGroup'
 import { Radio } from './Radio'
 import { RadioGroupProps } from './RadioGroup.types'
 
+enum Theme {
+  System = 'System',
+  Light = 'Light',
+  Dark = 'Dark',
+}
+
 export default {
   title: getTitle(base),
   component: RadioGroup,
@@ -21,13 +27,13 @@ export default {
       },
     },
   },
-} as Meta<RadioGroupProps>
+} as Meta<RadioGroupProps<Theme>>
 
-const Template: Story<RadioGroupProps> = ({
+const Template: Story<RadioGroupProps<Theme>> = ({
   value: valueProp,
   ...props
 }) => {
-  const [value, setValue] = useState(() => valueProp)
+  const [value, setValue] = useState<Theme | undefined>(() => valueProp)
 
   useEffect(function watchValueToChange() {
     setValue(valueProp)
@@ -39,16 +45,16 @@ const Template: Story<RadioGroupProps> = ({
       onValueChange={setValue}
       {...props}
     >
-      <Radio value="System">System</Radio>
-      <Radio value="Light">Light</Radio>
-      <Radio value="Dark">Dark</Radio>
+      <Radio value={Theme.System}>{ Theme.System }</Radio>
+      <Radio value={Theme.Light}>{ Theme.Light }</Radio>
+      <Radio value={Theme.Dark}>{ Theme.Dark }</Radio>
     </RadioGroup>
   )
 }
 
 export const Primary = Template.bind({})
 Primary.args = {
-  value: 'System',
+  value: Theme.System,
   disabled: false,
   required: false,
   direction: 'vertical',

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.styled.ts
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.styled.ts
@@ -14,7 +14,7 @@ const OUTER_INDICATOR_SIZE = 18
 const OUTER_INDICATOR_MARGIN = 1
 const INNER_INDICATOR_SIZE = 8
 
-export const RadioGroupPrimitiveItem = styled(RadioGroupPrimitive.Item)<RadioProps>`
+export const RadioGroupPrimitiveItem = styled(RadioGroupPrimitive.Item)<RadioProps<string>>`
   all: unset;
   position: relative;
   display: flex;

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.test.tsx
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.test.tsx
@@ -16,8 +16,8 @@ describe('RadioGroup', () => {
     radioGroupProps,
     radioProps,
   }: {
-    radioGroupProps?: RadioGroupProps
-    radioProps?: Partial<RadioProps>
+    radioGroupProps?: RadioGroupProps<string>
+    radioProps?: Partial<RadioProps<string>>
   } = {}) => render(
     <RadioGroup {...radioGroupProps}>
       { VALUES.map(value => (

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.types.ts
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.types.ts
@@ -6,7 +6,7 @@ import { BezierComponentProps, ChildrenProps } from 'Types/ComponentProps'
 import { FormComponentProps } from 'Components/Forms'
 import { StackProps } from 'Components/Stack'
 
-interface RadioGroupOptions<Value extends string = string> {
+interface RadioGroupOptions<Value extends string> {
   /**
    * The controlled value of the radio item to check.
    * Should be used in conjunction with `onValueChange`.
@@ -38,7 +38,7 @@ interface RadioGroupOptions<Value extends string = string> {
   onValueChange?: (value: Value) => void
 }
 
-interface RadioOptions<Value extends string = string> {
+interface RadioOptions<Value extends string> {
   /**
    * The value given as data when submitted with a `RadioGroupProps.name`.
    */
@@ -52,14 +52,14 @@ interface RadioOptions<Value extends string = string> {
 
 type RadioFormComponentProps = Pick<FormComponentProps, 'disabled' | 'required'>
 
-export interface RadioGroupProps<Value extends string = string> extends
+export interface RadioGroupProps<Value extends string> extends
   BezierComponentProps,
   ChildrenProps,
   RadioFormComponentProps,
   Omit<React.HTMLAttributes<HTMLDivElement>, keyof RadioGroupOptions<Value> | keyof RadioGroupPrimitive.RadioGroupProps>,
   RadioGroupOptions<Value> {}
 
-export interface RadioProps<Value extends string = string> extends
+export interface RadioProps<Value extends string> extends
   BezierComponentProps,
   ChildrenProps,
   RadioFormComponentProps,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->

value의 타입 추론이 잘 이루어지도록 개선하고, 관련 테스트(스토리)를 추가합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

생략

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- #1131 
