### PR TITLE
Fix passing a number to the `width` prop of a `SegmentedControl` to work correctly

### DIFF
--- a/.changeset/ninety-books-behave.md
+++ b/.changeset/ninety-books-behave.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix passing a number to the `width` prop of a `SegmentedControl` to work correctly.

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -8,6 +8,8 @@ import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 import * as TabsPrimitive from '@radix-ui/react-tabs'
 import classNames from 'classnames'
 
+import { isNumber } from '~/src/utils/typeUtils'
+
 import { Divider } from '~/src/components/Divider'
 import useFormFieldProps from '~/src/components/Forms/useFormFieldProps'
 
@@ -61,7 +63,7 @@ function SegmentedControlItemListImpl<
 
   const style = useMemo(() => ({
     ...styleProp,
-    '--bezier-react-segmented-control-width': width,
+    '--bezier-react-segmented-control-width': isNumber(width) ? `${width}px` : width,
   } as React.CSSProperties), [
     styleProp,
     width,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

Fix passing a number to the `width` prop of a `SegmentedControl` to work correctly

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

None

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

None