### PR TITLE
fix(segmented-control): fix incorrect button type of `SegmentedControlItem`

### DIFF
--- a/.changeset/fast-bottles-judge.md
+++ b/.changeset/fast-bottles-judge.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Change `SegmentedControlItem` button element type from 'submit' to 'button'.

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
@@ -64,6 +64,7 @@ const Item = forwardRef<HTMLButtonElement, ItemProps<SegmentedControlType>>(func
     <Styled.Item
       {...rest}
       ref={ref}
+      type="button"
       data-checked={ariaAttr(checked)}
     >
       <AlphaStack


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [x] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

`SegmentedControlItem` 컴포넌트 내부의 HTMLButtonElement 의 타입을 button으로 변경합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- 원래는 Radix UI에 의해서 런타임에 `type: button` 이 주입되어야합니다. 
- **하지만 `type` 속성을 `SegmentedControl` 에서 이미 정의하고 사용하고 있어, 오버라이드가 제대로 되지 않은 문제가 있었습니다.**
- `type` 속성을 명시적으로 button으로 주입하여 해결합니다.
- HTMLAttributes로 사용될 수 있는 Key의 경우, 컴포넌트의 속성으로 사용하지 않도록 예방책이 필요할 거 같습니다 🤔

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

No
