### PR TITLE
Fix wrong typing of `TabAction` prop

### DIFF
--- a/.changeset/cuddly-cows-hammer.md
+++ b/.changeset/cuddly-cows-hammer.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+add type cast to fix incorrect type infer in `TabAction` component

--- a/packages/bezier-react/src/components/Tabs/TabAction.tsx
+++ b/packages/bezier-react/src/components/Tabs/TabAction.tsx
@@ -42,12 +42,12 @@ const getIconSizeBy = (size: TabSize) => {
  * `TabAction` is a button for more action to open a new link or navigate to a different url.
  * If it has `href` props, it should act as a link.
  */
-export const TabAction = forwardRef(function TabAction<Link extends string | undefined>({
+export const TabAction = forwardRef(function TabAction({
   href,
   children,
   onClick,
   ...rest
-}: TabActionProps<Link>, forwardedRef: React.Ref<TabActionElement<Link>>,
+}, forwardedRef,
 ) {
   const { size } = useTabListContext()
 
@@ -88,4 +88,8 @@ export const TabAction = forwardRef(function TabAction<Link extends string | und
       </Styled.ToolbarLink>
     )
   )
-})
+}) as <Link extends string | undefined>(
+  props: TabActionProps<Link> & {
+    ref?: React.ForwardedRef<TabActionElement<Link>>
+  }
+) => JSX.Element


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] ~~[Component] I wrote **a unit test** about the implementation.~~
- [ ] ~~[Component] I wrote **a storybook document** about the implementation.~~
- [ ] ~~[Component] I tested the implementation in **various browsers**.~~
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] ~~[*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.~~

## Related Issue

Fixes #1126

## Summary
<!-- Please add a summary of the modification. -->

- `TabAction`은 `href` 를 받으면 `a` 로, 그렇지 않으면 `button` 으로 동작하지만 event handler 에 대한 타입은 항상 `button` 에 대한 event handler 로 정의되어 있습니다. 이것을 수정합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- typescript 에서는 higher order function에 대해 제네릭 타입의 추론이 가능하지만, `forwardRef`처럼 반환타입이 추가로 속성(`displayName`, `defaultProps`)을 가지게 되면 이것이 제대로 동작하지 않습니다. 참고: https://stackoverflow.com/a/58473012/22224797
- 위에서 제시한 assertion 을 하지 않고 `myRef` 같이 custom 한 ref prop 을 열거나 글로벌하게 `forwardRef` 타입을 변경하는 것은 베지어에 적용할 수 없다고 생각하여, assertion 을 해서 아래처럼 타입이 제대로 잡히게 했습니다. 

- As-is

<img width="535" alt="image" src="https://github.com/channel-io/bezier-react/assets/28595102/bcb9c689-91a6-45e1-9d37-35a6f5561cf3">

[href 있을 때]

<img width="619" alt="image" src="https://github.com/channel-io/bezier-react/assets/28595102/71e895fd-2660-4654-aa25-46876509cb38">

[href 없을 때]

- To-be

<img width="537" alt="image" src="https://github.com/channel-io/bezier-react/assets/28595102/7c358738-9926-4af2-a0a1-214a1863ddf7">

[href 있을 때]

<img width="608" alt="image" src="https://github.com/channel-io/bezier-react/assets/28595102/bf9b2bc0-c2b6-4dee-af55-6b1730c06f25">

[href 없을 때]


## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

- No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

- https://github.com/microsoft/TypeScript/pull/30215 
- https://stackoverflow.com/a/58473012/22224797
