### PR TITLE
feat(tooltip): add container prop

### DIFF
--- a/.changeset/new-pots-brake.md
+++ b/.changeset/new-pots-brake.md
@@ -1,0 +1,20 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Add `container` property to `Tooltip` component.
+
+```tsx
+const [container, setContainer] = useState<HTMLDivElement | null>(null)
+
+return (
+  <div ref={setContainer}>
+    <Tooltip
+      content="Lorem ipsum"
+      container={container}
+    >
+      <div />
+    </Tooltip>
+  </div>
+)
+```

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,8 +1,5 @@
 /* External dependencies */
-import React, {
-  useState,
-  useCallback,
-} from 'react'
+import React, { useState } from 'react'
 import { base } from 'paths.macro'
 import {
   type Story,
@@ -82,20 +79,19 @@ const Target = styled.div`
 `
 
 const Template: Story<TooltipProps> = (props) => {
-  const [showTarget, setShowTarget] = useState(true)
-
-  const handleClick = useCallback(() => {
-    setShowTarget(false)
-  }, [])
+  const [container, setContainer] = useState<HTMLDivElement | null>(null)
 
   return (
-    <Tooltip {...props}>
-      { showTarget && (
-        <Target onClick={handleClick}>
+    <div ref={setContainer}>
+      <Tooltip
+        {...props}
+        container={container}
+      >
+        <Target>
           Target
         </Target>
-      ) }
-    </Tooltip>
+      </Tooltip>
+    </div>
   )
 }
 

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -32,6 +32,7 @@ function Tooltip(
     placement = TooltipPosition.BottomCenter,
     disabled = false,
     offset = 4,
+    container,
     keepInContainer = false,
     allowHover = false,
     delayShow = 0,
@@ -103,6 +104,7 @@ function Tooltip(
           placement={placement}
           offset={offset}
           allowHover={allowHover}
+          container={container}
           keepInContainer={keepInContainer}
           tooltipContainer={tooltipContainerRef.current}
           forwardedRef={forwardedRef}
@@ -123,6 +125,7 @@ function Tooltip(
     placement,
     offset,
     allowHover,
+    container,
     keepInContainer,
     forwardedRef,
     contentTestId,

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
@@ -13,6 +13,7 @@ import {
 interface TooltipOptions {
   placement?: TooltipPosition
   offset?: number
+  container?: HTMLElement | null
   keepInContainer?: boolean
   allowHover?: boolean
   delayShow?: number
@@ -33,6 +34,7 @@ export default interface TooltipProps extends
 
 export interface TooltipContentProps extends Pick<
 TooltipOptions,
+'container' |
 'keepInContainer' |
 'placement' |
 'offset' |
@@ -50,7 +52,7 @@ export interface GetTooltipStyle extends Required<Pick<TooltipOptions, 'placemen
   tooltipContainer: HTMLDivElement
 }
 
-export interface GetReplacement extends Required<Pick<TooltipOptions, 'placement' | 'keepInContainer'>> {
+export interface GetReplacement extends Required<Pick<TooltipOptions, 'placement' | 'container' | 'keepInContainer'>> {
   tooltip: HTMLDivElement
 }
 

--- a/packages/bezier-react/src/components/Tooltip/TooltipContent.tsx
+++ b/packages/bezier-react/src/components/Tooltip/TooltipContent.tsx
@@ -80,6 +80,7 @@ const TooltipContent: React.FC<TooltipContentProps> = ({
   contentClassName,
   contentInterpolation,
   disabled = false,
+  container: givenContainer,
   keepInContainer = false,
   placement = TooltipPosition.BottomCenter,
   tooltipContainer,
@@ -93,6 +94,8 @@ const TooltipContent: React.FC<TooltipContentProps> = ({
   const mergedRef = useMergeRefs<HTMLDivElement>(tooltipRef, forwardedRef)
   const [replacement, setReplacement] = useState(placement)
 
+  const container = givenContainer || getRootElement()
+
   const handleClickTooltip = useCallback((event: HTMLElementEventMap['click']) => {
     event.stopPropagation()
   }, [])
@@ -103,11 +106,13 @@ const TooltipContent: React.FC<TooltipContentProps> = ({
     if (!tooltipRef.current) { return }
     const newPlacement = getReplacement({
       tooltip: tooltipRef.current,
+      container,
       keepInContainer,
       placement,
     })
     setReplacement(newPlacement)
   }, [
+    container,
     keepInContainer,
     placement,
   ])
@@ -151,7 +156,7 @@ const TooltipContent: React.FC<TooltipContentProps> = ({
           </EllipsisableContent>
         </Content>
       </ContentWrapper>,
-      getRootElement(),
+      container,
     )
   )
 }

--- a/packages/bezier-react/src/components/Tooltip/utils.ts
+++ b/packages/bezier-react/src/components/Tooltip/utils.ts
@@ -1,5 +1,4 @@
 /* Internal dependencies */
-import { getRootElement } from '~/src/utils/domUtils'
 import {
   TooltipPosition,
   type GetTooltipStyle,
@@ -8,10 +7,11 @@ import {
 
 export function getReplacement({
   tooltip,
+  container,
   keepInContainer,
   placement,
 }: GetReplacement): TooltipPosition {
-  if (!keepInContainer) {
+  if (!keepInContainer || !container) {
     return placement
   }
 
@@ -21,12 +21,13 @@ export function getReplacement({
     top: tooltipTop,
     left: tooltipLeft,
   } = tooltip.getBoundingClientRect()
+
   const {
     width: rootWidth,
     height: rootHeight,
     top: rootTop,
     left: rootLeft,
-  } = getRootElement().getBoundingClientRect()
+  } = container.getBoundingClientRect()
 
   const isOverTop = tooltipTop < rootTop
   const isOverBottom = tooltipTop + tooltipHeight > rootTop + rootHeight


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [x] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

`Tooltip` 에 `container` 속성을 추가합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

`Overlay` 와 동일하게, 별도의 `container` 속성을 지정하면 해당 노드 아래에 렌더되도록 할 수 있습니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No. container를 지정하지 않을 경우 기본값은 `getRootElement()` 의 반환값으로 동일합니다.

## References
<!-- External documents based on workarounds or reviewers should refer to -->

None
