### PR TITLE
Added `title` props on tooltip component

### DIFF
--- a/.changeset/tiny-countries-deliver.md
+++ b/.changeset/tiny-countries-deliver.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Add title props on tooltip

--- a/.changeset/tiny-countries-deliver.md
+++ b/.changeset/tiny-countries-deliver.md
@@ -2,4 +2,4 @@
 "@channel.io/bezier-react": minor
 ---
 
-Add title props on tooltip
+Add `title` props on `Tooltip`

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -59,7 +59,7 @@ Primary.args = {
   allowHover: false,
   delayShow: undefined,
   delayHide: undefined,
-  title: '',
+  title: 'Lorem Ipsum is simply dummy text',
   children: (<Button text="Button" />),
   content: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.',
   description: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.stories.tsx
@@ -59,6 +59,7 @@ Primary.args = {
   allowHover: false,
   delayShow: undefined,
   delayHide: undefined,
+  title: '',
   children: (<Button text="Button" />),
   content: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.',
   description: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.styled.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.styled.ts
@@ -40,6 +40,11 @@ export const TextContainer = styled.div`
   overflow: hidden;
 `
 
+export const Title = styled(Text).attrs({ typo: Typography.Size13, bold: true })`
+  margin-bottom: 2px;
+  color: ${({ foundation }) => foundation?.subTheme?.['txt-black-darkest']};
+`
+
 export const Content = styled(Text).attrs({ typo: Typography.Size13 })`
   color: ${({ foundation }) => foundation?.subTheme?.['txt-black-darkest']};
   /* NOTE: Line height of Typography.Size13  */

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -164,6 +164,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip
   onShow: onShowProp,
   onHide: onHideProp,
   disabled,
+  title,
   content,
   description,
   icon,
@@ -274,6 +275,8 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip
         >
           <Styled.TooltipContent forwardedAs={as}>
             <Styled.TextContainer>
+              { title && (<Styled.Title>{ title } </Styled.Title>) }
+
               <Styled.Content>
                 { content }
               </Styled.Content>

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -275,7 +275,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip
         >
           <Styled.TooltipContent forwardedAs={as}>
             <Styled.TextContainer>
-              { title && (<Styled.Title>{ title } </Styled.Title>) }
+              { title && (<Styled.Title>{ title }</Styled.Title>) }
 
               <Styled.Content>
                 { content }

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
@@ -54,6 +54,10 @@ interface TooltipOptions {
    */
   defaultShow?: boolean
   /**
+   * An element that sits above the tooltip content.
+   */
+  title?: React.ReactNode
+  /**
    * An element that sits below the tooltip content.
    */
   description?: React.ReactNode
@@ -130,5 +134,5 @@ export interface TooltipProps extends
   ChildrenProps<React.ReactElement>,
   ContentProps,
   DisableProps,
-  Omit<React.HTMLAttributes<HTMLDivElement>, keyof ContentProps | keyof ChildrenProps>,
+  Omit<React.HTMLAttributes<HTMLDivElement>, 'title' | keyof ContentProps | keyof ChildrenProps>,
   TooltipOptions {}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - **macOS: Chrome**

## Summary
<!-- Please brief explanation of the changes made -->
Added `title` props on tooltip component

## Details
<!-- Please elaborate description of the changes -->
![image](https://github.com/channel-io/bezier-react/assets/42037851/06d00c62-2156-46d9-8f89-d2bd58e116f4)

As this PR, I added `title` element at tooltip component.
It should be shows title of this tooltip.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->
No
