### PR TITLE
Fix module resolve error in library usage

### DIFF
--- a/.changeset/thirty-birds-develop.md
+++ b/.changeset/thirty-birds-develop.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix module resolve error in library usage

--- a/packages/bezier-react/src/components/Avatars/Avatar/Avatar.tsx
+++ b/packages/bezier-react/src/components/Avatars/Avatar/Avatar.tsx
@@ -8,7 +8,9 @@ import {
 } from '~/src/utils/typeUtils'
 import { noop } from '~/src/utils/functionUtils'
 import { Status, StatusSize } from '~/src/components/Status'
-import defaultAvatarUrl from '~/src/components/Avatars/assets/defaultAvatar.svg'
+// NOTE: Don't fix it. When using absolute paths, a module resolve error occurs at runtime.
+// eslint-disable-next-line no-restricted-imports
+import defaultAvatarUrl from '../assets/defaultAvatar.svg'
 import useProgressiveImage from './useProgressiveImage'
 import AvatarProps, { AvatarSize } from './Avatar.types'
 import { AvatarImage, AvatarWrapper, StatusWrapper } from './Avatar.styled'

--- a/packages/bezier-react/src/components/Avatars/Avatar/Avatar.tsx
+++ b/packages/bezier-react/src/components/Avatars/Avatar/Avatar.tsx
@@ -8,7 +8,7 @@ import {
 } from '~/src/utils/typeUtils'
 import { noop } from '~/src/utils/functionUtils'
 import { Status, StatusSize } from '~/src/components/Status'
-// NOTE: Don't fix it. When using absolute paths, a module resolve error occurs at runtime.
+// NOTE: Don't fix it. When using absolute paths, a module resolve error occurs at the runtime of the library consumer.
 // eslint-disable-next-line no-restricted-imports
 import defaultAvatarUrl from '../assets/defaultAvatar.svg'
 import useProgressiveImage from './useProgressiveImage'


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->

`Avatar` 의  default avatar asset 경로를 상대 경로로 변경합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

라이브러리 사용처에서 아래와 같이 module resolve error가 발생하는 케이스를 수정합니다. (#1109 이전으로 롤백)

```
Uncaught Error: Cannot find module '~/src/components/Avatars/assets/defaultAvatar.svg'
    at webpackMissingModule (Avatar.js:12:50)
    at eval (Avatar.js:12:174)
    at ./node_modules/@channel.io/bezier-react/build/src/components/Avatars/Avatar/Avatar.js (bundle.js:6767:1)
    at options.factory (bundle.js:86921:31)
    at __webpack_require__ (bundle.js:86275:33)
    at fn (bundle.js:86563:21)
    at eval (ManagerAvatar.tsx:12:83)
    at ./src/components/ManagerAvatar/ManagerAvatar.tsx (bundle.js:22051:1)
    at options.factory (bundle.js:86921:31)
    at __webpack_require__ (bundle.js:86275:33)
```

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

없음
