### PR TITLE
fix(segmented-control): fix the styling of SegmentedControlItem's content area

### DIFF
--- a/.changeset/nine-tools-fail.md
+++ b/.changeset/nine-tools-fail.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix the styling of `SegmentedControlItem`'s content area.

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -14,8 +14,15 @@ import { Text } from '~/src/components/Text'
 
 import { SegmentedControlSize } from './SegmentedControl.types'
 
-export const ItemLabel = styled(Text).attrs({ bold: true })`
+export const ItemContainer = styled(AlphaStack).attrs({
+  direction: 'horizontal',
+  align: 'center',
+  spacing: 2,
+})`
   z-index: ${ZIndex.Float};
+`
+
+export const ItemLabel = styled(Text).attrs({ bold: true })`
   padding: 1px 4px;
 `
 

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
@@ -9,8 +9,6 @@ import * as TabsPrimitive from '@radix-ui/react-tabs'
 import useMergeRefs from '~/src/hooks/useMergeRefs'
 import { ariaAttr } from '~/src/utils/domUtils'
 
-import { AlphaStack } from '~/src/components/AlphaStack'
-
 import {
   type SegmentedControlItemProps,
   type SegmentedControlProps,
@@ -66,16 +64,13 @@ const Item = forwardRef<HTMLButtonElement, ItemProps<SegmentedControlType>>(func
       ref={ref}
       data-checked={ariaAttr(checked)}
     >
-      <AlphaStack
-        direction="vertical"
-        spacing={2}
-      >
+      <Styled.ItemContainer>
         { leftContent }
         <Styled.ItemLabel>
           { children }
         </Styled.ItemLabel>
         { rightContent }
-      </AlphaStack>
+      </Styled.ItemContainer>
     </Styled.Item>
   )
 })


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [ ] I wrote a PR title in **English**.
- [ ] I added an appropriate **label** to the PR.
- [ ] I wrote a commit message in **English**.
- [ ] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

`SegmentedControlItem` 의 컨텐츠 영역 스타일링을 올바르게 수정합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- 사이드 컨텐츠가 가로축을 기준으로 정렬되도록 수정
- 사이드 컨텐츠가 인디케이터에 의해 가려지지 않도록 수정

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

None
