### PR TITLE
remove overrided padding from valueItemContainer

### DIFF
--- a/.changeset/gold-cows-impress.md
+++ b/.changeset/gold-cows-impress.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+change keyvalue item padding

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.test.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.test.tsx
@@ -373,7 +373,7 @@ describe('KeyValueListItem', () => {
         const rootValueContainer = rendered.lastChild
         expect(rootValueContainer).toHaveStyle('display: flex;')
         expect(rootValueContainer).toHaveStyle('flex: 1;')
-        expect(rootValueContainer).toHaveStyle('padding: 0 6px;')
+        expect(rootValueContainer).toHaveStyle('padding: 4px 6px;')
         expect(rootValueContainer).toHaveStyle('min-height: 28px;')
       })
     })

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueMultiLineListItem.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueMultiLineListItem.styled.ts
@@ -20,5 +20,4 @@ export const KeyItemContainer = styled(KeyValueListItemContainer)`
 export const ValueItemContainer = styled(KeyValueListItemContainer)`
   flex: 1;
   min-height: 28px;
-  padding: 0 6px;
 `


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

Fixes #0000 <!-- Please link to issue if one exists -->

## Summary
<!-- Please add a summary of the modification. -->

### Current
<img width="348" alt="image" src="https://user-images.githubusercontent.com/69702813/232683672-1413f616-34cf-4729-a3f2-8c24b9c62b96.png">

### Figma ScreenShot
<img width="347" alt="image" src="https://user-images.githubusercontent.com/69702813/232711616-8cd57d96-8617-4f92-a198-3e4dece04658.png">

### Fixed
<img width="335" alt="image" src="https://user-images.githubusercontent.com/69702813/232711825-35f5f635-95a0-43ff-ba81-a8dd7a06b41b.png">


So remove padding property from `ValueItemContainer` in order to fix it.

현재 `ValueItemContainer`의 패딩은 `0 6px`인데, 이것은 피그마의 패딩과 다릅니다.

이로 인해 [데스크에서 MultiIine 컴포넌트가 한줄일때 이상해보이는 문제점](https://github.com/channel-io/ch-desk-web/issues/12666)이 있었습니다. 

현재 스타일은 기존의 padding인 `4px 6px`를 오버라이드하므로, 이를 삭제하여 원래 패딩을 사용하도록합니다.


## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->


## References
<!-- External documents based on workarounds or reviewers should refer to -->

[Figma](https://www.figma.com/file/99k33ZxchcPKTz2tzJlZeE/Components?node-id=1164-12605&t=3W14fNTlqUQg8UwA-4)