### PR TITLE
Fix padding of `ListItem` to 4 when its size is M

### DIFF
--- a/.changeset/clean-berries-help.md
+++ b/.changeset/clean-berries-help.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix padding of `ListItem` to 4 when its size is M

--- a/packages/bezier-react/src/components/ListItem/utils.ts
+++ b/packages/bezier-react/src/components/ListItem/utils.ts
@@ -22,7 +22,7 @@ export function getStyleOfSize(size?: ListItemSize) {
     case ListItemSize.M:
     default:
       return css`
-        padding: 6px;
+        padding: 4px;
         ${({ foundation }) => foundation?.rounding.round6};
       `
   }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

## Summary
<!-- Please brief explanation of the changes made --> 

- `ListItem` 사이즈가 `M` 일 때 패딩이 디자인 시안에 나온 4px과 다르게 6px 로 되어 있는 버그를 수정합니다.

![image](https://github.com/channel-io/bezier-react/assets/28595102/aceb45b3-6de4-4ac2-9fd1-2bc5ef8b221e)

- (컴포넌트를 사용하는 곳 많아 테스트 후 open 예정입니다.)

## Details
<!-- Please elaborate description of the changes -->


### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

