### PR TITLE
Fix an issue with code coverage not being collected properly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
     <<: *defaults
     steps:
       - *attach_workspace
-      - run: yarn test
+      - run: yarn test:ci
       - codecov/upload:
           file: './packages/bezier-react/coverage/lcov.info'
           token: $CODECOV_TOKEN

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
+    "test:ci": "turbo run test:ci",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "release": "turbo run build --filter=@channel.io/bezier-react && changeset publish",
     "storybook": "yarn workspace @channel.io/bezier-react storybook",

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -25,6 +25,7 @@
     "typecheck": "yarn find-deadcode && tsc --build --verbose",
     "find-deadcode": "ts-prune -e -p ./tsconfig.prune.json",
     "test": "jest --onlyChanged",
+    "test:ci": "jest --ci --coverage",
     "test:watch": "jest --watch",
     "update-snapshot": "jest --updateSnapshot",
     "clean": "run-s 'clean:*'",

--- a/turbo.json
+++ b/turbo.json
@@ -24,6 +24,13 @@
       ]
     },
     "test": {
+      "inputs": [
+        "src/**/*.tsx",
+        "src/**/*.ts",
+        "src/**/*.js"
+      ]
+    },
+    "test:ci": {
       "outputs": [
         "coverage/**"
       ],


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

#1251 의 사이드 이펙트 해소. 4449f8f 에서 `--onlyChanged` flag가 추가되면서 테스트 커버리지가 제대로 수집되고 있지 않던 문제를 해결합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

`test:ci` 워크스페이스 공용 커맨드를 추가하여, precommit용 테스트 커맨드와 ci용 테스트 커버리지 수집을 위한 커맨드를 구분하는 방식으로 수정합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

None
