### PR TITLE
Add z-index and opacity tokens, Add token category to js build artifacts

### DIFF
--- a/.changeset/metal-planets-peel.md
+++ b/.changeset/metal-planets-peel.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-tokens": minor
+---
+
+Add z-index and opacity tokens.

--- a/.changeset/silent-falcons-behave.md
+++ b/.changeset/silent-falcons-behave.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-tokens": minor
+---
+
+Add categories by token to the JavaScript build file.

--- a/packages/bezier-tokens/scripts/lib/format.ts
+++ b/packages/bezier-tokens/scripts/lib/format.ts
@@ -11,15 +11,25 @@ const { fileHeader } = formatHelpers
 export const customJsCjs: CustomFormat = {
   name: 'custom/js/cjs',
   formatter({ dictionary, file }) {
+    const categorizedTokens = dictionary.allTokens.reduce((acc, token) => {
+      const fileNameWithoutExtension = token.filePath.split('/').pop()!.split('.').shift()!
+      acc[fileNameWithoutExtension] = acc[fileNameWithoutExtension] || []
+      acc[fileNameWithoutExtension].push(token)
+      return acc
+    }, {} as Record<string, typeof dictionary.allTokens>)
+
     return (
       `${fileHeader({ file })
       }module.exports = {` +
-      `\n${
-        dictionary.allTokens
-          .map((token) => `  "${token.name}": ${JSON.stringify(token.value)},`)
-          .join('\n')
-      }\n` +
-      '}'
+      `${Object.keys(categorizedTokens).map(category => (
+        `\n  "${category}": {\n` +
+          `${
+            categorizedTokens[category]
+              .map((token) => `    "${token.name}": ${JSON.stringify(token.value)},`)
+              .join('\n')
+          }\n  }`
+      ))}\n` +
+      '}\n'
     )
   },
 }
@@ -27,15 +37,25 @@ export const customJsCjs: CustomFormat = {
 export const customJsEsm: CustomFormat = {
   name: 'custom/js/esm',
   formatter({ dictionary, file }) {
+    const categorizedTokens = dictionary.allTokens.reduce((acc, token) => {
+      const fileNameWithoutExtension = token.filePath.split('/').pop()!.split('.').shift()!
+      acc[fileNameWithoutExtension] = acc[fileNameWithoutExtension] || []
+      acc[fileNameWithoutExtension].push(token)
+      return acc
+    }, {} as Record<string, typeof dictionary.allTokens>)
+
     return (
       `${fileHeader({ file })
       }export default {` +
-      `\n${
-        dictionary.allTokens
-          .map((token) => `  "${token.name}": ${JSON.stringify(token.value)},`)
-          .join('\n')
-      }\n` +
-      '}'
+      `${Object.keys(categorizedTokens).map(category => (
+        `\n  "${category}": {\n` +
+          `${
+            categorizedTokens[category]
+              .map((token) => `    "${token.name}": ${JSON.stringify(token.value)},`)
+              .join('\n')
+          }\n  }`
+      ))}\n` +
+      '}\n'
     )
   },
 }

--- a/packages/bezier-tokens/src/global/opacity.json
+++ b/packages/bezier-tokens/src/global/opacity.json
@@ -1,0 +1,7 @@
+{
+  "opacity": {
+    "disabled": {
+      "value": 0.4
+    }
+  }
+}

--- a/packages/bezier-tokens/src/global/z-index.json
+++ b/packages/bezier-tokens/src/global/z-index.json
@@ -1,0 +1,28 @@
+{
+  "z-index": {
+    "hidden": {
+      "value": -1
+    },
+    "base": {
+      "value": 0
+    },
+    "floating": {
+      "value": 1
+    },
+    "overlay": {
+      "value": 1000
+    },
+    "modal": {
+      "value": 1100
+    },
+    "toast": {
+      "value": 1200
+    },
+    "tooltip": {
+      "value": 1300
+    },
+    "important": {
+      "value": 2000
+    }
+  }
+}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

- z-index와 opacity 디자인 토큰을 추가합니다. 
  - 모든 플랫폼을 위한 토큰은 아니고, bezier-react에서만 사용하기 위한 임시 토큰으로 추가했습니다. (기존 `Constants/` 디렉터리 하위)
- JS 빌드 아티팩트에 토큰별 카테고리를 추가합니다. json 파일명이 토큰의 카테고리가 됩니다. 기존 `SemanticNames` 과 같이 카테고리별타입스크립트 타입을 쉽게 뽑아내기 위한 변경입니다.

## Details
<!-- Please elaborate description of the changes -->

토큰별 카테고리에 대해: 아래와 같이 타입을 추출하여 사용할 수 있습니다.

```tsx
// AS-IS
color: SemanticNames

// TO-BE
color: keyof typeof tokens.lightTheme.color
```

JS 빌드 아티팩트가 아래와 같은 형식으로 변경됩니다.

```tsx
// AS-IS 모두 1-depth로 flat한 구조
// TO-BE
export default {
  "color": { ... }
  "typography": { ... } 
  ...
}
```

> 생각들:
> 색상 토큰에 color prefix를 붙이는 걸 고민했으나, 기존 팀의 컨벤션과 마이그레이션 비용을 고려하여 작업하지 않았음.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

Yes
