### PR TITLE
fix(text-field): fix type of `TextFieldRef.getDOMNode`

### DIFF
--- a/.changeset/purple-tips-invent.md
+++ b/.changeset/purple-tips-invent.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix return type of `TextFieldRef.getDOMNode()` to `HTMLInputElement | null`

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.types.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.types.ts
@@ -52,7 +52,7 @@ export interface TextFieldRef {
   selectAll(): void
   unselect(): void
   getBoundingClientRect(): ClientRect | DOMRect
-  getDOMNode(): Element | Text | null
+  getDOMNode(): HTMLInputElement | null
 }
 
 type ChangeEventHandler = React.ChangeEventHandler<HTMLInputElement>


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

TextField의 `TextFieldRef.getDOMNode()` 의 반환 타입을 올바르게 변경합니다.

## Details
<!-- Please elaborate description of the changes -->

-  `getDOMNode()` 이 실제로 반환하는(추론되는) 타입으로 변경합니다: `HTMLInputElement | null`
- `value` 등 프로퍼티에 타입 에러없이 접근할 수 있도록 수정합니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
