### PR TITLE
feat(checkbox): apply a generic type to the checked type of Checkbox

### DIFF
--- a/.changeset/silent-mayflies-change.md
+++ b/.changeset/silent-mayflies-change.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Apply a generic type to the `checked` type of `Checkbox`

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.stories.tsx
@@ -5,7 +5,7 @@ import { Meta, Story } from '@storybook/react'
 
 /* Internal dependencies */
 import { getTitle } from '~/src/utils/storyUtils'
-import { CheckboxProps } from './Checkbox.types'
+import { CheckboxProps, CheckedState } from './Checkbox.types'
 import { Checkbox } from './Checkbox'
 
 export default {
@@ -25,7 +25,7 @@ export default {
   },
 } as Meta
 
-const Template: Story<CheckboxProps> = ({ children, ...otherCheckboxProps }) => (
+const Template: Story<CheckboxProps<CheckedState>> = ({ children, ...otherCheckboxProps }) => (
   <Checkbox {...otherCheckboxProps}>
     { children }
   </Checkbox>

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.styled.ts
@@ -40,7 +40,7 @@ const focusStyle = css`
   ${checkIconFocusStyle}
 `
 
-export const CheckboxPrimitiveRoot = styled(CheckboxPrimitive.Root)<CheckboxProps>`
+export const CheckboxPrimitiveRoot = styled(CheckboxPrimitive.Root)<CheckboxProps<any>>`
   all: unset;
   display: flex;
   align-items: center;

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event'
 /* Internal dependencies */
 import { render } from '~/src/utils/testUtils'
 import { Checkbox } from './Checkbox'
-import { CheckboxProps } from './Checkbox.types'
+import { CheckboxProps, CheckedState } from './Checkbox.types'
 
 const VALUES = ['0', '1', '2']
 
@@ -14,14 +14,14 @@ describe('Checkbox', () => {
   const renderCheckbox = ({
     children,
     ...rest
-  }: CheckboxProps = {}) => render(
+  }: CheckboxProps<CheckedState> = {}) => render(
     <Checkbox {...rest}>
       { children }
     </Checkbox>,
   )
 
   const renderCheckboxes = (
-    props: Omit<CheckboxProps, 'children'> = {},
+    props: Omit<CheckboxProps<CheckedState>, 'children'> = {},
   ) => render(
     <div role="group">
       { VALUES.map(value => (

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.tsx
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.tsx
@@ -7,7 +7,7 @@ import useId from '~/src/hooks/useId'
 import { IconSize, CheckBoldIcon, HyphenBoldIcon } from '~/src/components/Icon'
 import { FormFieldSize } from '~/src/components/Forms'
 import useFormFieldProps from '~/src/components/Forms/useFormFieldProps'
-import { CheckboxProps } from './Checkbox.types'
+import { CheckboxProps, CheckedState } from './Checkbox.types'
 import * as Styled from './Checkbox.styled'
 
 type CheckIconProps = {} | {
@@ -37,40 +37,12 @@ const CheckIcon = forwardRef<SVGSVGElement, CheckIconProps>(function CheckIcon(
   )
 })
 
-/**
- * `Checkbox` is a control that allows the user to toggle between checked and not checked.
- * It can be used with labels or standalone.
- *
- * @example
- *
- * ```tsx
- * const [checked, setChecked] = useState(false)
- * // Controlled / With label
- * <Checkbox
- *   checked={checked}
- *   onCheckedChange={setChecked}
- * >
- *   Label
- * </Checkbox>
- * // Controlled / Standalone
- * <Checkbox
- *   checked={checked}
- *   onCheckedChange={setChecked}
- * />
- * // Uncontrolled
- * <Checkbox
- *   defaultChecked={true}
- * >
- *   Label
- * </Checkbox>
- * ```
- */
-export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(function Checkbox({
+function CheckboxImpl<Checked extends CheckedState>({
   children,
   checked,
   id: idProp,
   ...rest
-}, forwardedRef) {
+}: CheckboxProps<Checked>, forwardedRef: React.Ref<HTMLButtonElement>) {
   const id = useId(idProp, 'bezier-checkbox')
   const {
     hasError,
@@ -108,4 +80,36 @@ export const Checkbox = forwardRef<HTMLButtonElement, CheckboxProps>(function Ch
       ) }
     </Styled.Container>
   )
-})
+}
+
+/**
+ * `Checkbox` is a control that allows the user to toggle between checked and not checked.
+ * It can be used with labels or standalone.
+ *
+ * @example
+ *
+ * ```tsx
+ * const [checked, setChecked] = useState(false)
+ * // Controlled / With label
+ * <Checkbox
+ *   checked={checked}
+ *   onCheckedChange={setChecked}
+ * >
+ *   Label
+ * </Checkbox>
+ * // Controlled / Standalone
+ * <Checkbox
+ *   checked={checked}
+ *   onCheckedChange={setChecked}
+ * />
+ * // Uncontrolled
+ * <Checkbox
+ *   defaultChecked={true}
+ * >
+ *   Label
+ * </Checkbox>
+ * ```
+ */
+export const Checkbox = forwardRef(CheckboxImpl) as <Checked extends CheckedState>(
+  props: CheckboxProps<Checked> & { ref?: React.ForwardedRef<HTMLButtonElement> }
+) => ReturnType<typeof CheckboxImpl<Checked>>

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.types.ts
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.types.ts
@@ -4,17 +4,17 @@ import { FormComponentProps } from '~/src/components/Forms'
 
 export type CheckedState = boolean | 'indeterminate'
 
-interface CheckboxOptions {
+interface CheckboxOptions<Checked extends CheckedState> {
   /**
    * The controlled checked state of the checkbox.
    * Must be used in conjunction with `onCheckedChange`.
    */
-  checked?: CheckedState
+  checked?: Checked
   /**
    * The checked state of the checkbox when it is initially rendered.
    * Use when you do not need to control its checked state.
    */
-  defaultChecked?: CheckedState
+  defaultChecked?: Checked
   /**
    * The unique id of the checkbox. It is created automatically by default.
    * It used by the label element in the checkbox.
@@ -33,12 +33,12 @@ interface CheckboxOptions {
   /**
    * Event handler called when the checked state of the checkbox changes.
    */
-  onCheckedChange?: (checked: CheckedState) => void
+  onCheckedChange?: (checked: Checked) => void
 }
 
-export interface CheckboxProps extends
+export interface CheckboxProps<Checked extends CheckedState> extends
   Omit<BezierComponentProps, 'as'>,
   ChildrenProps,
   FormComponentProps,
-  Omit<React.HTMLAttributes<HTMLButtonElement>, keyof CheckboxOptions>,
-  CheckboxOptions {}
+  Omit<React.HTMLAttributes<HTMLButtonElement>, keyof CheckboxOptions<Checked>>,
+  CheckboxOptions<Checked> {}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

`Checkbox` 컴포넌트의 `checked` prop에 제네릭 타입을 적용합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

`checked` 의 타입, `CheckedState` 는 `boolean | 'indeterminate'` 입니다. 여기서 `'indeterminate'` 타입은 체크박스 유즈 케이스상 사용처가 거의 없고, 대부분은 `boolean` 으로만 상태를 컨트롤합니다. 이러한 대부분의 케이스에서 불필요한 `'indeterminate'` 타입이 에러를 발생시키는 불편함을 해소하기위해 `checked` prop에 제네릭 타입을 적용합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

None