### PR TITLE
ci(github): create an action to send notifications to the Channel Desk app

### DIFF
--- a/.github/workflows/prereleased.yml
+++ b/.github/workflows/prereleased.yml
@@ -1,0 +1,42 @@
+name: Prereleased
+
+on:
+  release:
+    types: [prereleased]
+
+jobs:
+  notify-prereleased:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ch-web-github-actions
+        uses: actions/checkout@v3
+        with:
+          repository: channel-io/ch-web-github-actions
+          token: ${{ secrets.ACTIONS_REPO_ACCESS_TOKEN }}
+          ref: main
+          path: ch-web-github-actions
+
+      - name: Send Channel Desk notification
+        uses: ./ch-web-github-actions/packages/action-ch-create-message
+        with:
+          stage: production
+          accessKey: ${{ secrets.CH_API_ACCESS_KEY_PRODUCTION }}
+          accessSecret: ${{ secrets.CH_API_ACCESS_SECRET_PRODUCTION }}
+          botName: Github
+          groupName: Release
+          blocks: |
+            [
+              {
+                "type": "text",
+                "value": "\n\n${{ github.event.repository.name }}: <b>${{ github.event.release.name }}</b>"
+              },
+              {
+                "type": "bullets",
+                "blocks": [
+                  {
+                    "type": "text",
+                    "value": "Release note: <link type=\"url\">${{ github.event.release.html_url }}</link>"
+                  }
+                ]
+              }
+            ]


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->

Prerelease가 완료되면 채널톡 데스크 어플리케이션의 릴리즈 방에 알림 메세지를 보내는 GitHub action을 구현합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

<img width="482" alt="image" src="https://user-images.githubusercontent.com/58209009/223365652-3076dcdc-74a9-45bb-a79c-c415ebdc881d.png">

- 개인 private repository에서 테스트한 스크린샷으로, 위와 같은 형태로 메세지가 전달됩니다.
- 인하우스의 메세지 알림이 일반적인 릴리즈에선 정상적으로 동작하나, 프리릴리즈에 대해서는 지원하지 않고 있기 때문에 자체적으로 액션을 구현했습니다. 메세지 파싱 로직이 인하우스에 구현된 것만큼 완벽하지 않기 때문에, 릴리즈 바디 대신에 주소를 첨부하는 방식으로 대체 구현했습니다.
- **TODO: Repo 토큰을 ch-builder의 토큰으로 변경해야함.**

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=prereleased#release
- https://github.com/channel-io/ch-web-github-actions