### PR TITLE
Remove the 100% width, 100% height style from `AlphaStack` component

### DIFF
--- a/.changeset/sour-pears-type.md
+++ b/.changeset/sour-pears-type.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Remove the 100% width, 100% height style from `AlphaStack` component

--- a/packages/bezier-react/src/components/AlphaStack/AlphaStack.styled.ts
+++ b/packages/bezier-react/src/components/AlphaStack/AlphaStack.styled.ts
@@ -11,8 +11,6 @@ export const Container = styled.div<ContainerProps>`
   gap: var(--bezier-alpha-stack-spacing);
   align-items: var(--bezier-alpha-stack-align);
   justify-content: var(--bezier-alpha-stack-justify);
-  width: 100%;
-  height: 100%;
 
   @supports not(gap: var(--bezier-alpha-stack-spacing)) {
     margin-top: calc(var(--bezier-alpha-stack-spacing) * -1);

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -32,8 +32,6 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   -webkit-justify-content: var(--bezier-alpha-stack-justify);
   -ms-flex-pack: var(--bezier-alpha-stack-justify);
   justify-content: var(--bezier-alpha-stack-justify);
-  width: 100%;
-  height: 100%;
 }
 
 .c5 {
@@ -364,8 +362,6 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   -webkit-justify-content: var(--bezier-alpha-stack-justify);
   -ms-flex-pack: var(--bezier-alpha-stack-justify);
   justify-content: var(--bezier-alpha-stack-justify);
-  width: 100%;
-  height: 100%;
 }
 
 .c6 {

--- a/packages/bezier-react/src/components/Forms/FormGroup/__snapshots__/FormGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormGroup/__snapshots__/FormGroup.test.tsx.snap
@@ -18,8 +18,6 @@ exports[`FormGroup > Snapshot > 1`] = `
   -webkit-justify-content: var(--bezier-alpha-stack-justify);
   -ms-flex-pack: var(--bezier-alpha-stack-justify);
   justify-content: var(--bezier-alpha-stack-justify);
-  width: 100%;
-  height: 100%;
 }
 
 .c1 {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

- #1249 

## Summary
<!-- Please add a summary of the modification. -->

Remove the 100% width, 100% height style from AlphaStack component

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

<img width="722" alt="스크린샷 2023-04-05 오후 3 27 25" src="https://user-images.githubusercontent.com/58209009/229998598-3f183a28-623b-4fb8-af25-411a04fc9681.png">

> `FormGroup` 스타일링이 틀어짐. 우측 참고

- `FormGroup` 에서 `height: 100%` 스타일이 `flex-wrap` 과 결합 시 의도치 않게 스타일링이 됩니다. 이를 해결합니다.
- 또한 width, height 100% 스타일은 `Stack` 컴포넌트의 정책으로 정해진 스타일이기때문에, `AlphaStack` 컴포넌트에 그대로 옮겨올 필요는 없다고 판단했습니다. (레퍼런스 참고)
- See #698

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- https://chakra-ui.com/docs/components/stack
- https://polaris.shopify.com/components/layout-and-structure/alpha-stack
