### PR TITLE
Fix no spacing between form fields and `FormLabel` and `FormHelperText` when `labelPosition="left"`

### DIFF
--- a/.changeset/kind-grapes-rescue.md
+++ b/.changeset/kind-grapes-rescue.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Fix no spacing between form fields and `FormLabel` and `FormHelperText` when `labelPosition="left"`.

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.styled.ts
@@ -11,10 +11,12 @@ const Box = styled.div<InterpolationProps>`
 
 export const TopLabelWrapper = styled(Box)`
   padding: 0 2px;
+  margin-bottom: 4px;
 `
 
 export const TopHelperTextWrapper = styled(Box)`
   padding: 0 2px;
+  margin-top: 4px;
 `
 
 export const Grid = styled(Box)`

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -43,7 +43,6 @@ const Container = forwardRef<HTMLElement, ContainerProps>(function Container({
         <AlphaStack
           ref={forwardedRef}
           direction="vertical"
-          spacing={4}
           testId={testId}
           {...rest}
         >

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -26,10 +26,12 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 
 .c2 {
   padding: 0 2px;
+  margin-bottom: 4px;
 }
 
 .c10 {
   padding: 0 2px;
+  margin-top: 4px;
 }
 
 .c5 {
@@ -193,7 +195,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   <div
     class="c0"
     data-testid="bezier-react-form-control"
-    style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+    style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 0px;"
   >
     <div
       class="c1 c2"
@@ -219,7 +221,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       <div
         class="c0"
         data-testid="bezier-react-form-control"
-        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 0px;"
       >
         <div
           class="c1 c2"
@@ -251,7 +253,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       <div
         class="c0"
         data-testid="bezier-react-form-control"
-        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 0px;"
       >
         <div
           class="c1 c2"
@@ -324,10 +326,12 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 
 .c7 {
   padding: 0 2px;
+  margin-bottom: 4px;
 }
 
 .c13 {
   padding: 0 2px;
+  margin-top: 4px;
 }
 
 .c1 {
@@ -567,7 +571,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       <div
         class="c5"
         data-testid="bezier-react-form-control"
-        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 0px;"
       >
         <div
           class="c0 c7"
@@ -599,7 +603,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       <div
         class="c5"
         data-testid="bezier-react-form-control"
-        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+        style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 0px;"
       >
         <div
           class="c0 c7"
@@ -672,10 +676,12 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 
 .c2 {
   padding: 0 2px;
+  margin-bottom: 4px;
 }
 
 .c8 {
   padding: 0 2px;
+  margin-top: 4px;
 }
 
 .c3 {
@@ -799,7 +805,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 <div
   class="c0"
   data-testid="bezier-react-form-control"
-  style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 4px;"
+  style="--bezier-form-control-left-label-wrapper-height: 36px; --bezier-alpha-stack-direction: column; --bezier-alpha-stack-justify: flex-start; --bezier-alpha-stack-align: stretch; --bezier-alpha-stack-spacing: 0px;"
 >
   <div
     class="c1 c2"
@@ -850,6 +856,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
 
 .c8 {
   padding: 0 2px;
+  margin-top: 4px;
 }
 
 .c1 {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

No

## Summary
<!-- Please add a summary of the modification. -->

Fix no spacing between form fields and `FormLabel` and `FormHelperText` when `labelPosition="left"`.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

Skip

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

No
