### PR TITLE
Remove console.error from the test and change some styling to classname based

### DIFF
--- a/.changeset/slow-nails-fix.md
+++ b/.changeset/slow-nails-fix.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Changed the styling of the active state of `OutlineItem`'s icon and the clickable state of `SectionLabel` to classname-based styling.

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.styled.ts
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.styled.ts
@@ -4,14 +4,11 @@ import {
   styled,
 } from '~/src/foundation'
 
-import { type ColorProps } from '~/src/types/ComponentProps'
 import { type InterpolationProps } from '~/src/types/Foundation'
 import { isNil } from '~/src/utils/typeUtils'
 
 import { Icon } from '~/src/components/Icon'
 import { LegacyIcon } from '~/src/components/LegacyIcon'
-
-import type OutlineItemProps from './OutlineItem.types'
 
 interface WrapperProps extends InterpolationProps {
   active: boolean
@@ -71,22 +68,18 @@ export const LeftContentWrapper = styled.div`
   margin-right: 8px;
 `
 
-interface StyledIconProps extends InterpolationProps, ColorProps {}
-
-export const StyledLegacyIcon = styled(LegacyIcon)<StyledIconProps & Pick<OutlineItemProps, 'active'>>`
-  color: ${props => {
-    if (props.active) { return props.foundation?.theme['bgtxt-blue-normal'] }
-    return props.foundation?.theme?.[props.color || 'txt-black-dark']
-  }};
+export const StyledLegacyIcon = styled(LegacyIcon)<InterpolationProps>`
+  &.active {
+    color: var(--bgtxt-blue-normal);
+  }
 
   ${({ interpolation }) => interpolation}
 `
 
-export const StyledIcon = styled(Icon)<StyledIconProps & Pick<OutlineItemProps, 'active'>>`
-  color: ${props => {
-    if (props.active) { return props.foundation?.theme['bgtxt-blue-normal'] }
-    return props.foundation?.theme?.[props.color || 'txt-black-dark']
-  }};
+export const StyledIcon = styled(Icon)<InterpolationProps>`
+  &.active {
+    color: var(--bgtxt-blue-normal);
+  }
 
   ${({ interpolation }) => interpolation}
 `

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.styled.ts
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.styled.ts
@@ -73,18 +73,18 @@ export const LeftContentWrapper = styled.div`
 
 interface StyledIconProps extends InterpolationProps, ColorProps {}
 
-export const StyledLegacyIcon = styled(LegacyIcon)<StyledIconProps & Pick<OutlineItemProps, 'active' | 'disableIconActive'>>`
+export const StyledLegacyIcon = styled(LegacyIcon)<StyledIconProps & Pick<OutlineItemProps, 'active'>>`
   color: ${props => {
-    if (!props.disableIconActive && props.active) { return props.foundation?.theme['bgtxt-blue-normal'] }
+    if (props.active) { return props.foundation?.theme['bgtxt-blue-normal'] }
     return props.foundation?.theme?.[props.color || 'txt-black-dark']
   }};
 
   ${({ interpolation }) => interpolation}
 `
 
-export const StyledIcon = styled(Icon)<StyledIconProps & Pick<OutlineItemProps, 'active' | 'disableIconActive'>>`
+export const StyledIcon = styled(Icon)<StyledIconProps & Pick<OutlineItemProps, 'active'>>`
   color: ${props => {
-    if (!props.disableIconActive && props.active) { return props.foundation?.theme['bgtxt-blue-normal'] }
+    if (props.active) { return props.foundation?.theme['bgtxt-blue-normal'] }
     return props.foundation?.theme?.[props.color || 'txt-black-dark']
   }};
 

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.test.tsx
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.test.tsx
@@ -117,7 +117,7 @@ describe('OutlineItem', () => {
       })
       const rendered = getByTestId(OUTLINE_ITEM_LEFT_ICON_TEST_ID)
 
-      expect(rendered).toHaveStyle(`color: ${LightFoundation.theme['bgtxt-blue-normal']};`)
+      expect(rendered).not.toHaveStyle(`color: ${LightFoundation.theme['bgtxt-blue-normal']};`)
     })
 
     it('shows given leftIconColor even if "active = true", if "disableIconActive = true"', () => {

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
@@ -170,34 +170,42 @@ function OutlineItem(
       )
     }
 
-    if (isIconName(leftIcon)) {
-      return (
-        <LeftContentWrapper>
-          <StyledLegacyIcon
-            testId={leftIconTestId}
-            className={iconClassName}
-            interpolation={iconInterpolation}
-            name={leftIcon}
-            size={IconSize.S}
-            active={(!disableIconActive && active) ? true : undefined}
-            color={leftIconColor}
-          />
-        </LeftContentWrapper>
-      )
-    }
+    const isLegacyIcon = isIconName(leftIcon)
+    const isIcon = isBezierIcon(leftIcon)
 
-    if (isBezierIcon(leftIcon)) {
+    if (isLegacyIcon || isIcon) {
+      const iconProps = {
+        testId: leftIconTestId,
+        className: iconClassName,
+        interpolation: iconInterpolation,
+        size: IconSize.S,
+        active: (!disableIconActive && active) ? true : undefined,
+        color: leftIconColor,
+      }
+
+      const Icon = (() => {
+        if (isLegacyIcon) {
+          return (
+            <StyledLegacyIcon
+              {...iconProps}
+              name={leftIcon}
+            />
+          )
+        }
+        if (isIcon) {
+          return (
+            <StyledIcon
+              {...iconProps}
+              source={leftIcon}
+            />
+          )
+        }
+        return <></>
+      })()
+
       return (
         <LeftContentWrapper>
-          <StyledIcon
-            testId={leftIconTestId}
-            className={iconClassName}
-            interpolation={iconInterpolation}
-            source={leftIcon}
-            size={IconSize.S}
-            active={(!disableIconActive && active) ? true : undefined}
-            color={leftIconColor}
-          />
+          { Icon }
         </LeftContentWrapper>
       )
     }

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
@@ -179,8 +179,7 @@ function OutlineItem(
             interpolation={iconInterpolation}
             name={leftIcon}
             size={IconSize.S}
-            active={active ? true : undefined}
-            disableIconActive={disableIconActive}
+            active={(!disableIconActive && active) ? true : undefined}
             color={leftIconColor}
           />
         </LeftContentWrapper>
@@ -196,8 +195,7 @@ function OutlineItem(
             interpolation={iconInterpolation}
             source={leftIcon}
             size={IconSize.S}
-            active={active ? true : undefined}
-            disableIconActive={disableIconActive}
+            active={(!disableIconActive && active) ? true : undefined}
             color={leftIconColor}
           />
         </LeftContentWrapper>

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
@@ -179,7 +179,7 @@ function OutlineItem(
             interpolation={iconInterpolation}
             name={leftIcon}
             size={IconSize.S}
-            active={active}
+            active={active ? true : undefined}
             disableIconActive={disableIconActive}
             color={leftIconColor}
           />
@@ -196,7 +196,7 @@ function OutlineItem(
             interpolation={iconInterpolation}
             source={leftIcon}
             size={IconSize.S}
-            active={active}
+            active={active ? true : undefined}
             disableIconActive={disableIconActive}
             color={leftIconColor}
           />

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
@@ -11,6 +11,7 @@ import {
   ChevronSmallRightIcon,
   isBezierIcon,
 } from '@channel.io/bezier-icons'
+import classNames from 'classnames'
 
 import { noop } from '~/src/utils/functionUtils'
 import { isNil } from '~/src/utils/typeUtils'
@@ -54,7 +55,7 @@ function OutlineItem(
     focused = false,
     leftContent,
     leftIcon,
-    leftIconColor,
+    leftIconColor = 'txt-black-dark',
     disableChevron = false,
     disableIconActive = false,
     name,
@@ -176,10 +177,12 @@ function OutlineItem(
     if (isLegacyIcon || isIcon) {
       const iconProps = {
         testId: leftIconTestId,
-        className: iconClassName,
+        className: classNames(
+          iconClassName,
+          (!disableIconActive && active) && 'active',
+        ),
         interpolation: iconInterpolation,
         size: IconSize.S,
-        active: (!disableIconActive && active) ? true : undefined,
         color: leftIconColor,
       }
 

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.styled.ts
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.styled.ts
@@ -8,18 +8,14 @@ import { type InterpolationProps } from '~/src/types/Foundation'
 import { LegacyIcon } from '~/src/components/LegacyIcon'
 import { Text } from '~/src/components/Text'
 
-interface ClickableElementProps {
-  clickable: true | undefined
-}
-
-function clickableElementStyle(clickable: true | undefined) {
-  return clickable && css`
+const clickableElementStyle = css`
+  &.clickable {
     cursor: pointer;
-  `
-}
+  }
+`
 
-const LeftIcon = styled(LegacyIcon)<ClickableElementProps>`
-  ${({ clickable }) => clickableElementStyle(clickable)}
+const LeftIcon = styled(LegacyIcon)`
+  ${clickableElementStyle}
 `
 
 const LeftContentWrapper = styled.div<InterpolationProps>`
@@ -61,26 +57,26 @@ const RightContentWrapper = styled.div<InterpolationProps>`
   ${({ interpolation }) => interpolation}
 `
 
-const RightItemWrapper = styled.div<ClickableElementProps>`
+const RightItemWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
   width: 20px;
   height: 20px;
 
-  ${({ clickable }) => clickableElementStyle(clickable)}
+  ${clickableElementStyle}
 `
 
 const ChildrenWrapper = styled.div<{ show: boolean }>`
   display: ${({ show }) => (show ? 'unset' : 'none')};
 `
 
-const Wrapper = styled.div<ClickableElementProps & InterpolationProps>`
+const Wrapper = styled.div<InterpolationProps>`
   display: flex;
   align-items: center;
   height: 28px;
 
-  ${({ clickable }) => clickableElementStyle(clickable)}
+  ${clickableElementStyle}
 
   ${({ interpolation }) => interpolation}
 `

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.styled.ts
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.styled.ts
@@ -1,4 +1,7 @@
-import { styled } from '~/src/foundation'
+import {
+  css,
+  styled,
+} from '~/src/foundation'
 
 import { type InterpolationProps } from '~/src/types/Foundation'
 
@@ -6,12 +9,12 @@ import { LegacyIcon } from '~/src/components/LegacyIcon'
 import { Text } from '~/src/components/Text'
 
 interface ClickableElementProps {
-  clickable: boolean
+  clickable: true | undefined
 }
 
-function clickableElementStyle(clickable: boolean): string | false {
-  return clickable && `
-  cursor: pointer;
+function clickableElementStyle(clickable: true | undefined) {
+  return clickable && css`
+    cursor: pointer;
   `
 }
 

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
@@ -52,7 +52,7 @@ function renderSectionLabelActionItem(props: SectionLabelItemProps, key?: string
     return (
       <Styled.RightItemWrapper
         key={key}
-        clickable={!isNil(onClick)}
+        clickable={!isNil(onClick) ? true : undefined}
         onClick={onClick}
       >
         <LegacyIcon
@@ -121,7 +121,7 @@ function SectionLabel({
           name={item.icon}
           size={IconSize.S}
           color={item.iconColor ?? 'txt-black-dark'}
-          clickable={!isNil(item.onClick)}
+          clickable={!isNil(item.onClick) ? true : undefined}
           onClick={item.onClick}
         />
       ) : item

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
@@ -3,6 +3,7 @@ import React, {
   useMemo,
 } from 'react'
 
+import classNames from 'classnames'
 import { v4 as uuid } from 'uuid'
 
 import { Typography } from '~/src/foundation'
@@ -37,6 +38,10 @@ export const SECTION_LABEL_TEST_LEFT_CONTENT_ID = 'bezier-react-section-label-le
 export const SECTION_LABEL_TEST_RIGHT_CONTENT_ID = 'bezier-react-section-label-right-content'
 export const SECTION_LABEL_TEST_HELP_CONTENT_ID = 'bezier-react-section-label-help-content'
 
+function clickableClassName(onClick?: React.MouseEventHandler) {
+  return !isNil(onClick) ? 'clickable' : undefined
+}
+
 function renderSectionLabelActionItem(props: SectionLabelItemProps, key?: string): React.ReactElement {
   if (!('icon' in props)) {
     return React.cloneElement(props, { key })
@@ -52,7 +57,7 @@ function renderSectionLabelActionItem(props: SectionLabelItemProps, key?: string
     return (
       <Styled.RightItemWrapper
         key={key}
-        clickable={!isNil(onClick) ? true : undefined}
+        className={clickableClassName(onClick)}
         onClick={onClick}
       >
         <LegacyIcon
@@ -118,10 +123,10 @@ function SectionLabel({
     'icon' in item
       ? (
         <Styled.LeftIcon
+          className={clickableClassName(item.onClick)}
           name={item.icon}
           size={IconSize.S}
           color={item.iconColor ?? 'txt-black-dark'}
-          clickable={!isNil(item.onClick) ? true : undefined}
           onClick={item.onClick}
         />
       ) : item
@@ -194,8 +199,10 @@ function SectionLabel({
     <div data-testid={SECTION_LABEL_TEST_ID}>
       { divider && <Divider orientation="horizontal" /> }
       <Styled.Wrapper
-        className={wrapperClassName}
-        clickable={!isNil(onClick)}
+        className={classNames(
+          wrapperClassName,
+          clickableClassName(onClick),
+        )}
         onClick={onClick}
         interpolation={wrapperInterpolation}
         {...props}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

jest 에서 발생하는 `console.error` 를 제거하여 테스트 결과의 가독성을 증가시킵니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- boolean value를 non-boolean value로 변경합니다 (`boolean` -> `true | undefined`)
- `active` 속성은 존재하는 DOM Attribute이기 때문에 Icon(svg)등에 필터링없이 주입될 경우 에러가 발생합니다. styled prop 대신, 클래스네임을 통한 스타일링으로 이를 해결합니다.

### Next

- `Checkbox` : 체크박스 아이콘의 ref에 접근할 수 없어 에러가 발생합니다. 이는 Icon에 forwardRef를 추가하는 별도 PR에서 해결하려고 합니다.
- `ListItem` : 동일하게 `active` 속성의 문제가 있으나, 스타일링이 복잡하고 사이즈가 커서 별도 PR에서 해결하려고 합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

없음
