### PR TITLE
Fixes an issue that causes the focus to move whenever the state changes when using `AutoFocus` component

### DIFF
--- a/.changeset/sixty-meals-drum.md
+++ b/.changeset/sixty-meals-drum.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Fixes an issue that causes the focus to move whenever the state changes when using `AutoFocus` component.

--- a/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
+++ b/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
@@ -1,7 +1,8 @@
 /* External dependencies */
 import React, {
   forwardRef,
-  useCallback,
+  useLayoutEffect,
+  useState,
 } from 'react'
 import { Slot } from '@radix-ui/react-slot'
 
@@ -32,13 +33,21 @@ export const AutoFocus = forwardRef<HTMLElement, AutoFocusProps>(function AutoFo
   when = true,
   ...rest
 }, forwardedRef) {
-  const focus = useCallback((node: HTMLElement | null) => {
-    if (node && when) {
-      node.focus()
-    }
-  }, [when])
+  const [target, setTarget] = useState<HTMLElement | null>(null)
 
-  const ref = useMergeRefs(focus, forwardedRef)
+  useLayoutEffect(function focus() {
+    if (target && when) {
+      target.focus()
+    }
+  }, [
+    target,
+    when,
+  ])
+
+  const ref = useMergeRefs(
+    setTarget as React.Ref<HTMLElement>,
+    forwardedRef,
+  )
 
   return (
     <Slot

--- a/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
+++ b/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
@@ -45,7 +45,7 @@ export const AutoFocus = forwardRef<HTMLElement, AutoFocusProps>(function AutoFo
   ])
 
   const ref = useMergeRefs(
-    setTarget as React.Ref<HTMLElement>,
+    setTarget,
     forwardedRef,
   )
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

state가 변할 때마다 `AutoFocus` 의 `HTMLElement.focus()` 메서드가 실행되는 버그를 수정합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

기존의 ref callback을 사용한 구현을 `useState`, `useLayoutEffect` 를 사용한 구현으로 변경했습니다. 

> _Unless you pass the same function reference for the ref callback on every render_, the callback will get temporarily detached and re-attached during ever re-render of the component.

리액트 공식 문서를 참고해봤을 때, 함수의 참조가 동일하다면 함수가 매 렌더마다 detach - attach 되면 안되는 거로 예상했지만 실제 동작은 달랐습니다. 상태 변경 시 함수가 계속 실행되어 `focus` 메서드가 매 렌더마다 실행되었습니다(re-attach).

`useState` 의 `setState` 함수를 ref callback으로 사용했을 경우엔 DOMNode가 Document에 attach 되었을 때 1번, detach 되었을 때 1번. 즉, 예상한 대로 동작하여 `useLayoutEffect` 와 함께 사용하는 방식으로 수정했습니다. 플리커링 방지를 위해(브라우저 Paint 시점 이전에 메서드를 실행함을 보장) `useEffect` 대신 `useLayoutEffect` 를 사용했습니다.

- 추가) radix-ui `Slot` 과 결합되었을 때의 이슈로 추정됩니다.

### etc

`useMergeRefs` : 타입을 교정하고, 함수를 분리하여 가독성을 높였습니다. ([참고](https://chakra-ui.com/docs/hooks/use-merge-refs#usage-combining-with-another-chakra-ui-hooks))

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- https://react.dev/reference/react-dom/components/common#ref-callback-parameters