### PR TITLE
Enhance `FormControl` component

### DIFF
--- a/.changeset/metal-ways-beg.md
+++ b/.changeset/metal-ways-beg.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Add forwardRef to `FormControl`.

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.stories.tsx
@@ -25,8 +25,8 @@ import {
   FormErrorMessage,
 } from '~/src/components/Forms/FormHelperText'
 import { Switch } from '~/src/components/Forms/Switch'
-import FormControl from './FormControl'
-import type FormControlProps from './FormControl.types'
+import { FormControl } from './FormControl'
+import { type FormControlProps } from './FormControl.types'
 
 export default {
   title: getTitle(base),

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.stories.tsx
@@ -31,6 +31,14 @@ import { type FormControlProps } from './FormControl.types'
 export default {
   title: getTitle(base),
   component: FormControl,
+  argTypes: {
+    labelPosition: {
+      control: {
+        type: 'radio',
+        options: ['top', 'left', undefined],
+      },
+    },
+  },
 } as Meta
 
 const Template: Story<FormControlProps> = (args) => (

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.styled.ts
@@ -25,17 +25,13 @@ export const Grid = styled(Box)`
   align-items: center;
 `
 
-interface LeftLabelWrapperProps {
-  height: number
-}
-
-export const LeftLabelWrapper = styled(Box)<LeftLabelWrapperProps>`
+export const LeftLabelWrapper = styled(Box)`
   display: flex;
   grid-row: 1 / 1;
   grid-column: 1 / 1;
   align-items: center;
   align-self: start;
-  height: ${({ height }) => height}px;
+  height: var(--bezier-form-control-left-label-wrapper-height);
 `
 
 export const LeftHelperTextWrapper = styled(TopHelperTextWrapper)`

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.styled.ts
@@ -4,20 +4,17 @@ import { type InterpolationProps } from '~/src/types/Foundation'
 
 const LEFT_LABEL_MIN_WIDTH = 150
 
-// FIXME(@ed): Top Position일 때, Stack 컴포넌트를 통해 Label, HelperText 간격을 주도록 변경
-export const Box = styled.div<InterpolationProps>`
+const Box = styled.div<InterpolationProps>`
   position: relative;
   ${({ interpolation }) => interpolation}
 `
 
 export const TopLabelWrapper = styled(Box)`
   padding: 0 2px;
-  margin-bottom: 4px;
 `
 
 export const TopHelperTextWrapper = styled(Box)`
   padding: 0 2px;
-  margin-top: 4px;
 `
 
 export const Grid = styled(Box)`

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.test.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.test.tsx
@@ -10,8 +10,11 @@ import {
   SingleFieldFormWithLabelFont,
   MOCK_CONSTS,
 } from './__mocks__/forms'
-import FormControl, { FORM_CONTROL_TEST_ID } from './FormControl'
-import type FormControlProps from './FormControl.types'
+import {
+  FormControl,
+  FORM_CONTROL_TEST_ID,
+} from './FormControl'
+import { type FormControlProps } from './FormControl.types'
 
 describe('FormControl >', () => {
   let props: FormControlProps

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -191,8 +191,12 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
   ])
 
   const containerStyle = useMemo(() => ({
+    ...style,
     '--bezier-form-control-left-label-wrapper-height': `${leftLabelWrapperHeight}px`,
-  } as React.CSSProperties), [leftLabelWrapperHeight])
+  } as React.CSSProperties), [
+    style,
+    leftLabelWrapperHeight,
+  ])
 
   if (!children) { return null }
 

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -112,7 +112,7 @@ function FormControl({
   const getLabelProps = useCallback<LabelPropsGetter>(ownProps => ({
     id: labelId,
     htmlFor: fieldId,
-    typo: labelPosition === 'left' ? Typography.Size14 : Typography.Size13,
+    typo: labelPosition === 'top' ? Typography.Size13 : Typography.Size14,
     Wrapper: labelPosition === 'top'
       ? Styled.TopLabelWrapper
       : Styled.LeftLabelWrapper,

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -13,6 +13,7 @@ import {
   omitBezierComponentProps,
   pickBezierComponentProps,
 } from '~/src/utils/propsUtils'
+import { AlphaStack } from '~/src/components/AlphaStack'
 // eslint-disable-next-line no-restricted-imports
 import FormFieldSize from '../FormFieldSize'
 import FormControlContext from './FormControlContext'
@@ -22,11 +23,44 @@ import {
   type LabelPropsGetter,
   type HelperTextPropsGetter,
   type ErrorMessagePropsGetter,
+  type ContainerProps,
 } from './FormControl.types'
 import type FormControlProps from './FormControl.types'
 import * as Styled from './FormControl.styled'
 
 export const FORM_CONTROL_TEST_ID = 'bezier-react-form-control'
+
+function Container({
+  labelPosition,
+  children,
+  testId,
+  ...rest
+}: ContainerProps) {
+  switch (labelPosition) {
+    case 'top':
+    default:
+      return (
+        <AlphaStack
+          direction="vertical"
+          spacing={4}
+          testId={testId}
+          {...rest}
+        >
+          { children }
+        </AlphaStack>
+      )
+
+    case 'left':
+      return (
+        <Styled.Grid
+          data-testid={testId}
+          {...rest}
+        >
+          { children }
+        </Styled.Grid>
+      )
+  }
+}
 
 function FormControl({
   id: idProp,
@@ -159,16 +193,12 @@ function FormControl({
 
   if (!children) { return null }
 
-  const Container = {
-    top: Styled.Box,
-    left: Styled.Grid,
-  }[labelPosition]
-
   return (
     <FormControlContext.Provider value={contextValue}>
       <Container
-        data-testid={testId}
+        labelPosition={labelPosition}
         {...bezierProps}
+        testId={testId}
       >
         { children }
       </Container>

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -17,8 +17,9 @@ import {
 import { AlphaStack } from '~/src/components/AlphaStack'
 // eslint-disable-next-line no-restricted-imports
 import FormFieldSize from '../FormFieldSize'
-import FormControlContext from './FormControlContext'
+import { FormControlContext } from './FormControlContext'
 import {
+  type FormControlProps,
   type GroupPropsGetter,
   type FieldPropsGetter,
   type LabelPropsGetter,
@@ -26,7 +27,6 @@ import {
   type ErrorMessagePropsGetter,
   type ContainerProps,
 } from './FormControl.types'
-import type FormControlProps from './FormControl.types'
 import * as Styled from './FormControl.styled'
 
 export const FORM_CONTROL_TEST_ID = 'bezier-react-form-control'

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -67,6 +67,7 @@ function FormControl({
   testId = FORM_CONTROL_TEST_ID,
   labelPosition = 'top',
   leftLabelWrapperHeight = FormFieldSize.M,
+  style,
   children,
   ...rest
 }: FormControlProps) {
@@ -114,17 +115,12 @@ function FormControl({
     typo: labelPosition === 'left' ? Typography.Size14 : Typography.Size13,
     Wrapper: labelPosition === 'top'
       ? Styled.TopLabelWrapper
-      : (({ children: labelElement }) => (
-        <Styled.LeftLabelWrapper height={leftLabelWrapperHeight}>
-          { labelElement }
-        </Styled.LeftLabelWrapper>
-      )),
+      : Styled.LeftLabelWrapper,
     ...ownProps,
   }), [
     fieldId,
     labelId,
     labelPosition,
-    leftLabelWrapperHeight,
   ])
 
   const getFieldProps = useCallback<FieldPropsGetter>(ownProps => ({
@@ -191,14 +187,19 @@ function FormControl({
     formCommonProps,
   ])
 
+  const containerStyle = useMemo(() => ({
+    '--bezier-form-control-left-label-wrapper-height': `${leftLabelWrapperHeight}px`,
+  } as React.CSSProperties), [leftLabelWrapperHeight])
+
   if (!children) { return null }
 
   return (
     <FormControlContext.Provider value={contextValue}>
       <Container
-        labelPosition={labelPosition}
         {...bezierProps}
+        style={containerStyle}
         testId={testId}
+        labelPosition={labelPosition}
       >
         { children }
       </Container>

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -39,7 +39,6 @@ const Container = forwardRef<HTMLElement, ContainerProps>(function Container({
 }, forwardedRef) {
   switch (labelPosition) {
     case 'top':
-    default:
       return (
         <AlphaStack
           ref={forwardedRef}
@@ -53,6 +52,7 @@ const Container = forwardRef<HTMLElement, ContainerProps>(function Container({
       )
 
     case 'left':
+    default:
       return (
         <Styled.Grid
           ref={forwardedRef}

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -36,9 +36,9 @@ function FormControl({
   children,
   ...rest
 }: FormControlProps) {
-  const [hasMultipleFields, setHasMultipleFields] = useState(false)
-  const [hasHelperText, setHasHelperText] = useState(false)
-  const [hasErrorMessage, setHasErrorMessage] = useState(false)
+  const [groupNode, setGroupNode] = useState<HTMLElement | null>(null)
+  const [helperTextNode, setHelperTextNode] = useState<HTMLElement | null>(null)
+  const [errorMessageNode, setErrorMessageNode] = useState<HTMLElement | null>(null)
 
   const id = useId(idProp, 'field')
   const groupId = `${id}-group`
@@ -46,15 +46,15 @@ function FormControl({
   const helperTextId = `${id}-help-text`
   const errorMessageId = `${id}-error-message`
 
-  const fieldId = hasMultipleFields ? undefined : id
+  const fieldId = groupNode ? undefined : id
 
   const describerId = useMemo(() => {
-    if (hasErrorMessage) { return errorMessageId }
-    if (hasHelperText) { return helperTextId }
+    if (errorMessageNode) { return errorMessageId }
+    if (helperTextNode) { return helperTextId }
     return undefined
   }, [
-    hasErrorMessage,
-    hasHelperText,
+    errorMessageNode,
+    helperTextNode,
     errorMessageId,
     helperTextId,
   ])
@@ -66,13 +66,12 @@ function FormControl({
     id: groupId,
     'aria-labelledby': labelId,
     'aria-describedby': describerId,
-    setIsRendered: setHasMultipleFields,
+    ref: setGroupNode,
     ...ownProps,
   }), [
     groupId,
     labelId,
     describerId,
-    setHasMultipleFields,
   ])
 
   const getLabelProps = useCallback<LabelPropsGetter>(ownProps => ({
@@ -96,20 +95,20 @@ function FormControl({
 
   const getFieldProps = useCallback<FieldPropsGetter>(ownProps => ({
     id: fieldId,
-    'aria-describedby': hasMultipleFields ? undefined : describerId,
+    'aria-describedby': groupNode ? undefined : describerId,
     ...formCommonProps,
     ...ownProps,
   }), [
     fieldId,
     describerId,
     formCommonProps,
-    hasMultipleFields,
+    groupNode,
   ])
 
   const getHelperTextProps = useCallback<HelperTextPropsGetter>(ownProps => ({
     id: helperTextId,
     visible: isNil(formCommonProps?.hasError) || !formCommonProps?.hasError,
-    setIsRendered: setHasHelperText,
+    ref: setHelperTextNode,
     Wrapper: labelPosition === 'top'
       ? Styled.TopHelperTextWrapper
       : Styled.LeftHelperTextWrapper,
@@ -123,7 +122,7 @@ function FormControl({
   const getErrorMessageProps = useCallback<ErrorMessagePropsGetter>(ownProps => ({
     id: errorMessageId,
     visible: isNil(formCommonProps?.hasError) || formCommonProps?.hasError,
-    setIsRendered: setHasErrorMessage,
+    ref: setErrorMessageNode,
     Wrapper: labelPosition === 'top'
       ? Styled.TopHelperTextWrapper
       : Styled.LeftHelperTextWrapper,

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -3,6 +3,7 @@ import React, {
   useState,
   useCallback,
   useMemo,
+  forwardRef,
 } from 'react'
 
 /* Internal dependencies */
@@ -30,17 +31,18 @@ import * as Styled from './FormControl.styled'
 
 export const FORM_CONTROL_TEST_ID = 'bezier-react-form-control'
 
-function Container({
+const Container = forwardRef<HTMLElement, ContainerProps>(function Container({
   labelPosition,
   children,
   testId,
   ...rest
-}: ContainerProps) {
+}, forwardedRef) {
   switch (labelPosition) {
     case 'top':
     default:
       return (
         <AlphaStack
+          ref={forwardedRef}
           direction="vertical"
           spacing={4}
           testId={testId}
@@ -53,6 +55,7 @@ function Container({
     case 'left':
       return (
         <Styled.Grid
+          ref={forwardedRef}
           data-testid={testId}
           {...rest}
         >
@@ -60,9 +63,9 @@ function Container({
         </Styled.Grid>
       )
   }
-}
+})
 
-function FormControl({
+export const FormControl = forwardRef<HTMLElement, FormControlProps>(function FormControl({
   id: idProp,
   testId = FORM_CONTROL_TEST_ID,
   labelPosition = 'top',
@@ -70,7 +73,7 @@ function FormControl({
   style,
   children,
   ...rest
-}: FormControlProps) {
+}, forwardedRef) {
   const [groupNode, setGroupNode] = useState<HTMLElement | null>(null)
   const [helperTextNode, setHelperTextNode] = useState<HTMLElement | null>(null)
   const [errorMessageNode, setErrorMessageNode] = useState<HTMLElement | null>(null)
@@ -197,6 +200,7 @@ function FormControl({
     <FormControlContext.Provider value={contextValue}>
       <Container
         {...bezierProps}
+        ref={forwardedRef}
         style={containerStyle}
         testId={testId}
         labelPosition={labelPosition}
@@ -205,6 +209,4 @@ function FormControl({
       </Container>
     </FormControlContext.Provider>
   )
-}
-
-export default FormControl
+})

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
@@ -25,19 +25,19 @@ interface WrapperProps {
   Wrapper: React.FunctionComponent<ChildrenProps>
 }
 
-interface SetRenderedProps {
-  setIsRendered: React.Dispatch<React.SetStateAction<boolean>>
+interface CallbackRefProps {
+  ref: (node: HTMLElement | null) => void
 }
 
 type PropsGetter<ExtraReturnType = {}> = <Props = {}>(props: Props) => Props & FormControlContextCommonValue & ExtraReturnType
 
-export type GroupPropsGetter = PropsGetter<SetRenderedProps & FormControlAriaProps>
+export type GroupPropsGetter = PropsGetter<CallbackRefProps & FormControlAriaProps>
 
 export type LabelPropsGetter = PropsGetter<WrapperProps>
 
 export type FieldPropsGetter = PropsGetter<Omit<FormControlAriaProps, 'aria-labelledby'>>
 
-export type HelperTextPropsGetter = PropsGetter<WrapperProps & SetRenderedProps & {
+export type HelperTextPropsGetter = PropsGetter<WrapperProps & CallbackRefProps & {
   visible: boolean
 }>
 

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
@@ -55,6 +55,11 @@ export interface FormControlContextValue extends FormComponentProps {
   getErrorMessageProps: ErrorMessagePropsGetter
 }
 
+export interface ContainerProps extends
+  BezierComponentProps,
+  ChildrenProps,
+  Pick<FormControlOptions, 'labelPosition'> {}
+
 export default interface FormControlProps extends
   BezierComponentProps,
   ChildrenProps,

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
@@ -60,7 +60,7 @@ export interface ContainerProps extends
   ChildrenProps,
   Pick<FormControlOptions, 'labelPosition'> {}
 
-export default interface FormControlProps extends
+export interface FormControlProps extends
   BezierComponentProps,
   ChildrenProps,
   FormComponentProps,

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControlContext.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControlContext.ts
@@ -4,6 +4,4 @@ import { createContext } from 'react'
 /* Internal dependencies */
 import { type FormControlContextValue } from '~/src/components/Forms/FormControl'
 
-const FormControlContext = createContext<FormControlContextValue | undefined>(undefined)
-
-export default FormControlContext
+export const FormControlContext = createContext<FormControlContextValue | undefined>(undefined)

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -2,20 +2,6 @@
 
 exports[`FormControl > Snapshot > With multiple field 1`] = `
 .c0 {
-  position: relative;
-}
-
-.c1 {
-  padding: 0 2px;
-  margin-bottom: 4px;
-}
-
-.c10 {
-  padding: 0 2px;
-  margin-top: 4px;
-}
-
-.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -34,13 +20,25 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   justify-content: var(--bezier-alpha-stack-justify);
 }
 
+.c1 {
+  position: relative;
+}
+
+.c2 {
+  padding: 0 2px;
+}
+
+.c10 {
+  padding: 0 2px;
+}
+
 .c5 {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
 }
 
-.c2 {
+.c3 {
   font-size: 1.3rem;
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
@@ -74,7 +72,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   transition-property: color;
 }
 
-.c3 {
+.c4 {
   display: block;
   text-align: left;
   word-break: break-word;
@@ -180,12 +178,12 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 }
 
 @supports not(gap:var(--bezier-alpha-stack-spacing)) {
-  .c4 {
+  .c0 {
     margin-top: calc(var(--bezier-alpha-stack-spacing) * -1);
     margin-left: calc(var(--bezier-alpha-stack-spacing) * -1);
   }
 
-  .c4 > * {
+  .c0 > * {
     margin-top: var(--bezier-alpha-stack-spacing);
     margin-left: var(--bezier-alpha-stack-spacing);
   }
@@ -195,12 +193,13 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   <div
     class="c0"
     data-testid="bezier-react-form-control"
+    style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
   >
     <div
-      class="c0 c1"
+      class="c1 c2"
     >
       <label
-        class="c2 c3"
+        class="c3 c4"
         color="txt-black-darkest"
         data-testid="bezier-react-form-label"
         id="form-label"
@@ -211,7 +210,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
     <div
       aria-describedby="form-help-text"
       aria-labelledby="form-label"
-      class="c4 c5"
+      class="c0 c5"
       data-testid="bezier-react-form-group"
       id="form-group"
       role="group"
@@ -220,12 +219,13 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       <div
         class="c0"
         data-testid="bezier-react-form-control"
+        style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
       >
         <div
-          class="c0 c1"
+          class="c1 c2"
         >
           <label
-            class="c2 c3"
+            class="c3 c4"
             color="txt-black-darkest"
             data-testid="bezier-react-form-label"
             for="field-:r3:"
@@ -251,12 +251,13 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       <div
         class="c0"
         data-testid="bezier-react-form-control"
+        style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
       >
         <div
-          class="c0 c1"
+          class="c1 c2"
         >
           <label
-            class="c2 c3"
+            class="c3 c4"
             color="txt-black-darkest"
             data-testid="bezier-react-form-label"
             for="field-:r4:"
@@ -282,7 +283,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       </div>
     </div>
     <div
-      class="c0 c10"
+      class="c1 c10"
     >
       <p
         class="c11 c12"
@@ -298,18 +299,35 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 `;
 
 exports[`FormControl > Snapshot > With multiple field and left label position 1`] = `
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: var(--bezier-alpha-stack-direction);
+  -ms-flex-direction: var(--bezier-alpha-stack-direction);
+  flex-direction: var(--bezier-alpha-stack-direction);
+  gap: var(--bezier-alpha-stack-spacing);
+  -webkit-align-items: var(--bezier-alpha-stack-align);
+  -webkit-box-align: var(--bezier-alpha-stack-align);
+  -ms-flex-align: var(--bezier-alpha-stack-align);
+  align-items: var(--bezier-alpha-stack-align);
+  -webkit-box-pack: var(--bezier-alpha-stack-justify);
+  -webkit-justify-content: var(--bezier-alpha-stack-justify);
+  -ms-flex-pack: var(--bezier-alpha-stack-justify);
+  justify-content: var(--bezier-alpha-stack-justify);
+}
+
 .c0 {
   position: relative;
 }
 
 .c7 {
   padding: 0 2px;
-  margin-bottom: 4px;
 }
 
 .c13 {
   padding: 0 2px;
-  margin-top: 4px;
 }
 
 .c1 {
@@ -343,25 +361,6 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 .c14 {
   grid-row: 2 / 2;
   grid-column: 2;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: var(--bezier-alpha-stack-direction);
-  -ms-flex-direction: var(--bezier-alpha-stack-direction);
-  flex-direction: var(--bezier-alpha-stack-direction);
-  gap: var(--bezier-alpha-stack-spacing);
-  -webkit-align-items: var(--bezier-alpha-stack-align);
-  -webkit-box-align: var(--bezier-alpha-stack-align);
-  -ms-flex-align: var(--bezier-alpha-stack-align);
-  align-items: var(--bezier-alpha-stack-align);
-  -webkit-box-pack: var(--bezier-alpha-stack-justify);
-  -webkit-justify-content: var(--bezier-alpha-stack-justify);
-  -ms-flex-pack: var(--bezier-alpha-stack-justify);
-  justify-content: var(--bezier-alpha-stack-justify);
 }
 
 .c6 {
@@ -566,8 +565,9 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 6px;"
     >
       <div
-        class="c0"
+        class="c5"
         data-testid="bezier-react-form-control"
+        style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
       >
         <div
           class="c0 c7"
@@ -597,8 +597,9 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         </div>
       </div>
       <div
-        class="c0"
+        class="c5"
         data-testid="bezier-react-form-control"
+        style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
       >
         <div
           class="c0 c7"
@@ -647,20 +648,37 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 
 exports[`FormControl > Snapshot > With single field 1`] = `
 .c0 {
-  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: var(--bezier-alpha-stack-direction);
+  -ms-flex-direction: var(--bezier-alpha-stack-direction);
+  flex-direction: var(--bezier-alpha-stack-direction);
+  gap: var(--bezier-alpha-stack-spacing);
+  -webkit-align-items: var(--bezier-alpha-stack-align);
+  -webkit-box-align: var(--bezier-alpha-stack-align);
+  -ms-flex-align: var(--bezier-alpha-stack-align);
+  align-items: var(--bezier-alpha-stack-align);
+  -webkit-box-pack: var(--bezier-alpha-stack-justify);
+  -webkit-justify-content: var(--bezier-alpha-stack-justify);
+  -ms-flex-pack: var(--bezier-alpha-stack-justify);
+  justify-content: var(--bezier-alpha-stack-justify);
 }
 
 .c1 {
-  padding: 0 2px;
-  margin-bottom: 4px;
-}
-
-.c7 {
-  padding: 0 2px;
-  margin-top: 4px;
+  position: relative;
 }
 
 .c2 {
+  padding: 0 2px;
+}
+
+.c8 {
+  padding: 0 2px;
+}
+
+.c3 {
   font-size: 1.3rem;
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
@@ -677,7 +695,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   transition-property: color;
 }
 
-.c8 {
+.c9 {
   font-size: 1.3rem;
   line-height: 1.8rem;
   margin: 0px 0px 0px 0px;
@@ -694,13 +712,13 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   transition-property: color;
 }
 
-.c3 {
+.c4 {
   display: block;
   text-align: left;
   word-break: break-word;
 }
 
-.c6 {
+.c7 {
   width: 100%;
   height: 100%;
   padding: 0;
@@ -713,23 +731,23 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   color: #000000D9;
 }
 
-.c6::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #00000066;
 }
 
-.c6::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #00000066;
 }
 
-.c6:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #00000066;
 }
 
-.c6::placeholder {
+.c7::placeholder {
   color: #00000066;
 }
 
-.c4 {
+.c5 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -756,25 +774,38 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   transition-property: border-color,box-shadow;
 }
 
-.c4 .c5 {
+.c5 .c6 {
   font-size: 1.4rem;
   line-height: 1.8rem;
 }
 
-.c9 {
+.c10 {
   display: block;
   text-align: left;
+}
+
+@supports not(gap:var(--bezier-alpha-stack-spacing)) {
+  .c0 {
+    margin-top: calc(var(--bezier-alpha-stack-spacing) * -1);
+    margin-left: calc(var(--bezier-alpha-stack-spacing) * -1);
+  }
+
+  .c0 > * {
+    margin-top: var(--bezier-alpha-stack-spacing);
+    margin-left: var(--bezier-alpha-stack-spacing);
+  }
 }
 
 <div
   class="c0"
   data-testid="bezier-react-form-control"
+  style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
 >
   <div
-    class="c0 c1"
+    class="c1 c2"
   >
     <label
-      class="c2 c3"
+      class="c3 c4"
       color="txt-black-darkest"
       data-testid="bezier-react-form-label"
       for="form"
@@ -784,24 +815,24 @@ exports[`FormControl > Snapshot > With single field 1`] = `
     </label>
   </div>
   <div
-    class="c4"
+    class="c5"
     data-testid="bezier-react-text-input"
     size="36"
   >
     <input
       aria-describedby="form-help-text"
       autocomplete="off"
-      class="c5 c6"
+      class="c6 c7"
       id="form"
       size="36"
       value=""
     />
   </div>
   <div
-    class="c0 c7"
+    class="c1 c8"
   >
     <p
-      class="c8 c9"
+      class="c9 c10"
       color="txt-black-dark"
       data-testid="bezier-react-form-helper-text"
       id="form-help-text"
@@ -819,7 +850,6 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
 
 .c8 {
   padding: 0 2px;
-  margin-top: 4px;
 }
 
 .c1 {

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   <div
     class="c0"
     data-testid="bezier-react-form-control"
-    style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+    style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
   >
     <div
       class="c1 c2"
@@ -219,7 +219,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       <div
         class="c0"
         data-testid="bezier-react-form-control"
-        style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
       >
         <div
           class="c1 c2"
@@ -251,7 +251,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       <div
         class="c0"
         data-testid="bezier-react-form-control"
-        style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
       >
         <div
           class="c1 c2"
@@ -355,7 +355,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   -webkit-align-self: start;
   -ms-flex-item-align: start;
   align-self: start;
-  height: 36px;
+  height: var(--bezier-form-control-left-label-wrapper-height);
 }
 
 .c14 {
@@ -541,10 +541,10 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   <div
     class="c0 c1"
     data-testid="bezier-react-form-control"
+    style="--bezier-form-control-left-label-wrapper-height: 36px;"
   >
     <div
       class="c0 c2"
-      height="36"
     >
       <label
         class="c3 c4"
@@ -567,7 +567,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       <div
         class="c5"
         data-testid="bezier-react-form-control"
-        style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
       >
         <div
           class="c0 c7"
@@ -599,7 +599,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       <div
         class="c5"
         data-testid="bezier-react-form-control"
-        style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
       >
         <div
           class="c0 c7"
@@ -799,7 +799,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 <div
   class="c0"
   data-testid="bezier-react-form-control"
-  style="--bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+  style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
 >
   <div
     class="c1 c2"
@@ -877,7 +877,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   -webkit-align-self: start;
   -ms-flex-item-align: start;
   align-self: start;
-  height: 36px;
+  height: var(--bezier-form-control-left-label-wrapper-height);
 }
 
 .c9 {
@@ -994,10 +994,10 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
 <div
   class="c0 c1"
   data-testid="bezier-react-form-control"
+  style="--bezier-form-control-left-label-wrapper-height: 36px;"
 >
   <div
     class="c0 c2"
-    height="36"
   >
     <label
       class="c3 c4"

--- a/packages/bezier-react/src/components/Forms/FormControl/index.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/index.ts
@@ -1,20 +1,10 @@
-import FormControl from './FormControl'
-import FormControlContext from './FormControlContext'
-import type FormControlProps from './FormControl.types'
-import type {
-  FormControlContextValue,
-  FormControlContextCommonValue,
-  FormControlAriaProps,
-} from './FormControl.types'
+export { FormControl } from './FormControl'
+
+export { FormControlContext } from './FormControlContext'
 
 export type {
   FormControlProps,
   FormControlContextValue,
   FormControlContextCommonValue,
   FormControlAriaProps,
-}
-
-export {
-  FormControl,
-  FormControlContext,
-}
+} from './FormControl.types'

--- a/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.tsx
+++ b/packages/bezier-react/src/components/Forms/FormGroup/FormGroup.tsx
@@ -1,10 +1,9 @@
 /* External dependencies */
-import React, {
-  forwardRef,
-  useEffect,
-} from 'react'
+import React, { forwardRef } from 'react'
 
 /* Internal dependencies */
+import { noop } from '~/src/utils/functionUtils'
+import useMergeRefs from '~/src/hooks/useMergeRefs'
 import useFormControlContext from '~/src/components/Forms/useFormControlContext'
 import type FormGroupProps from './FormGroup.types'
 import * as Styled from './FormGroup.styled'
@@ -24,25 +23,20 @@ forwardedRef: React.Ref<HTMLDivElement>,
   const contextValue = useFormControlContext()
 
   const {
-    setIsRendered,
+    ref,
     ...ownProps
   } = contextValue?.getGroupProps(rest) ?? {
-    setIsRendered: undefined,
+    ref: noop,
     ...rest,
   }
 
-  useEffect(() => {
-    setIsRendered?.(true)
-    return function cleanUp() {
-      setIsRendered?.(false)
-    }
-  }, [setIsRendered])
+  const mergedRef = useMergeRefs(ref, forwardedRef)
 
   return (
     <Styled.Stack
       {...ownProps}
       data-testid={testId}
-      ref={forwardedRef}
+      ref={mergedRef}
       justify="start"
       align="stretch"
       spacing={spacing}

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -1,13 +1,14 @@
 /* External dependencies */
 import React, {
   forwardRef,
-  useEffect,
   useMemo,
 } from 'react'
 
 /* Internal dependencies */
 import { Typography } from '~/src/foundation'
+import { noop } from '~/src/utils/functionUtils'
 import { isEmpty } from '~/src/utils/typeUtils'
+import useMergeRefs from '~/src/hooks/useMergeRefs'
 import useFormControlContext from '~/src/components/Forms/useFormControlContext'
 import type {
   BaseHelperTextProps,
@@ -37,15 +38,17 @@ forwardedRef: ForwardedRef,
 
   const {
     visible,
-    setIsRendered,
+    ref,
     Wrapper,
     ...ownProps
   } = getProps?.(rest) ?? {
     visible: true,
-    setIsRendered: undefined,
+    ref: noop,
     Wrapper: React.Fragment,
     ...rest,
   }
+
+  const mergedRef = useMergeRefs(ref, forwardedRef)
 
   const shouldRendered = useMemo(() => (
     !isEmpty(children) && visible
@@ -54,24 +57,13 @@ forwardedRef: ForwardedRef,
     children,
   ])
 
-  useEffect(() => {
-    setIsRendered?.(shouldRendered)
-  }, [
-    shouldRendered,
-    setIsRendered,
-  ])
-
-  useEffect(() => function cleanUp() {
-    setIsRendered?.(false)
-  }, [setIsRendered])
-
   if (!shouldRendered) { return null }
 
   return (
     <Wrapper>
       <Styled.HelperText
         {...ownProps}
-        ref={forwardedRef}
+        ref={mergedRef}
         forwardedAs={as}
         typo={typo}
       >


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

`FormControl` 컴포넌트를 개선합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- forwardRef를 추가합니다.
- `useEffect` 를 통해 마운트 여부를 체크하던 로직을 Callback ref를 사용한 방식으로 리팩토링합니다. 컨텍스트 사용처에서 더 깔끔한 방식으로 마운트 여부를 체크할 수 있도록 합니다.
  - 정확히 말하면 리팩토링은 아닙니다. 기존의 마운트 여부를 React Component 라이프사이클에서 DOM Node의 라이프사이클(렌더링 여부)로 체크하도록 변경했기때문에 더 의도에 맞는 코드가 되었습니다.
- TODO Resolve: labelPosition top일 때, Wrapper에 `AlphaStack` 을 사용하도록 리팩토링합니다.
- labelPosition left일 때, styled prop을 통해 leftLabelHeight를 전달받던 것을 CSS Variable로 리팩토링합니다.
- 기타 스타일 수정

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

None
