### PR TITLE
Enhance conditional rendering logic for `Tooltip` based on `content` prop

### DIFF
--- a/.changeset/spotty-elephants-give.md
+++ b/.changeset/spotty-elephants-give.md
@@ -2,4 +2,4 @@
 "@channel.io/bezier-react": minor
 ---
 
-`Tooltip`: If `content` property has a nil value, it will no longer render the content.
+`Tooltip`: If `content` property has a nil or empty string value, it will no longer render the content.

--- a/.changeset/spotty-elephants-give.md
+++ b/.changeset/spotty-elephants-give.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+`Tooltip`: If `content` property has a nil value, it will no longer render the content.

--- a/packages/bezier-react/src/components/Forms/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/Slider/__snapshots__/Slider.test.tsx.snap
@@ -147,7 +147,6 @@ exports[`Slider Snapshot should match snapshot 1`] = `
         data-radix-collection-item=""
         data-state="closed"
         role="slider"
-        style=""
         tabindex="0"
       />
     </span>

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.test.tsx
@@ -121,7 +121,8 @@ describe('Tooltip', () => {
     })
 
     it('If the `delayShow` property is greater than 0, the tooltip should be delayed by that number of ms before appearing.', async () => {
-      const { getByRole, queryByRole } = renderTooltip({ delayShow: 1000, content: 'tooltip content' })
+      // NOTE: (@ed) To avoid test failure due to timing issue
+      const { getByRole, queryByRole } = renderTooltip({ delayShow: 1000 - 10, content: 'tooltip content' })
       await user.hover(getByRole('button'))
       expect(queryByRole('tooltip')).not.toBeInTheDocument()
       await waitFor(() => {
@@ -130,7 +131,8 @@ describe('Tooltip', () => {
     })
 
     it('If the `delayHide` property is greater than 0, the tooltip should be delayed by that number of ms before disappearing.', async () => {
-      const { getByRole, queryByRole } = renderTooltip({ delayHide: 1000, content: 'tooltip content' })
+      // NOTE: (@ed) To avoid test failure due to timing issue
+      const { getByRole, queryByRole } = renderTooltip({ delayHide: 1000 - 10, content: 'tooltip content' })
       await user.hover(getByRole('button'))
       await user.unhover(getByRole('button'))
       expect(queryByRole('tooltip')).toBeInTheDocument()

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.test.tsx
@@ -40,42 +40,42 @@ describe('Tooltip', () => {
 
   describe('ARIA', () => {
     it('should be accessible', () => {
-      const { container } = renderTooltip({ defaultShow: true })
+      const { container } = renderTooltip({ defaultShow: true, content: 'tooltip content' })
       expect(isInaccessible(container)).toBe(false)
     })
 
     it('The element that serves as the tooltip container has role `tooltip`.', () => {
-      const { getByRole } = renderTooltip({ defaultShow: true })
+      const { getByRole } = renderTooltip({ defaultShow: true, content: 'tooltip content' })
       expect(getByRole('tooltip')).toBeInTheDocument()
     })
 
     it('The element that triggers the tooltip references the tooltip element with `aria-describedby`.', () => {
-      const { getByRole } = renderTooltip({ defaultShow: true })
+      const { getByRole } = renderTooltip({ defaultShow: true, content: 'tooltip content' })
       expect(getByRole('button')).toHaveAttribute('aria-describedby', getByRole('tooltip').id)
     })
   })
 
   describe('User Interactions', () => {
     it('The tooltip content should be visible when hover over the trigger.', async () => {
-      const { getByRole } = renderTooltip()
+      const { getByRole } = renderTooltip({ content: 'tooltip content' })
       await user.hover(getByRole('button'))
       expect(getByRole('tooltip')).toBeInTheDocument()
     })
 
     it('The tooltip content should be visible when the keyboard focuses on the trigger.', async () => {
-      const { getByRole } = renderTooltip()
+      const { getByRole } = renderTooltip({ content: 'tooltip content' })
       await user.tab()
       expect(getByRole('tooltip')).toBeInTheDocument()
     })
 
     it('When the tooltip content is visible, pressing Esc should hide the tooltip content.', async () => {
-      const { queryByRole } = renderTooltip({ defaultShow: true })
+      const { queryByRole } = renderTooltip({ defaultShow: true, content: 'tooltip content' })
       await user.keyboard('{Escape}')
       expect(queryByRole('tooltip')).not.toBeInTheDocument()
     })
 
     it('When the `allowHover` property is true, the tooltip content should be hoverable.', async () => {
-      const { getByRole } = renderTooltip({ allowHover: true })
+      const { getByRole } = renderTooltip({ allowHover: true, content: 'tooltip content' })
       await user.hover(getByRole('button'))
       await user.hover(getByRole('tooltip'))
       expect(getByRole('tooltip')).toBeInTheDocument()
@@ -83,21 +83,37 @@ describe('Tooltip', () => {
 
     it('When the tooltip is visible, the `onShow` handler should be called.', async () => {
       const onShow = jest.fn()
-      const { getByRole } = renderTooltip({ onShow })
+      const { getByRole } = renderTooltip({ onShow, content: 'tooltip content' })
       await user.hover(getByRole('button'))
       expect(onShow).toHaveBeenCalled()
     })
 
     it('When the tooltip is hidden, the `onHide` handler should be called.', async () => {
       const onHide = jest.fn()
-      const { getByRole } = renderTooltip({ onHide })
+      const { getByRole } = renderTooltip({ onHide, content: 'tooltip content' })
       await user.hover(getByRole('button'))
       await user.unhover(getByRole('button'))
       expect(onHide).toHaveBeenCalled()
     })
 
+    it('If the `content` property is undefined, the tooltip should not be visible when hovering over it or with keyboard focus.', async () => {
+      const { getByRole, queryByRole } = renderTooltip({ content: undefined })
+      await user.hover(getByRole('button'))
+      expect(queryByRole('tooltip')).not.toBeInTheDocument()
+      await user.tab()
+      expect(queryByRole('tooltip')).not.toBeInTheDocument()
+    })
+
+    it('If the `content` property is null, the tooltip should not be visible when hovering over it or with keyboard focus.', async () => {
+      const { getByRole, queryByRole } = renderTooltip({ content: null })
+      await user.hover(getByRole('button'))
+      expect(queryByRole('tooltip')).not.toBeInTheDocument()
+      await user.tab()
+      expect(queryByRole('tooltip')).not.toBeInTheDocument()
+    })
+
     it('If the `disabled` property is true, the tooltip should not be visible when hovering over it or with keyboard focus.', async () => {
-      const { getByRole, queryByRole } = renderTooltip({ disabled: true })
+      const { getByRole, queryByRole } = renderTooltip({ disabled: true, content: 'tooltip content' })
       await user.hover(getByRole('button'))
       expect(queryByRole('tooltip')).not.toBeInTheDocument()
       await user.tab()
@@ -105,7 +121,7 @@ describe('Tooltip', () => {
     })
 
     it('If the `delayShow` property is greater than 0, the tooltip should be delayed by that number of ms before appearing.', async () => {
-      const { getByRole, queryByRole } = renderTooltip({ delayShow: 1000 })
+      const { getByRole, queryByRole } = renderTooltip({ delayShow: 1000, content: 'tooltip content' })
       await user.hover(getByRole('button'))
       expect(queryByRole('tooltip')).not.toBeInTheDocument()
       await waitFor(() => {
@@ -114,7 +130,7 @@ describe('Tooltip', () => {
     })
 
     it('If the `delayHide` property is greater than 0, the tooltip should be delayed by that number of ms before disappearing.', async () => {
-      const { getByRole, queryByRole } = renderTooltip({ delayHide: 1000 })
+      const { getByRole, queryByRole } = renderTooltip({ delayHide: 1000, content: 'tooltip content' })
       await user.hover(getByRole('button'))
       await user.unhover(getByRole('button'))
       expect(queryByRole('tooltip')).toBeInTheDocument()
@@ -134,7 +150,7 @@ describe('TooltipProvider', () => {
       delayShow={0}
       {...rest}
     >
-      <Tooltip>
+      <Tooltip content="tooltip content">
         <button type="button">
           Trigger
         </button>

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.test.tsx
@@ -112,6 +112,14 @@ describe('Tooltip', () => {
       expect(queryByRole('tooltip')).not.toBeInTheDocument()
     })
 
+    it('If the `content` property is empty string, the tooltip should not be visible when hovering over it or with keyboard focus.', async () => {
+      const { getByRole, queryByRole } = renderTooltip({ content: '' })
+      await user.hover(getByRole('button'))
+      expect(queryByRole('tooltip')).not.toBeInTheDocument()
+      await user.tab()
+      expect(queryByRole('tooltip')).not.toBeInTheDocument()
+    })
+
     it('If the `disabled` property is true, the tooltip should not be visible when hovering over it or with keyboard focus.', async () => {
       const { getByRole, queryByRole } = renderTooltip({ disabled: true, content: 'tooltip content' })
       await user.hover(getByRole('button'))

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -13,7 +13,7 @@ import { getRootElement } from '~/src/utils/domUtils'
 import { createContext } from '~/src/utils/reactUtils'
 import {
   isBoolean,
-  isNil,
+  isEmpty,
 } from '~/src/utils/typeUtils'
 
 import {
@@ -280,7 +280,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip
   content,
   ...rest
 }, forwardedRef) {
-  if (disabled || isNil(content)) {
+  if (disabled || isEmpty(content)) {
     return children ?? null
   }
 

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -11,9 +11,13 @@ import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 
 import { getRootElement } from '~/src/utils/domUtils'
 import { createContext } from '~/src/utils/reactUtils'
-import { isBoolean } from '~/src/utils/typeUtils'
+import {
+  isBoolean,
+  isNil,
+} from '~/src/utils/typeUtils'
 
 import {
+  type TooltipImplProps,
   TooltipPosition,
   type TooltipProps,
   type TooltipProviderProps,
@@ -137,30 +141,12 @@ export function TooltipProvider({
   )
 }
 
-/**
- * `Tooltip` is a component that shows additional information when the mouse hovers or the keyboard is focused.
- *
- * @example
- *
- * ```tsx
- * // Anatomy of the Tooltip
- * <TooltipProvider>
- *   <Tooltip />
- * </TooltipProvider>
- *
- * // Example of a Tooltip with a button
- * <Tooltip content="Ta-da!">
- *   <button>Hover me</button>
- * </Tooltip>
- * ```
- */
-export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip({
+const TooltipImpl = forwardRef<HTMLDivElement, TooltipImplProps>(function TooltipImpl({
   as,
   children,
   defaultShow,
   onShow: onShowProp,
   onHide: onHideProp,
-  disabled,
   content,
   description,
   icon,
@@ -201,8 +187,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip
   }, [onHideProp])
 
   const onOpenChange = useCallback((open: boolean) => {
-    if (disabled) { return }
-
     if (open) {
       onShow()
       return
@@ -222,7 +206,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip
 
     onHide()
   }, [
-    disabled,
     delayHide,
     onShow,
     onHide,
@@ -271,5 +254,43 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip
         </TooltipPrimitive.Content>
       </TooltipPrimitive.Portal>
     </TooltipPrimitive.Root>
+  )
+})
+
+/**
+ * `Tooltip` is a component that shows additional information when the mouse hovers or the keyboard is focused.
+ *
+ * @example
+ *
+ * ```tsx
+ * // Anatomy of the Tooltip
+ * <TooltipProvider>
+ *   <Tooltip />
+ * </TooltipProvider>
+ *
+ * // Example of a Tooltip with a button
+ * <Tooltip content="Ta-da!">
+ *   <button>Hover me</button>
+ * </Tooltip>
+ * ```
+ */
+export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip({
+  children,
+  disabled,
+  content,
+  ...rest
+}, forwardedRef) {
+  if (disabled || isNil(content)) {
+    return children ?? null
+  }
+
+  return (
+    <TooltipImpl
+      ref={forwardedRef}
+      content={content}
+      {...rest}
+    >
+      { children }
+    </TooltipImpl>
   )
 })

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
@@ -125,10 +125,13 @@ export interface TooltipProviderProps extends
   ChildrenProps,
   TooltipProviderOptions {}
 
-export interface TooltipProps extends
+export interface TooltipImplProps extends
   BezierComponentProps,
   ChildrenProps<React.ReactElement>,
   ContentProps,
-  DisableProps,
   Omit<React.HTMLAttributes<HTMLDivElement>, keyof ContentProps | keyof ChildrenProps>,
   TooltipOptions {}
+
+export interface TooltipProps extends
+  DisableProps,
+  TooltipImplProps {}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [x] [Component] I wrote **a unit test** about the implementation.
- [ ] [Component] I wrote **a storybook document** about the implementation.
- [ ] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] [*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.

## Related Issue

- https://github.com/channel-io/ch-desk-web/issues/13798 (Private)

## Summary
<!-- Please add a summary of the modification. -->

`content` 속성이 nil 값일때, 툴팁을 렌더하지 않도록 조건부 렌더링 로직을 추가합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- 이전 `LegacyTootlip` 의 로직을 되돌립니다.
- `disabled` 속성의 경우에도 조건부 렌더링을 적용하여 불필요한 코드 실행을 방지하도록 개선합니다.

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- External documents based on workarounds or reviewers should refer to -->

없음
