### PR TITLE
Add codemod for mixin interpolation

### DIFF
--- a/.changeset/two-adults-pay.md
+++ b/.changeset/two-adults-pay.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-codemod": minor
+---
+
+Add codemod for mixin interpolation

--- a/packages/bezier-codemod/README.md
+++ b/packages/bezier-codemod/README.md
@@ -102,14 +102,18 @@ import { styled } from "@channel.io/bezier-react";
 
 const Wrapper = styled.div`
   color: ${({ foundation }) => foundation?.theme?.["txt-black-dark"]};
+
   ${({ foundation }) => foundation?.rounding.round12};
+
   ${({ foundation }) =>
     foundation?.border?.getBorder(0.5, foundation.theme["bdr-black-light"], {
       top: false,
       right: false,
       left: false,
     })};
+
   ${({ foundation }) => foundation?.elevation?.ev1()};
+
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS("color")};
 `;
 ```
@@ -121,10 +125,58 @@ import { styled } from "@channel.io/bezier-react";
 
 const Wrapper = styled.div`
   color: var(--txt-black-dark);
+
+  overflow: hidden;
   border-radius: var(--radius-12);
-  border-bottom: 0.5px solid var(--bdr-black-light);
+
+  border-color: var(--bdr-black-light);
+  border-style: none none solid none;
+  border-width: 0.5px;
+
   background-color: var(--bg-white-low);
   box-shadow: var(--ev-1);
