### PR TITLE
Apply the reimplemented `Tooltip` to internal components

### DIFF
--- a/.changeset/eleven-jobs-invite.md
+++ b/.changeset/eleven-jobs-invite.md
@@ -1,0 +1,8 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Apply the re-implemented `Tooltip` component to `Help`, `KeyValueListItem`, and `SectionLabel` components.
+
+- Change onClick handler type of `ItemAction` of `KeyValueListItem` to the correct one.
+- The type of `help` property of `SectionLabel` is changed to `React.ReactNode`.

--- a/packages/bezier-react/src/components/Help/Help.styled.ts
+++ b/packages/bezier-react/src/components/Help/Help.styled.ts
@@ -1,17 +1,14 @@
 import { styled } from '~/src/foundation'
 
 import { Icon as BaseIcon } from '~/src/components/Icon'
-import { LegacyTooltip as BaseTooltip } from '~/src/components/LegacyTooltip'
 
 export const Icon = styled(BaseIcon)``
 
-export const Tooltip = styled(BaseTooltip)`
-  display: flex;
-  align-items: center;
-  justify-content: center;
+export const Trigger = styled.div`
+  line-height: 0;
 
-  &:hover {
-    > ${Icon} {
+  &:not([data-state="closed"]) {
+    ${Icon} {
       color: ${({ foundation }) => foundation?.theme?.['txt-black-darkest']};
     }
   }

--- a/packages/bezier-react/src/components/Help/Help.tsx
+++ b/packages/bezier-react/src/components/Help/Help.tsx
@@ -5,6 +5,7 @@ import { HelpFilledIcon } from '@channel.io/bezier-icons'
 import { isEmpty } from '~/src/utils/typeUtils'
 
 import { IconSize } from '~/src/components/Icon'
+import { Tooltip } from '~/src/components/Tooltip'
 
 import type HelpProps from './Help.types'
 
@@ -20,14 +21,19 @@ function Help({
   if (isEmpty(children)) { return null }
 
   return (
-    <Styled.Tooltip {...rest} content={children}>
-      <Styled.Icon
-        testId={HELP_TEST_ID}
-        source={HelpFilledIcon}
-        size={IconSize.XS}
-        color="txt-black-dark"
-      />
-    </Styled.Tooltip>
+    <Tooltip
+      {...rest}
+      content={children}
+    >
+      <Styled.Trigger>
+        <Styled.Icon
+          testId={HELP_TEST_ID}
+          source={HelpFilledIcon}
+          size={IconSize.XS}
+          color="txt-black-dark"
+        />
+      </Styled.Trigger>
+    </Tooltip>
   )
 }
 

--- a/packages/bezier-react/src/components/Help/Help.types.ts
+++ b/packages/bezier-react/src/components/Help/Help.types.ts
@@ -3,9 +3,9 @@ import {
   type ChildrenProps,
 } from '~/src/types/ComponentProps'
 
-import { type LegacyTooltipProps } from '~/src/components/LegacyTooltip'
+import { type TooltipProps } from '~/src/components/Tooltip'
 
 export default interface HelpProps extends
   BezierComponentProps,
   ChildrenProps,
-  Omit<LegacyTooltipProps, 'content'> {}
+  Omit<TooltipProps, 'content'> {}

--- a/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.test.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/KeyValueListItem.test.tsx
@@ -8,8 +8,6 @@ import userEvent from '@testing-library/user-event'
 
 import { render } from '~/src/utils/testUtils'
 
-import { TOOLTIP_TEST_ID } from '~/src/components/LegacyTooltip/LegacyTooltip'
-
 import KeyValueListItem from './KeyValueListItem'
 import { TEST_ID_MAP } from './KeyValueListItem.const'
 import { type KeyValueListItemProps } from './KeyValueListItem.types'
@@ -168,11 +166,17 @@ describe('KeyValueListItem', () => {
         expect(actions.onClick).toBeCalledTimes(2)
       })
 
-      it('actions의 tooltip이 있으면, tooltip이 렌더링된다.', () => {
+      it('actions의 tooltip이 있으면, tooltip이 렌더링된다.', async () => {
+        const user = userEvent.setup()
+
         const actions: KeyValueListItemActionProps = { icon: BadgeIcon, tooltip: 'tooltip' }
-        const { getByTestId } = renderComponent({ actions })
-        const rendered = getByTestId(TOOLTIP_TEST_ID)
-        expect(rendered).toBeInTheDocument()
+        const { getByRole, getByTestId } = renderComponent({ actions })
+        const rendered = getByTestId(TEST_ID_MAP.ACTIONS_ITEM)
+        const actionItemIconWrapper = rendered?.firstChild
+        const actionItemIcon = actionItemIconWrapper?.firstChild
+
+        await user.hover(actionItemIcon as HTMLElement)
+        expect(getByRole('tooltip')).toBeInTheDocument()
       })
     })
 

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.styled.ts
@@ -8,7 +8,6 @@ import { isNil } from '~/src/utils/typeUtils'
 
 import { Icon } from '~/src/components/Icon'
 import { LegacyIcon } from '~/src/components/LegacyIcon'
-import { LegacyTooltip } from '~/src/components/LegacyTooltip'
 
 export const ItemActionWrapper = styled.div`
   display: flex;
@@ -21,7 +20,9 @@ interface ActionWrapperProps extends AdditionalColorProps<['hoverBackground', 'h
 export const ActionIcon = styled(Icon)``
 export const ActionLegacyIcon = styled(LegacyIcon)``
 
-export const ActionIconWrapper = styled.div<ActionWrapperProps>`
+export const ActionIconWrapper = styled.button<ActionWrapperProps>`
+  all: unset;
+
   display: ${({ show }) => (show ? 'flex' : 'none')};
   align-items: center;
   justify-content: center;
@@ -31,7 +32,8 @@ export const ActionIconWrapper = styled.div<ActionWrapperProps>`
 
   ${({ foundation }) => foundation?.rounding?.round6}
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     ${({ foundation, hoverBackgroundColor }) => !isNil(hoverBackgroundColor) && css`
       background-color: ${foundation?.theme?.[hoverBackgroundColor]};
     `}
@@ -48,8 +50,4 @@ export const ActionIconWrapper = styled.div<ActionWrapperProps>`
       `}
     }
   }
