### PR TITLE
fix(avatar): fix status wrapper to grow in size to fit its children

### DIFF
--- a/.changeset/dull-melons-buy.md
+++ b/.changeset/dull-melons-buy.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix status wrapper of avatar to grow in size to fit its children

--- a/packages/bezier-react/src/components/Avatars/Avatar/Avatar.styled.ts
+++ b/packages/bezier-react/src/components/Avatars/Avatar/Avatar.styled.ts
@@ -89,4 +89,5 @@ export const StatusWrapper = styled.div`
   position: absolute;
   right: var(--bezier-avatar-computed-status-gap, 0);
   bottom: var(--bezier-avatar-computed-status-gap, 0);
+  display: flex;
 `

--- a/packages/bezier-react/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/bezier-react/src/components/Avatars/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -172,6 +172,10 @@ exports[`Avatar > should have right -2px, bottom -2px style on StatusWrapper 1`]
   position: absolute;
   right: var(--bezier-avatar-computed-status-gap,0);
   bottom: var(--bezier-avatar-computed-status-gap,0);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 @supports (background:paint(smooth-corners)) {
@@ -217,6 +221,10 @@ exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when 
   position: absolute;
   right: var(--bezier-avatar-computed-status-gap,0);
   bottom: var(--bezier-avatar-computed-status-gap,0);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 @supports (background:paint(smooth-corners)) {
@@ -262,6 +270,10 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
   position: absolute;
   right: var(--bezier-avatar-computed-status-gap,0);
   bottom: var(--bezier-avatar-computed-status-gap,0);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 @supports (background:paint(smooth-corners)) {
@@ -307,6 +319,10 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
   position: absolute;
   right: var(--bezier-avatar-computed-status-gap,0);
   bottom: var(--bezier-avatar-computed-status-gap,0);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 @supports (background:paint(smooth-corners)) {
@@ -352,6 +368,10 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
   position: absolute;
   right: var(--bezier-avatar-computed-status-gap,0);
   bottom: var(--bezier-avatar-computed-status-gap,0);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 @supports (background:paint(smooth-corners)) {
@@ -397,6 +417,10 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
   position: absolute;
   right: var(--bezier-avatar-computed-status-gap,0);
   bottom: var(--bezier-avatar-computed-status-gap,0);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 @supports (background:paint(smooth-corners)) {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/next-v1/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

Fix status wrapper to grow in size to fit its children

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- Change the status wrapper to flexbox

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

No
