### PR TITLE
fix: correctly change children prop in components that pass children prop directly to radix-ui `Slot`

### DIFF
--- a/.changeset/pink-actors-own.md
+++ b/.changeset/pink-actors-own.md
@@ -1,0 +1,12 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Correctly change `children` prop on components that pass `children` prop directly to radix-ui `Slot`.
+
+**BREAKING_CHANGE**: `children` prop of the following components will be changed from `React.ReactNode` to `React.ReactElement`.
+
+- `Tooltip`
+- `ModalTrigger`
+- `ModalClose`
+- `VisuallyHidden`

--- a/packages/bezier-react/src/components/Modals/Modal/Modal.types.ts
+++ b/packages/bezier-react/src/components/Modals/Modal/Modal.types.ts
@@ -128,10 +128,10 @@ export interface ModalFooterProps extends
   ModalFooterOptions {}
 
 export interface ModalTriggerProps extends
-  ChildrenProps {}
+  ChildrenProps<React.ReactElement> {}
 
 export interface ModalCloseProps extends
-  ChildrenProps {}
+  ChildrenProps<React.ReactElement> {}
 
 export interface ModalContentContextValue extends
   NonNullable<Pick<ModalContentOptions, 'showCloseIcon'>> {}

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
@@ -116,8 +116,8 @@ export interface TooltipProviderProps extends
 
 export interface TooltipProps extends
   BezierComponentProps,
-  ChildrenProps,
+  ChildrenProps<React.ReactElement>,
   ContentProps,
   DisableProps,
-  Omit<React.HTMLAttributes<HTMLDivElement>, keyof ContentProps>,
+  Omit<React.HTMLAttributes<HTMLDivElement>, keyof ContentProps | keyof ChildrenProps>,
   TooltipOptions {}

--- a/packages/bezier-react/src/components/VisuallyHidden/VisuallyHidden.types.ts
+++ b/packages/bezier-react/src/components/VisuallyHidden/VisuallyHidden.types.ts
@@ -1,4 +1,4 @@
 import { type ChildrenProps } from '~/src/types/ComponentProps'
 
 export interface VisuallyHiddenProps extends
-  ChildrenProps {}
+  ChildrenProps<React.ReactElement> {}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

컴포넌트의 `children` prop을 통해, 내부의 radix-ui `Slot` 컴포넌트의 children에 직접 전달하는 경우 타입을 올바르게 수정합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

https://github.com/radix-ui/primitives/blob/eca6babd188df465f64f23f3584738b85dba610e/packages/react/slot/src/Slot.tsx#L60-L71

```tsx
const SlotClone = React.forwardRef<any, SlotCloneProps>((props, forwardedRef) => {
  const { children, ...slotProps } = props;


  if (React.isValidElement(children)) {
    return React.cloneElement(children, {
      ...mergeProps(slotProps, children.props),
      ref: forwardedRef ? composeRefs(forwardedRef, (children as any).ref) : (children as any).ref,
    });
  }


  return React.Children.count(children) > 1 ? React.Children.only(null) : null;
});
```

- `Slot` 내부 구현을 보면, children이 [isValidElement](https://react.dev/reference/react/isValidElement)가 아닌 경우 마지막 return 문으로 이동하게 됩니다.
- `React.Children.only(null)` 의 경우 `null` 이 `React.ReactElement` 가 아니므로, assertion이 무조건 실패하는 구문입니다. (아마 개발 환경에서 에러 메세지를 잘 출력하기 위한 용도인 거 같습니다.)
- 그리고 count가 1이더라도 삼항 연산자에 의해 결과적으로 `null` 을 리턴하게 됩니다. 즉, 아무것도 렌더하지 않습니다. 
- 결과적으로 `Slot` 이 런타임에도 엔지니어가 기대한 대로 안전하게 동작하기 위해선 `children` 의 prop이 `React.ReactNode` 가 아니라 `React.ReactElement` 가 되어야합니다.
- 사용처에서 컴파일 타임에 오류를 미리 감지할 수 있도록 타입을 올바르게 수정합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

Yes

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- https://github.com/radix-ui/primitives/tree/main/packages/react/slot/src
- https://react.dev/reference/react/Children#children-only
