### PR TITLE
fix(toast): change portal target element in ToastProvider

### DIFF
--- a/.changeset/five-jars-love.md
+++ b/.changeset/five-jars-love.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": major
+---
+
+Change root element of `createPortal` in `<ToastProvider />`.

--- a/.changeset/five-jars-love.md
+++ b/.changeset/five-jars-love.md
@@ -1,5 +1,5 @@
 ---
-"@channel.io/bezier-react": major
+"@channel.io/bezier-react": minor
 ---
 
 Change root element of `createPortal` in `<ToastProvider />`.

--- a/packages/bezier-react/src/components/Toast/ToastProvider.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastProvider.tsx
@@ -19,11 +19,14 @@ import { ToastContextProvider } from './ToastContext'
 import ToastController from './ToastController'
 import ToastElement from './ToastElement'
 import useToastProviderValues from './useToastContextValues'
+import useIsMounted from '~/src/hooks/useIsMounted'
 
 function ToastProvider({
   autoDismissTimeout = 3000,
   children = [],
 }: ToastProviderProps) {
+  const isMounted = useIsMounted()
+
   const toastContextValue = useToastProviderValues()
   const {
     leftToasts,
@@ -77,12 +80,12 @@ function ToastProvider({
   return (
     <ToastContextProvider value={toastContextValue}>
       { children }
-      { createPortal(
+      { isMounted && document.body && createPortal(
         [
           createContainer(ToastPlacement.BottomLeft, leftToasts),
           createContainer(ToastPlacement.BottomRight, rightToasts),
         ],
-        getRootElement(),
+        document.body,
       ) }
     </ToastContextProvider>
   )

--- a/packages/bezier-react/src/components/Toast/ToastProvider.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastProvider.tsx
@@ -7,7 +7,7 @@ import {
   css,
 } from '~/src/foundation'
 
-import { getRootElement } from '~/src/utils/domUtils'
+import useIsMounted from '~/src/hooks/useIsMounted'
 
 import {
   ToastPlacement,
@@ -19,7 +19,6 @@ import { ToastContextProvider } from './ToastContext'
 import ToastController from './ToastController'
 import ToastElement from './ToastElement'
 import useToastProviderValues from './useToastContextValues'
-import useIsMounted from '~/src/hooks/useIsMounted'
 
 function ToastProvider({
   autoDismissTimeout = 3000,

--- a/packages/bezier-react/src/components/Toast/ToastProvider.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastProvider.tsx
@@ -8,6 +8,7 @@ import {
 } from '~/src/foundation'
 
 import useIsMounted from '~/src/hooks/useIsMounted'
+import { getRootElement } from '~/src/utils/domUtils'
 
 import {
   ToastPlacement,
@@ -79,12 +80,12 @@ function ToastProvider({
   return (
     <ToastContextProvider value={toastContextValue}>
       { children }
-      { isMounted && document.body && createPortal(
+      { isMounted && createPortal(
         [
           createContainer(ToastPlacement.BottomLeft, leftToasts),
           createContainer(ToastPlacement.BottomRight, rightToasts),
         ],
-        document.body,
+        getRootElement(),
       ) }
     </ToastContextProvider>
   )

--- a/packages/bezier-react/src/hooks/useIsMounted.ts
+++ b/packages/bezier-react/src/hooks/useIsMounted.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react"
+
+
+export default function useIsMounted() {
+  const [isMounted, setIsMounted] = useState(false)
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  return isMounted
+}

--- a/packages/bezier-react/src/hooks/useIsMounted.ts
+++ b/packages/bezier-react/src/hooks/useIsMounted.ts
@@ -1,5 +1,7 @@
-import { useEffect, useState } from "react"
-
+import {
+  useEffect,
+  useState,
+} from 'react'
 
 export default function useIsMounted() {
   const [isMounted, setIsMounted] = useState(false)


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

Fixes #1481 <!-- Please link to issue if one exists -->

## Summary
<!-- Please add a summary of the modification. -->
`ssr-window`에서 제공하는 fake DOM이 `React.createPortal`과 호환되지 않아 발생한 이슈를 해결하는 PR입니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->
issue 내용 참조

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

