### PR TITLE
Introduce `AutoFocus` component

### DIFF
--- a/.changeset/popular-gifts-sparkle.md
+++ b/.changeset/popular-gifts-sparkle.md
@@ -1,0 +1,13 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Introduce `AutoFocus` component.
+
+`AutoFocus` is a component that automatically focuses its child component when they are added to the document. It is useful when you want to focus on a specific element when the component is mounted. It doesn't render any DOM node.
+
+```tsx
+<AutoFocus>
+  <button>Close</button>
+</AutoFocus>
+```

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 
 # Owner of bezier-react
 
+/packages/bezier-react/src/components/AutoFocus/ @sungik-choi
 /packages/bezier-react/src/components/Avatars/ @sungik-choi
 /packages/bezier-react/src/components/Banner/ @sungik-choi
 /packages/bezier-react/src/components/Button/ @sungik-choi

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -124,6 +124,7 @@
     "@radix-ui/react-checkbox": "^1.0.3",
     "@radix-ui/react-separator": "^1.0.0",
     "@radix-ui/react-slider": "^1.0.0",
+    "@radix-ui/react-slot": "^1.0.1",
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.1",
     "@radix-ui/react-toolbar": "^1.0.1",

--- a/packages/bezier-react/src/components/AutoFocus/AutoFocus.test.tsx
+++ b/packages/bezier-react/src/components/AutoFocus/AutoFocus.test.tsx
@@ -1,0 +1,37 @@
+/* External dependencies */
+import React from 'react'
+
+/* Internal dependencies */
+import { render } from '~/src/utils/testUtils'
+import { AutoFocus } from './AutoFocus'
+import { type AutoFocusProps } from './AutoFocus.types'
+
+describe('AutoFocus', () => {
+  const renderComponent = ({ children }: AutoFocusProps) => render(
+    <AutoFocus>{ children }</AutoFocus>,
+  )
+
+  it('should focus on the child element - HTMLDivElement', () => {
+    const { getByText } = renderComponent({
+      children: <div tabIndex={-1}>Close</div>,
+    })
+    const rendered = getByText('Close')
+    expect(rendered).toHaveFocus()
+  })
+
+  it('should focus on the child element - HTMLButtonElement', () => {
+    const { getByRole } = renderComponent({
+      children: <button type="button">Close</button>,
+    })
+    const rendered = getByRole('button')
+    expect(rendered).toHaveFocus()
+  })
+
+  it('should focus on the child element - HTMLInputElement', () => {
+    const { getByRole } = renderComponent({
+      children: <input type="text" />,
+    })
+    const rendered = getByRole('textbox')
+    expect(rendered).toHaveFocus()
+  })
+})

--- a/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
+++ b/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
@@ -1,0 +1,35 @@
+/* External dependencies */
+import React, { useCallback } from 'react'
+import { Slot } from '@radix-ui/react-slot'
+
+/* Internal dependencies */
+import { type AutoFocusProps } from './AutoFocus.types'
+
+/**
+ * `AutoFocus` is a component that automatically focuses its child component when they are added to the document.
+ * It is useful when you want to focus on a specific element when the component is mounted.
+ * It doesn't render any DOM node.
+ *
+ * @example
+ *
+ * ```tsx
+ * <AutoFocus>
+ *   <button>Close</button>
+ * </AutoFocus>
+ * ```
+ */
+export function AutoFocus({
+  children,
+}: AutoFocusProps) {
+  const focus = useCallback((node: HTMLElement | null) => {
+    if (node) {
+      node.focus()
+    }
+  }, [])
+
+  return (
+    <Slot ref={focus}>
+      { children }
+    </Slot>
+  )
+}

--- a/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
+++ b/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
@@ -1,8 +1,12 @@
 /* External dependencies */
-import React, { useCallback } from 'react'
+import React, {
+  forwardRef,
+  useCallback,
+} from 'react'
 import { Slot } from '@radix-ui/react-slot'
 
 /* Internal dependencies */
+import useMergeRefs from '~/src/hooks/useMergeRefs'
 import { type AutoFocusProps } from './AutoFocus.types'
 
 /**
@@ -18,18 +22,20 @@ import { type AutoFocusProps } from './AutoFocus.types'
  * </AutoFocus>
  * ```
  */