+
   transition: color var(--transition-s);
 `;
+```
+
+### Mixin interpolation to CSS Variable
+
+**`mixin-to-css-variable`**
+
+Replace mixin interpolation to css variable
+For example:
+
+```tsx
+import {
+  styled,
+  inputWrapperStyle,
+  focusedInputWrapperStyle,
+  erroredInputWrapperStyle,
+} from "@channel.io/bezier-react";
+
+const Wrapper = styled.div`
+  ${inputWrapperStyle};
+
+  ${({ focus }) => focus && focusedInputWrapperStyle};
+
+  ${({ focus, whisper }) => focus && whisper && erroredInputWrapperStyle};
+`;
+```
+
+Transforms into:
+
+```tsx
+import { styled } from "@channel.io/bezier-react";
+
+const Wrapper = styled.div`
+  box-shadow: var(--input-box-shadow);
+
+  ${({ focus }) => focus && css`
+  box-shadow: var(--input-box-shadow-focused);
+`};
+
+  ${({ focus, whisper }) => focus && whisper && css`
+  box-shadow: var(--input-box-shadow-invalid);
+`};
 ```

--- a/packages/bezier-codemod/src/App.tsx
+++ b/packages/bezier-codemod/src/App.tsx
@@ -27,6 +27,7 @@ import foundationToCssVariableTransition from './transforms/foundation-to-css-va
 import foundationToCssVariable from './transforms/foundation-to-css-variable.js'
 import iconNameToBezierIcon from './transforms/icon-name-to-bezier-icon.js'
 import iconsToBezierIcons from './transforms/icons-to-bezier-icons.js'
+import mixinToCssVariable from './transforms/mixin-to-css-variable.js'
 
 enum Step {
   SelectTransformer,
@@ -45,6 +46,7 @@ enum Option {
   FoundationToCssVariableRounding = 'foundation-to-css-variable-rounding',
   FoundationToCssVariableTransition = 'foundation-to-css-variable-transition',
   FoundationToCssVariable = 'foundation-to-css-variable',
+  MixinToCssVariable = 'mixin-to-css-variable',
   Exit = 'Exit',
 }
 
@@ -60,6 +62,7 @@ const transformMap = {
   [Option.FoundationToCssVariableRounding]: foundationToCssVariableRounding,
   [Option.FoundationToCssVariableTransition]: foundationToCssVariableTransition,
   [Option.FoundationToCssVariable]: foundationToCssVariable,
+  [Option.MixinToCssVariable]: mixinToCssVariable,
 }
 
 const options = (Object.keys(transformMap) as Option[]).map((transformName) => ({

--- a/packages/bezier-codemod/src/transforms/mixin-to-css-variable.ts
+++ b/packages/bezier-codemod/src/transforms/mixin-to-css-variable.ts
@@ -5,6 +5,12 @@ import {
   ts,
 } from 'ts-morph'
 
+import {
+  getImportDeclaration,
+  hasNamedImport,
+  removeNamedImport,
+} from '../utils/import.js'
+
 const cssVariableByMixin = {
   inputTextStyle: 'color: var(--txt-black-darkest);',
   inputWrapperStyle: 'box-shadow: var(--input-box-shadow);',
@@ -28,8 +34,8 @@ const replaceMixin = (sourceFile: SourceFile) => {
           )
         }
 
-        const bezierReactImport = sourceFile.getImportDeclarations().find((declaration) => declaration.getModuleSpecifier().getLiteralValue() === '@channel.io/bezier-react')
-        const hasCssImport = sourceFile.getImportDeclarations().flatMap((declaration) => declaration.getNamedImports()).some((namedImport) => namedImport.getText() === 'css')
+        const bezierReactImport = getImportDeclaration(sourceFile, '@channel.io/bezier-react')
+        const hasCssImport = hasNamedImport(sourceFile, 'css')
 
         if (!node.wasForgotten() && node.getText().includes(mixin)) {
           if (!hasCssImport) {
@@ -55,12 +61,8 @@ const replaceMixin = (sourceFile: SourceFile) => {
 
   const isChanged = sourceFile.getText() !== oldSourceFileText
   if (isChanged) {
-    sourceFile
-      .getImportDeclarations()
-      .find((declaration) => declaration.getModuleSpecifier().getLiteralValue() === '@channel.io/bezier-react')
-      ?.getNamedImports()
-      .filter(v => Object.keys(cssVariableByMixin).includes(v.getText()))
-      .forEach(v => v.remove())
+    Object.keys(cssVariableByMixin)
+      .forEach(v => removeNamedImport(sourceFile, v))
 
     sourceFile.formatText({
       semicolons: ts.SemicolonPreference.Remove,

--- a/packages/bezier-codemod/src/transforms/mixin-to-css-variable.ts
+++ b/packages/bezier-codemod/src/transforms/mixin-to-css-variable.ts
@@ -18,9 +18,7 @@ const cssVariableByMixin = {
   erroredInputWrapperStyle: 'box-shadow: var(--input-box-shadow-invalid);',
 }
 
-const replaceMixin = (sourceFile: SourceFile) => {
-  const oldSourceFileText = sourceFile.getText()
-
+const replaceTemplateExpression = (sourceFile: SourceFile) => {
   sourceFile
     .getDescendantsOfKind(SyntaxKind.TemplateExpression).forEach((node) => {
       for (const [mixin, cssVariable] of Object.entries(cssVariableByMixin)) {
@@ -58,12 +56,21 @@ const replaceMixin = (sourceFile: SourceFile) => {
         }
       }
     })
+}
+
+const removeMixinImports = (sourceFile: SourceFile) => {
+  Object.keys(cssVariableByMixin)
+    .forEach(v => removeNamedImport(sourceFile, v))
+}
+
+const replaceMixin = (sourceFile: SourceFile) => {
+  const oldSourceFileText = sourceFile.getText()
+
+  replaceTemplateExpression(sourceFile)
 
   const isChanged = sourceFile.getText() !== oldSourceFileText
   if (isChanged) {
-    Object.keys(cssVariableByMixin)
-      .forEach(v => removeNamedImport(sourceFile, v))
-
+    removeMixinImports(sourceFile)
     sourceFile.formatText({
       semicolons: ts.SemicolonPreference.Remove,
     })

--- a/packages/bezier-codemod/src/transforms/mixin-to-css-variable.ts
+++ b/packages/bezier-codemod/src/transforms/mixin-to-css-variable.ts
@@ -1,0 +1,72 @@
+/* eslint-disable no-template-curly-in-string */
+import {
+  type SourceFile,
+  SyntaxKind,
+  ts,
+} from 'ts-morph'
+
+const cssVariableByMixin = {
+  inputTextStyle: 'color: var(--txt-black-darkest);',
+  inputWrapperStyle: 'box-shadow: var(--input-box-shadow);',
+  focusedInputWrapperStyle: 'box-shadow: var(--input-box-shadow-focused);',
+  erroredInputWrapperStyle: 'box-shadow: var(--input-box-shadow-invalid);',
+}
+
+const replaceMixin = (sourceFile: SourceFile) => {
+  const oldSourceFileText = sourceFile.getText()
+
+  sourceFile
+    .getDescendantsOfKind(SyntaxKind.TemplateExpression).forEach((node) => {
+      for (const [mixin, cssVariable] of Object.entries(cssVariableByMixin)) {
+        if (!node.wasForgotten() && node.getText().includes(`\${${mixin}}`)) {
+          node.replaceWithText(
+            node.getText()
+              .replaceAll(
+                `\${${mixin}}`, cssVariable,
+              )
+              .replaceAll(';;', ';'),
+          )
+        }
+
+        const bezierReactImport = sourceFile.getImportDeclarations().find((declaration) => declaration.getModuleSpecifier().getLiteralValue() === '@channel.io/bezier-react')
+        const hasCssImport = sourceFile.getImportDeclarations().flatMap((declaration) => declaration.getNamedImports()).some((namedImport) => namedImport.getText() === 'css')
+
+        if (!node.wasForgotten() && node.getText().includes(mixin)) {
+          if (!hasCssImport) {
+            if (bezierReactImport) {
+              bezierReactImport.addNamedImport('css')
+            } else {
+              sourceFile.insertImportDeclaration(0, {
+                namedImports: ['css'],
+                moduleSpecifier: '@channel.io/bezier-react',
+              })
+            }
+          }
+
+          node.replaceWithText(
+            node
+              .getText()
+              .replaceAll(mixin, `css\`\n  ${cssVariable};\n\``)
+              .replaceAll(';;', ';'),
+          )
+        }
+      }
+    })
+
+  const isChanged = sourceFile.getText() !== oldSourceFileText
+  if (isChanged) {
+    sourceFile
+      .getImportDeclarations()
+      .find((declaration) => declaration.getModuleSpecifier().getLiteralValue() === '@channel.io/bezier-react')
+      ?.getNamedImports()
+      .filter(v => Object.keys(cssVariableByMixin).includes(v.getText()))
+      .forEach(v => v.remove())
+
+    sourceFile.formatText({
+      semicolons: ts.SemicolonPreference.Remove,
+    })
+  }
+  return isChanged
+}
+
+export default replaceMixin

