### PR TITLE
build(rollup): add browser exports condition to module resolve

### DIFF
--- a/.changeset/kind-cars-perform.md
+++ b/.changeset/kind-cars-perform.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fixes an issue where the height of `TextArea` component is not specified correctly. Modify the build settings to match the package.json exports fields change in 8.5.0 of `react-textarea-autosize`.

--- a/packages/bezier-react/rollup.config.mjs
+++ b/packages/bezier-react/rollup.config.mjs
@@ -43,7 +43,10 @@ const generateConfig = ({
       peerDeps: true,
       packagePath: './package.json',
     }),
-    nodeResolve({ extensions }),
+    nodeResolve({
+      browser: true,
+      extensions,
+    }),
     /**
      * **IMPORTANT**: Order matters!
      * When using @rollup/plugin-babel with @rollup/plugin-commonjs in the same Rollup configuration,


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

- rollup `plugin-node-resolve` 의 옵션에 `browser: true` 를 추가하여, package.json의 exports 필드 중 `browser` 를 함께 확인하도록 수정합니다. 
- 이 변경으로 `TextArea` 컴포넌트의 높이가 올바르게 지정되지 않는 문제를 수정합니다.

## Details
<!-- Please elaborate description of the changes -->

`react-textarea-autosize@8.5.0` 버전에서 https://github.com/Andarist/react-textarea-autosize/pull/373 변경사항이 적용되었습니다. 라이브러리의 빌드 최적화 전략이 변경되며 package.json의 exports 필드가 수정되었는데, 기존 브라우저 API를 사용하는 빌드 아티팩트는 `browsers` 필드 하위에 포함되도록 변경되었습니다. 마찬가지로 여기서 브레이킹 체인지가 발생했는데, 기존 `main`, `module` 필드가 가르키는 아티팩트들에서는 브라우저 API를 사용하지 않는 버전으로 변경되었습니다.

rollup의 `plugin-node-resolve`는 기본값으로 `exports` 필드를 확인할 때, `default`, `module`, `import` 3가지의 조건 필드만을 확인합니다. 여기에 `browser` 필드가 없으므로, 번들 시 브라우저 API를 사용하지 않는 버전의 react-textarea-autosize가 포함되게 됩니다.

플러그인의 `browser` 속성을 `true` 로 변경하여 모듈 해석 시 `browser` 필드(`exports.brower`, `browser`)도 참고하도록 변경합니다.

> If true, instructs the plugin to use the browser module resolutions in package.json and adds 'browser' to exportConditions if it is not present so browser conditionals in exports are applied.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- #1609 
- https://www.npmjs.com/package/@rollup/plugin-node-resolve
- https://nodejs.org/api/packages.html#community-conditions-definitions