-export function AutoFocus({
+export const AutoFocus = forwardRef<HTMLElement, AutoFocusProps>(function AutoFocus({
   children,
-}: AutoFocusProps) {
+}, forwardedRef) {
   const focus = useCallback((node: HTMLElement | null) => {
     if (node) {
       node.focus()
     }
   }, [])
 
+  const ref = useMergeRefs(focus, forwardedRef)
+
   return (
-    <Slot ref={focus}>
+    <Slot ref={ref}>
       { children }
     </Slot>
   )
-}
+})

--- a/packages/bezier-react/src/components/AutoFocus/AutoFocus.types.ts
+++ b/packages/bezier-react/src/components/AutoFocus/AutoFocus.types.ts
@@ -1,0 +1,5 @@
+/* Internal dependencies */
+import { type ChildrenProps } from '~/src/types/ComponentProps'
+
+export interface AutoFocusProps extends
+  ChildrenProps {}

--- a/packages/bezier-react/src/components/AutoFocus/index.ts
+++ b/packages/bezier-react/src/components/AutoFocus/index.ts
@@ -1,0 +1,3 @@
+export { AutoFocus } from './AutoFocus'
+
+export { type AutoFocusProps } from './AutoFocus.types'

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.test.tsx
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.test.tsx
@@ -5,6 +5,7 @@ import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event'
 
 /* Internal dependencies */
 import { render } from '~/src/utils/testUtils'
+import { AutoFocus } from '~/src/components/AutoFocus'
 import { Modal } from './Modal'
 import { ModalContent } from './ModalContent'
 import { ModalHeader } from './ModalHeader'
@@ -273,6 +274,37 @@ describe('Modal', () => {
         await user.click(getByRole('button', { name: CLOSE_TEXT }))
         expect(onHide).toBeCalledTimes(1)
       })
+    })
+  })
+
+  describe('With AutoFocus', () => {
+    const renderModalWithAutoFocus = () => render(
+      <Modal>
+        <ModalTrigger>
+          <button type="button">{ TRIGGER_TEXT }</button>
+        </ModalTrigger>
+        <ModalContent>
+          <ModalBody>
+            <input type="text" />
+          </ModalBody>
+          <ModalFooter
+            leftContent={(<div />)}
+            rightContent={(
+              <ModalClose>
+                <AutoFocus>
+                  <button type="button">{ CLOSE_TEXT }</button>
+                </AutoFocus>
+              </ModalClose>
+            )}
+          />
+        </ModalContent>
+      </Modal>,
+    )
+
+    it('should focus the element wrapped by AutoFocus', async () => {
+      const { getByRole } = renderModalWithAutoFocus()
+      await user.click(getByRole('button', { name: TRIGGER_TEXT }))
+      expect(getByRole('button', { name: CLOSE_TEXT })).toHaveFocus()
     })
   })
 })

--- a/packages/bezier-react/src/index.ts
+++ b/packages/bezier-react/src/index.ts
@@ -5,6 +5,7 @@ export { default as BezierProvider } from '~/src/providers/BezierProvider'
 export * from '~/src/foundation'
 
 /* Components */
+export * from '~/src/components/AutoFocus'
 export * from '~/src/components/Avatars/Avatar'
 export * from '~/src/components/Avatars/AvatarGroup'
 export * from '~/src/components/Avatars/CheckableAvatar'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2005,6 +2005,7 @@ __metadata:
     "@radix-ui/react-radio-group": ^1.1.0
     "@radix-ui/react-separator": ^1.0.0
     "@radix-ui/react-slider": ^1.0.0
+    "@radix-ui/react-slot": ^1.0.1
     "@radix-ui/react-switch": ^1.0.1
     "@radix-ui/react-tabs": ^1.0.1
     "@radix-ui/react-toolbar": ^1.0.1
@@ -3534,7 +3535,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-slot@npm:1.0.1":
+"@radix-ui/react-slot@npm:1.0.1, @radix-ui/react-slot@npm:^1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-slot@npm:1.0.1"
   dependencies:


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [x] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [x] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

`AutoFocus` 컴포넌트를 추가합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

`AutoFocus` 컴포넌트는 autoFocus 기능을 사용처에서 선언적으로 사용할 수 있도록 만들어진 컴포넌트입니다. 하위 Children의 노드가 도큐먼트에 추가될 때, 포커스가 해당 노드로 이동하도록 합니다.

`Modal` 이 마운트될 때 특정 버튼 등에 포커스가 이동하도록 구현하고 싶은 경우 사용하기 적합합니다.

```tsx
<AutoFocus>
  <button>Close</button>
</AutoFocus>
```

### chore

- 구현을 위해 Radix UI의 Slot 패키지 추가

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- https://www.radix-ui.com/docs/primitives/utilities/slot
