### PR TITLE
fix invalid design token config

### DIFF
--- a/.changeset/wicked-months-sparkle.md
+++ b/.changeset/wicked-months-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-tokens": minor
+---
+
+Remove unused tokens and add missing unit to radius tokens.

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -1,4 +1,7 @@
-import StyleDictionary, { type Config } from 'style-dictionary'
+import StyleDictionary, {
+  type Config,
+  type Platform,
+} from 'style-dictionary'
 
 import {
   customJsCjs,
@@ -16,12 +19,18 @@ const TokenBuilder = StyleDictionary
   .registerFormat(customJsCjs)
   .registerFormat(customJsEsm)
 
-const COMMON_WEB_TRANSFORMS = [
-  'attribute/cti',
-  'name/cti/kebab',
-  customFontPxToRem.name,
-  customRadiusPx.name,
-]
+function defineWebPlatform(options: Platform): Platform {
+  return {
+    transforms: [
+      'attribute/cti',
+      'name/cti/kebab',
+      customFontPxToRem.name,
+      customRadiusPx.name,
+    ],
+    basePxFontSize: 10,
+    ...options,
+  }
+}
 
 interface DefineConfigOptions {
   source: string[]
@@ -39,8 +48,7 @@ function defineConfig({
   return {
     source,
     platforms: {
-      'js/cjs': {
-        transforms: COMMON_WEB_TRANSFORMS,
+      'js/cjs': defineWebPlatform({
         buildPath: 'dist/cjs/',
         files: [
           {
@@ -49,9 +57,8 @@ function defineConfig({
             filter: (token) => token.filePath.includes(destination),
           },
         ],
-      },
-      'js/esm': {
-        transforms: COMMON_WEB_TRANSFORMS,
+      }),
+      'js/esm': defineWebPlatform({
         buildPath: 'dist/esm/',
         files: [
           {
@@ -60,10 +67,8 @@ function defineConfig({
             filter: (token) => token.filePath.includes(destination),
           },
         ],
-      },
-      css: {
-        transforms: COMMON_WEB_TRANSFORMS,
-        basePxFontSize: 10,
+      }),
+      css: defineWebPlatform({
         buildPath: 'dist/css/',
         files: [
           {
@@ -76,7 +81,7 @@ function defineConfig({
             },
           },
         ],
-      },
+      }),
     },
   }
 }

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -4,19 +4,23 @@ import {
   customJsCjs,
   customJsEsm,
 } from './lib/format'
-import { customFontPxToRem } from './lib/transform'
+import {
+  customFontPxToRem,
+  customRadiusPx,
+} from './lib/transform'
 import { toCamelCase } from './lib/utils'
 
-const TokenBuilder = StyleDictionary.registerTransform(customFontPxToRem)
+const TokenBuilder = StyleDictionary
+  .registerTransform(customFontPxToRem)
+  .registerTransform(customRadiusPx)
   .registerFormat(customJsCjs)
   .registerFormat(customJsEsm)
 
 const COMMON_WEB_TRANSFORMS = [
   'attribute/cti',
   'name/cti/kebab',
-  'size/rem',
-  'color/css',
   customFontPxToRem.name,
+  customRadiusPx.name,
 ]
 
 interface DefineConfigOptions {

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -48,7 +48,7 @@ function defineConfig({
   return {
     source,
     platforms: {
-      'js/cjs': defineWebPlatform({
+      'web/cjs': defineWebPlatform({
         buildPath: 'dist/cjs/',
         files: [
           {
@@ -58,7 +58,7 @@ function defineConfig({
           },
         ],
       }),
-      'js/esm': defineWebPlatform({
+      'web/esm': defineWebPlatform({
         buildPath: 'dist/esm/',
         files: [
           {
@@ -68,7 +68,7 @@ function defineConfig({
           },
         ],
       }),
-      css: defineWebPlatform({
+      'web/css': defineWebPlatform({
         buildPath: 'dist/css/',
         files: [
           {

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -8,13 +8,13 @@ import {
   customJsEsm,
 } from './lib/format'
 import {
-  customFontPxToRem,
+  customFontRem,
   customRadiusPx,
 } from './lib/transform'
 import { toCamelCase } from './lib/utils'
 
 const TokenBuilder = StyleDictionary
-  .registerTransform(customFontPxToRem)
+  .registerTransform(customFontRem)
   .registerTransform(customRadiusPx)
   .registerFormat(customJsCjs)
   .registerFormat(customJsEsm)
@@ -24,7 +24,7 @@ function defineWebPlatform(options: Platform): Platform {
     transforms: [
       'attribute/cti',
       'name/cti/kebab',
-      customFontPxToRem.name,
+      customFontRem.name,
       customRadiusPx.name,
     ],
     basePxFontSize: 10,

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -3,6 +3,8 @@ import type {
   Transform,
 } from 'style-dictionary'
 
+import { endsWithNumber } from './utils'
+
 type CustomTransform = Named<Transform<unknown>>
 
 export const customFontPxToRem: CustomTransform = {
@@ -15,5 +17,18 @@ export const customFontPxToRem: CustomTransform = {
   },
   transformer(token, options) {
     return `${token.value / ((options && options.basePxFontSize) || 16)}rem`
+  },
+}
+
+export const customRadiusPx: CustomTransform = {
+  name: 'custom/radius/px',
+  type: 'value',
+  transitive: true,
+  matcher(token) {
+    const { attributes: { category } = {} } = token
+    return category === 'radius'
+  },
+  transformer(token) {
+    return endsWithNumber(token.value) ? `${token.value}px` : token.value
   },
 }

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -7,8 +7,8 @@ import { endsWithNumber } from './utils'
 
 type CustomTransform = Named<Transform<unknown>>
 
-export const customFontPxToRem: CustomTransform = {
-  name: 'custom/font/pxToRem',
+export const customFontRem: CustomTransform = {
+  name: 'custom/font/rem',
   type: 'value',
   transitive: true,
   matcher(token) {

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -1,2 +1,4 @@
 export const toCamelCase = (str: string) =>
   str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (_, char) => char.toUpperCase())
+
+export const endsWithNumber = (str: string) => /\d$/.test(str)

--- a/packages/bezier-tokens/src/global/font.json
+++ b/packages/bezier-tokens/src/global/font.json
@@ -77,14 +77,11 @@
     },
     "family": {
       "sans": {
-        "system": {
-          "value": "-apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Roboto', system-ui, sans-serif"
-        },
         "kr": {
-          "value": "'Inter', 'NotoSansKR', 'NotoSansJP', {font.family.sans.system}"
+          "value": "'Inter', 'NotoSansKR', 'NotoSansJP', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Roboto', system-ui, sans-serif"
         },
         "jp": {
-          "value": "'Inter', 'NotoSansJP', 'NotoSansKR', {font.family.sans.system}"
+          "value": "'Inter', 'NotoSansJP', 'NotoSansKR', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Segoe UI', 'Roboto', system-ui, sans-serif"
         }
       },
       "mono": {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

design token의 잘못된 설정을 몇 수정하고, 리팩토링을 적용합니다.

## Details
<!-- Please elaborate description of the changes -->

- font-familiy 토큰을 올바른 포맷으로 수정합니다. 불필요해진 system-font 토큰은 제거합니다.
- radius 토큰에 누락된 px 유닛을 추가합니다.
- cjs/esm 빌드에서 basePxFontSize가 누락되어 rem이 16px 기준으로 계산되고 있었던 걸 수정합니다.
- 리팩토링: 변수명 수정 및 함수 분리

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

Yes (alpha version)
