### PR TITLE
fix(rollup): change to include babel helper functions in the bundle

### DIFF
--- a/.changeset/beige-lies-sparkle.md
+++ b/.changeset/beige-lies-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix module resolve errors that occur in CJS environments.

--- a/packages/bezier-react/babel.config.js
+++ b/packages/bezier-react/babel.config.js
@@ -10,7 +10,6 @@ module.exports = {
     ['@babel/preset-typescript', { isTSX: true, allExtensions: true }],
   ],
   plugins: [
-    '@babel/plugin-transform-runtime',
     ['babel-plugin-styled-components', {
       minify: true,
       pure: true,

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -60,7 +60,6 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.22.5",
-    "@babel/plugin-transform-runtime": "^7.22.5",
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-react": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
@@ -107,7 +106,6 @@
     "paths.macro": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "regenerator-runtime": "^0.13.11",
     "rollup": "^3.25.1",
     "rollup-plugin-node-externals": "^6.1.1",
     "rollup-plugin-visualizer": "^5.9.2",
@@ -130,7 +128,6 @@
     }
   },
   "dependencies": {
-    "@babel/runtime": "^7.22.5",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-radio-group": "^1.1.3",

--- a/packages/bezier-react/rollup.config.mjs
+++ b/packages/bezier-react/rollup.config.mjs
@@ -26,7 +26,6 @@ const generateConfig = ({
 }) => defineConfig({
   input: 'src/index.ts',
   output,
-  external: [/@babel\/runtime/],
   plugins: [
     alias({
       entries: [{
@@ -53,7 +52,7 @@ const generateConfig = ({
      */
     commonjs(),
     babel({
-      babelHelpers: 'runtime',
+      babelHelpers: 'bundled',
       exclude: 'node_modules/**',
       extensions,
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,22 +2510,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/plugin-transform-runtime@npm:7.22.5"
-  dependencies:
-    "@babel/helper-module-imports": ^7.22.5
-    "@babel/helper-plugin-utils": ^7.22.5
-    babel-plugin-polyfill-corejs2: ^0.4.3
-    babel-plugin-polyfill-corejs3: ^0.8.1
-    babel-plugin-polyfill-regenerator: ^0.5.0
-    semver: ^6.3.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 52cf177045b5f61a6cfc36b45aa7629586dc00a28371a09ef03e877a627f520efd51817ad8cceabaaa25f266e069859b36a5ac5018afeaa7f37aafa9325df4d8
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-transform-shorthand-properties@npm:^7.12.1, @babel/plugin-transform-shorthand-properties@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-transform-shorthand-properties@npm:7.18.6"
@@ -3038,7 +3022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.22.5":
+"@babel/runtime@npm:^7.20.13":
   version: 7.22.5
   resolution: "@babel/runtime@npm:7.22.5"
   dependencies:
@@ -3520,11 +3504,9 @@ __metadata:
   resolution: "@channel.io/bezier-react@workspace:packages/bezier-react"
   dependencies:
     "@babel/core": ^7.22.5
-    "@babel/plugin-transform-runtime": ^7.22.5
     "@babel/preset-env": ^7.22.5
     "@babel/preset-react": ^7.22.5
     "@babel/preset-typescript": ^7.22.5
-    "@babel/runtime": ^7.22.5
     "@channel.io/bezier-icons": ^0.4.0
     "@channel.io/react-docgen-typescript-plugin": ^1.0.0
     "@mdx-js/react": ^1.6.22
@@ -3582,7 +3564,6 @@ __metadata:
     react-dom: ^18.2.0
     react-resize-detector: ^9.1.0
     react-textarea-autosize: ^8.4.1
-    regenerator-runtime: ^0.13.11
     rollup: ^3.25.1
     rollup-plugin-node-externals: ^6.1.1
     rollup-plugin-visualizer: ^5.9.2


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

Fixes #1458 

## Summary
<!-- Please add a summary of the modification. -->

바벨 헬퍼 함수를 번들에 포함하도록 변경합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

#1458 의 근본적인 원인은 해결하기 어려웠습니다. 대신, 바벨 헬퍼를 external 모듈에서 제거하고 번들에 포함함으로써 내부 의존성이 사용하는 ESM 버전의 바벨 헬퍼를 CJS용으로 트랜스파일링하도록 변경했습니다.

아래와 같은 방식으로 변경되어, 사용처에서 모듈 시스템 충돌로 인한 문제는 발생하지 않게 됩니다.

```js
/* dist/cjs/node_modules/@radix-ui/react-tooltip/dist/index.js */
'use strict';

var _extends = require('../node_modules/@babel/runtime/helpers/esm/extends.js');
```

```js
/* ../node_modules/@babel/runtime/helpers/esm/extends.js */
'use strict';

Object.defineProperty(exports, '__esModule', { value: true });

function _extends() {
  _extends = Object.assign ? Object.assign.bind() : function (target) {
    for (var i = 1; i < arguments.length; i++) {
      var source = arguments[i];
      for (var key in source) {
        if (Object.prototype.hasOwnProperty.call(source, key)) {
          target[key] = source[key];
        }
      }
    }
    return target;
  };
  return _extends.apply(this, arguments);
}

exports.default = _extends;
//# sourceMappingURL=extends.js.map
```

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No,

번들 사이즈가 증가했으나, 헬퍼 함수가 많이 사용되지도 않고, 사이즈도 굉장히 작기 때문에 증가 폭은 작습니다. (673.67KB -> 666.3KB)

## References
<!-- External documents based on workarounds or reviewers should refer to -->

없음
