### PR TITLE
fix: change the identifier of the bezier icon to a string literal instead of a symbol

### DIFF
--- a/.changeset/afraid-pumas-agree.md
+++ b/.changeset/afraid-pumas-agree.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-icons": minor
+---
+
+Change the identifier of the bezier icon to a string literal instead of a symbol

--- a/packages/bezier-icons/rollup.config.mjs
+++ b/packages/bezier-icons/rollup.config.mjs
@@ -68,7 +68,7 @@ declare module '*.svg' {
 }
 
 export declare type IconSource = React.FunctionComponent<React.SVGProps<SVGSVGElement>>
-export declare type BezierIcon = IconSource & { __type: 'BezierIcon' }
+export declare type BezierIcon = IconSource & { __bezier__icon: true }
 
 export declare function isBezierIcon(arg: unknown): arg is BezierIcon
 export declare function createBezierIcon(icon: IconSource): BezierIcon

--- a/packages/bezier-icons/utils/index.ts
+++ b/packages/bezier-icons/utils/index.ts
@@ -3,17 +3,17 @@
  * so set the type inside this module to 'any'.
  */
 
-const BEZIER_ICON_SYMBOL = Symbol('bezier.icon')
+const BEZIER_ICON_ID = '__bezier__icon'
 
 export function isBezierIcon(arg: any) {
   return (
     typeof arg === 'function' &&
-    arg[BEZIER_ICON_SYMBOL] === true
+    arg[BEZIER_ICON_ID] === true
   )
 }
 
 export function createBezierIcon(source: any) {
   const clone = source
-  clone[BEZIER_ICON_SYMBOL] = true
+  clone[BEZIER_ICON_ID] = true
   return clone
 }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

아이콘 컴포넌트의 식별자를 심볼에서 문자열 리터럴로 변경합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

식별자가 심볼일 경우 아래와 같은 문제가 발생할 수 있습니다. (했습니다...)

- A 패키지의 의존성 bezier-icons / A 패키지 내부의 B 패키지의 의존성 bezier-icons
- A 패키지에서 import한 IconSource를, B 패키지 내부에서 import한 isBezierIcon 을 통해 아이콘의 고유성을 체크하는 경우
- A 패키지와 B 패키지의 bezier-icons 모듈이 각기 다르기 때문에, Symbol이 2번 선언되고 아이콘 고유성 체크가 실패하게 됩니다.

bezier-react에 peer dependency로 bezier-icons를 추가하는 방식으로 문제를 해결할 수도 있습니다. 하지만 bezier-icons는 bezier-react와 꼭 쌍으로 사용해야하는 패키지가 아니고, bezier-react를 사용하는 사용처에서도 아이콘을 사용하지 않음에도 bezier-icons를 설치해야하는 불편함이 발생하게 됩니다. 또한 굳이 Symbol을 사용할 정도로 엄격하게 고유성 체크를 할 필요는 없다고 판단하여 이 PR의 해결 방식을 적용했습니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No. (bezier-react에선 Breaking Change입니다)

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- [채널 데스크 관련 버그 제보 (private)](https://desk.channel.io/root/threads/groups/Bug-10/6482863e14b6cf9c6928/6482863e14b6cf9c6928)

