### PR TITLE
fix(checkbox): fix FormControl's id always overrides Checkbox's id prop

### DIFF
--- a/.changeset/friendly-spoons-enjoy.md
+++ b/.changeset/friendly-spoons-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix `FormControl`'s id always overrides `Checkbox`'s id prop

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.test.tsx
@@ -137,7 +137,7 @@ describe('Checkbox', () => {
     }: {
       children?: React.ReactNode
       formControlProps?: Omit<FormControlProps, 'children'>
-      checkboxProps?: Omit<CheckboxProps, 'children'>
+      checkboxProps?: Omit<CheckboxProps<CheckedState>, 'children'>
     }) => render(
       <FormControl {...formControlProps}>
         <Checkbox {...checkboxProps}>

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 
 /* Internal dependencies */
 import { render } from '~/src/utils/testUtils'
+import { FormControl, FormControlProps } from '~/src/components/Forms/FormControl'
 import { Checkbox } from './Checkbox'
 import { CheckboxProps, CheckedState } from './Checkbox.types'
 
@@ -125,6 +126,49 @@ describe('Checkbox', () => {
       expect(checkbox).toHaveFocus()
       await user.keyboard('{ }')
       expect(onCheckedChange).toBeCalledTimes(1)
+    })
+  })
+
+  describe('With FormControl', () => {
+    const renderCheckboxWithFormControl = ({
+      children,
+      formControlProps = {},
+      checkboxProps = {},
+    }: {
+      children?: React.ReactNode
+      formControlProps?: Omit<FormControlProps, 'children'>
+      checkboxProps?: Omit<CheckboxProps, 'children'>
+    }) => render(
+      <FormControl {...formControlProps}>
+        <Checkbox {...checkboxProps}>
+          { children }
+        </Checkbox>
+      </FormControl>,
+    )
+
+    it('FormControl\'s disabled prop should be passed to Checkbox', () => {
+      const { getByRole } = renderCheckboxWithFormControl({ formControlProps: { disabled: true } })
+      expect(getByRole('checkbox')).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('FormControl\'s hasError prop should be passed to Checkbox', () => {
+      const { getByRole } = renderCheckboxWithFormControl({ formControlProps: { hasError: true } })
+      expect(getByRole('checkbox')).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('FormControl\'s required prop should be passed to Checkbox', () => {
+      const { getByRole } = renderCheckboxWithFormControl({ formControlProps: { required: true } })
+      expect(getByRole('checkbox')).toHaveAttribute('aria-required', 'true')
+    })
+
+    it('FormControl\'s id prop should be passed to Checkbox', () => {
+      const { getByRole } = renderCheckboxWithFormControl({ formControlProps: { id: 'form-control-id' } })
+      expect(getByRole('checkbox')).toHaveAttribute('id', 'form-control-id')
+    })
+
+    it('FormControl\'s id prop should be overwritten by Checkbox\'s id prop', () => {
+      const { getByRole } = renderCheckboxWithFormControl({ formControlProps: { id: 'form-control-id' }, checkboxProps: { id: 'checkbox-id' } })
+      expect(getByRole('checkbox')).toHaveAttribute('id', 'checkbox-id')
     })
   })
 })

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.tsx
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.tsx
@@ -43,11 +43,13 @@ function CheckboxImpl<Checked extends CheckedState>({
   id: idProp,
   ...rest
 }: CheckboxProps<Checked>, forwardedRef: React.Ref<HTMLButtonElement>) {
-  const id = useId(idProp, 'bezier-checkbox')
   const {
+    id: formFieldId,
     hasError,
     ...formFieldProps
   } = useFormFieldProps(rest)
+
+  const id = useId(idProp ?? formFieldId, 'bezier-checkbox')
 
   const containerStyle = {
     '--bezier-checkbox-height': children ? `${FormFieldSize.M}px` : 'auto',


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [x] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

`FormControl` 컨텍스트 아래 있을 때, 해당 컨텍스트의 id가 `Checkbox` 컴포넌트에 직접 주입한 id를 덮어씌우는 문제를 해결합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

Skip

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

None