### PR TITLE
Add missing `display` property of `Avatar`

### DIFF
--- a/.changeset/yellow-flies-complain.md
+++ b/.changeset/yellow-flies-complain.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Add missing `display: block` property of `Avatar`'s style.

--- a/packages/bezier-react/src/components/Avatars/Avatar/Avatar.styled.ts
+++ b/packages/bezier-react/src/components/Avatars/Avatar/Avatar.styled.ts
@@ -11,6 +11,7 @@ import { AvatarSize } from './Avatar.types'
 export const AvatarWrapper = styled.div<InterpolationProps>`
   all: unset;
   position: relative;
+  display: block;
 
   &.disabled {
     pointer-events: none;

--- a/packages/bezier-react/src/components/Avatars/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/Avatars/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`AvatarGroup Ellipsis type - Count Snapshot 1`] = `
 .c1 {
   all: unset;
   position: relative;
+  display: block;
 }
 
 .c1.disabled {
@@ -305,6 +306,7 @@ exports[`AvatarGroup Ellipsis type - Icon Snapshot 1`] = `
 .c1 {
   all: unset;
   position: relative;
+  display: block;
 }
 
 .c1.disabled {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

Add missing `display` property of `Avatar`.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

#1335 에서 `all: unset` 이 추가되었습니다. `as` 속성을 통해 엘리먼트를 변경 시 기본 스타일시트가 적용되게 하지 않도록 하기 위해서였는데, HTMLDivElement의 기본 속성 `display: block` 또한 마찬가지로 초기화되고 있었습니다. 이를 수정합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

None