--- a/packages/bezier-codemod/src/transforms/tests/mixin-to-css-variable.ts/fixtures/mixin1.input.tsx
+++ b/packages/bezier-codemod/src/transforms/tests/mixin-to-css-variable.ts/fixtures/mixin1.input.tsx
@@ -1,0 +1,31 @@
+import { 
+  styled, 
+  inputWrapperStyle, 
+  focusedInputWrapperStyle, 
+  erroredInputWrapperStyle,
+} from '@channel.io/bezier-react'
+
+const Wrapper = styled.div`
+  position: relative;
+  background-color: ${({ foundation }) =>
+    foundation?.theme?.['bg-grey-lightest']};
+  border-radius: 12px;
+
+  ${inputWrapperStyle};
+
+  ${({ focus }) => focus && focusedInputWrapperStyle};
+
+  ${({ focus, whisper }) => focus && whisper && erroredInputWrapperStyle};
+`
+
+const Wrapper = styled.div`
+  ${inputWrapperStyle}
+`
+
+const Wrapper = styled.div`
+  ${focusedInputWrapperStyle};
+`
+
+const Wrapper = styled.div`
+  ${erroredInputWrapperStyle};
+`

--- a/packages/bezier-codemod/src/transforms/tests/mixin-to-css-variable.ts/fixtures/mixin1.output.tsx
+++ b/packages/bezier-codemod/src/transforms/tests/mixin-to-css-variable.ts/fixtures/mixin1.output.tsx
@@ -1,0 +1,32 @@
+import {
+  styled, css
+} from '@channel.io/bezier-react'
+
+const Wrapper = styled.div`
+  position: relative;
+  background-color: ${({ foundation }) =>
+    foundation?.theme?.['bg-grey-lightest']};
+  border-radius: 12px;
+
+  box-shadow: var(--input-box-shadow);
+
+  ${({ focus }) => focus && css`
+  box-shadow: var(--input-box-shadow-focused);
+`};
+
+  ${({ focus, whisper }) => focus && whisper && css`
+  box-shadow: var(--input-box-shadow-invalid);
+`};
+`
+
+const Wrapper = styled.div`
+  box-shadow: var(--input-box-shadow);
+`
+
+const Wrapper = styled.div`
+  box-shadow: var(--input-box-shadow-focused);
+`
+
+const Wrapper = styled.div`
+  box-shadow: var(--input-box-shadow-invalid);
+`

