### PR TITLE
fix(bezier-codemod): exclude `LegacyIcon` from `iconSourceNamePattern`

### DIFF
--- a/.changeset/slimy-queens-remember.md
+++ b/.changeset/slimy-queens-remember.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-codemod": patch
+---
+
+`icons-to-bezier-icons` : Remove `LegacyIcon` from the migration target module name pattern

--- a/packages/bezier-codemod/src/transforms/icons-to-bezier-icons.ts
+++ b/packages/bezier-codemod/src/transforms/icons-to-bezier-icons.ts
@@ -8,7 +8,7 @@ import {
   ts,
 } from 'ts-morph'
 
-const iconSourceNamePattern = /^[A-Z][a-zA-Z]*Icon$/
+const iconSourceNamePattern = /^(?!LegacyIcon$)[A-Z][a-zA-Z]*Icon$/
 const iconModuleNames = ['isBezierIcon', 'createBezierIcon', 'IconSource', 'BezierIcon', 'IconName']
 
 interface CollectResult {

--- a/packages/bezier-codemod/src/transforms/tests/icons-to-bezier-icons/fixtures/input.tsx
+++ b/packages/bezier-codemod/src/transforms/tests/icons-to-bezier-icons/fixtures/input.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { AllIcon, Button, CheckIcon as CheckIconSource, Icon, type IconName, IconSize } from '@channel.io/bezier-react'
+import { AllIcon, Button, CheckIcon as CheckIconSource, Icon, type IconName, IconSize, LegacyIcon } from '@channel.io/bezier-react'
 
 import { Foo } from './foo'
 

--- a/packages/bezier-codemod/src/transforms/tests/icons-to-bezier-icons/fixtures/output.tsx
+++ b/packages/bezier-codemod/src/transforms/tests/icons-to-bezier-icons/fixtures/output.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { AllIcon, CheckIcon as CheckIconSource, type IconName } from '@channel.io/bezier-icons'
-import { Button, Icon, IconSize } from '@channel.io/bezier-react'
+import { Button, Icon, IconSize, LegacyIcon } from '@channel.io/bezier-react'
 
 import { Foo } from './foo'
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [x] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

Exclude `LegacyIcon` from `iconSourceNamePattern`

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- `LegacyIcon` 은 '@channel.io/bezier-react' 에서 import 를 유지하도록 합니다. 

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

None
