### PR TITLE
remove container prop to `Tooltip` components and add contentWrapperStyle prop

### DIFF
--- a/.changeset/shy-bulldogs-brush.md
+++ b/.changeset/shy-bulldogs-brush.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Remove `container` property from `Tooltip` component and add `contentWrapperStyle` property.

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import {
   type Meta,
@@ -79,22 +79,15 @@ const Target = styled.div`
   border-radius: 4px;
 `
 
-const Template: Story<TooltipProps> = (props) => {
-  const [container, setContainer] = useState<HTMLDivElement | null>(null)
-
-  return (
-    <div ref={setContainer}>
-      <Tooltip
-        {...props}
-        container={container}
-      >
-        <Target>
-          Target
-        </Target>
-      </Tooltip>
-    </div>
-  )
-}
+const Template: Story<TooltipProps> = (props) => (
+  <Tooltip
+    {...props}
+  >
+    <Target>
+      Target
+    </Target>
+  </Tooltip>
+)
 
 export const Primary = Template.bind({})
 

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -27,6 +27,7 @@ function Tooltip(
     className,
     contentClassName,
     contentInterpolation,
+    contentWrapperStyle,
     content = null,
     lazy = false, // optional prop 에서 추후 default behavior 를 lazy 하게 바꿀 예정
     placement = TooltipPosition.BottomCenter,
@@ -99,6 +100,7 @@ function Tooltip(
           content={content}
           contentClassName={contentClassName}
           contentInterpolation={contentInterpolation}
+          contentWrapperStyle={contentWrapperStyle}
           disabled={disabled}
           placement={placement}
           offset={offset}
@@ -119,6 +121,7 @@ function Tooltip(
     content,
     contentClassName,
     contentInterpolation,
+    contentWrapperStyle,
     disabled,
     placement,
     offset,

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -32,7 +32,6 @@ function Tooltip(
     placement = TooltipPosition.BottomCenter,
     disabled = false,
     offset = 4,
-    container,
     keepInContainer = false,
     allowHover = false,
     delayShow = 0,
@@ -104,7 +103,6 @@ function Tooltip(
           placement={placement}
           offset={offset}
           allowHover={allowHover}
-          container={container}
           keepInContainer={keepInContainer}
           tooltipContainer={tooltipContainerRef.current}
           forwardedRef={forwardedRef}
@@ -125,7 +123,6 @@ function Tooltip(
     placement,
     offset,
     allowHover,
-    container,
     keepInContainer,
     forwardedRef,
     contentTestId,

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
@@ -12,7 +12,6 @@ import {
 interface TooltipOptions {
   placement?: TooltipPosition
   offset?: number
-  container?: HTMLElement | null
   keepInContainer?: boolean
   allowHover?: boolean
   delayShow?: number
@@ -33,7 +32,6 @@ export default interface TooltipProps extends
 
 export interface TooltipContentProps extends Pick<
 TooltipOptions,
-'container' |
 'keepInContainer' |
 'placement' |
 'offset' |
@@ -51,7 +49,7 @@ export interface GetTooltipStyle extends Required<Pick<TooltipOptions, 'placemen
   tooltipContainer: HTMLDivElement
 }
 
-export interface GetReplacement extends Required<Pick<TooltipOptions, 'placement' | 'container' | 'keepInContainer'>> {
+export interface GetReplacement extends Required<Pick<TooltipOptions, 'placement' | 'keepInContainer'>> {
   tooltip: HTMLDivElement
 }
 

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
@@ -25,7 +25,7 @@ export default interface TooltipProps extends
   ChildrenProps,
   ContentProps,
   DisableProps,
-  AdditionalStylableProps<'content'>,
+  AdditionalStylableProps<'content' | 'contentWrapper'>,
   React.HTMLAttributes<HTMLDivElement>,
   TooltipOptions {
 }
@@ -39,7 +39,7 @@ TooltipOptions,
 >,
   RenderConfigProps,
   ContentProps,
-  AdditionalStylableProps<'content'>,
+  AdditionalStylableProps<'content' | 'contentWrapper'>,
   DisableProps {
   tooltipContainer: HTMLDivElement | null
   forwardedRef: Ref<HTMLDivElement>

--- a/packages/bezier-react/src/components/Tooltip/TooltipContent.tsx
+++ b/packages/bezier-react/src/components/Tooltip/TooltipContent.tsx
@@ -83,7 +83,6 @@ const TooltipContent: React.FC<TooltipContentProps> = ({
   contentClassName,
   contentInterpolation,
   disabled = false,
-  container: givenContainer,
   keepInContainer = false,
   placement = TooltipPosition.BottomCenter,
   tooltipContainer,
@@ -97,8 +96,6 @@ const TooltipContent: React.FC<TooltipContentProps> = ({
   const mergedRef = useMergeRefs<HTMLDivElement>(tooltipRef, forwardedRef)
   const [replacement, setReplacement] = useState(placement)
 
-  const container = givenContainer || getRootElement()
-
   const handleClickTooltip = useCallback((event: HTMLElementEventMap['click']) => {
     event.stopPropagation()
   }, [])
@@ -109,13 +106,11 @@ const TooltipContent: React.FC<TooltipContentProps> = ({
     if (!tooltipRef.current) { return }
     const newPlacement = getReplacement({
       tooltip: tooltipRef.current,
-      container,
       keepInContainer,
       placement,
     })
     setReplacement(newPlacement)
   }, [
-    container,
     keepInContainer,
     placement,
   ])
@@ -159,7 +154,7 @@ const TooltipContent: React.FC<TooltipContentProps> = ({
           </EllipsisableContent>
         </Content>
       </ContentWrapper>,
-      container,
+      getRootElement(),
     )
   )
 }

--- a/packages/bezier-react/src/components/Tooltip/TooltipContent.tsx
+++ b/packages/bezier-react/src/components/Tooltip/TooltipContent.tsx
@@ -82,6 +82,7 @@ const TooltipContent: React.FC<TooltipContentProps> = ({
   content,
   contentClassName,
   contentInterpolation,
+  contentWrapperStyle: givenContentWrapperStyle,
   disabled = false,
   keepInContainer = false,
   placement = TooltipPosition.BottomCenter,
@@ -119,17 +120,21 @@ const TooltipContent: React.FC<TooltipContentProps> = ({
 
   const contentWrapperStyle = useMemo(() => {
     if (tooltipContainer) {
-      return getTooltipStyle({
-        tooltipContainer,
-        placement: replacement,
-        offset,
-        allowHover,
-      })
+      return {
+        ...givenContentWrapperStyle,
+        ...getTooltipStyle({
+          tooltipContainer,
+          placement: replacement,
+          offset,
+          allowHover,
+        }),
+      }
     }
 
     return {}
   }, [
     tooltipContainer,
+    givenContentWrapperStyle,
     replacement,
     offset,
     allowHover,

--- a/packages/bezier-react/src/components/Tooltip/utils.ts
+++ b/packages/bezier-react/src/components/Tooltip/utils.ts
@@ -1,3 +1,5 @@
+import { getRootElement } from '~/src/utils/domUtils'
+
 import {
   type GetReplacement,
   type GetTooltipStyle,
@@ -6,11 +8,10 @@ import {
 
 export function getReplacement({
   tooltip,
-  container,
   keepInContainer,
   placement,
 }: GetReplacement): TooltipPosition {
-  if (!keepInContainer || !container) {
+  if (!keepInContainer) {
     return placement
   }
 
@@ -26,7 +27,7 @@ export function getReplacement({
     height: rootHeight,
     top: rootTop,
     left: rootLeft,
-  } = container.getBoundingClientRect()
+  } = getRootElement().getBoundingClientRect()
 
   const isOverTop = tooltipTop < rootTop
   const isOverBottom = tooltipTop + tooltipHeight > rootTop + rootHeight


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [x] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue
None

## Summary
<!-- Please add a summary of the modification. -->
- `Tooltip` 에 `container` 속성을 제거합니다.
- `Tooltip` 에 `contentWrapperStyle` 속성을 추가합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->
- 외부 container 속성을 지정했을 때 해당 노드 아래에 렌더되도록 할 수 있게 수정하였으나 Tooltip의 로직은 container를 고려해 작성이 되지 않았습니다.
- 따라서 별도의 contentWrapperStyle 속성을 지정하여 필요에 따라 zIndex 등의 스타일을 설정할 수 있게 수정합니다. (이는 임시방편이며 현재 새로운 Tooltip 컴포넌트를 재구현중에 있습니다.)

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

## References
<!-- External documents based on workarounds or reviewers should refer to -->
- #1254 
- #1291 
