### PR TITLE
feat(theme-vars): extend the ThemeVars scope type

### DIFF
--- a/.changeset/sixty-houses-wink.md
+++ b/.changeset/sixty-houses-wink.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+- extend the ThemeVars scope type

--- a/packages/bezier-react/src/foundation/ThemeVars.ts
+++ b/packages/bezier-react/src/foundation/ThemeVars.ts
@@ -7,7 +7,7 @@ import { createGlobalStyle } from './FoundationStyledComponent'
 type ThemeRecord = Record<string, string>
 
 export interface ThemeVarsAdditionalType {
-  scope?: AnyStyledComponent
+  scope?: AnyStyledComponent | string
 }
 
 function generateCSSVar(theme?: ThemeRecord, prefix?: string) {


### PR DESCRIPTION
fix ThemeVars scope to also accept string type

<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

없음

## Summary
<!-- Please add a summary of the modification. -->
- ThemeVars의 scope가 string type도 받도록 확장
  - ThemeVars에 타입 의존성이 있는 BezierProvider의 prop 중 `themeVarsScope` 타입도 확장됨.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

## References
<!-- External documents based on workarounds or reviewers should refer to -->
[관련 채널톡 논의 스레드](https://desk.channel.io/root/threads/groups/WebFrontDev-82762/6493f76b65d2ad7e083d/6493f76b65d2ad7e083d)