-`
-
-export const ActionIconTooltip = styled(LegacyTooltip)`
-  margin-left: auto;
 `

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.tsx
@@ -19,6 +19,7 @@ import {
 import { IconSize } from '~/src/components/Icon'
 import { TEST_ID_MAP } from '~/src/components/KeyValueListItem/KeyValueListItem.const'
 import { isIconName } from '~/src/components/LegacyIcon'
+import { Tooltip } from '~/src/components/Tooltip'
 
 import {
   type ItemActionProps,
@@ -75,9 +76,12 @@ function ItemAction(
 
       if (!isEmpty(action.tooltip)) {
         return (
-          <Styled.ActionIconTooltip key={key} content={action.tooltip}>
+          <Tooltip
+            key={key}
+            content={action.tooltip}
+          >
             { iconElement }
-          </Styled.ActionIconTooltip>
+          </Tooltip>
         )
       }
       return iconElement

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.types.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.types.ts
@@ -15,7 +15,7 @@ export type ItemActionWithIcon = {
   icon: IconName | BezierIcon
   tooltip?: string
   show?: boolean
-  onClick?: React.MouseEventHandler<HTMLDivElement>
+  onClick?: React.MouseEventHandler<HTMLButtonElement>
 } & AdditionalColorProps<['icon', 'hoverBackground', 'hoverIcon']>
 
 export type KeyValueListItemActionProps = ItemActionWithIcon | React.ReactElement

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.stories.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.stories.tsx
@@ -127,7 +127,7 @@ const Template: Story<SectionLabelProps & {
         />
       </SectionLabel>
       <SectionLabel
-        help={{ tooltipContent: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.' }}
+        help="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         rightContent={{ icon: open ? 'chevron-down' : 'chevron-right' }}
         {...otherSectionLabelProps}
       />

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.styled.ts
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.styled.ts
@@ -5,6 +5,7 @@ import {
 
 import { type InterpolationProps } from '~/src/types/Foundation'
 
+import { Help as BaseHelp } from '~/src/components/Help'
 import { LegacyIcon } from '~/src/components/LegacyIcon'
 import { Text } from '~/src/components/Text'
 
@@ -42,9 +43,7 @@ const ContentWrapper = styled.div<InterpolationProps>`
   ${({ interpolation }) => interpolation}
 `
 
-const HelpIconWrapper = styled.div`
-  width: 16px;
-  height: 16px;
+const Help = styled(BaseHelp)`
   margin-left: 8px;
 `
 
