### PR TITLE
feat(bezier-react): add `contentInterpolation` on `Select` component

### DIFF
--- a/.changeset/quiet-queens-perform.md
+++ b/.changeset/quiet-queens-perform.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Add contentInterpolation to Select component

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.styled.ts
@@ -81,10 +81,12 @@ export const Trigger = styled.button<TriggerProps>`
   `}
 `
 
-export const MainContentWrapper = styled.div`
+export const MainContentWrapper = styled.div<InterpolationProps>`
   display: flex;
   align-items: center;
   overflow: hidden;
+
+  ${({ interpolation }) => interpolation}
 `
 
 interface DropdownProps extends InterpolationProps {

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
@@ -52,6 +52,7 @@ function Select({
   style,
   className,
   interpolation,
+  contentInterpolation,
   dropdownInterpolation,
   size = SelectSize.M,
   defaultFocus = false,
@@ -183,7 +184,7 @@ forwardedRef: Ref<SelectRef>,
         onClick={handleClickTrigger}
         {...ownProps}
       >
-        <Styled.MainContentWrapper>
+        <Styled.MainContentWrapper interpolation={contentInterpolation}>
           { LeftComponent }
           <Text
             testId={triggerTextTestId}

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.types.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.types.ts
@@ -47,7 +47,7 @@ interface SelectProps extends
   SizeProps<SelectSize>,
   SideContentProps<BezierIcon | React.ReactNode, BezierIcon | React.ReactNode>,
   AdditionalTestIdProps<['trigger', 'triggerText', 'dropdown']>,
-  AdditionalStylableProps<'dropdown'>,
+  AdditionalStylableProps<['dropdown', 'content']>,
   AdditionalColorProps<['icon', 'text']>,
   FormComponentProps,
   SelectOptions {}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->
- `Select` 컴포넌트에 `MainContentWrapper` 에 대한 스타일 커스텀 니즈(너비 및 컨텐츠 정렬 방식)가 있어 이를 반영하는 PR을 생성했습니다.

## Details
<!-- Please elaborate description of the changes -->
- `Select` 컴포넌트에 `contentInterpolation` prop이 추가됩니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
- No
