### PR TITLE
Remove `react-resize-detector` used in `SegmentedControl`

### DIFF
--- a/.changeset/angry-emus-repeat.md
+++ b/.changeset/angry-emus-repeat.md
@@ -1,0 +1,6 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fixed a rendering bug that occurs when using `react-resize-detector` and `asChild`prop of `radix-ui` simultaneously.
+- Removed indicator adjusting logic by `react-resize-detector` using css transform property

--- a/packages/bezier-react/src/components/Divider/Divider.styled.ts
+++ b/packages/bezier-react/src/components/Divider/Divider.styled.ts
@@ -5,7 +5,7 @@ import {
 
 import type DividerProps from './Divider.types'
 
-const DIVIDER_THICKNESS = 1
+export const DIVIDER_THICKNESS = 1
 const DIVIDER_INDENT_SIZE = 6
 
 interface StyledDividerProps extends DividerProps {

--- a/packages/bezier-react/src/components/Divider/index.ts
+++ b/packages/bezier-react/src/components/Divider/index.ts
@@ -1,2 +1,3 @@
 export { default as Divider } from './Divider'
 export type { default as DividerProps } from './Divider.types'
+export { DIVIDER_THICKNESS } from './Divider.styled'

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -40,7 +40,6 @@ export const Indicator = styled.div`
   position: absolute;
   top: 0;
   left: 0;
-  z-index: ${ZIndex.Float};
 
   width: var(--bezier-react-segmented-control-indicator-width);
   height: var(--bezier-react-segmented-control-indicator-height);

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -38,7 +38,7 @@ export const Indicator = styled.div`
   --bezier-react-segmented-control-indicator-height: auto;
 
   position: absolute;
-  top: 0;
+  top: --bezier-react-segmented-control-indicator-top;
   left: 0;
 
   width: var(--bezier-react-segmented-control-indicator-width);
@@ -48,7 +48,7 @@ export const Indicator = styled.div`
   /* NOTE: (@ed) Overrides the elevation mixin. Do not change the order! */
   background-color: var(--bg-white-high);
 
-  transform: var(--bezier-react-segmented-control-indicator-transform);
+  transform: translateX(var(--bezier-react-segmented-control-indicator-translateX));
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS('transform', indicatorTransitionMeta.duration)}
 `
 
@@ -116,13 +116,6 @@ export const Item = styled.button`
 
   &:not([data-checked]):not(&:disabled):hover {
     background-color: var(--bg-black-light);
-  }
-
-  &[data-checked] ~ ${Indicator} {
-    transform: translateX(var(--bezier-react-segmented-control-indicator-translateX));
-    width: var(--bezier-react-segmented-control-indicator-width);
-    height: var(--bezier-react-segmented-control-indicator-height);
-    top: var(--bezier-react-segmented-control-indicator-top);
   }
 `
 

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -33,7 +33,8 @@ const indicatorTransitionMeta = {
 }
 
 export const Indicator = styled.div`
-  --bezier-react-segmented-control-indicator-transform: none;
+  --bezier-react-segmented-control-indicator-translateX: none;
+  --bezier-react-segmented-control-indicator-left: auto;
   --bezier-react-segmented-control-indicator-width: auto;
   --bezier-react-segmented-control-indicator-height: auto;
 

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -38,9 +38,8 @@ export const Indicator = styled.div`
   --bezier-react-segmented-control-indicator-height: auto;
 
   position: absolute;
-  top: --bezier-react-segmented-control-indicator-top;
-  left: 0;
-
+  top: 50%;
+  left: var(--bezier-react-segmented-control-indicator-left);
   width: var(--bezier-react-segmented-control-indicator-width);
   height: var(--bezier-react-segmented-control-indicator-height);
 
@@ -48,7 +47,7 @@ export const Indicator = styled.div`
   /* NOTE: (@ed) Overrides the elevation mixin. Do not change the order! */
   background-color: var(--bg-white-high);
 
-  transform: translateX(var(--bezier-react-segmented-control-indicator-translateX));
+  transform: translateX(var(--bezier-react-segmented-control-indicator-translateX)) translateY(-50%);
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS('transform', indicatorTransitionMeta.duration)}
 `
 

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -1,6 +1,6 @@
 /* stylelint-disable declaration-block-semicolon-newline-after, rule-empty-line-before */
 import {
-  Transition,
+  TransitionDuration,
   Typography,
   styled,
 } from '~/src/foundation'
@@ -28,10 +28,6 @@ export const paddingBySegmentedControlSize = {
   [SegmentedControlSize.L]: 4,
 }
 
-const indicatorTransitionMeta = {
-  duration: Transition.TransitionDuration.M,
-}
-
 export const Indicator = styled.div`
   --bezier-react-segmented-control-indicator-translateX: none;
   --bezier-react-segmented-control-indicator-left: auto;
@@ -49,7 +45,7 @@ export const Indicator = styled.div`
   background-color: var(--bg-white-high);
 
   transform: translateX(var(--bezier-react-segmented-control-indicator-translateX)) translateY(-50%);
-  ${({ foundation }) => foundation?.transition?.getTransitionsCSS('transform', indicatorTransitionMeta.duration)}
+  ${({ foundation }) => foundation?.transition?.getTransitionsCSS('transform', TransitionDuration.M)}
 `
 
 export const ItemContainer = styled(AlphaStack).attrs({

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -28,6 +28,31 @@ export const paddingBySegmentedControlSize = {
   [SegmentedControlSize.L]: 4,
 }
 
+export const indicatorTransitionMeta = {
+  duration: Transition.TransitionDuration.M,
+}
+
+export const Indicator = styled.div`
+  --bezier-react-segmented-control-indicator-transform: none;
+  --bezier-react-segmented-control-indicator-width: auto;
+  --bezier-react-segmented-control-indicator-height: auto;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: ${ZIndex.Float};
+
+  width: var(--bezier-react-segmented-control-indicator-width);
+  height: var(--bezier-react-segmented-control-indicator-height);
+
+  ${({ foundation }) => foundation?.elevation.ev1()}
+  /* NOTE: (@ed) Overrides the elevation mixin. Do not change the order! */
+  background-color: var(--bg-white-high);
+
+  transform: var(--bezier-react-segmented-control-indicator-transform);
+  ${({ foundation }) => foundation?.transition?.getTransitionsCSS('transform', indicatorTransitionMeta.duration)}
+`
+
 export const ItemContainer = styled(AlphaStack).attrs({
   direction: 'horizontal',
   align: 'center',
@@ -100,31 +125,6 @@ export const Item = styled.button`
     height: var(--bezier-react-segmented-control-indicator-height);
     top: var(--bezier-react-segmented-control-indicator-top);
   }
-`
-
-export const indicatorTransitionMeta = {
-  duration: Transition.TransitionDuration.M,
-}
-
-export const Indicator = styled.div`
-  --bezier-react-segmented-control-indicator-transform: none;
-  --bezier-react-segmented-control-indicator-width: auto;
-  --bezier-react-segmented-control-indicator-height: auto;
-
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: ${ZIndex.Float};
-
-  width: var(--bezier-react-segmented-control-indicator-width);
-  height: var(--bezier-react-segmented-control-indicator-height);
-
-  ${({ foundation }) => foundation?.elevation.ev1()}
-  /* NOTE: (@ed) Overrides the elevation mixin. Do not change the order! */
-  background-color: var(--bg-white-high);
-
-  transform: var(--bezier-react-segmented-control-indicator-transform);
-  ${({ foundation }) => foundation?.transition?.getTransitionsCSS('transform', indicatorTransitionMeta.duration)}
 `
 
 export const Container = styled(AlphaStack).attrs({ direction: 'horizontal' })`

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -28,7 +28,7 @@ export const paddingBySegmentedControlSize = {
   [SegmentedControlSize.L]: 4,
 }
 
-export const indicatorTransitionMeta = {
+const indicatorTransitionMeta = {
   duration: Transition.TransitionDuration.M,
 }
 

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -14,6 +14,20 @@ import { Text } from '~/src/components/Text'
 
 import { SegmentedControlSize } from './SegmentedControl.types'
 
+export const heightBySegmentedControlSize = {
+  [SegmentedControlSize.XS]: 24,
+  [SegmentedControlSize.S]: 28,
+  [SegmentedControlSize.M]: 36,
+  [SegmentedControlSize.L]: 44,
+}
+
+export const paddingBySegmentedControlSize = {
+  [SegmentedControlSize.XS]: 1,
+  [SegmentedControlSize.S]: 2,
+  [SegmentedControlSize.M]: 2,
+  [SegmentedControlSize.L]: 4,
+}
+
 export const ItemContainer = styled(AlphaStack).attrs({
   direction: 'horizontal',
   align: 'center',
@@ -79,6 +93,13 @@ export const Item = styled.button`
   &:not([data-checked]):not(&:disabled):hover {
     background-color: var(--bg-black-light);
   }
+
+  &[data-checked] ~ ${Indicator} {
+    transform: translateX(var(--bezier-react-segmented-control-indicator-translateX));
+    width: var(--bezier-react-segmented-control-indicator-width);
+    height: var(--bezier-react-segmented-control-indicator-height);
+    top: var(--bezier-react-segmented-control-indicator-top);
+  }
 `
 
 export const indicatorTransitionMeta = {
@@ -116,8 +137,8 @@ export const Container = styled(AlphaStack).attrs({ direction: 'horizontal' })`
   background-color: var(--bg-black-lighter);
 
   &.${SegmentedControlSize.XS} {
-    height: 24px;
-    padding: 1px;
+    height: ${heightBySegmentedControlSize[SegmentedControlSize.XS]}px;
+    padding: ${paddingBySegmentedControlSize[SegmentedControlSize.XS]}px;
     border-radius: 6px;
     ${Typography.Size13}
 
@@ -132,8 +153,8 @@ export const Container = styled(AlphaStack).attrs({ direction: 'horizontal' })`
   }
 
   &.${SegmentedControlSize.S} {
-    height: 28px;
-    padding: 2px;
+    height: ${heightBySegmentedControlSize[SegmentedControlSize.S]}px;
+    padding: ${paddingBySegmentedControlSize[SegmentedControlSize.S]}px;
     border-radius: 8px;
     ${Typography.Size14}
 
@@ -148,8 +169,8 @@ export const Container = styled(AlphaStack).attrs({ direction: 'horizontal' })`
   }
 
   &.${SegmentedControlSize.M} {
-    height: 36px;
-    padding: 2px;
+    height: ${heightBySegmentedControlSize[SegmentedControlSize.M]}px;
+    padding: ${paddingBySegmentedControlSize[SegmentedControlSize.M]}px;
     border-radius: 8px;
     ${Typography.Size14}
 
@@ -164,8 +185,8 @@ export const Container = styled(AlphaStack).attrs({ direction: 'horizontal' })`
   }
 
   &.${SegmentedControlSize.L} {
-    height: 44px;
-    padding: 4px;
+    height: ${heightBySegmentedControlSize[SegmentedControlSize.L]}px;
+    padding: ${paddingBySegmentedControlSize[SegmentedControlSize.L]}px;
     border-radius: 12px;
     ${Typography.Size14}
 

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.test.tsx
@@ -305,18 +305,7 @@ describe('SegmentedControl >', () => {
   })
 
   describe('Indicator', () => {
-    const targetDOMRect = { top: 10, left: 10, width: 100, height: 100 } as DOMRect
-    const containerDOMRect = { top: 5, left: 5 } as DOMRect
-
-    beforeEach(() => {
-      jest.spyOn(Element.prototype, 'getBoundingClientRect')
-        // NOTE: (@ed): Order matters. 1. target DOMRect
-        .mockImplementationOnce(jest.fn(() => targetDOMRect))
-        // NOTE: (@ed): Order matters. 2. container DOMRect
-        .mockImplementationOnce(jest.fn(() => containerDOMRect))
-    })
-
-    it('The size of the indicator should be the same as that of the selected item', () => {
+    it('has appropriate css variable in style', () => {
       const { getByTestId } = renderComponent({
         type: 'radiogroup',
         value: MOCK_UI_DATA[0].value,
@@ -324,22 +313,9 @@ describe('SegmentedControl >', () => {
 
       const indicator = getByTestId(SEGMENTED_CONTROL_INDICATOR_TEST_ID)
 
-      expect(indicator).toHaveStyle(`--bezier-react-segmented-control-indicator-width: ${targetDOMRect.width}px`)
-      expect(indicator).toHaveStyle(`--bezier-react-segmented-control-indicator-height: ${targetDOMRect.height}px`)
       expect(indicator).toHaveStyle('width: var(--bezier-react-segmented-control-indicator-width)')
       expect(indicator).toHaveStyle('height: var(--bezier-react-segmented-control-indicator-height)')
-    })
-
-    it('The position of the indicator should be the same as that of the selected item', () => {
-      const { getByTestId } = renderComponent({
-        type: 'radiogroup',
-        value: MOCK_UI_DATA[0].value,
-      })
-
-      const indicator = getByTestId(SEGMENTED_CONTROL_INDICATOR_TEST_ID)
-
-      expect(indicator).toHaveStyle(`--bezier-react-segmented-control-indicator-transform: translate(${targetDOMRect.left - containerDOMRect.left}px, ${targetDOMRect.top - containerDOMRect.top}px)`)
-      expect(indicator).toHaveStyle('transform: var(--bezier-react-segmented-control-indicator-transform)')
+      expect(indicator).toHaveStyle('transform: translateX(var(--bezier-react-segmented-control-indicator-translateX)) translateY(-50%)')
     })
   })
 

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -26,6 +26,7 @@ import {
 import {
   SegmentedControlContextProvider,
   SegmentedControlItemListContextProvider,
+  type SegmentedControlItemListContextValue,
   useSegmentedControlContext,
 } from './SegmentedControlContext'
 import { useSegmentedControlIndicator } from './SegmentedControlIndicator'
@@ -42,6 +43,7 @@ function SegmentedControlItemListImpl<
   ...rest
 }: SegmentedControlItemListProps<Type, Value>, forwardedRef: React.Ref<HTMLDivElement>) {
   const [selectedElement, setSelectedElement] = useState<HTMLButtonElement | null>(null)
+  const [index, setIndex] = useState<number | null>(null)
 
   const {
     type,
@@ -57,9 +59,15 @@ function SegmentedControlItemListImpl<
     refs: [forwardedRef],
   })
 
-  const contextValue = useMemo(() => ({
+  const contextValue: SegmentedControlItemListContextValue = useMemo(() => ({
     setSelectedElement,
-  }), [])
+    index,
+    length: React.Children.count(children),
+    setIndex,
+  }), [
+    children,
+    index,
+  ])
 
   const style = useMemo(() => ({
     ...styleProp,
@@ -88,11 +96,10 @@ function SegmentedControlItemListImpl<
     >
       <Styled.Container>
         <SegmentedControlItemListContextProvider value={contextValue}>
-          { renderIndicator() }
-
+          { /* index props 을 노출안하게 */ }
           { React.Children.map(children, (child, index) => {
             if (index === 0) {
-              return child
+              return React.cloneElement(child, { index })
             }
 
             return (
@@ -101,10 +108,12 @@ function SegmentedControlItemListImpl<
                   withoutParallelIndent
                   orientation="vertical"
                 />
-                { child }
+                { React.cloneElement(child, { index }) }
               </>
             )
           }) }
+
+          { renderIndicator() }
         </SegmentedControlItemListContextProvider>
       </Styled.Container>
     </SegmentedControlItemList>

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -25,6 +25,7 @@ import {
 } from './SegmentedControl.types'
 import {
   SegmentedControlContextProvider,
+  SegmentedControlItemContextProvider,
   SegmentedControlItemListContextProvider,
   type SegmentedControlItemListContextValue,
   useSegmentedControlContext,
@@ -85,23 +86,19 @@ function SegmentedControlItemListImpl<
     >
       <Styled.Container>
         <SegmentedControlItemListContextProvider value={contextValue}>
-          { /* index props 을 노출안하게 */ }
-          { React.Children.map(children, (child, index) => {
-            if (index === 0) {
-              return React.cloneElement(child, { index })
-            }
-
-            return (
-              <>
+          { React.Children.map(children, (child, _index) => (
+            <>
+              { _index !== 0 && (
                 <Divider
                   withoutParallelIndent
                   orientation="vertical"
                 />
-                { React.cloneElement(child, { index }) }
-              </>
-            )
-          }) }
-
+              ) }
+              <SegmentedControlItemContextProvider value={_index}>
+                { child }
+              </SegmentedControlItemContextProvider>
+            </>
+          )) }
           <SegmentedControlIndicator />
         </SegmentedControlItemListContextProvider>
       </Styled.Container>

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -29,7 +29,7 @@ import {
   type SegmentedControlItemListContextValue,
   useSegmentedControlContext,
 } from './SegmentedControlContext'
-import { useSegmentedControlIndicator } from './SegmentedControlIndicator'
+import { SegmentedControlIndicator } from './SegmentedControlIndicator'
 
 import * as Styled from './SegmentedControl.styled'
 
@@ -41,8 +41,7 @@ function SegmentedControlItemListImpl<
   style: styleProp,
   className: classNameProp,
   ...rest
-}: SegmentedControlItemListProps<Type, Value>, forwardedRef: React.Ref<HTMLDivElement>) {
-  const [selectedElement, setSelectedElement] = useState<HTMLButtonElement | null>(null)
+}: SegmentedControlItemListProps<Type, Value>) {
   const [index, setIndex] = useState<number | null>(null)
 
   const {
@@ -51,16 +50,7 @@ function SegmentedControlItemListImpl<
     width,
   } = useSegmentedControlContext('SegmentedControlItemList')
 
-  const {
-    containerRef: ref,
-    render: renderIndicator,
-  } = useSegmentedControlIndicator({
-    target: selectedElement,
-    refs: [forwardedRef],
-  })
-
   const contextValue: SegmentedControlItemListContextValue = useMemo(() => ({
-    setSelectedElement,
     index,
     length: React.Children.count(children),
     setIndex,
@@ -89,7 +79,6 @@ function SegmentedControlItemListImpl<
   return (
     <SegmentedControlItemList
       asChild
-      ref={ref}
       style={style}
       className={className}
       {...rest}
@@ -113,7 +102,7 @@ function SegmentedControlItemListImpl<
             )
           }) }
 
-          { renderIndicator() }
+          <SegmentedControlIndicator />
         </SegmentedControlItemListContextProvider>
       </Styled.Container>
     </SegmentedControlItemList>

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -43,7 +43,7 @@ function SegmentedControlItemListImpl<
   className: classNameProp,
   ...rest
 }: SegmentedControlItemListProps<Type, Value>) {
-  const [index, setIndex] = useState<number | null>(null)
+  const [selectedItemIndex, setSelectedItemIndex] = useState<number | null>(null)
 
   const {
     type,
@@ -52,12 +52,12 @@ function SegmentedControlItemListImpl<
   } = useSegmentedControlContext('SegmentedControlItemList')
 
   const contextValue: SegmentedControlItemListContextValue = useMemo(() => ({
-    index,
-    length: React.Children.count(children),
-    setIndex,
+    selectedItemIndex,
+    itemCount: React.Children.count(children),
+    setSelectedItemIndex,
   }), [
     children,
-    index,
+    selectedItemIndex,
   ])
 
   const style = useMemo(() => ({
@@ -86,15 +86,15 @@ function SegmentedControlItemListImpl<
     >
       <Styled.Container>
         <SegmentedControlItemListContextProvider value={contextValue}>
-          { React.Children.map(children, (child, _index) => (
+          { React.Children.map(children, (child, index) => (
             <>
-              { _index !== 0 && (
+              { index !== 0 && (
                 <Divider
                   withoutParallelIndent
                   orientation="vertical"
                 />
               ) }
-              <SegmentedControlItemContextProvider value={_index}>
+              <SegmentedControlItemContextProvider value={index}>
                 { child }
               </SegmentedControlItemContextProvider>
             </>

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlContext.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlContext.ts
@@ -12,8 +12,11 @@ export const [
   useSegmentedControlContext,
 ] = createContext<SegmentedControlContextValue | null>(null, 'SegmentedControl')
 
-interface SegmentedControlItemListContextValue {
+export type SegmentedControlItemListContextValue = {
   setSelectedElement: (node: HTMLButtonElement | null) => void
+  length: number
+  index: number | null
+  setIndex: (index: number | null) => void
 }
 
 export const [

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlContext.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlContext.ts
@@ -18,6 +18,13 @@ export type SegmentedControlItemListContextValue = {
   setIndex: (index: number | null) => void
 }
 
+export type SegmentedControlItemContextValue = number
+
+export const [
+  SegmentedControlItemContextProvider,
+  useSegmentedControlItemContext,
+] = createContext<SegmentedControlItemContextValue | null>(null, 'SegmentedControlItem')
+
 export const [
   SegmentedControlItemListContextProvider,
   useSegmentedControlItemListContext,

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlContext.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlContext.ts
@@ -18,12 +18,10 @@ export type SegmentedControlItemListContextValue = {
   setIndex: (index: number | null) => void
 }
 
-export type SegmentedControlItemContextValue = number
-
 export const [
   SegmentedControlItemContextProvider,
   useSegmentedControlItemContext,
-] = createContext<SegmentedControlItemContextValue | null>(null, 'SegmentedControlItem')
+] = createContext<number | null>(null, 'SegmentedControlItem')
 
 export const [
   SegmentedControlItemListContextProvider,

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlContext.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlContext.ts
@@ -13,7 +13,6 @@ export const [
 ] = createContext<SegmentedControlContextValue | null>(null, 'SegmentedControl')
 
 export type SegmentedControlItemListContextValue = {
-  setSelectedElement: (node: HTMLButtonElement | null) => void
   length: number
   index: number | null
   setIndex: (index: number | null) => void

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlContext.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlContext.ts
@@ -13,9 +13,9 @@ export const [
 ] = createContext<SegmentedControlContextValue | null>(null, 'SegmentedControl')
 
 export type SegmentedControlItemListContextValue = {
-  length: number
-  index: number | null
-  setIndex: (index: number | null) => void
+  itemCount: number
+  selectedItemIndex: number | null
+  setSelectedItemIndex: (index: number | null) => void
 }
 
 export const [

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
@@ -9,6 +9,8 @@ import * as Styled from './SegmentedControl.styled'
 
 export const SEGMENTED_CONTROL_INDICATOR_TEST_ID = 'bezier-react-segmented-control-indicator'
 
+const DIVIDER_THICKNESS = 1
+
 export function SegmentedControlIndicator() {
   const { index, length } = useSegmentedControlItemListContext('SegmentedControlIndicator')
   const { size } = useSegmentedControlContext('SegmentedControlIndicator')
@@ -18,11 +20,11 @@ export function SegmentedControlIndicator() {
   const containerPadding = Styled.paddingBySegmentedControlSize[size]
   const containerHeight = Styled.heightBySegmentedControlSize[size]
 
-  const dividerTotalWidth = `${length - 1}px`
+  const dividerTotalWidth = `${(length - 1) * DIVIDER_THICKNESS}px`
   const containerHorizontalPadding = `${2 * containerPadding}px`
 
   const style = {
-    '--bezier-react-segmented-control-indicator-translateX': `calc(${index * 100}% + ${index}px)`,
+    '--bezier-react-segmented-control-indicator-translateX': `calc(${index * 100}% + ${index * DIVIDER_THICKNESS}px)`,
     '--bezier-react-segmented-control-indicator-width': `calc((100% - ${dividerTotalWidth} - ${containerHorizontalPadding}) / ${length})`,
     '--bezier-react-segmented-control-indicator-height': `${containerHeight - (2 * containerPadding)}px`,
     '--bezier-react-segmented-control-indicator-left': `${containerPadding}px`,

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
@@ -13,11 +13,19 @@ export function SegmentedControlIndicator() {
   const { index, length } = useSegmentedControlItemListContext('SegmentedControlIndicator')
   const { size } = useSegmentedControlContext('SegmentedControlIndicator')
 
+  if (index === null) { return null }
+
+  const containerPadding = Styled.paddingBySegmentedControlSize[size]
+  const containerHeight = Styled.heightBySegmentedControlSize[size]
+
+  const dividerTotalWidth = `${length - 1}px`
+  const containerHorizontalPadding = `${2 * containerPadding}px`
+
   const style = {
-    '--bezier-react-segmented-control-indicator-translateX': `${index * 100}%`,
-    '--bezier-react-segmented-control-indicator-width': `${index !== null ? `calc((100% - ${length - 1}px) / ${length})` : 0} `,
-    '--bezier-react-segmented-control-indicator-height': `${Styled.heightBySegmentedControlSize[size] - (Styled.paddingBySegmentedControlSize[size] * 2)}px`,
-    '--bezier-react-segmented-control-indicator-top': `${Styled.paddingBySegmentedControlSize[size]}px`,
+    '--bezier-react-segmented-control-indicator-translateX': `calc(${index * 100}% + ${index}px)`,
+    '--bezier-react-segmented-control-indicator-width': `calc((100% - ${dividerTotalWidth} - ${containerHorizontalPadding}) / ${length})`,
+    '--bezier-react-segmented-control-indicator-height': `${containerHeight - (2 * containerPadding)}px`,
+    '--bezier-react-segmented-control-indicator-left': `${containerPadding}px`,
   } as React.CSSProperties
 
   return (

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { DIVIDER_THICKNESS } from '~/src/components/Divider'
+
 import {
   useSegmentedControlContext,
   useSegmentedControlItemListContext,
@@ -8,8 +10,6 @@ import {
 import * as Styled from './SegmentedControl.styled'
 
 export const SEGMENTED_CONTROL_INDICATOR_TEST_ID = 'bezier-react-segmented-control-indicator'
-
-const DIVIDER_THICKNESS = 1
 
 export function SegmentedControlIndicator() {
   const { selectedItemIndex, itemCount } = useSegmentedControlItemListContext('SegmentedControlIndicator')

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
@@ -12,20 +12,20 @@ export const SEGMENTED_CONTROL_INDICATOR_TEST_ID = 'bezier-react-segmented-contr
 const DIVIDER_THICKNESS = 1
 
 export function SegmentedControlIndicator() {
-  const { index, length } = useSegmentedControlItemListContext('SegmentedControlIndicator')
+  const { selectedItemIndex, itemCount } = useSegmentedControlItemListContext('SegmentedControlIndicator')
   const { size } = useSegmentedControlContext('SegmentedControlIndicator')
 
-  if (index === null) { return null }
+  if (selectedItemIndex === null) { return null }
 
   const containerPadding = Styled.paddingBySegmentedControlSize[size]
   const containerHeight = Styled.heightBySegmentedControlSize[size]
 
-  const dividerTotalWidth = `${(length - 1) * DIVIDER_THICKNESS}px`
+  const dividerTotalWidth = `${(itemCount - 1) * DIVIDER_THICKNESS}px`
   const containerHorizontalPadding = `${2 * containerPadding}px`
 
   const style = {
-    '--bezier-react-segmented-control-indicator-translateX': `calc(${index * 100}% + ${index * DIVIDER_THICKNESS}px)`,
-    '--bezier-react-segmented-control-indicator-width': `calc((100% - ${dividerTotalWidth} - ${containerHorizontalPadding}) / ${length})`,
+    '--bezier-react-segmented-control-indicator-translateX': `calc(${selectedItemIndex * 100}% + ${selectedItemIndex * DIVIDER_THICKNESS}px)`,
+    '--bezier-react-segmented-control-indicator-width': `calc((100% - ${dividerTotalWidth} - ${containerHorizontalPadding}) / ${itemCount})`,
     '--bezier-react-segmented-control-indicator-height': `${containerHeight - (2 * containerPadding)}px`,
     '--bezier-react-segmented-control-indicator-left': `${containerPadding}px`,
   } as React.CSSProperties

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
@@ -8,6 +8,11 @@ import { useResizeDetector } from 'react-resize-detector'
 
 import useMergeRefs from '~/src/hooks/useMergeRefs'
 
+import {
+  useSegmentedControlContext,
+  useSegmentedControlItemListContext,
+} from './SegmentedControlContext'
+
 import * as Styled from './SegmentedControl.styled'
 
 export const SEGMENTED_CONTROL_INDICATOR_TEST_ID = 'bezier-react-segmented-control-indicator'
@@ -23,65 +28,75 @@ const SegmentedControlIndicator = function SegmentedControlIndicator({
 }) {
   const [indicatorNode, setIndicatorNode] = useState<HTMLDivElement | null>(null)
   const [indicatorStyle, setIndicatorStyle] = useState<React.CSSProperties>({})
+  const { index, length } = useSegmentedControlItemListContext('SegmentedControlIndicator')
+  const { size } = useSegmentedControlContext('SegmentedControlIndicator')
+  
+  const style = {
+    '--bezier-react-segmented-control-indicator-translateX': `${index * 100}%`,
+    '--bezier-react-segmented-control-indicator-width': `calc((100% - ${length - 1}px) / ${length})`,
+    '--bezier-react-segmented-control-indicator-height': `${Styled.heightBySegmentedControlSize[size] - (Styled.paddingBySegmentedControlSize[size] * 2)}px`,
+    '--bezier-react-segmented-control-indicator-top': `${Styled.paddingBySegmentedControlSize[size]}px`,
+  }
 
-  useLayoutEffect(function pauseTransitionOnMount() {
-    let timer: NodeJS.Timeout | undefined
+  // useLayoutEffect(function pauseTransitionOnMount() {
+  //   let timer: NodeJS.Timeout | undefined
 
-    if (indicatorNode) {
-      setIndicatorStyle(prev => ({
-        ...prev,
-        transition: 'none',
-      }))
+  //   if (indicatorNode) {
+  //     setIndicatorStyle(prev => ({
+  //       ...prev,
+  //       transition: 'none',
+  //     }))
 
-      timer = setTimeout(() => {
-        setIndicatorStyle(prev => ({
-          ...prev,
-          transition: undefined,
-        }))
-      }, Styled.indicatorTransitionMeta.duration)
-    }
+  //     timer = setTimeout(() => {
+  //       setIndicatorStyle(prev => ({
+  //         ...prev,
+  //         transition: undefined,
+  //       }))
+  //     }, Styled.indicatorTransitionMeta.duration)
+  //   }
 
-    return function cleanUp() {
-      clearTimeout(timer)
-    }
-  }, [indicatorNode])
+  //   return function cleanUp() {
+  //     clearTimeout(timer)
+  //   }
+  // }, [indicatorNode])
 
-  useLayoutEffect(function updatePosition() {
-    if (indicatorNode && container && target) {
-      const {
-        top,
-        left,
-        width: selectedElementWidth,
-        height: selectedElementHeight,
-      } = target.getBoundingClientRect()
+  // useLayoutEffect(function updatePosition() {
+  //   if (indicatorNode && container && target) {
+  //     const {
+  //       top,
+  //       left,
+  //       width: selectedElementWidth,
+  //       height: selectedElementHeight,
+  //     } = target.getBoundingClientRect()
 
-      const {
-        top: containerTop,
-        left: containerLeft,
-      } = container.getBoundingClientRect()
+  //     const {
+  //       top: containerTop,
+  //       left: containerLeft,
+  //     } = container.getBoundingClientRect()
 
-      setIndicatorStyle(prev => ({
-        ...prev,
-        '--bezier-react-segmented-control-indicator-transform': `translate(${left - containerLeft}px, ${top - containerTop}px)`,
-        '--bezier-react-segmented-control-indicator-width': `${selectedElementWidth}px`,
-        '--bezier-react-segmented-control-indicator-height': `${selectedElementHeight}px`,
-      }))
-    }
-  }, [
-    // NOTE: (@ed) to force update indicator position on container size change
-    updateKey,
-    indicatorNode,
-    container,
-    target,
-  ])
+  //     setIndicatorStyle(prev => ({
+  //       ...prev,
+  //       '--bezier-react-segmented-control-indicator-transform': `translate(${left - containerLeft}px, ${top - containerTop}px)`,
+  //       '--bezier-react-segmented-control-indicator-width': `${selectedElementWidth}px`,
+  //       '--bezier-react-segmented-control-indicator-height': `${selectedElementHeight}px`,
+  //     }))
+  //   }
+  // }, [
+  //   // NOTE: (@ed) to force update indicator position on container size change
+  //   updateKey,
+  //   indicatorNode,
+  //   container,
+  //   target,
+  // ])
 
   if (!target) { return null }
 
   return (
     <Styled.Indicator
       ref={setIndicatorNode}
-      style={indicatorStyle}
+      // style={indicatorStyle}
       data-testid={SEGMENTED_CONTROL_INDICATOR_TEST_ID}
+      style={style as React.CSSProperties}
     />
   )
 }

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
@@ -1,12 +1,4 @@
-import React, {
-  useCallback,
-  useLayoutEffect,
-  useState,
-} from 'react'
-
-import { useResizeDetector } from 'react-resize-detector'
-
-import useMergeRefs from '~/src/hooks/useMergeRefs'
+import React from 'react'
 
 import {
   useSegmentedControlContext,
@@ -17,127 +9,21 @@ import * as Styled from './SegmentedControl.styled'
 
 export const SEGMENTED_CONTROL_INDICATOR_TEST_ID = 'bezier-react-segmented-control-indicator'
 
-const SegmentedControlIndicator = function SegmentedControlIndicator({
-  target,
-  container,
-  updateKey,
-}: {
-  target: HTMLElement | null
-  container: HTMLElement | null
-  updateKey?: string
-}) {
-  const [indicatorNode, setIndicatorNode] = useState<HTMLDivElement | null>(null)
-  const [indicatorStyle, setIndicatorStyle] = useState<React.CSSProperties>({})
+export function SegmentedControlIndicator() {
   const { index, length } = useSegmentedControlItemListContext('SegmentedControlIndicator')
   const { size } = useSegmentedControlContext('SegmentedControlIndicator')
-  
+
   const style = {
     '--bezier-react-segmented-control-indicator-translateX': `${index * 100}%`,
-    '--bezier-react-segmented-control-indicator-width': `calc((100% - ${length - 1}px) / ${length})`,
+    '--bezier-react-segmented-control-indicator-width': `${index !== null ? `calc((100% - ${length - 1}px) / ${length})` : 0} `,
     '--bezier-react-segmented-control-indicator-height': `${Styled.heightBySegmentedControlSize[size] - (Styled.paddingBySegmentedControlSize[size] * 2)}px`,
     '--bezier-react-segmented-control-indicator-top': `${Styled.paddingBySegmentedControlSize[size]}px`,
-  }
-
-  // useLayoutEffect(function pauseTransitionOnMount() {
-  //   let timer: NodeJS.Timeout | undefined
-
-  //   if (indicatorNode) {
-  //     setIndicatorStyle(prev => ({
-  //       ...prev,
-  //       transition: 'none',
-  //     }))
-
-  //     timer = setTimeout(() => {
-  //       setIndicatorStyle(prev => ({
-  //         ...prev,
-  //         transition: undefined,
-  //       }))
-  //     }, Styled.indicatorTransitionMeta.duration)
-  //   }
-
-  //   return function cleanUp() {
-  //     clearTimeout(timer)
-  //   }
-  // }, [indicatorNode])
-
-  // useLayoutEffect(function updatePosition() {
-  //   if (indicatorNode && container && target) {
-  //     const {
-  //       top,
-  //       left,
-  //       width: selectedElementWidth,
-  //       height: selectedElementHeight,
-  //     } = target.getBoundingClientRect()
-
-  //     const {
-  //       top: containerTop,
-  //       left: containerLeft,
-  //     } = container.getBoundingClientRect()
-
-  //     setIndicatorStyle(prev => ({
-  //       ...prev,
-  //       '--bezier-react-segmented-control-indicator-transform': `translate(${left - containerLeft}px, ${top - containerTop}px)`,
-  //       '--bezier-react-segmented-control-indicator-width': `${selectedElementWidth}px`,
-  //       '--bezier-react-segmented-control-indicator-height': `${selectedElementHeight}px`,
-  //     }))
-  //   }
-  // }, [
-  //   // NOTE: (@ed) to force update indicator position on container size change
-  //   updateKey,
-  //   indicatorNode,
-  //   container,
-  //   target,
-  // ])
-
-  if (!target) { return null }
+  } as React.CSSProperties
 
   return (
     <Styled.Indicator
-      ref={setIndicatorNode}
-      // style={indicatorStyle}
       data-testid={SEGMENTED_CONTROL_INDICATOR_TEST_ID}
-      style={style as React.CSSProperties}
+      style={style}
     />
   )
-}
-
-export function useSegmentedControlIndicator<Element extends HTMLElement>({
-  target,
-  refs,
-}: {
-  target: HTMLElement | null
-  refs: React.Ref<Element>[]
-}) {
-  const [container, setContainer] = useState<Element | null>(null)
-
-  const {
-    width: containerWidth,
-    height: containerHeight,
-    ref: resizeDetectorRef,
-  } = useResizeDetector<Element>()
-
-  const containerSizeKey = `${containerWidth}-${containerHeight}`
-
-  const containerRef = useMergeRefs(
-    ...refs,
-    resizeDetectorRef,
-    setContainer,
-  )
-
-  const render = useCallback(() => (
-    <SegmentedControlIndicator
-      target={target}
-      container={container}
-      updateKey={containerSizeKey}
-    />
-  ), [
-    target,
-    container,
-    containerSizeKey,
-  ])
-
-  return {
-    containerRef,
-    render,
-  } as const
 }

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
@@ -40,21 +40,21 @@ const Item = forwardRef<HTMLButtonElement, ItemProps<SegmentedControlType>>(func
   rightContent,
   ...rest
 }, forwardedRef) {
-  const { setIndex } = useSegmentedControlItemListContext('SegmentedControlItem')
+  const { setSelectedItemIndex } = useSegmentedControlItemListContext('SegmentedControlItem')
   const index = useSegmentedControlItemContext('SegmentedControlItem')
 
   const checked = type === 'radiogroup'
     ? (rest as ItemProps<typeof type>)?.['data-state'] === 'checked'
     : (rest as ItemProps<typeof type>)?.['data-state'] === 'active'
 
-  useEffect(function setSelectedItemIndex() {
+  useEffect(function setSelectedItem() {
     if (checked) {
-      setIndex(index)
+      setSelectedItemIndex(index)
     }
   }, [
     checked,
     index,
-    setIndex,
+    setSelectedItemIndex,
   ])
 
   return (

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
@@ -15,6 +15,7 @@ import {
 } from './SegmentedControl.types'
 import {
   useSegmentedControlContext,
+  useSegmentedControlItemContext,
   useSegmentedControlItemListContext,
 } from './SegmentedControlContext'
 
@@ -31,20 +32,16 @@ type ItemProps<Type extends SegmentedControlType> = (
 & React.HTMLAttributes<HTMLButtonElement>
 & Partial<SegmentedControlItemProps<Type>>
 & Required<Pick<SegmentedControlProps<Type, string>, 'type'>>
-/**
- * TODO[@epic=segmented-control]: index prop 을 노출시키지 않게 변경
- */
-& { index: number }
 
 const Item = forwardRef<HTMLButtonElement, ItemProps<SegmentedControlType>>(function Item({
   children,
   type,
   leftContent,
   rightContent,
-  index,
   ...rest
 }, forwardedRef) {
   const { setIndex } = useSegmentedControlItemListContext('SegmentedControlItem')
+  const index = useSegmentedControlItemContext('SegmentedControlItem')
 
   const checked = type === 'radiogroup'
     ? (rest as ItemProps<typeof type>)?.['data-state'] === 'checked'

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
@@ -33,7 +33,7 @@ type ItemProps<Type extends SegmentedControlType> = (
 & Partial<SegmentedControlItemProps<Type>>
 & Required<Pick<SegmentedControlProps<Type, string>, 'type'>>
 /**
- * TODO: index prop 을 노출시키지 않게 변경
+ * TODO[@epic=segmented-control]: index prop 을 노출시키지 않게 변경
  */
 & { index: number }
 
@@ -45,24 +45,23 @@ const Item = forwardRef<HTMLButtonElement, ItemProps<SegmentedControlType>>(func
   index,
   ...rest
 }, forwardedRef) {
-  const { setSelectedElement, setIndex } = useSegmentedControlItemListContext('SegmentedControlItem')
+  const { setIndex } = useSegmentedControlItemListContext('SegmentedControlItem')
 
   const checked = type === 'radiogroup'
     ? (rest as ItemProps<typeof type>)?.['data-state'] === 'checked'
     : (rest as ItemProps<typeof type>)?.['data-state'] === 'active'
 
+  // TODO[@epic=segmented-control]: setIndex when clicked
   const ref = useMergeRefs(
     forwardedRef,
-    useCallback((node: HTMLButtonElement | null) => {
+    useCallback(() => {
       if (checked) {
-        setSelectedElement(node)
         setIndex(index)
       }
     }, [
       checked,
       index,
       setIndex,
-      setSelectedElement,
     ]),
   )
 

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
@@ -1,12 +1,11 @@
 import React, {
   forwardRef,
-  useCallback,
+  useEffect,
 } from 'react'
 
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 import * as TabsPrimitive from '@radix-ui/react-tabs'
 
-import useMergeRefs from '~/src/hooks/useMergeRefs'
 import { ariaAttr } from '~/src/utils/domUtils'
 
 import {
@@ -51,24 +50,20 @@ const Item = forwardRef<HTMLButtonElement, ItemProps<SegmentedControlType>>(func
     ? (rest as ItemProps<typeof type>)?.['data-state'] === 'checked'
     : (rest as ItemProps<typeof type>)?.['data-state'] === 'active'
 
-  // TODO[@epic=segmented-control]: setIndex when clicked
-  const ref = useMergeRefs(
-    forwardedRef,
-    useCallback(() => {
-      if (checked) {
-        setIndex(index)
-      }
-    }, [
-      checked,
-      index,
-      setIndex,
-    ]),
-  )
+  useEffect(function setSelectedItemIndex() {
+    if (checked) {
+      setIndex(index)
+    }
+  }, [
+    checked,
+    index,
+    setIndex,
+  ])
 
   return (
     <Styled.Item
       {...rest}
-      ref={ref}
+      ref={forwardedRef}
       type="button"
       data-checked={ariaAttr(checked)}
     >

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlItem.tsx
@@ -32,15 +32,20 @@ type ItemProps<Type extends SegmentedControlType> = (
 & React.HTMLAttributes<HTMLButtonElement>
 & Partial<SegmentedControlItemProps<Type>>
 & Required<Pick<SegmentedControlProps<Type, string>, 'type'>>
+/**
+ * TODO: index prop 을 노출시키지 않게 변경
+ */
+& { index: number }
 
 const Item = forwardRef<HTMLButtonElement, ItemProps<SegmentedControlType>>(function Item({
   children,
   type,
   leftContent,
   rightContent,
+  index,
   ...rest
 }, forwardedRef) {
-  const { setSelectedElement } = useSegmentedControlItemListContext('SegmentedControlItem')
+  const { setSelectedElement, setIndex } = useSegmentedControlItemListContext('SegmentedControlItem')
 
   const checked = type === 'radiogroup'
     ? (rest as ItemProps<typeof type>)?.['data-state'] === 'checked'
@@ -51,9 +56,12 @@ const Item = forwardRef<HTMLButtonElement, ItemProps<SegmentedControlType>>(func
     useCallback((node: HTMLButtonElement | null) => {
       if (checked) {
         setSelectedElement(node)
+        setIndex(index)
       }
     }, [
       checked,
+      index,
+      setIndex,
       setSelectedElement,
     ]),
   )


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English**.
- [x] I added an appropriate **label** to the PR.
- [x] I wrote a commit message in **English**.
- [x] I wrote a commit message according to [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] [I added the appropriate **changeset**](https://github.com/channel-io/bezier-react/blob/main/CONTRIBUTING.md#add-a-changeset) for the changes.
- [ ] ~~[Component] I wrote **a unit test** about the implementation.~~
- [ ] ~~[Component] I wrote **a storybook document** about the implementation.~~
- [x] [Component] I tested the implementation in **various browsers**.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox
- [ ] ~~[*New* Component] I added my username to the correct directory in the `CODEOWNERS` file.~~

## Related Issue

Resolves #1573
Resolves #1351 

## Summary
<!-- Please add a summary of the modification. -->

#1573 에서 서술한 버그를 수정하고 `SegmentedControlIndicator`의 애니메이션 구현 방식을 변경합니다.

## Details
<!-- Please add a detailed description of the modification. (such as AS-IS/TO-DO)-->

- #1573 에서 설명하는 것처럼 `SegmentedControl` 의 무한 렌더링 버그를 고치려면 `react-resize-detector`의 버전을 낮추거나 구현 방법을 `react-resize-detector` 를 사용안하는 방식으로 변경해야 합니다.

- 그런데 애초에 `react-resize-detector` 를 사용하고 있었던 이유를 보면,  `Indicator`의 애니메이션을 구현하기 위해 현재 선택된 아이템과 다음에 선택하는 아이템의 [`DOMRect`](https://developer.mozilla.org/en-US/docs/Web/API/DOMRect) 기준으로 `Indicator`가 움직이는 좌표값을 계산하고 있어서, `SegmentedControl` 를 담고있는 컨테이너의 `width` 가 변경될때마다 이 계산 로직을 업데이트 해줘야 했습니다.

- 이렇게 `width`가 변경될 때마다 이펙트를 걸어줘서 렌더링을 다시하는 것은 불필요하게 복잡한 계산 로직이 필요하고 성능에도 좋지 않기 때문에 `react-resize-detector`를 가능하면 없애는 방식이 좋겠다고 판단했습니다. 비슷한 애니메이션을 구현한 [레퍼런스](https://codepen.io/havardob/pen/ExVaELV)를 참고하여, `SegmentedControlItem`이 선택되면 몇 번째 아이템이 선택되었는지 감지해서 이것으로 `Indicator`의 `transform: translateX(...)` 안을 조정하는 방식으로 구현했습니다.

note) 해당 pr 의 변경사항이 적용되면 `LegacySegmentedControl` 에서만 `react-resize-detector` 를 사용하게 되서 레거시를 지우면 의존성도 제거할 수 있습니다

## Breaking change or not (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
- No

## References
<!-- External documents based on workarounds or reviewers should refer to -->
- #1573
- [`DOMRect`](https://developer.mozilla.org/en-US/docs/Web/API/DOMRect)
- [애니메이션 레퍼런스](https://codepen.io/havardob/pen/ExVaELV)