--- a/packages/bezier-codemod/src/transforms/tests/mixin-to-css-variable.ts/mixin-to-css-variable.test.ts
+++ b/packages/bezier-codemod/src/transforms/tests/mixin-to-css-variable.ts/mixin-to-css-variable.test.ts
@@ -2,7 +2,7 @@ import { testTransformFunction } from '../../../utils/test.js'
 import mixinTransform from '../../mixin-to-css-variable.js'
 
 describe('mixin transform', () => {
-  it('should transform foundation to css variable', () => {
+  it('should transform mixin interpolation to css variable', () => {
     testTransformFunction(__dirname, 'mixin1', mixinTransform)
   })
 })

--- a/packages/bezier-codemod/src/transforms/tests/mixin-to-css-variable.ts/mixin-to-css-variable.test.ts
+++ b/packages/bezier-codemod/src/transforms/tests/mixin-to-css-variable.ts/mixin-to-css-variable.test.ts
@@ -1,0 +1,8 @@
+import { testTransformFunction } from '../../../utils/test.js'
+import mixinTransform from '../../mixin-to-css-variable.js'
+
+describe('mixin transform', () => {
+  it('should transform foundation to css variable', () => {
+    testTransformFunction(__dirname, 'mixin1', mixinTransform)
+  })
+})

--- a/packages/bezier-codemod/src/utils/import.ts
+++ b/packages/bezier-codemod/src/utils/import.ts
@@ -1,0 +1,18 @@
+import { type SourceFile } from 'ts-morph'
+
+export const getImportDeclaration = (sourceFile: SourceFile, specifier: string) =>
+  sourceFile
+    .getImportDeclarations()
+    .find((declaration) => declaration.getModuleSpecifier().getLiteralValue() === specifier)
+
+export const getNamedImport = (sourceFile: SourceFile, namedImport: string) =>
+  sourceFile
+    .getImportDeclarations()
+    .flatMap((declaration) => declaration.getNamedImports())
+    .find((importSpecifier) => importSpecifier.getText() === namedImport)
+
+export const hasNamedImport = (sourceFile: SourceFile, namedImport: string) =>
+  !!getNamedImport(sourceFile, namedImport)
+
+export const removeNamedImport = (sourceFile: SourceFile, namedImport: string) =>
+  getNamedImport(sourceFile, namedImport)?.remove()


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- FIxes https://github.com/channel-io/bezier-react/issues/1778

## Summary
<!-- Please brief explanation of the changes made -->

- Mixin interpolation 을 css variable 을 사용한 스타일 코드로 변환하는 codemod 를 추가합니다.
- As-is
```typescript
import { 
  styled, 
  inputWrapperStyle, 
  focusedInputWrapperStyle, 
  erroredInputWrapperStyle,
} from '@channel.io/bezier-react'

const Wrapper = styled.div`
  position: relative;
  background-color: ${({ foundation }) =>
    foundation?.theme?.['bg-grey-lightest']};
  border-radius: 12px;
  ${inputWrapperStyle};
  ${({ focus }) => focus && focusedInputWrapperStyle};
  ${({ focus, whisper }) => focus && whisper && erroredInputWrapperStyle};
`
```

- To-be
```typescript
import {
  styled, css
} from '@channel.io/bezier-react'

const Wrapper = styled.div`
  position: relative;
  background-color: ${({ foundation }) =>
    foundation?.theme?.['bg-grey-lightest']};
  border-radius: 12px;
  box-shadow: var(--input-box-shadow);
  ${({ focus }) => focus && css`
  box-shadow: var(--input-box-shadow-focused);
`};
  ${({ focus, whisper }) => focus && whisper && css`
  box-shadow: var(--input-box-shadow-invalid);
`};
`
```



## Details
<!-- Please elaborate description of the changes -->

- import 관련 유틸을 추가합니다.
- 여러 줄에 걸친 코드로 변경할 때 인덴트까지 잘 유지하면서 변경하는 것이 쉽지 않아서, 이 부분은 사용처의 포매팅을 기대해야 할 것 같네요. 

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

- No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- [Ts-morph](https://ts-morph.com/)
- [AST Viewer](https://ts-ast-viewer.com/#code/JYWwDg9gTgLgBAbzgKDnAzjAngGwKYAmANCmsAHZgCuMA6lAIZhh5QDK2+JqcAZhAGMq6QgElKNekxbtOebmlZRoYiXUbNWHXPOQBfPspBwA5AAEBACwblyeHADpgEAPQAjPAC9grALRQ8BgEYE2RkAQhyTDgpTSg4AF4MOQIHAmAANwADHkh0YBhncgAuOACcBkKMvABuHjcggGsAc2UqcgJfCJxoUoASBAAKJH52gkqiuD0ASkSAPh40UY6JyIB+BxhLPBA8DYBtEzdm31a8LF8cYGbLGDxMEwBdPTq0N2gCP0Z04VKARgATGAAB6vOADCjUdTSLRyF48AbDPiCYRTWYJObIoToOAAMlxWOEqihsRk2nw8LQiJGKPQJAA7pZgOgZGj5oScfi4IzmayuUoVARxCSNGS4XUskA)
