### PR TITLE
build(bezier-icons): change rollup's cjs namespace helper to follow TypeScript's behavior

### DIFF
--- a/.changeset/late-moose-camp.md
+++ b/.changeset/late-moose-camp.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-icons": patch
+---
+
+Change rollup's cjs namespace helper to follow TypeScript's behavior

--- a/packages/bezier-icons/rollup.config.mjs
+++ b/packages/bezier-icons/rollup.config.mjs
@@ -220,14 +220,6 @@ function svgBuild(options = {}) {
 }
 
 /**
- * We know react only ships cjs with a default export. By being explicit here,
- * we get to shave off some unneeded interop code
- */
-function interop(id) {
-  return id === 'react' ? 'defaultOnly' : 'auto'
-}
-
-/**
  * Split into individual chunks for smooth tree shaking.
  */
 function manualChunks(id) {
@@ -255,7 +247,15 @@ export default defineConfig({
       format: 'cjs',
       entryFileNames: '[name].js',
       chunkFileNames: '[name].js',
-      interop,
+      /**
+       * "auto" combines both "esModule" and "default" by injecting helpers that contain code that detects at runtime
+       * if the required value contains the __esModule property.
+       * Adding this property is a hack implemented by TypeScript esModuleInterop,
+       * Babel and other tools to signify that the required value is the namespace of a transpiled ES module.:
+       *
+       * @see: https://rollupjs.org/configuration-options/#output-interop
+       */
+      interop: 'auto',
       manualChunks,
     },
     {
@@ -263,7 +263,6 @@ export default defineConfig({
       format: 'esm',
       entryFileNames: '[name].mjs',
       chunkFileNames: '[name].mjs',
-      interop,
       manualChunks,
     },
   ],


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

- #1375 

## Summary
<!-- Please add a summary of the modification. -->

Change rollup's cjs namespace helper to follow TypeScript's behavior

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- jest가 rollup interop defaultOnly로 설정된 cjs 모듈을 제대로 해석하지 못해, auto로 변경합니다.
- 아이콘 cjs 모듈의 사이즈는 헬퍼 함수로 인해 소폭 증가하게 됩니다.
- 번들 사이즈에 가장 크리티컬한 채널 프론트에서는 esm 모듈을 사용하므로 번들 사이즈 변경에 큰 문제는 없을 거로 판단했습니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- https://rollupjs.org/configuration-options/#output-interop
