### PR TITLE
build(yarn): change the enableTransparentWorkspaces option to the default of true

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,16 @@ jobs:
           paths:
             - .
 
+  build:
+    <<: *defaults
+    steps:
+      - *attach_workspace
+      - run: yarn build --filter=bezier-icons
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .
+
   lint:
     <<: *defaults
     steps:
@@ -70,12 +80,15 @@ workflows:
   lint_and_test:
     jobs:
       - install
+      - build:
+          requires:
+            - install
       - lint:
           requires:
-            - install
+            - build
       - typecheck:
           requires:
-            - install
+            - build
       - test:
           requires:
-            - install
+            - build

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
+      - name: Build Packages
+        run: yarn build --filter=bezier-icons
+
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         id: chromatic

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,5 @@
 nodeLinker: node-modules
 
-enableTransparentWorkspaces: false
-
 npmScopes:
   channel-io:
     npmPublishRegistry: "https://npm.pkg.github.com/"

--- a/packages/bezier-react/.ts-prunerc
+++ b/packages/bezier-react/.ts-prunerc
@@ -1,0 +1,3 @@
+{
+  "ignore": "bezier-icons"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,14 +2834,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@channel.io/bezier-icons@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "@channel.io/bezier-icons@npm:0.1.1"
-  checksum: 8fedb5142e6ff158b8e07e04f1defd8ec3a595b29558fdefc345af8ff20da6478d05bc0dea82ba58f153571ad96bb25716b76ef92d1027c30747afa13b100f51
-  languageName: node
-  linkType: hard
-
-"@channel.io/bezier-icons@workspace:packages/bezier-icons":
+"@channel.io/bezier-icons@^0.1.1, @channel.io/bezier-icons@workspace:packages/bezier-icons":
   version: 0.0.0-use.local
   resolution: "@channel.io/bezier-icons@workspace:packages/bezier-icons"
   dependencies:


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

- #1375 

## Summary
<!-- Please add a summary of the modification. -->

- enableTransparentWorkspaces 옵션을 기본값 true로 변경합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- #1375 에서 ts-prune 관련 문제로 인해 enableTransparentWorkspaces 옵션을 false로 변경했습니다.
- version packages 시, install 과정에서 버전 업된 패키지(npm publish는 되지 않은)를 workspace 내부 링크된 패키지를 참조하지 않고, 실제 배포된 패키지를 찾으면서 설치 에러가 발생하는 문제가 있었습니다.
- 이를 롤백하고, ts-morph가 workspace 내부 모듈은 무시하는 설정을 추가하여 해결합니다.
- yarn install 이후 아이콘 패키지를 빌드하는 설정을 추가합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

 None
