### PR TITLE
Remove `IconName` type from `icon` prop (`Badge`, `NavGroup`, `NavItem`, `Toast`)

### DIFF
--- a/.changeset/brown-bottles-protect.md
+++ b/.changeset/brown-bottles-protect.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Change icon prop type from `iconName` to `BezierIcon`

--- a/.changeset/brown-bottles-protect.md
+++ b/.changeset/brown-bottles-protect.md
@@ -1,5 +1,5 @@
 ---
-"@channel.io/bezier-react": patch
+"@channel.io/bezier-react": minor
 ---
 
 Change icon prop type from `iconName` to `BezierIcon`

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.styled.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.styled.ts
@@ -7,7 +7,6 @@ import { type AdditionalColorProps } from '~/src/types/ComponentProps'
 import { isNil } from '~/src/utils/typeUtils'
 
 import { Icon } from '~/src/components/Icon'
-import { LegacyIcon } from '~/src/components/LegacyIcon'
 
 export const ItemActionWrapper = styled.div`
   display: flex;
@@ -18,7 +17,6 @@ interface ActionWrapperProps extends AdditionalColorProps<['hoverBackground', 'h
 }
 
 export const ActionIcon = styled(Icon)``
-export const ActionLegacyIcon = styled(LegacyIcon)``
 
 export const ActionIconWrapper = styled.button<ActionWrapperProps>`
   all: unset;
