### PR TITLE
fix(tooltip): fix to show ellipsis even when no spaces are present

### DIFF
--- a/packages/bezier-react/src/components/Tooltip/Tooltip.styled.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.styled.ts
@@ -113,6 +113,10 @@ export const TooltipContent = styled(AlphaStack).attrs({
   ${({ interpolation }) => interpolation}
 `
 
+export const TextContainer = styled.div`
+  overflow: hidden;
+`
+
 export const Content = styled(Text).attrs({ typo: Typography.Size13 })`
   color: ${({ foundation }) => foundation?.subTheme?.['txt-black-darkest']};
   /* NOTE: Line height of Typography.Size13  */

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -272,7 +272,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip
           hideWhenDetached
         >
           <Styled.TooltipContent forwardedAs={as}>
-            <div>
+            <Styled.TextContainer>
               <Styled.Content>
                 { content }
               </Styled.Content>
@@ -282,7 +282,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip
                   { description }
                 </Styled.Description>
               ) }
-            </div>
+            </Styled.TextContainer>
 
             { icon && (
               <Styled.Icon source={icon} />


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

None

## Summary
<!-- Please add a summary of the modification. -->

`Tootlip` 컨텐츠가 띄어 쓰기가 없는 텍스트더라도 말줄임 처리가 잘 되도록 수정합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

텍스트 컨테이너에 `overflow: hidden` 을 추가합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

없음
