### PR TITLE
Enhance pre-commit related configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.32.0",
     "eslint-config-bezier": "workspace:*",
-    "husky": "^6.0.0",
+    "husky": "^8.0.3",
     "lint-staged": "^13.0.3",
     "npm-run-all": "^4.1.5",
     "stylelint": "^13.8.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "verify": "ts-node -P ./supports/tsconfig/script.json ./scripts/check-yarn-version.ts",
     "lint-staged": "lint-staged",
     "changeset": "changeset",
-    "prepare": "husky install"
+    "postinstall": "husky install"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.7",

--- a/packages/bezier-figma-plugin/.lintstagedrc.json
+++ b/packages/bezier-figma-plugin/.lintstagedrc.json
@@ -1,4 +1,4 @@
-{ 
-  "src/**/*.(js|ts)?(x)": "yarn lint:js",
-  "src/**/*.styled.{js,ts}": "yarn lint:style"
+{
+  "**/*.(js|ts)?(x)": "yarn lint:js",
+  "**/*.styled.{js,ts}": "yarn lint:style"
 }

--- a/packages/bezier-react/.lintstagedrc.json
+++ b/packages/bezier-react/.lintstagedrc.json
@@ -1,4 +1,4 @@
-{ 
-  "src/**/*.(js|ts)?(x)": "yarn lint:js",
-  "src/**/*.styled.{js,ts}": "yarn lint:style"
+{
+  "**/*.(js|ts)?(x)": "yarn lint:js",
+  "**/*.styled.{js,ts}": "yarn lint:style"
 }

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -24,7 +24,7 @@
     "lint:style": "stylelint --cache '**/*.styled.{js,ts}'",
     "typecheck": "yarn find-deadcode && tsc --build --verbose",
     "find-deadcode": "ts-prune -e -p ./tsconfig.prune.json",
-    "test": "jest",
+    "test": "jest --onlyChanged",
     "test:watch": "jest --watch",
     "update-snapshot": "jest --updateSnapshot",
     "clean": "run-s 'clean:*'",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13606,12 +13606,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"husky@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "husky@npm:6.0.0"
+"husky@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "husky@npm:8.0.3"
   bin:
     husky: lib/bin.js
-  checksum: db6da76a670b2cd1e967990decfd291e6f35a5aee4d362208a51771474d3b4896d526acb4bf0413c2d7154716e42a4d8b6cc19f2bb108e48d1f554624c723a00
+  checksum: 837bc7e4413e58c1f2946d38fb050f5d7324c6f16b0fd66411ffce5703b294bd21429e8ba58711cd331951ee86ed529c5be4f76805959ff668a337dbfa82a1b0
   languageName: node
   linkType: hard
 
@@ -19894,7 +19894,7 @@ __metadata:
     cz-conventional-changelog: ^3.3.0
     eslint: ^7.32.0
     eslint-config-bezier: "workspace:*"
-    husky: ^6.0.0
+    husky: ^8.0.3
     lint-staged: ^13.0.3
     npm-run-all: ^4.1.5
     stylelint: ^13.8.0


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

Precommit 관련 개발 환경을 개선합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- Husky 최신 버전 업데이트
- Yarn 2+ 에서 지원하지 않는 `prepare` script을 `postinstall` 스크립트로 전환 ([#](https://typicode.github.io/husky/#/?id=install))
- `jest --onlyChanged` 추가: 의존성을 파악하여 변경된 모듈에 해당하는 부분만 테스트 케이스가 실행되도록 개선
- lintstaged의 path가 lint 스크립트의 path와 동일하게 개선 

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

None