@@ -86,7 +85,7 @@ export default {
   LeftContentWrapper,
   ContentText,
   ContentWrapper,
-  HelpIconWrapper,
+  Help,
   RightContentWrapper,
   RightItemWrapper,
   ChildrenWrapper,

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.test.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.test.tsx
@@ -6,11 +6,11 @@ import { render } from '~/src/utils/testUtils'
 
 import { BUTTON_TEST_ID } from '~/src/components/Button/Button'
 import { DIVIDER_TEST_ID } from '~/src/components/Divider/Divider'
+import { HELP_TEST_ID } from '~/src/components/Help/Help'
 import { ICON_TEST_ID } from '~/src/components/Icon/Icon'
 
 import SectionLabel, {
   SECTION_LABEL_TEST_CONTENT_ID,
-  SECTION_LABEL_TEST_HELP_CONTENT_ID,
   SECTION_LABEL_TEST_ID,
   SECTION_LABEL_TEST_LEFT_CONTENT_ID,
   SECTION_LABEL_TEST_RIGHT_CONTENT_ID,
@@ -83,15 +83,12 @@ describe('SectionLabel', () => {
     expect(leftIcon?.id).toBe('foo')
   })
 
-  it('renders help content with default color if the help prop exists', () => {
+  it('renders help icon if help prop exists', () => {
     const { getByTestId } = renderComponent({
       help: <div>happy</div>,
     })
-    const helpContent = getByTestId(SECTION_LABEL_TEST_HELP_CONTENT_ID)
-
-    const helpIcon = helpContent.children.item(0)
-    expect(helpIcon).toHaveAttribute('data-testid', ICON_TEST_ID)
-    expect(helpIcon).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']};`)
+    const helpContent = getByTestId(HELP_TEST_ID)
+    expect(helpContent).toBeInTheDocument()
   })
 
   it('does not render right content if given null', () => {

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.test.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.test.tsx
@@ -85,30 +85,13 @@ describe('SectionLabel', () => {
 
   it('renders help content with default color if the help prop exists', () => {
     const { getByTestId } = renderComponent({
-      help: {
-        tooltipContent: <div>happy</div>,
-      },
+      help: <div>happy</div>,
     })
     const helpContent = getByTestId(SECTION_LABEL_TEST_HELP_CONTENT_ID)
 
     const helpIcon = helpContent.children.item(0)
     expect(helpIcon).toHaveAttribute('data-testid', ICON_TEST_ID)
     expect(helpIcon).toHaveStyle(`color: ${LightFoundation.theme['txt-black-dark']};`)
-  })
-
-  it('renders help content with specified icon and icon color', () => {
-    const { getByTestId } = renderComponent({
-      help: {
-        icon: 'weather-snow',
-        tooltipContent: <div>happy</div>,
-        iconColor: 'txt-white-normal',
-      },
-    })
-    const helpContent = getByTestId(SECTION_LABEL_TEST_HELP_CONTENT_ID)
-
-    const helpIcon = helpContent.children.item(0)
-    expect(helpIcon).toHaveAttribute('data-testid', ICON_TEST_ID)
-    expect(helpIcon).toHaveStyle(`color: ${LightFoundation.theme['txt-white-normal']};`)
   })
 
   it('does not render right content if given null', () => {

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
@@ -25,7 +25,6 @@ import {
 import { Divider } from '~/src/components/Divider'
 import { IconSize } from '~/src/components/Icon'
 import { LegacyIcon } from '~/src/components/LegacyIcon'
-import { LegacyTooltip } from '~/src/components/LegacyTooltip'
 
 import { type SectionLabelItemProps } from './SectionLabel.types'
 import type SectionLabelProps from './SectionLabel.types'
@@ -181,18 +180,9 @@ function SectionLabel({
   ])
 
   const helpContent = useMemo(() => !isNil(help) && (
-    <LegacyTooltip
-      content={help.tooltipContent}
-      allowHover
-    >
-      <Styled.HelpIconWrapper data-testid={SECTION_LABEL_TEST_HELP_CONTENT_ID}>
-        <LegacyIcon
-          name={help.icon ?? 'help-filled'}
-          size={IconSize.XS}
-          color={help.iconColor ?? 'txt-black-dark'}
-        />
-      </Styled.HelpIconWrapper>
-    </LegacyTooltip>
+    <Styled.Help data-testid={SECTION_LABEL_TEST_HELP_CONTENT_ID}>
+      { help }
+    </Styled.Help>
   ), [help])
 
   return (

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
@@ -35,7 +35,6 @@ export const SECTION_LABEL_TEST_ID = 'bezier-react-section-label'
 export const SECTION_LABEL_TEST_CONTENT_ID = 'bezier-react-section-label-content'
 export const SECTION_LABEL_TEST_LEFT_CONTENT_ID = 'bezier-react-section-label-left-content'
 export const SECTION_LABEL_TEST_RIGHT_CONTENT_ID = 'bezier-react-section-label-right-content'
-export const SECTION_LABEL_TEST_HELP_CONTENT_ID = 'bezier-react-section-label-help-content'
 
 function clickableClassName(onClick?: React.MouseEventHandler) {
   return !isNil(onClick) ? 'clickable' : undefined
@@ -180,7 +179,7 @@ function SectionLabel({
   ])
 
   const helpContent = useMemo(() => !isNil(help) && (
-    <Styled.Help data-testid={SECTION_LABEL_TEST_HELP_CONTENT_ID}>
+    <Styled.Help>
       { help }
     </Styled.Help>
   ), [help])

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.types.ts
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.types.ts
@@ -11,15 +11,8 @@ import type {
   SideContentProps,
 } from '~/src/types/ComponentProps'
 
-import type { IconSize } from '~/src/components/Icon'
-
 interface IconInfo extends AdditionalColorProps<'icon'> {
   icon: IconName
-}
-
-interface SectionLabelHelpProps extends Partial<IconInfo> {
-  iconSize?: IconSize
-  tooltipContent: React.ReactNode
 }
 
 export type SectionLabelItemProps = (IconInfo & {
@@ -29,7 +22,7 @@ export type SectionLabelItemProps = (IconInfo & {
 interface SectionLabelOptions {
   open?: boolean
   divider?: boolean
-  help?: SectionLabelHelpProps
+  help?: React.ReactNode
   onClick?: React.MouseEventHandler
 }
 

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -269,6 +269,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip
           sideOffset={offset}
           avoidCollisions={keepInContainer}
           collisionPadding={8}
+          hideWhenDetached
         >
           <Styled.TooltipContent forwardedAs={as}>
             <div>


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

- #1291 

## Summary
<!-- Please add a summary of the modification. -->

#1291 의 새로운 `Tooltip` 컴포넌트를 `Tooltip` 을 사용하는 아래 디자인 시스템 컴포넌트에 적용합니다.

- `Help`
- `KeyValueListItem`
- `SectionLabel` (`Help`)

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- 새로운 Tooltip 컴포넌트의 스펙에 맞게 스타일링 수정
- 실패하는 테스크 케이스 수정

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

Yes

`help` type of `SectionLabelProps` is changed to `React.ReactNode`.

## References
<!-- External documents based on workarounds or reviewers should refer to -->

없음
