### PR TITLE
Add `Tooltip` to `Slider` and other enhancements

### DIFF
--- a/.changeset/cyan-seas-jam.md
+++ b/.changeset/cyan-seas-jam.md
@@ -1,0 +1,8 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Add `Tooltip` to the thumb of `Slider`.
+
+- `disableTooltip` property is added to `SliderProps`.
+- The default value of `defaultValue` property of `SliderProps` is changed from `[5]` to `[0]`.

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.stories.tsx
@@ -46,4 +46,5 @@ Primary.args = {
   min: 0,
   max: 10,
   step: 1,
+  disableTooltip: false,
 }

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.stories.tsx
@@ -15,22 +15,12 @@ export default {
   title: getTitle(base),
   component: Slider,
   argTypes: {
-    width: {
+    value: {
       control: {
-        type: 'text',
+        type: 'array',
       },
     },
-    min: {
-      control: {
-        type: 'number',
-      },
-    },
-    max: {
-      control: {
-        type: 'number',
-      },
-    },
-    step: {
+    minStepsBetweenThumbs: {
       control: {
         type: 'number',
       },
@@ -38,11 +28,8 @@ export default {
     onValueChange: {
       action: 'onValueChange',
     },
-    onThumbPointerDown: {
-      action: 'onThumbPointerDown',
-    },
-    onThumbPointerUp: {
-      action: 'onThumbPointerUp',
+    onValueCommit: {
+      action: 'onValueCommit',
     },
   },
 } as Meta
@@ -51,53 +38,12 @@ const Template: Story<SliderProps> = (args) => <Slider {...args} />
 
 export const Primary = Template.bind({})
 Primary.args = {
-  width: '285',
+  width: 285,
   defaultValue: [5],
-  value: [2],
+  value: undefined,
+  disabled: false,
+  guide: [5],
   min: 0,
   max: 10,
   step: 1,
-}
-
-export const Uncontrolled = Template.bind({})
-Uncontrolled.args = {
-  width: '285',
-  defaultValue: [5],
-  value: [2],
-  min: 0,
-  max: 10,
-  step: 1,
-}
-
-export const Disabled = Template.bind({})
-Disabled.args = {
-  width: '285',
-  defaultValue: [5],
-  value: [2],
-  min: 0,
-  max: 10,
-  step: 1,
-  disabled: true,
-}
-
-export const WithGuide = Template.bind({})
-WithGuide.args = {
-  width: '285',
-  defaultValue: [5],
-  value: [2],
-  guide: [0, 1, 2, 3, 4, 5, 10],
-  min: 0,
-  max: 10,
-  step: 1,
-}
-
-export const MultipleThumbs = Template.bind({})
-MultipleThumbs.args = {
-  width: '285',
-  defaultValue: [3, 7],
-  value: [2, 4],
-  min: 0,
-  max: 10,
-  step: 1,
-  minStepsBetweenThumbs: 1,
 }

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
@@ -59,10 +59,13 @@ export const SliderPrimitiveRoot = styled(SliderPrimitive.Root)<InterpolationPro
   height: ${SLIDER_THUMB_SIZE}px;
 
   touch-action: none;
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  cursor: pointer;
   user-select: none;
 
-  opacity: ${({ disabled }) => (disabled ? DisabledOpacity : 'initial')};
+  &[data-disabled] {
+    cursor: not-allowed;
+    opacity: ${DisabledOpacity};
+  }
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['opacity'])};
   ${({ interpolation }) => interpolation}

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
@@ -1,10 +1,12 @@
+import * as SliderPrimitive from '@radix-ui/react-slider'
+
 import {
   css,
   styled,
 } from '~/src/foundation'
 
 import DisabledOpacity from '~/src/constants/DisabledOpacity'
-import { toLength } from '~/src/utils/styleUtils'
+import type { InterpolationProps } from '~/src/types/Foundation'
 
 import { focusedInputWrapperStyle } from '~/src/components/Forms/Inputs/mixins'
 
@@ -46,16 +48,14 @@ function calculateGuideLeftPosition({
   `
 }
 
-interface SliderRootProps extends SliderProps {
-  width: NonNullable<SliderProps['width']>
-}
+export const SliderPrimitiveRoot = styled(SliderPrimitive.Root)<InterpolationProps>`
+  --bezier-slider-width: auto;
 
-export const SliderRoot = styled.div<SliderRootProps>`
   position: relative;
   display: flex;
   align-items: center;
 
-  width: ${({ width }) => toLength(width, '36px')};
+  width: var(--bezier-slider-width);
   height: ${SLIDER_THUMB_SIZE}px;
 
   touch-action: none;

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
@@ -71,29 +71,21 @@ export const SliderPrimitiveRoot = styled(SliderPrimitive.Root)<InterpolationPro
   ${({ interpolation }) => interpolation}
 `
 
-interface SliderTrackProps extends SliderProps {}
-
-export const SliderTrack = styled.div<SliderTrackProps>`
+export const SliderPrimitiveTrack = styled(SliderPrimitive.Track)`
   position: relative;
   flex: 1;
   height: ${SLIDER_TRACK_RANGE_HEIGHT}px;
 
   ${({ foundation }) => foundation?.rounding?.round3}
   background-color: ${({ foundation }) => foundation?.theme?.['bg-black-dark']};
-
-  ${({ interpolation }) => interpolation}
 `
 
-interface SliderRangeProps extends SliderProps {}
-
-export const SliderRange = styled.div<SliderRangeProps>`
+export const SliderPrimitiveRange = styled(SliderPrimitive.Range)`
   position: absolute;
   height: 100%;
 
   ${({ foundation }) => foundation?.rounding?.round3}
   background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-green-normal']};
-
-  ${({ interpolation }) => interpolation}
 `
 
 interface SliderGuideProps extends SliderProps {

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
@@ -113,9 +113,7 @@ export const SliderGuide = styled.div<SliderGuideProps>`
   ${({ interpolation }) => interpolation}
 `
 
-interface SliderThumbProps extends SliderProps {}
-
-export const SliderThumb = styled.div<SliderThumbProps>`
+export const SliderThumb = styled.div`
   all: unset;
   display: block;
 
@@ -136,5 +134,4 @@ export const SliderThumb = styled.div<SliderThumbProps>`
   }
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['box-shadow'])}
-  ${({ interpolation }) => interpolation}
 `

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
@@ -1,63 +1,21 @@
 import * as SliderPrimitive from '@radix-ui/react-slider'
 
-import {
-  css,
-  styled,
-} from '~/src/foundation'
+import { styled } from '~/src/foundation'
 
 import DisabledOpacity from '~/src/constants/DisabledOpacity'
 import type { InterpolationProps } from '~/src/types/Foundation'
 
 import { focusedInputWrapperStyle } from '~/src/components/Forms/Inputs/mixins'
 
-import type SliderProps from './Slider.types'
-
-const SLIDER_TRACK_RANGE_HEIGHT = 6
-const SLIDER_THUMB_SIZE = 20
-const SLIDER_GUIDE_WIDTH = 2
-const SLIDER_GUIDE_HEIGHT = 8
-
-interface CalculateGuideBottomPosition {
-  gap: number
-}
-
-function calculateGuideBottomPosition({
-  gap,
-}: CalculateGuideBottomPosition) {
-  return css`
-    bottom: calc(${SLIDER_GUIDE_HEIGHT}px + ${SLIDER_GUIDE_HEIGHT / 2}px + ${gap}px);
-  `
-}
-
-interface CalculateGuideLeftPosition {
-  min: number
-  max: number
-  guideValue: number
-}
-
-function calculateGuideLeftPosition({
-  min,
-  max,
-  guideValue,
-}: CalculateGuideLeftPosition) {
-  const relativePositionPercentage = (guideValue / (max - min)) * 100
-  const thumbOffsetPx = (((max + min) / 2) - guideValue) * (SLIDER_THUMB_SIZE / ((max - min)))
-
-  return css`
-    left: calc(${relativePositionPercentage}% - ${SLIDER_GUIDE_WIDTH / 2}px + ${thumbOffsetPx}px);
-  `
-}
-
 export const SliderPrimitiveRoot = styled(SliderPrimitive.Root)<InterpolationProps>`
   --bezier-slider-width: auto;
+  --bezier-slider-thumb-size: 20px;
 
   position: relative;
   display: flex;
   align-items: center;
-
   width: var(--bezier-slider-width);
-  height: ${SLIDER_THUMB_SIZE}px;
-
+  height: var(--bezier-slider-thumb-size);
   touch-action: none;
   cursor: pointer;
   user-select: none;
@@ -74,54 +32,55 @@ export const SliderPrimitiveRoot = styled(SliderPrimitive.Root)<InterpolationPro
 export const SliderPrimitiveTrack = styled(SliderPrimitive.Track)`
   position: relative;
   flex: 1;
-  height: ${SLIDER_TRACK_RANGE_HEIGHT}px;
-
-  ${({ foundation }) => foundation?.rounding?.round3}
-  background-color: ${({ foundation }) => foundation?.theme?.['bg-black-dark']};
+  height: 6px;
+  background-color: var(--bg-black-dark);
+  border-radius: 3px;
 `
 
 export const SliderPrimitiveRange = styled(SliderPrimitive.Range)`
   position: absolute;
   height: 100%;
-
-  ${({ foundation }) => foundation?.rounding?.round3}
-  background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-green-normal']};
+  background-color: var(--bgtxt-green-normal);
+  border-radius: 3px;
 `
 
-interface SliderGuideProps extends SliderProps {
-  min: NonNullable<SliderProps['min']>
-  max: NonNullable<SliderProps['max']>
-  guideValue: number
-}
+export const GuideContainer = styled.div`
+  --bezier-slider-guide-height: 8px;
 
-export const SliderGuide = styled.div<SliderGuideProps>`
   position: absolute;
-  ${calculateGuideBottomPosition({ gap: 3 })}
-  ${({ min, max, guideValue }) => calculateGuideLeftPosition({ min, max, guideValue })}
+  top: calc(-1 * (var(--bezier-slider-guide-height) + 3px));
+  left: calc(var(--bezier-slider-thumb-size) / 2);
+  width: calc(100% - var(--bezier-slider-thumb-size));
+`
 
-  width: ${SLIDER_GUIDE_WIDTH}px;
-  height: ${SLIDER_GUIDE_HEIGHT}px;
+export const SliderGuide = styled.div`
+  --bezier-slider-guide-left: 0;
 
-  ${({ foundation }) => foundation?.rounding?.round1}
-  background-color: ${({ foundation }) => foundation?.theme?.['bg-black-light']};
-
-  ${({ interpolation }) => interpolation}
+  position: absolute;
+  top: 0;
+  left: var(--bezier-slider-guide-left);
+  width: 2px;
+  height: var(--bezier-slider-guide-height);
+  background-color: var(--bg-black-light);
+  border-radius: 1px;
+  transform: translateX(-50%);
 `
 
 export const SliderThumb = styled.div`
   all: unset;
   display: block;
+  width: var(--bezier-slider-thumb-size);
+  height: var(--bezier-slider-thumb-size);
+  border-radius: 12px;
 
-  width: ${SLIDER_THUMB_SIZE}px;
-  height: ${SLIDER_THUMB_SIZE}px;
-
-  ${({ foundation }) => foundation?.rounding?.round12}
   ${({ foundation }) => foundation?.elevation?.ev2()}
-  background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-absolute-white-dark']};
+  /* stylelint-disable order/properties-order */
+  /* NOTE: Override the background-color property inside ev mixin */
+  background-color: var(--bgtxt-absolute-white-dark);
 
   &:hover {
     ${({ foundation }) => foundation?.elevation?.ev3()}
-    background-color: ${({ foundation }) => foundation?.theme?.['bgtxt-absolute-white-dark']};
+    background-color: var(--bgtxt-absolute-white-dark);
   }
 
   &:focus-visible {

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
@@ -230,13 +230,15 @@ describe('Slider', () => {
       const { getByRole, getAllByText } = renderSlider({ defaultValue: [0] })
       const sliderThumb = getByRole('slider')
       await user.click(sliderThumb)
+      expect(getByRole('tooltip')).toBeInTheDocument()
       expect(getAllByText('0')[0]).toBeInTheDocument()
     })
 
     it('should not show tooltip when disableTooltip is true', async () => {
-      const { getByRole, queryAllByText } = renderSlider({ defaultValue: [0], disableTooltip: true })
+      const { getByRole, queryByRole, queryAllByText } = renderSlider({ defaultValue: [0], disableTooltip: true })
       const sliderThumb = getByRole('slider')
       await user.click(sliderThumb)
+      expect(queryByRole('tooltip')).not.toBeInTheDocument()
       expect(queryAllByText('0')[0]).toBeUndefined()
     })
   })

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
@@ -37,7 +37,6 @@ describe('Slider', () => {
       it('should render thumb with "slider" role', () => {
         const { getAllByRole } = renderSlider()
         const sliderThumb = getAllByRole('slider')
-
         expect(sliderThumb).toHaveLength(1)
         expect(sliderThumb[0]).toBeInTheDocument()
       })
@@ -45,7 +44,6 @@ describe('Slider', () => {
       it('should render multiple thumb when multiple defaultValue is specified', () => {
         const { getAllByRole } = renderSlider({ defaultValue: [4, 5, 6] })
         const sliderThumb = getAllByRole('slider')
-
         expect(sliderThumb).toHaveLength(3)
         expect(sliderThumb[0]).toBeInTheDocument()
         expect(sliderThumb[1]).toBeInTheDocument()
@@ -55,7 +53,6 @@ describe('Slider', () => {
       it('should not render thumb when defaultValue is not specified', () => {
         const { queryAllByRole } = renderSlider({ defaultValue: [] })
         const sliderThumb = queryAllByRole('slider')
-
         expect(sliderThumb).toHaveLength(0)
       })
     })
@@ -64,7 +61,6 @@ describe('Slider', () => {
       it('should have default value on "aria-valuemin", "aria-valuemax" attribute when no props specified', () => {
         const { getAllByRole } = renderSlider()
         const sliderThumb = getAllByRole('slider')
-
         expect(sliderThumb).toHaveLength(1)
         expect(sliderThumb[0]).toHaveAttribute('aria-valuemin', '0')
         expect(sliderThumb[0]).toHaveAttribute('aria-valuemax', '10')
@@ -73,7 +69,6 @@ describe('Slider', () => {
       it('should have proper value on "aria-valuemin", "aria-valuemax" attribute', () => {
         const { getAllByRole } = renderSlider({ min: -50, max: 70 })
         const sliderThumb = getAllByRole('slider')
-
         expect(sliderThumb).toHaveLength(1)
         expect(sliderThumb[0]).toHaveAttribute('aria-valuemin', '-50')
         expect(sliderThumb[0]).toHaveAttribute('aria-valuemax', '70')
@@ -86,7 +81,7 @@ describe('Slider', () => {
         const sliderThumb = getAllByRole('slider')
 
         expect(sliderThumb).toHaveLength(1)
-        expect(sliderThumb[0]).toHaveAttribute('aria-valuenow', '5')
+        expect(sliderThumb[0]).toHaveAttribute('aria-valuenow', '0')
       })
 
       it('should have proper value on "aria-valuenow" attribute', () => {
@@ -104,14 +99,12 @@ describe('Slider', () => {
       it('should have "false" value on "aria-disabled" attribute when disabled prop is false', () => {
         const { getByTestId } = renderSlider({ disabled: false })
         const slider = getByTestId(SLIDER_TEST_ID)
-
         expect(slider).toHaveAttribute('aria-disabled', 'false')
       })
 
       it('should have "true" value on "aria-disabled" attribute when disabled prop is true', () => {
         const { getByTestId } = renderSlider({ disabled: true })
         const slider = getByTestId(SLIDER_TEST_ID)
-
         expect(slider).toHaveAttribute('aria-disabled', 'true')
       })
     })

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 
+import { isInaccessible } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { LightFoundation } from '~/src/foundation'
-
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
 import { render } from '~/src/utils/testUtils'
 
 import {
   SLIDER_TEST_ID,
-  SLIDER_THUMB_TEST_ID,
   Slider,
 } from './Slider'
 import type SliderProps from './Slider.types'
@@ -17,66 +14,25 @@ import type SliderProps from './Slider.types'
 describe('Slider', () => {
   const renderSlider = (props?: Partial<SliderProps>) => render(<Slider {...props} />)
 
-  describe('no props specified', () => {
-    it('should render default Slider', () => {
-      const { getByTestId, getAllByTestId } = renderSlider()
-      const slider = getByTestId(SLIDER_TEST_ID)
-      const sliderThumb = getAllByTestId(SLIDER_THUMB_TEST_ID)
+  let user: ReturnType<typeof userEvent.setup>
 
-      expect(slider).toHaveStyle('position: relative')
-      expect(slider).toHaveStyle('display: flex')
-      expect(slider).toHaveStyle('align-items: center')
-      expect(slider).toHaveStyle('width: 36px')
-      expect(slider).toHaveStyle('height: 20px')
+  beforeEach(() => {
+    user = userEvent.setup()
+  })
 
-      expect(sliderThumb).toHaveLength(1)
-      expect(sliderThumb[0]).toHaveStyle('display: block')
-      expect(sliderThumb[0]).toHaveStyle('width: 20px')
-      expect(sliderThumb[0]).toHaveStyle('height: 20px')
-      expect(sliderThumb[0]).toHaveStyle('border-radius: 12px')
-      expect(sliderThumb[0]).toHaveStyle(`background-color: ${LightFoundation.theme['bgtxt-absolute-white-dark']}`)
-      // eslint-disable-next-line max-len
-      expect(sliderThumb[0]).toHaveStyle(`box-shadow: inset 0 0 2px 0 ${LightFoundation.theme['shdw-inner-base']}, 0 0 2px 1px ${LightFoundation.theme['shdw-base']}, 0 2px 6px ${LightFoundation.theme['shdw-small']}`)
+  describe('Snapshot', () => {
+    it('should match snapshot', () => {
+      const { container } = renderSlider({ defaultValue: [5], guide: [5] })
+      expect(container).toMatchSnapshot()
     })
   })
 
-  describe('width', () => {
-    it('should render Slider with given width (number)', () => {
-      const { getByTestId } = renderSlider({ width: 300 })
-      const slider = getByTestId(SLIDER_TEST_ID)
-
-      expect(slider).toHaveStyle('width: 300px')
+  describe('ARIA', () => {
+    it('should be accessible', () => {
+      const { container } = renderSlider()
+      expect(isInaccessible(container)).toBe(false)
     })
 
-    it('should render Slider with given width (string)', () => {
-      const { getByTestId } = renderSlider({ width: '500px' })
-      const slider = getByTestId(SLIDER_TEST_ID)
-
-      expect(slider).toHaveStyle('width: 500px')
-    })
-  })
-
-  describe('guide', () => {
-    // TODO: add test
-  })
-
-  describe('disabled', () => {
-    it('should render default Slider when disabled is false', () => {
-      const { getByTestId } = renderSlider({ disabled: false })
-      const slider = getByTestId(SLIDER_TEST_ID)
-
-      expect(slider).toHaveStyle('opacity: initial')
-    })
-
-    it('should render disabled Slider when disabled is true', () => {
-      const { getByTestId } = renderSlider({ disabled: true })
-      const slider = getByTestId(SLIDER_TEST_ID)
-
-      expect(slider).toHaveStyle(`opacity: ${DisabledOpacity}`)
-    })
-  })
-
-  describe('accessibility', () => {
     describe('role', () => {
       it('should render thumb with "slider" role', () => {
         const { getAllByRole } = renderSlider()
@@ -161,52 +117,127 @@ describe('Slider', () => {
     })
   })
 
-  describe('onValueChange', () => {
-    it('should be executed when the `value` prop changes', () => {
-      const onValueChange = jest.fn()
-      let value = [3]
-      const { rerender } = renderSlider({ value, onValueChange })
-      expect(onValueChange).toHaveBeenCalledTimes(1)
-
-      // change value with a new array
-      value = [5]
-      rerender(<Slider {...{ value, onValueChange }} />)
-
-      expect(onValueChange).toHaveBeenCalledTimes(2)
+  describe('User Interactions', () => {
+    it('should focus on the thumb when clicked', async () => {
+      const { getByRole } = renderSlider()
+      const sliderThumb = getByRole('slider')
+      await user.click(sliderThumb)
+      expect(sliderThumb).toHaveFocus()
     })
 
-    it('should not be executed when the `value` prop has the same reference', () => {
+    it('should focus on the thumb when user presses tab key', async () => {
+      const { getByRole } = renderSlider()
+      const sliderThumb = getByRole('slider')
+      await user.tab()
+      expect(sliderThumb).toHaveFocus()
+    })
+
+    it('should not focus on the thumb when disabled', async () => {
+      const { getByRole } = renderSlider({ disabled: true })
+      const sliderThumb = getByRole('slider')
+      await user.click(sliderThumb)
+      expect(sliderThumb).not.toHaveFocus()
+      await user.tab()
+      expect(sliderThumb).not.toHaveFocus()
+    })
+
+    it('should increments/decrements by the step value when user presses Arrow key', async () => {
+      const { getByRole } = renderSlider({ defaultValue: [0], step: 2 })
+      const sliderThumb = getByRole('slider')
+      await user.tab()
+      await user.keyboard('[ArrowRight]')
+      expect(sliderThumb).toHaveAttribute('aria-valuenow', '2')
+      await user.keyboard('[ArrowLeft]')
+      expect(sliderThumb).toHaveAttribute('aria-valuenow', '0')
+      await user.keyboard('[ArrowUp]')
+      expect(sliderThumb).toHaveAttribute('aria-valuenow', '2')
+      await user.keyboard('[ArrowDown]')
+      expect(sliderThumb).toHaveAttribute('aria-valuenow', '0')
+    })
+
+    it('should increments/decrements by the larger step value when user presses PageUp/PageDown key', async () => {
+      const { getByRole } = renderSlider({ defaultValue: [0] })
+      const sliderThumb = getByRole('slider')
+      await user.tab()
+      await user.keyboard('[PageUp]')
+      expect(sliderThumb).toHaveAttribute('aria-valuenow', '10')
+      await user.keyboard('[PageDown]')
+      expect(sliderThumb).toHaveAttribute('aria-valuenow', '0')
+    })
+
+    it('should increments/decrements by the larger step value when user presses Shift + ArrowUp/Down key', async () => {
+      const { getByRole } = renderSlider({ defaultValue: [0] })
+      const sliderThumb = getByRole('slider')
+      await user.tab()
+      await user.keyboard('{Shift>}[ArrowUp]')
+      expect(sliderThumb).toHaveAttribute('aria-valuenow', '10')
+      await user.keyboard('{Shift>}[ArrowDown]')
+      expect(sliderThumb).toHaveAttribute('aria-valuenow', '0')
+    })
+
+    it('should set the maximum/minimum value when user presses Home/End key', async () => {
+      const { getByRole } = renderSlider({ defaultValue: [0], min: 10, max: 100 })
+      const sliderThumb = getByRole('slider')
+      await user.tab()
+      await user.keyboard('[End]')
+      expect(sliderThumb).toHaveAttribute('aria-valuenow', '100')
+      await user.keyboard('[Home]')
+      expect(sliderThumb).toHaveAttribute('aria-valuenow', '10')
+    })
+
+    it('`onValueChange` function should be executed when the value changes', async () => {
       const onValueChange = jest.fn()
-      const value = [3]
-      const { rerender } = renderSlider({ value, onValueChange })
+      renderSlider({ onValueChange })
+      await user.tab()
+      await user.keyboard('[ArrowRight]')
       expect(onValueChange).toHaveBeenCalledTimes(1)
+    })
 
-      // change value with the same reference
-      value.splice(0, 1, 3)
-      rerender(<Slider {...{ value, onValueChange }} />)
-
-      expect(onValueChange).toHaveBeenCalledTimes(1)
+    it('If there are more than one thumb, the steps between them should not be less than `minStepsBetweenThumbs`.', async () => {
+      const { getAllByRole } = renderSlider({ defaultValue: [0, 2], minStepsBetweenThumbs: 2 })
+      const [firstThumb, secondThumb] = getAllByRole('slider')
+      await user.tab()
+      await user.keyboard('[ArrowRight]')
+      expect(firstThumb).not.toHaveAttribute('aria-valuenow', '1')
+      await user.tab()
+      await user.keyboard('[ArrowLeft]')
+      expect(secondThumb).not.toHaveAttribute('aria-valuenow', '1')
     })
   })
 
-  describe('user interactions', () => {
-    it('Click and ArrowLeft key', async () => {
-      const user = userEvent.setup()
-      const { getAllByTestId } = renderSlider({
-        value: [4, 6],
-      })
+  describe('Style', () => {
+    it('should render Slider with given width (number)', () => {
+      const { getByTestId } = renderSlider({ width: 300 })
+      const slider = getByTestId(SLIDER_TEST_ID)
+      expect(slider).toHaveStyle('--bezier-slider-width: 300px')
+    })
 
-      const sliderThumbs = getAllByTestId(SLIDER_THUMB_TEST_ID)
+    it('should render Slider with given width (string)', () => {
+      const { getByTestId } = renderSlider({ width: '500px' })
+      const slider = getByTestId(SLIDER_TEST_ID)
+      expect(slider).toHaveStyle('--bezier-slider-width: 500px')
+    })
+  })
 
-      expect(sliderThumbs).toHaveLength(2)
-      expect(sliderThumbs[0]).toHaveAttribute('aria-valuenow', '4')
-      expect(sliderThumbs[1]).toHaveAttribute('aria-valuenow', '6')
+  describe('Tooltip', () => {
+    it('should show tooltip when user hovers on the thumb', async () => {
+      const { getByRole, getAllByText } = renderSlider({ defaultValue: [0] })
+      const sliderThumb = getByRole('slider')
+      await user.hover(sliderThumb)
+      expect(getAllByText('0')[0]).toBeInTheDocument()
+    })
 
-      await user.click(sliderThumbs[0])
-      await user.keyboard('[ArrowLeft]')
+    it('should show tooltip when user focuses on the thumb', async () => {
+      const { getAllByText } = renderSlider({ defaultValue: [0] })
+      await user.tab()
+      expect(getAllByText('0')[0]).toBeInTheDocument()
+    })
 
-      expect(sliderThumbs[0]).toHaveAttribute('aria-valuenow', '3')
-      expect(sliderThumbs[1]).toHaveAttribute('aria-valuenow', '6')
+    it('should show tooltip when user clicks on the thumb', async () => {
+      const { getByRole, getAllByText } = renderSlider({ defaultValue: [0] })
+      const sliderThumb = getByRole('slider')
+      await user.click(sliderThumb)
+      expect(getAllByText('0')[0]).toBeInTheDocument()
     })
   })
 })

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.test.tsx
@@ -232,5 +232,12 @@ describe('Slider', () => {
       await user.click(sliderThumb)
       expect(getAllByText('0')[0]).toBeInTheDocument()
     })
+
+    it('should not show tooltip when disableTooltip is true', async () => {
+      const { getByRole, queryAllByText } = renderSlider({ defaultValue: [0], disableTooltip: true })
+      const sliderThumb = getByRole('slider')
+      await user.click(sliderThumb)
+      expect(queryAllByText('0')[0]).toBeUndefined()
+    })
   })
 })

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -16,14 +16,16 @@ import * as Styled from './Slider.styled'
 export const SLIDER_TEST_ID = 'bezier-react-slider'
 export const SLIDER_THUMB_TEST_ID = 'bezier-react-slider-thumb'
 
+const DEFAULT_VALUE: number[] = [5]
+
 export const Slider = forwardRef(function Slider(
   {
     width = 36,
     guide,
     onThumbPointerDown = noop,
     onThumbPointerUp = noop,
-    defaultValue = [5],
-    value,
+    defaultValue = DEFAULT_VALUE,
+    value: valueProp = DEFAULT_VALUE,
     disabled = false,
     min = 0,
     max = 10,
@@ -34,11 +36,11 @@ export const Slider = forwardRef(function Slider(
   }: SliderProps,
   forwardedRef: React.Ref<HTMLDivElement>,
 ) {
-  const [currentValue, setCurrentValue] = useState<number[]>(value ?? defaultValue)
+  const [value, setValue] = useState<number[]>(valueProp)
 
   useEffect(function updateCurrentValue() {
     if (value) {
-      setCurrentValue(value)
+      setValue(value)
       onValueChange(value)
     }
   }, [
@@ -47,35 +49,35 @@ export const Slider = forwardRef(function Slider(
   ])
 
   const handleValueChange: (value: number[]) => void = useCallback((_value) => {
-    setCurrentValue(_value)
+    setValue(_value)
     onValueChange(_value)
   }, [onValueChange])
 
   const handlePointerDown: React.PointerEventHandler<HTMLElement> = useCallback(() => {
     if (!disabled) {
-      onThumbPointerDown(currentValue)
+      onThumbPointerDown(value)
     }
   }, [
     disabled,
     onThumbPointerDown,
-    currentValue,
+    value,
   ])
 
   const handlePointerUp: React.PointerEventHandler<HTMLElement> = useCallback(() => {
     if (!disabled) {
-      onThumbPointerUp(currentValue)
+      onThumbPointerUp(value)
     }
   }, [
     disabled,
     onThumbPointerUp,
-    currentValue,
+    value,
   ])
 
   return (
     <SliderPrimitive.Root
       asChild
       defaultValue={defaultValue}
-      value={currentValue}
+      value={value}
       disabled={disabled}
       min={min}
       max={max}
@@ -105,7 +107,7 @@ export const Slider = forwardRef(function Slider(
             guideValue={guideValue}
           />
         )) }
-        { currentValue.map((v, i) => (
+        { value.map((v, i) => (
           <SliderPrimitive.Thumb
             asChild
             // eslint-disable-next-line react/no-array-index-key

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -18,7 +18,6 @@ import type SliderProps from './Slider.types'
 import * as Styled from './Slider.styled'
 
 export const SLIDER_TEST_ID = 'bezier-react-slider'
-export const SLIDER_THUMB_TEST_ID = 'bezier-react-slider-thumb'
 
 const SliderGuide = memo<Record<'min' | 'max' | 'value', number>>(function SliderGuide({
   min,
@@ -54,7 +53,6 @@ const SliderThumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEleme
       onPointerDownOutside={onPointerDownOutside}
     >
       <Styled.SliderThumb
-        data-testid={SLIDER_THUMB_TEST_ID}
         ref={forwardedRef}
         {...props}
       />
@@ -85,6 +83,7 @@ export const Slider = forwardRef<HTMLSpanElement, SliderProps>(function Slider({
       }}
       data-testid={SLIDER_TEST_ID}
       ref={forwardedRef}
+      orientation="horizontal"
       defaultValue={defaultValue}
       value={value}
       disabled={disabled}

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -20,6 +20,20 @@ import * as Styled from './Slider.styled'
 export const SLIDER_TEST_ID = 'bezier-react-slider'
 export const SLIDER_THUMB_TEST_ID = 'bezier-react-slider-thumb'
 
+const SliderGuide = memo<Record<'min' | 'max' | 'value', number>>(function SliderGuide({
+  min,
+  max,
+  value,
+}) {
+  return (
+    <Styled.SliderGuide
+      style={{
+        '--bezier-slider-guide-left': `${(value / (max - min)) * 100}%`,
+      } as React.CSSProperties}
+    />
+  )
+})
+
 /* NOTE: Props are injected at runtime by `SliderPrimitive.Thumb`. */
 const SliderThumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(function SliderThumb(
   props,
@@ -48,36 +62,19 @@ const SliderThumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEleme
   )
 })
 
-const SliderGuide = memo<Record<'min' | 'max' | 'value', number>>(function SliderGuide({
-  min,
-  max,
+export const Slider = forwardRef<HTMLSpanElement, SliderProps>(function Slider({
+  style,
+  width = 36,
+  guide,
+  defaultValue = [5],
   value,
-}) {
-  return (
-    <Styled.SliderGuide
-      style={{
-        '--bezier-slider-guide-left': `${(value / (max - min)) * 100}%`,
-      } as React.CSSProperties}
-    />
-  )
-})
-
-export const Slider = forwardRef(function Slider(
-  {
-    style,
-    width = 36,
-    guide,
-    defaultValue = [5],
-    value,
-    disabled = false,
-    min = 0,
-    max = 10,
-    step = 1,
-    minStepsBetweenThumbs = 0,
-    ...rest
-  }: SliderProps,
-  forwardedRef: React.Ref<HTMLSpanElement>,
-) {
+  disabled = false,
+  min = 0,
+  max = 10,
+  step = 1,
+  minStepsBetweenThumbs = 0,
+  ...rest
+}, forwardedRef) {
   const targetValue = value || defaultValue
 
   return (

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -1,5 +1,6 @@
 import React, {
   forwardRef,
+  memo,
   useCallback,
 } from 'react'
 
@@ -47,6 +48,20 @@ const SliderThumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEleme
   )
 })
 
+const SliderGuide = memo<Record<'min' | 'max' | 'value', number>>(function SliderGuide({
+  min,
+  max,
+  value,
+}) {
+  return (
+    <Styled.SliderGuide
+      style={{
+        '--bezier-slider-guide-left': `${(value / (max - min)) * 100}%`,
+      } as React.CSSProperties}
+    />
+  )
+})
+
 export const Slider = forwardRef(function Slider(
   {
     style,
@@ -84,16 +99,20 @@ export const Slider = forwardRef(function Slider(
     >
       <Styled.SliderPrimitiveTrack>
         <Styled.SliderPrimitiveRange />
-      </Styled.SliderPrimitiveTrack>
 
-      { guide?.map((guideValue) => (
-        <Styled.SliderGuide
-          key={`slider-guide-${guideValue}`}
-          min={min}
-          max={max}
-          guideValue={guideValue}
-        />
-      )) }
+        { guide && (
+          <Styled.GuideContainer>
+            { guide.map((guideValue) => (
+              <SliderGuide
+                key={`slider-guide-${guideValue}`}
+                min={min}
+                max={max}
+                value={guideValue}
+              />
+            )) }
+          </Styled.GuideContainer>
+        ) }
+      </Styled.SliderPrimitiveTrack>
 
       { targetValue.map((_, i) => (
         <SliderPrimitive.Thumb

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -1,4 +1,7 @@
-import React, { forwardRef } from 'react'
+import React, {
+  forwardRef,
+  useCallback,
+} from 'react'
 
 import * as SliderPrimitive from '@radix-ui/react-slider'
 
@@ -24,11 +27,17 @@ const Thumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(f
 ) {
   const value = props?.['aria-valuenow']
 
+  // NOTE: Prevents the tooltip from closing when the thumb is clicked.
+  const onPointerDownOutside = useCallback((e: MouseEvent) => {
+    e.preventDefault()
+  }, [])
+
   return (
     <Tooltip
       content={value}
       offset={6}
       placement={TooltipPosition.TopCenter}
+      onPointerDownOutside={onPointerDownOutside}
     >
       <Styled.SliderThumb
         data-testid={SLIDER_THUMB_TEST_ID}

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -11,6 +11,7 @@ import { isNumber } from '~/src/utils/typeUtils'
 import {
   Tooltip,
   TooltipPosition,
+  type TooltipProps,
 } from '~/src/components/Tooltip'
 
 import type SliderProps from './Slider.types'
@@ -41,7 +42,7 @@ const SliderThumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEleme
   const value = props?.['aria-valuenow']
 
   // NOTE: Prevents the tooltip from closing when the thumb is clicked.
-  const onPointerDownOutside = useCallback((e: MouseEvent) => {
+  const onPointerDownOutside = useCallback<Required<TooltipProps>['onPointerDownOutside']>((e) => {
     e.preventDefault()
   }, [])
 

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -5,7 +5,6 @@ import React, {
 
 import * as SliderPrimitive from '@radix-ui/react-slider'
 
-import { noop } from '~/src/utils/functionUtils'
 import { isNumber } from '~/src/utils/typeUtils'
 
 import {
@@ -60,7 +59,6 @@ export const Slider = forwardRef(function Slider(
     max = 10,
     step = 1,
     minStepsBetweenThumbs = 0,
-    onValueChange = noop,
     ...rest
   }: SliderProps,
   forwardedRef: React.Ref<HTMLSpanElement>,
@@ -82,7 +80,6 @@ export const Slider = forwardRef(function Slider(
       max={max}
       step={step}
       minStepsBetweenThumbs={minStepsBetweenThumbs}
-      onValueChange={onValueChange}
       {...rest}
     >
       <SliderPrimitive.Track asChild>

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -21,7 +21,7 @@ export const SLIDER_TEST_ID = 'bezier-react-slider'
 export const SLIDER_THUMB_TEST_ID = 'bezier-react-slider-thumb'
 
 /* NOTE: Props are injected at runtime by `SliderPrimitive.Thumb`. */
-const Thumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(function Thumb(
+const SliderThumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(function SliderThumb(
   props,
   forwardedRef,
 ) {
@@ -108,7 +108,7 @@ export const Slider = forwardRef(function Slider(
           key={`slider-thumb-${i}`}
           asChild
         >
-          <Thumb />
+          <SliderThumb />
         </SliderPrimitive.Thumb>
       )) }
     </Styled.SliderPrimitiveRoot>

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -82,13 +82,9 @@ export const Slider = forwardRef(function Slider(
       minStepsBetweenThumbs={minStepsBetweenThumbs}
       {...rest}
     >
-      <SliderPrimitive.Track asChild>
-        <Styled.SliderTrack>
-          <SliderPrimitive.Range asChild>
-            <Styled.SliderRange />
-          </SliderPrimitive.Range>
-        </Styled.SliderTrack>
-      </SliderPrimitive.Track>
+      <Styled.SliderPrimitiveTrack>
+        <Styled.SliderPrimitiveRange />
+      </Styled.SliderPrimitiveTrack>
 
       { guide?.map((guideValue) => (
         <Styled.SliderGuide

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -64,7 +64,7 @@ export const Slider = forwardRef<HTMLSpanElement, SliderProps>(function Slider({
   style,
   width = 36,
   guide,
-  defaultValue = [5],
+  defaultValue = [0],
   value,
   disabled = false,
   min = 0,

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -1,7 +1,6 @@
 import React, {
   forwardRef,
   memo,
-  useCallback,
 } from 'react'
 
 import * as SliderPrimitive from '@radix-ui/react-slider'
@@ -11,7 +10,6 @@ import { isNumber } from '~/src/utils/typeUtils'
 import {
   Tooltip,
   TooltipPosition,
-  type TooltipProps,
 } from '~/src/components/Tooltip'
 
 import type SliderProps from './Slider.types'
@@ -35,27 +33,31 @@ const SliderGuide = memo<Record<'min' | 'max' | 'value', number>>(function Slide
 })
 
 /* NOTE: Props are injected at runtime by `SliderPrimitive.Thumb`. */
-const SliderThumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(function SliderThumb(
-  props,
-  forwardedRef,
-) {
-  const value = props?.['aria-valuenow']
+const SliderThumb = forwardRef<HTMLDivElement, Pick<SliderProps, 'disableTooltip'> & React.HTMLAttributes<HTMLDivElement>>(function SliderThumb({
+  disableTooltip,
+  ...rest
+}, forwardedRef) {
+  const value = rest?.['aria-valuenow']
 
-  // NOTE: Prevents the tooltip from closing when the thumb is clicked.
-  const onPointerDownOutside = useCallback<Required<TooltipProps>['onPointerDownOutside']>((e) => {
-    e.preventDefault()
-  }, [])
+  if (disableTooltip) {
+    return (
+      <Styled.SliderThumb
+        ref={forwardedRef}
+        {...rest}
+      />
+    )
+  }
 
   return (
     <Tooltip
       content={value}
       offset={6}
       placement={TooltipPosition.TopCenter}
-      onPointerDownOutside={onPointerDownOutside}
+      onPointerDownOutside={e => e.preventDefault()}
     >
       <Styled.SliderThumb
         ref={forwardedRef}
-        {...props}
+        {...rest}
       />
     </Tooltip>
   )
@@ -89,6 +91,7 @@ export const Slider = forwardRef<HTMLSpanElement, SliderProps>(function Slider({
   max = 10,
   step = 1,
   minStepsBetweenThumbs = 0,
+  disableTooltip = false,
   ...rest
 }, forwardedRef) {
   const targetValue = value || defaultValue
@@ -134,7 +137,7 @@ export const Slider = forwardRef<HTMLSpanElement, SliderProps>(function Slider({
           key={`slider-thumb-${i}`}
           asChild
         >
-          <SliderThumb />
+          <SliderThumb disableTooltip={disableTooltip} />
         </SliderPrimitive.Thumb>
       )) }
     </Styled.SliderPrimitiveRoot>

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -1,13 +1,9 @@
-import React, {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react'
+import React, { forwardRef } from 'react'
 
 import * as SliderPrimitive from '@radix-ui/react-slider'
 
 import { noop } from '~/src/utils/functionUtils'
+import { isNil } from '~/src/utils/typeUtils'
 
 import type SliderProps from './Slider.types'
 
@@ -23,7 +19,7 @@ export const Slider = forwardRef(function Slider(
     width = 36,
     guide,
     defaultValue = DEFAULT_VALUE,
-    value: valueProp = DEFAULT_VALUE,
+    value,
     disabled = false,
     min = 0,
     max = 10,
@@ -34,22 +30,7 @@ export const Slider = forwardRef(function Slider(
   }: SliderProps,
   forwardedRef: React.Ref<HTMLDivElement>,
 ) {
-  const [value, setValue] = useState<number[]>(valueProp)
-
-  useEffect(function updateCurrentValue() {
-    if (value) {
-      setValue(value)
-      onValueChange(value)
-    }
-  }, [
-    value,
-    onValueChange,
-  ])
-
-  const handleValueChange: (value: number[]) => void = useCallback((_value) => {
-    setValue(_value)
-    onValueChange(_value)
-  }, [onValueChange])
+  const targetValue = isNil(value) ? defaultValue : value
 
   return (
     <SliderPrimitive.Root
@@ -60,7 +41,7 @@ export const Slider = forwardRef(function Slider(
       min={min}
       max={max}
       step={step}
-      onValueChange={handleValueChange}
+      onValueChange={onValueChange}
       minStepsBetweenThumbs={minStepsBetweenThumbs}
     >
       <Styled.SliderRoot
@@ -85,7 +66,7 @@ export const Slider = forwardRef(function Slider(
             guideValue={guideValue}
           />
         )) }
-        { value.map((v, i) => (
+        { targetValue.map((v, i) => (
           <SliderPrimitive.Thumb
             asChild
             // eslint-disable-next-line react/no-array-index-key

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -60,6 +60,23 @@ const SliderThumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEleme
   )
 })
 
+/**
+ * An input component where the user selects a value from within a given range.
+ * The value of the slider is shown in a tooltip, and in some cases you can add a guide scale.
+ *
+ * @example
+ *
+ * ```tsx
+ * const [value, setValue] = useState([1])
+ * // Controlled
+ * <Slider
+ *   value={value}
+ *   onValueChange={setValue}
+ * />
+ * // Uncontrolled
+ * <Slider defaultValue={[1]} />
+ * ```
+ */
 export const Slider = forwardRef<HTMLSpanElement, SliderProps>(function Slider({
   style,
   width = 36,

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -3,7 +3,8 @@ import React, { forwardRef } from 'react'
 import * as SliderPrimitive from '@radix-ui/react-slider'
 
 import { noop } from '~/src/utils/functionUtils'
-import { isNil } from '~/src/utils/typeUtils'
+
+import { Tooltip } from '~/src/components/Tooltip'
 
 import type SliderProps from './Slider.types'
 
@@ -12,13 +13,26 @@ import * as Styled from './Slider.styled'
 export const SLIDER_TEST_ID = 'bezier-react-slider'
 export const SLIDER_THUMB_TEST_ID = 'bezier-react-slider-thumb'
 
-const DEFAULT_VALUE: number[] = [5]
+/* NOTE: Props are injected at runtime by `SliderPrimitive.Thumb`. */
+const Thumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(function Thumb(props, ref) {
+  const value = props?.['aria-valuenow']
+
+  return (
+    <Tooltip content={value}>
+      <Styled.SliderThumb
+        data-testid={SLIDER_THUMB_TEST_ID}
+        ref={ref}
+        {...props}
+      />
+    </Tooltip>
+  )
+})
 
 export const Slider = forwardRef(function Slider(
   {
     width = 36,
     guide,
-    defaultValue = DEFAULT_VALUE,
+    defaultValue = [5],
     value,
     disabled = false,
     min = 0,
@@ -30,7 +44,7 @@ export const Slider = forwardRef(function Slider(
   }: SliderProps,
   forwardedRef: React.Ref<HTMLDivElement>,
 ) {
-  const targetValue = isNil(value) ? defaultValue : value
+  const targetValue = value || defaultValue
 
   return (
     <SliderPrimitive.Root
@@ -58,6 +72,7 @@ export const Slider = forwardRef(function Slider(
             </SliderPrimitive.Range>
           </Styled.SliderTrack>
         </SliderPrimitive.Track>
+
         { guide?.map((guideValue) => (
           <Styled.SliderGuide
             key={`slider-guide-${guideValue}`}
@@ -66,15 +81,14 @@ export const Slider = forwardRef(function Slider(
             guideValue={guideValue}
           />
         )) }
-        { targetValue.map((v, i) => (
+
+        { targetValue.map((_, i) => (
           <SliderPrimitive.Thumb
-            asChild
             // eslint-disable-next-line react/no-array-index-key
             key={`slider-thumb-${i}`}
+            asChild
           >
-            <Styled.SliderThumb
-              data-testid={SLIDER_THUMB_TEST_ID}
-            />
+            <Thumb />
           </SliderPrimitive.Thumb>
         )) }
       </Styled.SliderRoot>

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -3,8 +3,12 @@ import React, { forwardRef } from 'react'
 import * as SliderPrimitive from '@radix-ui/react-slider'
 
 import { noop } from '~/src/utils/functionUtils'
+import { isNumber } from '~/src/utils/typeUtils'
 
-import { Tooltip } from '~/src/components/Tooltip'
+import {
+  Tooltip,
+  TooltipPosition,
+} from '~/src/components/Tooltip'
 
 import type SliderProps from './Slider.types'
 
@@ -14,14 +18,21 @@ export const SLIDER_TEST_ID = 'bezier-react-slider'
 export const SLIDER_THUMB_TEST_ID = 'bezier-react-slider-thumb'
 
 /* NOTE: Props are injected at runtime by `SliderPrimitive.Thumb`. */
-const Thumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(function Thumb(props, ref) {
+const Thumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(function Thumb(
+  props,
+  forwardedRef,
+) {
   const value = props?.['aria-valuenow']
 
   return (
-    <Tooltip content={value}>
+    <Tooltip
+      content={value}
+      offset={6}
+      placement={TooltipPosition.TopCenter}
+    >
       <Styled.SliderThumb
         data-testid={SLIDER_THUMB_TEST_ID}
-        ref={ref}
+        ref={forwardedRef}
         {...props}
       />
     </Tooltip>
@@ -30,6 +41,7 @@ const Thumb = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(f
 
 export const Slider = forwardRef(function Slider(
   {
+    style,
     width = 36,
     guide,
     defaultValue = [5],
@@ -38,60 +50,58 @@ export const Slider = forwardRef(function Slider(
     min = 0,
     max = 10,
     step = 1,
-    onValueChange = noop,
     minStepsBetweenThumbs = 0,
+    onValueChange = noop,
     ...rest
   }: SliderProps,
-  forwardedRef: React.Ref<HTMLDivElement>,
+  forwardedRef: React.Ref<HTMLSpanElement>,
 ) {
   const targetValue = value || defaultValue
 
   return (
-    <SliderPrimitive.Root
-      asChild
+    <Styled.SliderPrimitiveRoot
+      style={{
+        ...style,
+        '--bezier-slider-width': isNumber(width) ? `${width}px` : width,
+      }}
+      data-testid={SLIDER_TEST_ID}
+      ref={forwardedRef}
       defaultValue={defaultValue}
       value={value}
       disabled={disabled}
       min={min}
       max={max}
       step={step}
-      onValueChange={onValueChange}
       minStepsBetweenThumbs={minStepsBetweenThumbs}
+      onValueChange={onValueChange}
+      {...rest}
     >
-      <Styled.SliderRoot
-        width={width}
-        disabled={disabled}
-        ref={forwardedRef}
-        data-testid={SLIDER_TEST_ID}
-        {...rest}
-      >
-        <SliderPrimitive.Track asChild>
-          <Styled.SliderTrack>
-            <SliderPrimitive.Range asChild>
-              <Styled.SliderRange />
-            </SliderPrimitive.Range>
-          </Styled.SliderTrack>
-        </SliderPrimitive.Track>
+      <SliderPrimitive.Track asChild>
+        <Styled.SliderTrack>
+          <SliderPrimitive.Range asChild>
+            <Styled.SliderRange />
+          </SliderPrimitive.Range>
+        </Styled.SliderTrack>
+      </SliderPrimitive.Track>
 
-        { guide?.map((guideValue) => (
-          <Styled.SliderGuide
-            key={`slider-guide-${guideValue}`}
-            min={min}
-            max={max}
-            guideValue={guideValue}
-          />
-        )) }
+      { guide?.map((guideValue) => (
+        <Styled.SliderGuide
+          key={`slider-guide-${guideValue}`}
+          min={min}
+          max={max}
+          guideValue={guideValue}
+        />
+      )) }
 
-        { targetValue.map((_, i) => (
-          <SliderPrimitive.Thumb
-            // eslint-disable-next-line react/no-array-index-key
-            key={`slider-thumb-${i}`}
-            asChild
-          >
-            <Thumb />
-          </SliderPrimitive.Thumb>
-        )) }
-      </Styled.SliderRoot>
-    </SliderPrimitive.Root>
+      { targetValue.map((_, i) => (
+        <SliderPrimitive.Thumb
+          // eslint-disable-next-line react/no-array-index-key
+          key={`slider-thumb-${i}`}
+          asChild
+        >
+          <Thumb />
+        </SliderPrimitive.Thumb>
+      )) }
+    </Styled.SliderPrimitiveRoot>
   )
 })

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -22,8 +22,6 @@ export const Slider = forwardRef(function Slider(
   {
     width = 36,
     guide,
-    onThumbPointerDown = noop,
-    onThumbPointerUp = noop,
     defaultValue = DEFAULT_VALUE,
     value: valueProp = DEFAULT_VALUE,
     disabled = false,
@@ -52,26 +50,6 @@ export const Slider = forwardRef(function Slider(
     setValue(_value)
     onValueChange(_value)
   }, [onValueChange])
-
-  const handlePointerDown: React.PointerEventHandler<HTMLElement> = useCallback(() => {
-    if (!disabled) {
-      onThumbPointerDown(value)
-    }
-  }, [
-    disabled,
-    onThumbPointerDown,
-    value,
-  ])
-
-  const handlePointerUp: React.PointerEventHandler<HTMLElement> = useCallback(() => {
-    if (!disabled) {
-      onThumbPointerUp(value)
-    }
-  }, [
-    disabled,
-    onThumbPointerUp,
-    value,
-  ])
 
   return (
     <SliderPrimitive.Root
@@ -112,8 +90,6 @@ export const Slider = forwardRef(function Slider(
             asChild
             // eslint-disable-next-line react/no-array-index-key
             key={`slider-thumb-${i}`}
-            onPointerDown={handlePointerDown}
-            onPointerUp={handlePointerUp}
           >
             <Styled.SliderThumb
               data-testid={SLIDER_THUMB_TEST_ID}

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.types.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.types.ts
@@ -4,13 +4,10 @@ import type { BezierComponentProps } from '~/src/types/ComponentProps'
 
 interface SliderOptions {
   /**
-   * CSS Width of entire slider.
-   * If given value is number or doesn't end with proper unit, `defaultUnit` is suffixed to given value.
-   *
-   * @see /packages/bezier-react/src/utils/styleUtils.ts
+   * Width of the slider.
    * @default 36
    */
-  width?: number | string
+  width?: React.CSSProperties['width']
 
   /**
    * When array of number `guide` is provided, guide mark will be shown above track regard to given value(s).

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.types.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.types.ts
@@ -50,6 +50,11 @@ interface SliderOptions {
    */
   minStepsBetweenThumbs?: number
   /**
+   * Whether to show the tooltip for the thumbs.
+   * @default false
+   */
+  disableTooltip?: boolean
+  /**
    * Event handler called when the value changes.
    */
   onValueChange?: (value: number[]) => void

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.types.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.types.ts
@@ -10,7 +10,7 @@ interface SliderOptions {
    */
   width?: React.CSSProperties['width']
   /**
-   * When array of number `guide` is provided, guide mark will be shown above track regard to given value(s).
+   * When array of number `guide` is provided, guide scale will be shown above track regard to given value(s).
    */
   guide?: number[]
   /**

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.types.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.types.ts
@@ -16,16 +16,6 @@ interface SliderOptions {
    * When array of number `guide` is provided, guide mark will be shown above track regard to given value(s).
    */
   guide?: number[]
-
-  /**
-   * Callback of slider thumb's `onpointerdown` event.
-   */
-  onThumbPointerDown?: (value: number[]) => void
-
-  /**
-   * Callback of slider thumb's `onpointerup` event.
-   */
-  onThumbPointerUp?: (value: number[]) => void
 }
 
 export default interface SliderProps extends

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.types.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.types.ts
@@ -1,6 +1,7 @@
-import type { SliderProps as SliderPrimitiveProps } from '@radix-ui/react-slider'
-
-import type { BezierComponentProps } from '~/src/types/ComponentProps'
+import type {
+  BezierComponentProps,
+  DisableProps,
+} from '~/src/types/ComponentProps'
 
 interface SliderOptions {
   /**
@@ -8,14 +9,59 @@ interface SliderOptions {
    * @default 36
    */
   width?: React.CSSProperties['width']
-
   /**
    * When array of number `guide` is provided, guide mark will be shown above track regard to given value(s).
    */
   guide?: number[]
+  /**
+   * The value of the slider when initially rendered.
+   * Use when you do not need to control the state of the slider.
+   * @default [0]
+   */
+  defaultValue?: number[]
+  /**
+   * The controlled value of the slider.
+   * Must be used in conjunction with `onValueChange`.
+   */
+  value?: number[]
+  /**
+   * The name of the slider.
+   * Submitted with its owning form as part of a name/value pair.
+   */
+  name?: string
+  /**
+   * The minimum value for the range.
+   * @default 0
+   */
+  min?: number
+  /**
+   * The maximum value for the range.
+   * @default 10
+   */
+  max?: number
+  /**
+   * The stepping interval.
+   * @default 1
+   */
+  step?: number
+  /**
+   * The minimum permitted steps between multiple thumbs.
+   * @default 0
+   */
+  minStepsBetweenThumbs?: number
+  /**
+   * Event handler called when the value changes.
+   */
+  onValueChange?: (value: number[]) => void
+  /**
+   * Event handler called when the value changes at the end of an interaction.
+   * Useful when you only need to capture a final value (e.g. to update a backend service).
+   */
+  onValueCommit?: (value: number[]) => void
 }
 
 export default interface SliderProps extends
   BezierComponentProps,
-  SliderPrimitiveProps,
+  DisableProps,
+  Omit<React.HTMLAttributes<HTMLSpanElement>, keyof SliderOptions>,
   SliderOptions {}

--- a/packages/bezier-react/src/components/Forms/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/Slider/__snapshots__/Slider.test.tsx.snap
@@ -1,0 +1,156 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Slider Snapshot should match snapshot 1`] = `
+.c0 {
+  --bezier-slider-width: auto;
+  --bezier-slider-thumb-size: 20px;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: var(--bezier-slider-width);
+  height: var(--bezier-slider-thumb-size);
+  touch-action: none;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: opacity;
+  transition-property: opacity;
+}
+
+.c0[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.c1 {
+  position: relative;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  height: 6px;
+  background-color: var(--bg-black-dark);
+  border-radius: 3px;
+}
+
+.c2 {
+  position: absolute;
+  height: 100%;
+  background-color: var(--bgtxt-green-normal);
+  border-radius: 3px;
+}
+
+.c3 {
+  --bezier-slider-guide-height: 8px;
+  position: absolute;
+  top: calc(-1 * (var(--bezier-slider-guide-height) + 3px));
+  left: calc(var(--bezier-slider-thumb-size) / 2);
+  width: calc(100% - var(--bezier-slider-thumb-size));
+}
+
+.c4 {
+  --bezier-slider-guide-left: 0;
+  position: absolute;
+  top: 0;
+  left: var(--bezier-slider-guide-left);
+  width: 2px;
+  height: var(--bezier-slider-guide-height);
+  background-color: var(--bg-black-light);
+  border-radius: 1px;
+  -webkit-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+  transform: translateX(-50%);
+}
+
+.c5 {
+  all: unset;
+  display: block;
+  width: var(--bezier-slider-thumb-size);
+  height: var(--bezier-slider-thumb-size);
+  border-radius: 12px;
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 2px 6px #00000014;
+  background-color: var(--bgtxt-absolute-white-dark);
+  -webkit-transition-delay: 0ms;
+  transition-delay: 0ms;
+  -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);
+  transition-timing-function: cubic-bezier(.3,0,0,1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow;
+}
+
+.c5:hover {
+  background-color: #FFFFFF;
+  box-shadow: inset 0 0 2px 0 #FFFFFF1F, 0 0 2px 1px #0000000D, 0 4px 12px #00000026;
+  background-color: var(--bgtxt-absolute-white-dark);
+}
+
+.c5:focus-visible {
+  box-shadow: 0 0 0 3px #5E56F04D, inset 0 0 0 1px #5E56F0;
+}
+
+<div>
+  <span
+    aria-disabled="false"
+    class="c0"
+    data-orientation="horizontal"
+    data-testid="bezier-react-slider"
+    dir="ltr"
+    foundation="[object Object]"
+    style="--bezier-slider-width: 36px; --radix-slider-thumb-transform: translateX(-50%);"
+  >
+    <span
+      class="c1"
+      data-orientation="horizontal"
+      foundation="[object Object]"
+    >
+      <span
+        class="c2"
+        data-orientation="horizontal"
+        foundation="[object Object]"
+        style="left: 0%; right: 50%;"
+      />
+      <div
+        class="c3"
+      >
+        <div
+          class="c4"
+          style="--bezier-slider-guide-left: 50%;"
+        />
+      </div>
+    </span>
+    <span
+      style="transform: var(--radix-slider-thumb-transform); position: absolute; left: calc(50% + 0px);"
+    >
+      <div
+        aria-orientation="horizontal"
+        aria-valuemax="10"
+        aria-valuemin="0"
+        aria-valuenow="5"
+        class="c5"
+        data-orientation="horizontal"
+        data-radix-collection-item=""
+        data-state="closed"
+        role="slider"
+        style=""
+        tabindex="0"
+      />
+    </span>
+  </span>
+</div>
+`;

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
@@ -54,14 +54,6 @@ interface TooltipOptions {
    */
   defaultShow?: boolean
   /**
-   * Callback function to be called when the tooltip is opened.
-   */
-  onShow?: () => void
-  /**
-   * Callback function to be called when the tooltip is closed.
-   */
-  onHide?: () => void
-  /**
    * An element that sits below the tooltip content.
    */
   description?: React.ReactNode
@@ -108,6 +100,24 @@ interface TooltipOptions {
    * @default 0
    */
   delayHide?: number
+  /**
+   * Callback function to be called when the tooltip is opened.
+   */
+  onShow?: () => void
+  /**
+   * Callback function to be called when the tooltip is closed.
+   */
+  onHide?: () => void
+  /**
+   * Event handler called when the escape key is down.
+   * It can be prevented by calling `event.preventDefault`.
+   */
+  onEscapeKeyDown?: (event: KeyboardEvent) => void
+  /**
+   * Event handler called when a pointer event occurs outside the bounds of the component.
+   * It can be prevented by calling `event.preventDefault`.
+   */
+  onPointerDownOutside?: (event: CustomEvent<{ originalEvent: PointerEvent }>) => void
 }
 
 export interface TooltipProviderProps extends


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [x] [Component] I wrote **a unit test** about the implementation.
- [x] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

- Fixes #1089
- #871 

## Summary
<!-- Please add a summary of the modification. -->

`Slider` 컴포넌트의 Thumb에 툴팁을 추가하고, 기타 개선사항들을 적용합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- `Slider` 컴포넌트의 Thumb에 툴팁을 추가합니다. 드래그하는 동안 툴팁이 가려지지 않도록, 툴팁에 `onPointerDownOutside` 속성을 추가하여 외부 클릭 시 툴팁이 닫히지 않도록 했습니다.
- 내부에 불필요한 로컬 상태를 제거합니다. `value` 값을 주더라도, `onValueChange` 핸들러를 넘기지 않으면 이전과 같이 툴팁이 비제어형 컴포넌트처럼 동작하지 않습니다. 제어형 컴포넌트로 동작하게 하기 위해선 사용처에서 명시적으로 상태와 그를 변경하는 핸들러를 넘겨주어야 합니다.
- 최대한 `asChild` 없이 단순하게 스타일링할 수 있도록(only className) 개선합니다.
- 가이드 눈금 위치를 결정하는 로직을 단순하게 변경하고, CSS variable을 사용하여 런타임 오버헤드가 생기지 않도록 개선합니다.
- `defaultValue` 속성의 기본값을 `5` 에서 `0` 으로 변경합니다. 더 예측하기 쉬운 기본값이라고 판단했습니다.
- 타입 선언에서 radix-ui `SliderProps` 과의 의존성을 제거합니다. 외부 인터페이스를 우리 라이브러리의 설계 의도에 맞게 관리하기 위해서, 내부 구현은 거의 동일하더라도 별도로 분리하는 게 좋다고 판단했습니다. (다른 컴포넌트들도 이와 같은 방식으로 작업하고 있습니다)
- 단위 테스트를 강화합니다. 키보드 단축키와 툴팁 등의 테스트 케이스를 추가했습니다.
- JSDoc을 추가합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

Yes

- Change default value of `defaultValue` prop from `[5]` to `[0]`

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- https://www.radix-ui.com/docs/primitives/components/slider
