### PR TITLE
Downgrade react-textarea-autosize version to 8.3.4 to fix SSR document error

### DIFF
--- a/.changeset/gentle-chefs-arrive.md
+++ b/.changeset/gentle-chefs-arrive.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Fix "document is not defined" error when building in SSR frameworks like Next.js.

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -135,7 +135,7 @@
     "@radix-ui/react-visually-hidden": "^1.0.3",
     "classnames": "^2.3.2",
     "react-resize-detector": "^9.1.0",
-    "react-textarea-autosize": "^8.5.3",
+    "react-textarea-autosize": "8.3.4",
     "ssr-window": "^4.0.2",
     "uuid": "^9.0.0"
   }

--- a/packages/bezier-react/rollup.config.mjs
+++ b/packages/bezier-react/rollup.config.mjs
@@ -43,10 +43,7 @@ const generateConfig = ({
       peerDeps: true,
       packagePath: './package.json',
     }),
-    nodeResolve({
-      browser: true,
-      extensions,
-    }),
+    nodeResolve({ extensions }),
     /**
      * **IMPORTANT**: Order matters!
      * When using @rollup/plugin-babel with @rollup/plugin-commonjs in the same Rollup configuration,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,12 +2073,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.22.5
   resolution: "@babel/runtime@npm:7.22.5"
   dependencies:
     regenerator-runtime: ^0.13.11
   checksum: 12a50b7de2531beef38840d17af50c55a094253697600cee255311222390c68eed704829308d4fd305e1b3dfbce113272e428e9d9d45b1730e0fede997eaceb1
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.10.2":
+  version: 7.23.2
+  resolution: "@babel/runtime@npm:7.23.2"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: 6c4df4839ec75ca10175f636d6362f91df8a3137f86b38f6cd3a4c90668a0fe8e9281d320958f4fbd43b394988958585a17c3aab2a4ea6bf7316b22916a371fb
   languageName: node
   linkType: hard
 
@@ -2575,7 +2584,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-resize-detector: ^9.1.0
-    react-textarea-autosize: ^8.5.3
+    react-textarea-autosize: 8.3.4
     rollup: ^3.29.1
     rollup-plugin-node-externals: ^6.1.1
     rollup-plugin-visualizer: ^5.9.2
@@ -19541,16 +19550,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-textarea-autosize@npm:^8.5.3":
-  version: 8.5.3
-  resolution: "react-textarea-autosize@npm:8.5.3"
+"react-textarea-autosize@npm:8.3.4":
+  version: 8.3.4
+  resolution: "react-textarea-autosize@npm:8.3.4"
   dependencies:
-    "@babel/runtime": ^7.20.13
+    "@babel/runtime": ^7.10.2
     use-composed-ref: ^1.3.0
     use-latest: ^1.2.1
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: b317c3763f37a89621bbafd0e6e2d068e7876790a5ae77f497adfd6ba9334ceea138c8a0b7d907bae0f79c765cb24e8b2ca2b8033b4144c0bce28571a3658921
+  checksum: 87360d4392276d4e87511a73be9b0634b8bcce8f4f648cf659334d993f25ad3d4062f468f1e1944fc614123acae4299580aad00b760c6a96cec190e076f847f5
   languageName: node
   linkType: hard
 
@@ -19757,6 +19766,13 @@ __metadata:
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "regenerator-runtime@npm:0.14.0"
+  checksum: 1c977ad82a82a4412e4f639d65d22be376d3ebdd30da2c003eeafdaaacd03fc00c2320f18120007ee700900979284fc78a9f00da7fb593f6e6eeebc673fba9a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

Fixes #1687 

## Summary
<!-- Please brief explanation of the changes made -->

- react-textarea-autosize의 버전을 `8.3.4` 로 다운그레이드하고, 버전을 고정합니다.
- revert #1637

## Details
<!-- Please elaborate description of the changes -->

#1637 에서 react-textarea-autosize의 변경으로 인해 rollup의 node module resolve 방식을 변경했습니다. SSR 환경에서도 browser용 번들을 바라보게되면서, `document` 관련 에러가 발생하여 빌드가 실패하는 문제가 발생했습니다.

이를 해결하고자 여러 방법을 고려해봤는데,

1. main module은 SSR용 모듈로 두고, browser용 exports field를 추가: 빌드 시 browser exports field를 고려하지 않고 있는 다른 사용처에서의 사이드 이펙트가 우려되어서 선택하지 않았습니다.
2. external dependency로 명시하여 peer dependency로 변경: Breaking change를 발생시키고 싶지 않았습니다. TextArea 컴포넌트를 사용하지 않는 사용처에서도 라이브러리 사용이 강제됩니다. peerDependenciesMeta.optional를 사용하는 방법으로 우회하더라도 매력적인 선택지는 아니라고 생각했습니다.
3. 런타임에 document 체크를 하는 로직 추가: 로직을 추가하고 테스트 해보았으나 여전히 에러가 발생했습니다. 자세히 빌드 과정(Next.js)을 뜯어보진 않았지만, 런타임을 고려하기 이전에 모든 모듈을 정적 분석 + 에러를 던지는 것으로 보입니다.
4. **다운그레이드 및 리버트**

기존에도 큰 문제없이 잘 동작하던 모듈이고, react-textarea-autosize의 변경사항을 봐도 서버 사이드에서 파일 사이즈의 감소 외에는 로직 변경이 없었습니다. 사용처에 별다른 영향이 없을 거로 판단하고 문제 해결을 위해 다운그레이드하는 방향으로 결정했습니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No. 이전 버전도 기존에 정상적으로 잘 동작하던 모듈입니다.

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- [관련 채널톡 스레드](https://desk.channel.io/root/groups/WebBezier-124831/6530b7edbda0b8528c47)
- https://github.com/Andarist/react-textarea-autosize/issues/335