@@ -39,12 +37,6 @@ export const ActionIconWrapper = styled.button<ActionWrapperProps>`
     `}
 
     ${ActionIcon} {
-      ${({ foundation, hoverIconColor }) => !isNil(hoverIconColor) && css`
-        color: ${foundation?.theme?.[hoverIconColor]};
-      `}
-    }
-
-    ${ActionLegacyIcon} {
       ${({ foundation, hoverIconColor }) => !isNil(hoverIconColor) && css`
         color: ${foundation?.theme?.[hoverIconColor]};
       `}

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.tsx
@@ -18,6 +18,7 @@ import {
 
 import { IconSize } from '~/src/components/Icon'
 import { TEST_ID_MAP } from '~/src/components/KeyValueListItem/KeyValueListItem.const'
+import { Tooltip } from '~/src/components/Tooltip'
 
 import {
   type ItemActionProps,

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.tsx
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.tsx
@@ -18,8 +18,6 @@ import {
 
 import { IconSize } from '~/src/components/Icon'
 import { TEST_ID_MAP } from '~/src/components/KeyValueListItem/KeyValueListItem.const'
-import { isIconName } from '~/src/components/LegacyIcon'
-import { Tooltip } from '~/src/components/Tooltip'
 
 import {
   type ItemActionProps,
@@ -33,16 +31,6 @@ function ActionIcon({
   icon,
   iconColor,
 }: ItemActionWithIcon) {
-  if (isIconName(icon)) {
-    return (
-      <Styled.ActionLegacyIcon
-        name={icon}
-        color={iconColor ?? 'txt-black-dark'}
-        size={IconSize.XS}
-      />
-    )
-  }
-
   return (
     <Styled.ActionIcon
       source={icon}

--- a/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.types.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/ItemActions/ItemAction.types.ts
@@ -1,9 +1,6 @@
 import type React from 'react'
 
-import {
-  type BezierIcon,
-  type IconName,
-} from '@channel.io/bezier-icons'
+import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
   AdditionalColorProps,
@@ -12,7 +9,7 @@ import type {
 } from '~/src/types/ComponentProps'
 
 export type ItemActionWithIcon = {
-  icon: IconName | BezierIcon
+  icon: BezierIcon
   tooltip?: string
   show?: boolean
   onClick?: React.MouseEventHandler<HTMLButtonElement>

--- a/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.types.ts
+++ b/packages/bezier-react/src/components/KeyValueListItem/common/KeyItem/KeyItem.types.ts
@@ -1,9 +1,6 @@
 import type React from 'react'
 
-import {
-  type BezierIcon,
-  type IconName,
-} from '@channel.io/bezier-icons'
+import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
   BezierComponentProps,
@@ -11,7 +8,7 @@ import type {
 } from '~/src/types/ComponentProps'
 
 interface KeyItemOptions {
-  keyIcon?: IconName | BezierIcon | React.ReactNode
+  keyIcon?: BezierIcon | React.ReactNode
 }
 
 export interface KeyItemProps extends

--- a/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.stories.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.stories.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 
-import { DotIcon } from '@channel.io/bezier-icons'
+import {
+  DotIcon,
+  SettingsIcon,
+} from '@channel.io/bezier-icons'
 import {
   type Meta,
   type Story,
@@ -12,7 +15,6 @@ import { getTitle } from '~/src/utils/storyUtils'
 import {
   Icon,
   IconSize,
-  SettingsIcon,
 } from '~/src/components/Icon'
 import { NavItem } from '~/src/components/Navigator/NavItem'
 

--- a/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.stories.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.stories.tsx
@@ -12,6 +12,7 @@ import { getTitle } from '~/src/utils/storyUtils'
 import {
   Icon,
   IconSize,
+  SettingsIcon,
 } from '~/src/components/Icon'
 import { NavItem } from '~/src/components/Navigator/NavItem'
 
@@ -54,6 +55,6 @@ Primary.args = {
   active: false,
   name: 'general',
   content: '일반 설정',
-  leftIcon: 'settings',
+  leftIcon: SettingsIcon,
   rightContent: <Icon source={DotIcon} size={IconSize.XS} color="bgtxt-orange-normal" />,
 }

--- a/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.test.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.test.tsx
@@ -22,7 +22,7 @@ describe('NavGroup Test >', () => {
 
   beforeEach(() => {
     props = {
-      leftIcon: 'dot',
+      leftIcon: DotIcon,
       name: 'general',
       content: 'test-content',
       rightContent: <Icon source={DotIcon} size={IconSize.XS} color="bgtxt-orange-normal" />,

--- a/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.tsx
@@ -17,10 +17,6 @@ import {
   Icon,
   IconSize,
 } from '~/src/components/Icon'
-import {
-  LegacyIcon,
-  isIconName,
-} from '~/src/components/LegacyIcon'
 import { Text } from '~/src/components/Text'
 
 import type NavGroupProps from './NavGroup.types'
@@ -61,7 +57,6 @@ function NavGroup({
 
   const hasChildren = !isNil(children)
   const chevronIconSource = open ? ChevronSmallDownIcon : ChevronSmallRightIcon
-  const showLeftIcon = isIconName(leftIcon)
   const ariaName = `${name}Menu`
 
   return (
@@ -80,14 +75,12 @@ function NavGroup({
         aria-controls={ariaName}
       >
         <LeftIconWrapper>
-          { showLeftIcon && (
-            <LegacyIcon
-              testId={NAV_GROUP_LEFT_ICON_TEST_ID}
-              name={leftIcon}
-              size={IconSize.S}
-              color={active ? 'bgtxt-blue-normal' : 'txt-black-dark'}
-            />
-          ) }
+          <Icon
+            testId={NAV_GROUP_LEFT_ICON_TEST_ID}
+            source={leftIcon}
+            size={IconSize.S}
+            color={active ? 'bgtxt-blue-normal' : 'txt-black-dark'}
+          />
         </LeftIconWrapper>
 
         <Text typo={Typography.Size14} truncated>

--- a/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.types.ts
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.types.ts
@@ -1,4 +1,4 @@
-import { type IconName } from '@channel.io/bezier-icons'
+import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
   ActivatableProps,
@@ -10,7 +10,7 @@ import type {
 
 interface NavGroupOptions {
   open?: boolean
-  leftIcon: IconName
+  leftIcon: BezierIcon
   name: string
   onClick?: (e?: React.MouseEvent, name?: string) => void
 }

--- a/packages/bezier-react/src/components/Navigator/NavItem/NavItem.test.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavItem/NavItem.test.tsx
@@ -4,6 +4,8 @@ import { LightTheme } from '~/src/foundation/Colors/Theme'
 
 import { render } from '~/src/utils/testUtils'
 
+import { DotIcon } from '~/src/components/Icon'
+
 import NavItem, {
   NAV_ITEM_LEFT_ICON_TEST_ID,
   NAV_ITEM_TEST_ID,
@@ -15,7 +17,7 @@ describe('NavItem Test >', () => {
 
   beforeEach(() => {
     props = {
-      leftIcon: 'dot',
+      leftIcon: DotIcon,
       name: 'general',
       content: 'test-content',
     }

--- a/packages/bezier-react/src/components/Navigator/NavItem/NavItem.test.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavItem/NavItem.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
+import { DotIcon } from '@channel.io/bezier-icons'
+
 import { LightTheme } from '~/src/foundation/Colors/Theme'
 
 import { render } from '~/src/utils/testUtils'
-
-import { DotIcon } from '~/src/components/Icon'
 
 import NavItem, {
   NAV_ITEM_LEFT_ICON_TEST_ID,

--- a/packages/bezier-react/src/components/Navigator/NavItem/NavItem.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavItem/NavItem.tsx
@@ -7,11 +7,10 @@ import { Typography } from '~/src/foundation'
 
 import { noop } from '~/src/utils/functionUtils'
 
-import { IconSize } from '~/src/components/Icon'
 import {
-  LegacyIcon,
-  isIconName,
-} from '~/src/components/LegacyIcon'
+  Icon,
+  IconSize,
+} from '~/src/components/Icon'
 import { Text } from '~/src/components/Text'
 
 import type NavItemProps from './NavItem.types'
@@ -48,8 +47,6 @@ function NavItem({
     onClick,
   ])
 
-  const showLeftIcon = isIconName(leftIcon)
-
   return (
     <Wrapper role="none">
       <Item
@@ -65,10 +62,10 @@ function NavItem({
         role="menuitem"
       >
         <LeftIconWrapper>
-          { showLeftIcon && (
-            <LegacyIcon
+          { leftIcon && (
+            <Icon
               testId={NAV_ITEM_LEFT_ICON_TEST_ID}
-              name={leftIcon}
+              source={leftIcon}
               size={IconSize.S}
               color={active ? 'bgtxt-blue-normal' : 'txt-black-dark'}
             />

--- a/packages/bezier-react/src/components/Navigator/NavItem/NavItem.types.ts
+++ b/packages/bezier-react/src/components/Navigator/NavItem/NavItem.types.ts
@@ -1,4 +1,4 @@
-import { type IconName } from '@channel.io/bezier-icons'
+import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
   ActivatableProps,
@@ -9,7 +9,7 @@ import type {
 } from '~/src/types/ComponentProps'
 
 interface NavItemOptions {
-  leftIcon?: IconName
+  leftIcon?: BezierIcon
   name: string
   target?: HTMLAnchorElement['target']
   onClick?: (e?: React.MouseEvent, name?: string) => void

--- a/packages/bezier-react/src/components/TagBadge/Badge/Badge.stories.tsx
+++ b/packages/bezier-react/src/components/TagBadge/Badge/Badge.stories.tsx
@@ -8,6 +8,7 @@ import { base } from 'paths.macro'
 
 import { getTitle } from '~/src/utils/storyUtils'
 
+import { AppleIcon } from '~/src/components/Icon'
 import {
   TagBadgeSize,
   TagBadgeVariant,
@@ -48,6 +49,6 @@ export const Primary: Story<BadgeProps> = Template.bind({})
 Primary.args = {
   children: 'Design',
   size: TagBadgeSize.M,
-  iconName: 'apple',
+  icon: AppleIcon,
   variant: TagBadgeVariant.Default,
 }

--- a/packages/bezier-react/src/components/TagBadge/Badge/Badge.stories.tsx
+++ b/packages/bezier-react/src/components/TagBadge/Badge/Badge.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { AppleIcon } from '@channel.io/bezier-icons'
 import {
   type Meta,
   type Story,
@@ -8,7 +9,6 @@ import { base } from 'paths.macro'
 
 import { getTitle } from '~/src/utils/storyUtils'
 
-import { AppleIcon } from '~/src/components/Icon'
 import {
   TagBadgeSize,
   TagBadgeVariant,

--- a/packages/bezier-react/src/components/TagBadge/Badge/Badge.tsx
+++ b/packages/bezier-react/src/components/TagBadge/Badge/Badge.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'
 
 import { isEmpty } from '~/src/utils/typeUtils'
 
-import { LegacyIcon } from '~/src/components/LegacyIcon'
+import { Icon } from '~/src/components/Icon'
 import {
   BADGE_TEXT_HORIZONTAL_PADDING,
   TAG_BADGE_ICON_SIZE,
@@ -25,7 +25,7 @@ export const BADGE_TEST_ID = 'bezier-react-badge'
 export const Badge = React.memo(function Badge({
   size = TagBadgeSize.M,
   variant = TagBadgeVariant.Default,
-  iconName,
+  icon,
   children,
   className,
   interpolation,
@@ -37,14 +37,14 @@ export const Badge = React.memo(function Badge({
   const bgSemanticName = useMemo(() => (getProperTagBadgeBgColor(variant)), [variant])
   const textSemanticName = useMemo(() => (getProperBadgeTextColor(variant)), [variant])
 
-  const IconComponent = useMemo(() => (iconName && (
-    <LegacyIcon
-      name={iconName}
+  const IconComponent = useMemo(() => (icon && (
+    <Icon
+      source={icon}
       size={TAG_BADGE_ICON_SIZE}
       color={textSemanticName}
     />
   )), [
-    iconName,
+    icon,
     textSemanticName,
   ])
 

--- a/packages/bezier-react/src/components/TagBadge/Badge/Badge.types.ts
+++ b/packages/bezier-react/src/components/TagBadge/Badge/Badge.types.ts
@@ -1,4 +1,4 @@
-import { type IconName } from '@channel.io/bezier-icons'
+import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import {
   type BezierComponentProps,
@@ -16,7 +16,7 @@ interface BadgeOptions {
   /**
    * Icon to be shown on the left side of the badge.
    */
-  iconName?: IconName
+  icon?: BezierIcon
 }
 
 interface BadgeProps extends

--- a/packages/bezier-react/src/components/TagBadge/TagBadge.mdx
+++ b/packages/bezier-react/src/components/TagBadge/TagBadge.mdx
@@ -36,7 +36,7 @@ import {
 <Story id="components-tagbadge--badge-without-text" />
 
 ```tsx
-<Badge variant={TagBadgeVariant.Red} iconName="block" />
+<Badge variant={TagBadgeVariant.Red} icon={BlockIcon} />
 ```
 
 ### Dismissible Tag

--- a/packages/bezier-react/src/components/TagBadge/TagBadge.stories.tsx
+++ b/packages/bezier-react/src/components/TagBadge/TagBadge.stories.tsx
@@ -13,6 +13,21 @@ import { getTitle } from '~/src/utils/storyUtils'
 import { gap } from '~/src/utils/styleUtils'
 
 import {
+  ArchiveIcon,
+  BlockIcon,
+  BookmarkFilledIcon,
+  CancelIcon,
+  CheckAllIcon,
+  ClockIcon,
+  ErrorTriangleFilledIcon,
+  HeartFilledIcon,
+  LightningFilledIcon,
+  StarFilledIcon,
+  TimeElapsedIcon,
+  TrendingUpIcon,
+  ViewIcon,
+} from '~/src/components/Icon'
+import {
   HStack,
   StackItem,
   VStack,
@@ -61,20 +76,20 @@ export const Overview: Story<{}> = () => (
     </StackItem>
     <StackItem>
       <Container>
-        <Badge iconName="clock" variant={TagBadgeVariant.Default}>default</Badge>
-        <Badge iconName="bookmark-filled" variant={TagBadgeVariant.Blue}>blue</Badge>
-        <Badge iconName="time-elapsed" variant={TagBadgeVariant.Cobalt}>cobalt</Badge>
-        <Badge iconName="view" variant={TagBadgeVariant.Teal}>teal</Badge>
-        <Badge iconName="lightning-filled" variant={TagBadgeVariant.Green}>green</Badge>
-        <Badge iconName="check-all" variant={TagBadgeVariant.Olive}>olive</Badge>
-        <Badge iconName="heart-filled" variant={TagBadgeVariant.Pink}>pink</Badge>
-        <Badge iconName="archive" variant={TagBadgeVariant.Navy}>navy</Badge>
-        <Badge iconName="star-filled" variant={TagBadgeVariant.Yellow}>yellow</Badge>
-        <Badge iconName="error-triangle-filled" variant={TagBadgeVariant.Orange}>orange</Badge>
-        <Badge iconName="block" variant={TagBadgeVariant.Red}>red</Badge>
-        <Badge iconName="trending-up" variant={TagBadgeVariant.Purple}>purple</Badge>
-        <Badge iconName="clock" variant={TagBadgeVariant.MonochromeDark}>monochrome-dark</Badge>
-        <Badge iconName="cancel" variant={TagBadgeVariant.MonochromeLight}>monochrome-light</Badge>
+        <Badge icon={ClockIcon} variant={TagBadgeVariant.Default}>default</Badge>
+        <Badge icon={BookmarkFilledIcon} variant={TagBadgeVariant.Blue}>blue</Badge>
+        <Badge icon={TimeElapsedIcon} variant={TagBadgeVariant.Cobalt}>cobalt</Badge>
+        <Badge icon={ViewIcon} variant={TagBadgeVariant.Teal}>teal</Badge>
+        <Badge icon={LightningFilledIcon} variant={TagBadgeVariant.Green}>green</Badge>
+        <Badge icon={CheckAllIcon} variant={TagBadgeVariant.Olive}>olive</Badge>
+        <Badge icon={HeartFilledIcon} variant={TagBadgeVariant.Pink}>pink</Badge>
+        <Badge icon={ArchiveIcon} variant={TagBadgeVariant.Navy}>navy</Badge>
+        <Badge icon={StarFilledIcon} variant={TagBadgeVariant.Yellow}>yellow</Badge>
+        <Badge icon={ErrorTriangleFilledIcon} variant={TagBadgeVariant.Orange}>orange</Badge>
+        <Badge icon={BlockIcon} variant={TagBadgeVariant.Red}>red</Badge>
+        <Badge icon={TrendingUpIcon} variant={TagBadgeVariant.Purple}>purple</Badge>
+        <Badge icon={ClockIcon} variant={TagBadgeVariant.MonochromeDark}>monochrome-dark</Badge>
+        <Badge icon={CancelIcon} variant={TagBadgeVariant.MonochromeLight}>monochrome-light</Badge>
       </Container>
     </StackItem>
   </VStack>
@@ -83,13 +98,13 @@ export const Overview: Story<{}> = () => (
 export const BadgeWithoutText: Story<{}> = () => (
   <HStack spacing={4}>
     <StackItem>
-      <Badge variant={TagBadgeVariant.Red} iconName="block" />
+      <Badge variant={TagBadgeVariant.Red} icon={BlockIcon} />
     </StackItem>
     <StackItem>
-      <Badge variant={TagBadgeVariant.Orange} iconName="error-triangle-filled" />
+      <Badge variant={TagBadgeVariant.Orange} icon={ErrorTriangleFilledIcon} />
     </StackItem>
     <StackItem>
-      <Badge variant={TagBadgeVariant.Green} iconName="lightning-filled" />
+      <Badge variant={TagBadgeVariant.Green} icon={LightningFilledIcon} />
     </StackItem>
   </HStack>
 )
@@ -129,20 +144,20 @@ const Items = styled.div`
 
 export const Gap: Story<{}> = () => (
   <Items>
-    <Badge iconName="clock" variant={TagBadgeVariant.Default}>default</Badge>
-    <Badge iconName="bookmark-filled" variant={TagBadgeVariant.Blue}>blue</Badge>
-    <Badge iconName="time-elapsed" variant={TagBadgeVariant.Cobalt}>cobalt</Badge>
-    <Badge iconName="view" variant={TagBadgeVariant.Teal}>teal</Badge>
-    <Badge iconName="lightning-filled" variant={TagBadgeVariant.Green}>green</Badge>
-    <Badge iconName="check-all" variant={TagBadgeVariant.Olive}>olive</Badge>
-    <Badge iconName="heart-filled" variant={TagBadgeVariant.Pink}>pink</Badge>
-    <Badge iconName="archive" variant={TagBadgeVariant.Navy}>navy</Badge>
-    <Badge iconName="star-filled" variant={TagBadgeVariant.Yellow}>yellow</Badge>
-    <Badge iconName="error-triangle-filled" variant={TagBadgeVariant.Orange}>orange</Badge>
-    <Badge iconName="block" variant={TagBadgeVariant.Red}>red</Badge>
-    <Badge iconName="trending-up" variant={TagBadgeVariant.Purple}>purple</Badge>
-    <Badge iconName="clock" variant={TagBadgeVariant.MonochromeDark}>monochrome-dark</Badge>
-    <Badge iconName="cancel" variant={TagBadgeVariant.MonochromeLight}>monochrome-light</Badge>
+    <Badge icon={ClockIcon} variant={TagBadgeVariant.Default}>default</Badge>
+    <Badge icon={BookmarkFilledIcon} variant={TagBadgeVariant.Blue}>blue</Badge>
+    <Badge icon={TimeElapsedIcon} variant={TagBadgeVariant.Cobalt}>cobalt</Badge>
+    <Badge icon={ViewIcon} variant={TagBadgeVariant.Teal}>teal</Badge>
+    <Badge icon={LightningFilledIcon} variant={TagBadgeVariant.Green}>green</Badge>
+    <Badge icon={CheckAllIcon} variant={TagBadgeVariant.Olive}>olive</Badge>
+    <Badge icon={HeartFilledIcon} variant={TagBadgeVariant.Pink}>pink</Badge>
+    <Badge icon={ArchiveIcon} variant={TagBadgeVariant.Navy}>navy</Badge>
+    <Badge icon={StarFilledIcon} variant={TagBadgeVariant.Yellow}>yellow</Badge>
+    <Badge icon={ErrorTriangleFilledIcon} variant={TagBadgeVariant.Orange}>orange</Badge>
+    <Badge icon={BlockIcon} variant={TagBadgeVariant.Red}>red</Badge>
+    <Badge icon={TrendingUpIcon} variant={TagBadgeVariant.Purple}>purple</Badge>
+    <Badge icon={ClockIcon} variant={TagBadgeVariant.MonochromeDark}>monochrome-dark</Badge>
+    <Badge icon={CancelIcon} variant={TagBadgeVariant.MonochromeLight}>monochrome-light</Badge>
   </Items>
 )
 
@@ -164,7 +179,7 @@ export const SizeVariant: Story<{}> = () => (
                 <Tag size={size}>{ label }</Tag>
               </StackItem>
               <StackItem>
-                <Badge size={size} iconName="clock">{ label }</Badge>
+                <Badge size={size} icon={ClockIcon}>{ label }</Badge>
               </StackItem>
             </HStack>
           </StackItem>
@@ -201,7 +216,7 @@ export const Variant: Story<{}> = () => (
                 <Tag variant={variant}>{ label }</Tag>
               </StackItem>
               <StackItem>
-                <Badge iconName="clock" variant={variant}>{ label }</Badge>
+                <Badge icon={ClockIcon} variant={variant}>{ label }</Badge>
               </StackItem>
             </HStack>
           </StackItem>

--- a/packages/bezier-react/src/components/TagBadge/TagBadge.stories.tsx
+++ b/packages/bezier-react/src/components/TagBadge/TagBadge.stories.tsx
@@ -1,18 +1,6 @@
 import React from 'react'
 
 import {
-  type Meta,
-  type Story,
-} from '@storybook/react'
-import base from 'paths.macro'
-
-import { styled } from '~/src/foundation'
-
-import { noop } from '~/src/utils/functionUtils'
-import { getTitle } from '~/src/utils/storyUtils'
-import { gap } from '~/src/utils/styleUtils'
-
-import {
   ArchiveIcon,
   BlockIcon,
   BookmarkFilledIcon,
@@ -26,7 +14,19 @@ import {
   TimeElapsedIcon,
   TrendingUpIcon,
   ViewIcon,
-} from '~/src/components/Icon'
+} from '@channel.io/bezier-icons'
+import {
+  type Meta,
+  type Story,
+} from '@storybook/react'
+import base from 'paths.macro'
+
+import { styled } from '~/src/foundation'
+
+import { noop } from '~/src/utils/functionUtils'
+import { getTitle } from '~/src/utils/storyUtils'
+import { gap } from '~/src/utils/styleUtils'
+
 import {
   HStack,
   StackItem,

--- a/packages/bezier-react/src/components/Toast/Toast.stories.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.stories.tsx
@@ -24,6 +24,7 @@ import {
   ButtonColorVariant,
   ButtonStyleVariant,
 } from '~/src/components/Button'
+import { ChannelSmileFilledIcon } from '~/src/components/Icon'
 import { ProgressBar } from '~/src/components/ProgressBar'
 import {
   StackItem,
@@ -59,7 +60,7 @@ export default {
         },
       },
     },
-    iconName: {
+    icon: {
       control: {
         type: 'select',
         options: [
@@ -100,7 +101,7 @@ Primary.args = {
   content: '안내문구입니다.\nnewLine',
   preset: ToastPreset.Default,
   appearance: undefined,
-  iconName: undefined,
+  icon: undefined,
   actionContent: '새로고침',
   onClick: noop,
 }
@@ -109,7 +110,7 @@ function Div({
   content,
   preset,
   appearance,
-  iconName,
+  icon,
   actionContent,
 }) {
   const toast = useToast()
@@ -127,7 +128,7 @@ function Div({
     toast.addToast(currentContent, {
       preset,
       appearance,
-      iconName,
+      icon,
       actionContent,
       onClick: () => handleAction(currentContent),
     })
@@ -137,7 +138,7 @@ function Div({
 
   const handleNeverDismiss = () => toast.addToast('이건 사라지지 않아요!', {
     appearance: ToastAppearance.Success,
-    iconName: 'channel-smile-filled',
+    icon: ChannelSmileFilledIcon,
     autoDismiss: false,
   })
 
@@ -168,7 +169,7 @@ export const WithAction: Story<ToastProps & WithActionProps> = ({
   content,
   preset,
   appearance,
-  iconName,
+  icon,
   actionContent,
 }) => (
   <Container id="story-wrapper">
@@ -179,7 +180,7 @@ export const WithAction: Story<ToastProps & WithActionProps> = ({
         content={content}
         preset={preset}
         appearance={appearance}
-        iconName={iconName}
+        icon={icon}
         actionContent={actionContent}
       />
     </ToastProvider>
@@ -191,7 +192,7 @@ WithAction.args = {
   content: '안내문구입니다.',
   preset: ToastPreset.Default,
   appearance: undefined,
-  iconName: undefined,
+  icon: undefined,
   actionContent: '액션 함수 테스트',
 }
 

--- a/packages/bezier-react/src/components/Toast/Toast.stories.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.stories.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
 } from 'react'
 
+import { ChannelSmileFilledIcon } from '@channel.io/bezier-icons'
 import {
   type Meta,
   type Story,
@@ -24,7 +25,6 @@ import {
   ButtonColorVariant,
   ButtonStyleVariant,
 } from '~/src/components/Button'
-import { ChannelSmileFilledIcon } from '~/src/components/Icon'
 import { ProgressBar } from '~/src/components/ProgressBar'
 import {
   StackItem,

--- a/packages/bezier-react/src/components/Toast/Toast.types.ts
+++ b/packages/bezier-react/src/components/Toast/Toast.types.ts
@@ -4,7 +4,10 @@ import {
 } from 'react'
 import type React from 'react'
 
-import { type IconName } from '@channel.io/bezier-icons'
+import {
+  type BezierIcon,
+  InfoFilledIcon,
+} from '@channel.io/bezier-icons'
 
 import { type TransitionDuration } from '~/src/foundation'
 
@@ -44,13 +47,13 @@ export enum ToastPreset {
 
 export interface ToastPresetType {
   appearance: ToastAppearance
-  iconName: IconName
+  icon: BezierIcon
 }
 
 interface ToastElementOptions {
   preset?: ToastPreset
   appearance?: ToastAppearance
-  iconName?: IconName
+  icon?: BezierIcon
   /**
    * @deprecated use React.ReactNode content props instead.
    */
@@ -81,7 +84,7 @@ export type OnDismissCallback = (id: ToastId) => void
 
 export type ToastOptions = {
   preset?: ToastPreset
-  iconName?: IconName
+  icon?: BezierIcon
   appearance?: ToastAppearance
   actionContent?: string
   autoDismiss?: boolean
@@ -92,7 +95,7 @@ export type ToastOptions = {
 }
 
 export const defaultOptions: ToastOptions = {
-  iconName: 'info-filled',
+  icon: InfoFilledIcon,
   appearance: ToastAppearance.Info,
   autoDismiss: false,
   onDismiss: noop,

--- a/packages/bezier-react/src/components/Toast/ToastElement.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastElement.tsx
@@ -41,7 +41,7 @@ const ToastElement = (
     preset = ToastPreset.Default,
     content = '',
     appearance,
-    iconName,
+    icon,
     actionContent,
     onClick,
     onDismiss,
@@ -66,7 +66,7 @@ const ToastElement = (
 
   const {
     appearance: presetAppearance,
-    iconName: presetIconName,
+    icon: presetIconName,
   } = useMemo(() => getToastPreset(preset), [preset])
 
   return (
@@ -78,8 +78,8 @@ const ToastElement = (
       <IconWrapper
         appearance={appearance ?? presetAppearance}
       >
-        <LegacyIcon
-          name={iconName ?? presetIconName}
+        <Icon
+          source={icon ?? presetIconName}
           size={IconSize.S}
         />
       </IconWrapper>

--- a/packages/bezier-react/src/components/Toast/ToastElement.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastElement.tsx
@@ -15,7 +15,6 @@ import {
   Icon,
   IconSize,
 } from '~/src/components/Icon'
-import { LegacyIcon } from '~/src/components/LegacyIcon'
 import { Text } from '~/src/components/Text'
 
 import type ToastProps from './Toast.types'

--- a/packages/bezier-react/src/components/Toast/ToastElement.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastElement.tsx
@@ -65,7 +65,7 @@ const ToastElement = (
 
   const {
     appearance: presetAppearance,
-    icon: presetIconName,
+    icon: presetIcon,
   } = useMemo(() => getToastPreset(preset), [preset])
 
   return (
@@ -78,7 +78,7 @@ const ToastElement = (
         appearance={appearance ?? presetAppearance}
       >
         <Icon
-          source={icon ?? presetIconName}
+          source={icon ?? presetIcon}
           size={IconSize.S}
         />
       </IconWrapper>

--- a/packages/bezier-react/src/components/Toast/ToastProvider.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastProvider.tsx
@@ -43,7 +43,7 @@ function ToastProvider({
         content,
         preset,
         appearance,
-        iconName,
+        icon,
         actionContent,
         onClick,
         id,
@@ -62,7 +62,7 @@ function ToastProvider({
           preset={preset}
           appearance={appearance}
           content={content}
-          iconName={iconName}
+          icon={icon}
           component={ToastElement}
           onDismiss={() => dismiss(id, onDismiss)}
           transform={css``}

--- a/packages/bezier-react/src/components/Toast/ToastService.test.ts
+++ b/packages/bezier-react/src/components/Toast/ToastService.test.ts
@@ -1,4 +1,4 @@
-import { InfoFilledIcon } from '~/src/components/Icon'
+import { InfoFilledIcon } from '@channel.io/bezier-icons'
 
 import { type ToastType } from './Toast.types'
 import ToastService from './ToastService'

--- a/packages/bezier-react/src/components/Toast/ToastService.test.ts
+++ b/packages/bezier-react/src/components/Toast/ToastService.test.ts
@@ -1,3 +1,5 @@
+import { InfoFilledIcon } from '~/src/components/Icon'
+
 import { type ToastType } from './Toast.types'
 import ToastService from './ToastService'
 
@@ -43,7 +45,7 @@ describe('ToastService', () => {
         appearance: 'info',
         autoDismiss: false,
         content: '0',
-        iconName: 'info-filled',
+        icon: InfoFilledIcon,
         rightSide: false,
         version: 0,
       }),

--- a/packages/bezier-react/src/components/Toast/useToastContextValues.test.tsx
+++ b/packages/bezier-react/src/components/Toast/useToastContextValues.test.tsx
@@ -1,9 +1,8 @@
+import { InfoFilledIcon } from '@channel.io/bezier-icons'
 import {
   act,
   renderHook,
 } from '@testing-library/react'
-
-import { InfoFilledIcon } from '~/src/components/Icon'
 
 import {
   ToastAppearance,

--- a/packages/bezier-react/src/components/Toast/useToastContextValues.test.tsx
+++ b/packages/bezier-react/src/components/Toast/useToastContextValues.test.tsx
@@ -3,6 +3,8 @@ import {
   renderHook,
 } from '@testing-library/react'
 
+import { InfoFilledIcon } from '~/src/components/Icon'
+
 import {
   ToastAppearance,
   type ToastType,
@@ -35,7 +37,7 @@ describe('ToastService', () => {
       expect.objectContaining({
         id: expect.stringMatching(UUID_V4_REGEX),
         content: '0',
-        iconName: 'info-filled',
+        icon: InfoFilledIcon,
         appearance: ToastAppearance.Info,
         autoDismiss: false,
         rightSide: false,
@@ -87,7 +89,7 @@ describe('ToastService', () => {
       expect.objectContaining({
         id: expect.stringMatching(UUID_V4_REGEX),
         content: '0',
-        iconName: 'info-filled',
+        icon: InfoFilledIcon,
         appearance: ToastAppearance.Info,
         autoDismiss: false,
         rightSide: false,
@@ -112,7 +114,7 @@ describe('ToastService', () => {
       expect.objectContaining({
         id: expect.stringMatching(UUID_V4_REGEX),
         content: '0',
-        iconName: 'info-filled',
+        icon: InfoFilledIcon,
         appearance: ToastAppearance.Info,
         autoDismiss: false,
         rightSide: false,
@@ -139,7 +141,7 @@ describe('ToastService', () => {
       expect.objectContaining({
         id: expect.stringMatching(UUID_V4_REGEX),
         content: '0',
-        iconName: 'info-filled',
+        icon: InfoFilledIcon,
         appearance: ToastAppearance.Info,
         autoDismiss: false,
         rightSide: false,

--- a/packages/bezier-react/src/components/Toast/utils.ts
+++ b/packages/bezier-react/src/components/Toast/utils.ts
@@ -1,12 +1,12 @@
-import { css } from '~/src/foundation'
-
 import {
   CheckCircleFilledIcon,
   ErrorTriangleFilledIcon,
   InfoFilledIcon,
   WifiIcon,
   WifiOffIcon,
-} from '~/src/components/Icon'
+} from '@channel.io/bezier-icons'
+
+import { css } from '~/src/foundation'
 
 import {
   ToastAppearance,

--- a/packages/bezier-react/src/components/Toast/utils.ts
+++ b/packages/bezier-react/src/components/Toast/utils.ts
@@ -1,6 +1,14 @@
 import { css } from '~/src/foundation'
 
 import {
+  CheckCircleFilledIcon,
+  ErrorTriangleFilledIcon,
+  InfoFilledIcon,
+  WifiIcon,
+  WifiOffIcon,
+} from '~/src/components/Icon'
+
+import {
   ToastAppearance,
   ToastIconColor,
   ToastPlacement,
@@ -61,28 +69,28 @@ const getToastPreset = (preset: ToastPreset): ToastPresetType => {
   switch (preset) {
     case ToastPreset.Success:
       return {
-        iconName: 'check-circle-filled',
+        icon: CheckCircleFilledIcon,
         appearance: ToastAppearance.Success,
       }
     case ToastPreset.Error:
       return {
-        iconName: 'error-triangle-filled',
+        icon: ErrorTriangleFilledIcon,
         appearance: ToastAppearance.Error,
       }
     case ToastPreset.Offline:
       return {
-        iconName: 'wifi-off',
+        icon: WifiOffIcon,
         appearance: ToastAppearance.Warning,
       }
     case ToastPreset.Online:
       return {
-        iconName: 'wifi',
+        icon: WifiIcon,
         appearance: ToastAppearance.Success,
       }
     case ToastPreset.Default:
     default:
       return {
-        iconName: 'info-filled',
+        icon: InfoFilledIcon,
         appearance: ToastAppearance.Info,
       }
   }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] ~~[Component] I wrote **a unit test** about the implementation.~~
- [ ] ~~[Component] I wrote **a storybook document** about the implementation.~~
- [x] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] ~~[*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.~~

## Related Issue

Partial fix of https://github.com/channel-io/bezier-react/issues/762

## Summary
<!-- Please add a summary of the modification. -->
- 아래 컴포넌트들에 대하여 `iconName` 을 `BezierIcon`으로 마이그레이션 합니다.
- [x] `Badge`
- [x] `NavGroup`
- [x] `NavItem`
- [x] `Toast`



## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- 해당 컴포넌트들은 이전에 마이그레이션 했던 `Select`, `KeyValueListItem` 등과 달리 `IconName`을 서버에서 받고 있지 않고 모두 클라이언트에서 들고 있어서 바로 breaking change 를 일으켜도 무방하다고 생각하여 `IconName` 을 제거했습니다.

- `KeyItem` 과 `ItemAction` 에 남아있는 `IconName` 을 지웠습니다.

- 이 pr 이 머지되면 이제 `Button` 관련된 컴포넌트(`Button` 과 `SectionLabel`) 가 남습니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
- Yes, components in summary do support `BezierIcon` type instead of `IconName` type for icon.

## References
<!-- External documents based on workarounds or reviewers should refer to -->
- https://github.com/channel-io/bezier-react/issues/762
