### PR TITLE
Migrate `DisabledOpacity` constant

### DIFF
--- a/packages/bezier-react/src/components/Avatars/Avatar/Avatar.styled.ts
+++ b/packages/bezier-react/src/components/Avatars/Avatar/Avatar.styled.ts
@@ -1,7 +1,6 @@
 /* stylelint-disable function-whitespace-after */
 import { styled } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
 import type { InterpolationProps } from '~/src/types/Foundation'
 
 import { AlphaSmoothCornersBox } from '~/src/components/AlphaSmoothCornersBox'
@@ -16,7 +15,7 @@ export const AvatarWrapper = styled.div<InterpolationProps>`
 
   &.disabled {
     pointer-events: none;
-    opacity: ${DisabledOpacity};
+    opacity: var(--opacity-disabled);
   }
 
   &.size-${AvatarSize.Size20} {

--- a/packages/bezier-react/src/components/Avatars/Avatar/Avatar.test.tsx
+++ b/packages/bezier-react/src/components/Avatars/Avatar/Avatar.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
 import { render } from '~/src/utils/test'
 
 import { StatusType } from '~/src/components/Status'
@@ -48,7 +47,7 @@ describe('Avatar >', () => {
     const { getByTestId } = renderAvatar({ disabled: true })
     const wrapper = getByTestId(AVATAR_WRAPPER_TEST_ID)
 
-    expect(wrapper).toHaveStyle(`opacity: ${DisabledOpacity}`)
+    expect(wrapper).toHaveStyle('opacity: var(--opacity-disabled)')
   })
 
   it('renders border style', () => {

--- a/packages/bezier-react/src/components/Avatars/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/Avatars/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`AvatarGroup Ellipsis type - Count Snapshot 1`] = `
 
 .c1.disabled {
   pointer-events: none;
-  opacity: 0.4;
+  opacity: var(--opacity-disabled);
 }
 
 .c1.size-20 {
@@ -317,7 +317,7 @@ exports[`AvatarGroup Ellipsis type - Icon Snapshot 1`] = `
 
 .c1.disabled {
   pointer-events: none;
-  opacity: 0.4;
+  opacity: var(--opacity-disabled);
 }
 
 .c1.size-20 {

--- a/packages/bezier-react/src/components/Button/Button.styled.ts
+++ b/packages/bezier-react/src/components/Button/Button.styled.ts
@@ -4,7 +4,6 @@ import {
   styled,
 } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
 import { gap } from '~/src/utils/style'
 import { isEmpty } from '~/src/utils/type'
 
@@ -427,7 +426,7 @@ export const ButtonWrapper = styled.button<ButtonWrapperProps>`
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   border: none;
   outline: none;
-  opacity: ${({ disabled }) => (disabled ? DisabledOpacity : 1)};
+  opacity: ${({ disabled }) => (disabled ? 'var(--opacity-disabled)' : 1)};
 
   &:focus:not(:disabled) {
     box-shadow: 0 0 0 3px var(--bgtxt-cobalt-light);

--- a/packages/bezier-react/src/components/Button/Button.test.tsx
+++ b/packages/bezier-react/src/components/Button/Button.test.tsx
@@ -7,7 +7,6 @@ import {
   TypoAbsoluteNumber,
 } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
 import { render } from '~/src/utils/test'
 
 import {
@@ -130,7 +129,7 @@ describe('Button Test >', () => {
       const disabledButton = getByTestId(BUTTON_TEST_ID)
 
       expect(disabledButton).toBeDisabled()
-      expect(disabledButton).toHaveStyle(`opacity: ${DisabledOpacity};`)
+      expect(disabledButton).toHaveStyle('opacity: var(--opacity-disabled);')
       expect(disabledButton).toHaveStyle('cursor: not-allowed;')
 
       expect(disabledButton).toMatchSnapshot()

--- a/packages/bezier-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/bezier-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`Button Test > Disabled Test > Button can have disabled attribute 1`] = 
   cursor: not-allowed;
   border: none;
   outline: none;
-  opacity: 0.4;
+  opacity: var(--opacity-disabled);
   -webkit-transition-delay: 0ms;
   transition-delay: 0ms;
   -webkit-transition-timing-function: cubic-bezier(.3,0,0,1);

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.styled.ts
@@ -6,7 +6,6 @@ import {
   styled,
 } from '~/src/foundation'
 
-
 import { touchableHover } from '~/src/utils/style'
 
 import {

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.styled.ts
@@ -6,7 +6,7 @@ import {
   styled,
 } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
+
 import { touchableHover } from '~/src/utils/style'
 
 import {
@@ -99,7 +99,7 @@ export const Container = styled.div`
 
   &[data-disabled] {
     cursor: not-allowed;
-    opacity: ${DisabledOpacity};
+    opacity: var(--opacity-disabled);
   }
 `
 

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.styled.ts
@@ -3,7 +3,7 @@ import {
   styled,
 } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
+
 import type { InterpolationProps } from '~/src/types/Foundation'
 
 import {
@@ -67,7 +67,7 @@ export const Trigger = styled.button<TriggerProps>`
 
   &:disabled {
     cursor: not-allowed;
-    opacity: ${DisabledOpacity};
+    opacity: var(--opacity-disabled);
   }
 
   &:not(:disabled):focus {

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.styled.ts
@@ -3,7 +3,6 @@ import {
   styled,
 } from '~/src/foundation'
 
-
 import type { InterpolationProps } from '~/src/types/Foundation'
 
 import {

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.test.tsx
@@ -211,7 +211,7 @@ describe('Select Test >', () => {
       const { getByTestId } = renderSelect({ disabled: true })
       const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
 
-      expect(trigger).toHaveStyle('opacity: 0.4')
+      expect(trigger).toHaveStyle('opacity: var(--opacity-disabled)')
     })
 
     it('should have not-allowed cursor style', () => {
@@ -244,7 +244,7 @@ describe('Select Test >', () => {
       const { getByTestId } = renderSelect({ readOnly: true, disabled: true })
       const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
 
-      expect(trigger).toHaveStyle('opacity: 0.4')
+      expect(trigger).toHaveStyle('opacity: var(--opacity-disabled)')
     })
   })
 
@@ -253,7 +253,7 @@ describe('Select Test >', () => {
       const { getByTestId } = renderSelect({ readOnly: true })
       const trigger = getByTestId(SELECT_TRIGGER_TEST_ID)
 
-      expect(trigger).not.toHaveStyle('opacity: 0.4')
+      expect(trigger).toHaveStyle('opacity: ;')
     })
 
     it('should have initial cursor style', () => {

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
 
 .c1:disabled {
   cursor: not-allowed;
-  opacity: 0.4;
+  opacity: var(--opacity-disabled);
 }
 
 .c1:not(:disabled):focus {
@@ -235,7 +235,7 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
 
 .c1:disabled {
   cursor: not-allowed;
-  opacity: 0.4;
+  opacity: var(--opacity-disabled);
 }
 
 .c1:not(:disabled):focus {

--- a/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.styled.ts
@@ -7,7 +7,7 @@ import {
   styled,
 } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
+
 import { type InterpolationProps } from '~/src/types/Foundation'
 
 import {
@@ -32,7 +32,7 @@ const Wrapper = styled.div<WrapperProps>`
   display: flex;
   align-items: center;
   background-color: ${({ foundation, bgColor }) => foundation?.theme?.[bgColor]};
-  opacity: ${({ disabled }) => disabled && DisabledOpacity};
+  opacity: ${({ disabled }) => disabled && 'var(--opacity-disabled)'};
 
   ${({ focused }) => focused && focusedInputWrapperStyle}
 

--- a/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.styled.ts
@@ -7,7 +7,6 @@ import {
   styled,
 } from '~/src/foundation'
 
-
 import { type InterpolationProps } from '~/src/types/Foundation'
 
 import {

--- a/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.test.tsx
@@ -5,7 +5,6 @@ import { act } from '@testing-library/react'
 
 import { LightFoundation } from '~/src/foundation'
 
-
 import { render } from '~/src/utils/test'
 
 import { COMMON_IME_CONTROL_KEYS } from '~/src/components/Forms/Inputs/constants/CommonImeControlKeys'
@@ -64,7 +63,7 @@ describe('TextArea 테스트 >', () => {
   it('disabled prop이 주입되었을 때는 root wrapper의 opacity가 0.4이어야 한다', () => {
     const { getByTestId } = renderComponent({ disabled: true })
     const rendered = getByTestId(TEXT_AREA_TEST_ID)
-    expect(rendered).toHaveStyle(`opacity: var(--opacity-disabled)`)
+    expect(rendered).toHaveStyle('opacity: var(--opacity-disabled)')
   })
 
   it('focus 상태일 때는 그에 맞는 shadow 스타일을 가져야 한다', () => {

--- a/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.test.tsx
@@ -5,7 +5,7 @@ import { act } from '@testing-library/react'
 
 import { LightFoundation } from '~/src/foundation'
 
-import disabledOpacity from '~/src/constants/DisabledOpacity'
+
 import { render } from '~/src/utils/test'
 
 import { COMMON_IME_CONTROL_KEYS } from '~/src/components/Forms/Inputs/constants/CommonImeControlKeys'
@@ -64,7 +64,7 @@ describe('TextArea 테스트 >', () => {
   it('disabled prop이 주입되었을 때는 root wrapper의 opacity가 0.4이어야 한다', () => {
     const { getByTestId } = renderComponent({ disabled: true })
     const rendered = getByTestId(TEXT_AREA_TEST_ID)
-    expect(rendered).toHaveStyle(`opacity: ${disabledOpacity}`)
+    expect(rendered).toHaveStyle(`opacity: var(--opacity-disabled)`)
   })
 
   it('focus 상태일 때는 그에 맞는 shadow 스타일을 가져야 한다', () => {

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.styled.ts
@@ -7,7 +7,7 @@ import {
   styled,
 } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
+
 import { type InterpolationProps } from '~/src/types/Foundation'
 
 import {
@@ -134,7 +134,7 @@ const Wrapper = styled.div<WrapperProps & InterpolationProps>`
   background-color: ${({ foundation, bgColor }) => foundation?.theme?.[bgColor]};
 
   ${({ borderRadius }) => borderRadius}
-  opacity: ${({ disabled }) => disabled && DisabledOpacity};
+  opacity: ${({ disabled }) => disabled && 'var(--opacity-disabled)'};
 
   ${({ variant }) => variant === TextFieldVariant.Primary && inputWrapperStyle}
   ${({ focused }) => focused && focusedInputWrapperStyle}

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.styled.ts
@@ -7,7 +7,6 @@ import {
   styled,
 } from '~/src/foundation'
 
-
 import { type InterpolationProps } from '~/src/types/Foundation'
 
 import {

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.styled.ts
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.styled.ts
@@ -6,7 +6,7 @@ import {
   styled,
 } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
+
 import { touchableHover } from '~/src/utils/style'
 
 import { FormFieldSize } from '~/src/components/Forms'
@@ -72,7 +72,7 @@ export const RadioGroupPrimitiveItem = styled(RadioGroupPrimitive.Item)<RadioPro
 
   &[data-disabled] {
     cursor: not-allowed;
-    opacity: ${DisabledOpacity};
+    opacity: var(--opacity-disabled);
 
     &::before {
       background-color: var(--bg-black-dark);

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.styled.ts
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.styled.ts
@@ -6,7 +6,6 @@ import {
   styled,
 } from '~/src/foundation'
 
-
 import { touchableHover } from '~/src/utils/style'
 
 import { FormFieldSize } from '~/src/components/Forms'

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -5,7 +5,7 @@ import {
   styled,
 } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
+
 import { ZIndex } from '~/src/constants/ZIndex'
 
 import { AlphaStack } from '~/src/components/AlphaStack'
@@ -189,7 +189,7 @@ export const Container = styled(AlphaStack).attrs({ direction: 'horizontal' })`
   }
 
   &[data-disabled] {
-    opacity: ${DisabledOpacity};
+    opacity: var(--opacity-disabled);
 
     ${Item},
     ${Indicator} {

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.styled.ts
@@ -5,7 +5,6 @@ import {
   styled,
 } from '~/src/foundation'
 
-
 import { ZIndex } from '~/src/constants/ZIndex'
 
 import { AlphaStack } from '~/src/components/AlphaStack'

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
@@ -2,7 +2,7 @@ import * as SliderPrimitive from '@radix-ui/react-slider'
 
 import { styled } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
+
 import type { InterpolationProps } from '~/src/types/Foundation'
 
 import { focusedInputWrapperStyle } from '~/src/components/Forms/Inputs/mixins'
@@ -22,7 +22,7 @@ export const SliderPrimitiveRoot = styled(SliderPrimitive.Root)<InterpolationPro
 
   &[data-disabled] {
     cursor: not-allowed;
-    opacity: ${DisabledOpacity};
+    opacity: var(--opacity-disabled);
   }
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['opacity'])};

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.styled.ts
@@ -2,7 +2,6 @@ import * as SliderPrimitive from '@radix-ui/react-slider'
 
 import { styled } from '~/src/foundation'
 
-
 import type { InterpolationProps } from '~/src/types/Foundation'
 
 import { focusedInputWrapperStyle } from '~/src/components/Forms/Inputs/mixins'

--- a/packages/bezier-react/src/components/Forms/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/Slider/__snapshots__/Slider.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Slider Snapshot should match snapshot 1`] = `
 
 .c0[data-disabled] {
   cursor: not-allowed;
-  opacity: 0.4;
+  opacity: var(--opacity-disabled);
 }
 
 .c1 {

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
@@ -1,6 +1,6 @@
 import { styled } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
+
 
 import { focusedInputWrapperStyle } from '~/src/components/Forms/Inputs/mixins'
 
@@ -54,7 +54,7 @@ export const SwitchRoot = styled.button<SwitchRootProps>`
 
   &:disabled {
     cursor: not-allowed;
-    opacity: ${DisabledOpacity};
+    opacity: var(--opacity-disabled);
   }
 
   &:focus-visible {

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.styled.ts
@@ -1,7 +1,5 @@
 import { styled } from '~/src/foundation'
 
-
-
 import { focusedInputWrapperStyle } from '~/src/components/Forms/Inputs/mixins'
 
 import type SwitchProps from './Switch.types'

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event'
 
 import { LightFoundation } from '~/src/foundation'
 
-
 import { render } from '~/src/utils/test'
 
 import {
@@ -113,7 +112,7 @@ describe('Switch', () => {
       })
       const switchComponent = getByTestId(SWITCH_TEST_ID)
 
-      expect(switchComponent).toHaveStyle(`opacity: var(--opacity-disabled)`)
+      expect(switchComponent).toHaveStyle('opacity: var(--opacity-disabled)')
       expect(switchComponent).toHaveStyle('cursor: not-allowed')
     })
   })

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 
 import { LightFoundation } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
+
 import { render } from '~/src/utils/test'
 
 import {
@@ -113,7 +113,7 @@ describe('Switch', () => {
       })
       const switchComponent = getByTestId(SWITCH_TEST_ID)
 
-      expect(switchComponent).toHaveStyle(`opacity: ${DisabledOpacity}`)
+      expect(switchComponent).toHaveStyle(`opacity: var(--opacity-disabled)`)
       expect(switchComponent).toHaveStyle('cursor: not-allowed')
     })
   })

--- a/packages/bezier-react/src/components/LegacyRadio/LegacyRadio.styled.ts
+++ b/packages/bezier-react/src/components/LegacyRadio/LegacyRadio.styled.ts
@@ -3,8 +3,6 @@ import {
   styled,
 } from '~/src/foundation'
 
-
-
 import {
   type LegacyRadioProps,
   type StyledRadioHandleProps,

--- a/packages/bezier-react/src/components/LegacyRadio/LegacyRadio.styled.ts
+++ b/packages/bezier-react/src/components/LegacyRadio/LegacyRadio.styled.ts
@@ -3,7 +3,7 @@ import {
   styled,
 } from '~/src/foundation'
 
-import DisabledOpacity from '~/src/constants/DisabledOpacity'
+
 
 import {
   type LegacyRadioProps,
@@ -17,7 +17,7 @@ export const StyledRadioWrapper = styled.div<LegacyRadioProps>`
     if (disabled) { return 'auto' }
     return 'pointer'
   }};
-  opacity: ${({ disabled }) => (disabled ? DisabledOpacity : 1)};
+  opacity: ${({ disabled }) => (disabled ? 'var(--opacity-disabled)' : 1)};
 `
 
 const StyledRadioHandleDot = css<StyledRadioHandleProps>`

--- a/packages/bezier-react/src/components/LegacyRadio/LegacyRadio.test.tsx
+++ b/packages/bezier-react/src/components/LegacyRadio/LegacyRadio.test.tsx
@@ -53,6 +53,6 @@ describe('Radio test >', () => {
 
     const renderedRadio = getByTestId(RADIO_TEST_ID)
 
-    expect(renderedRadio).toHaveStyle('opacity: 0.4;')
+    expect(renderedRadio).toHaveStyle('opacity: var(--opacity-disabled);')
   })
 })

--- a/packages/bezier-react/src/components/ListItem/ListItem.styled.ts
+++ b/packages/bezier-react/src/components/ListItem/ListItem.styled.ts
@@ -7,7 +7,7 @@ import {
   styled,
 } from '~/src/foundation'
 
-import disabledOpacity from '~/src/constants/DisabledOpacity'
+
 
 import { Icon } from '~/src/components/Icon'
 
@@ -112,7 +112,7 @@ export const StyledIcon = styled(Icon)<IconWrapperProps>`
   color: ${({ foundation, variant, active }) => (
     foundation?.theme?.[getColorFromColorVariantWithDefaultValue(variant, active ? 'bgtxt-blue-normal' : 'txt-black-dark')]
   )};
-  
+
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS('color', TransitionDuration.M)};
 `
 
@@ -138,10 +138,10 @@ export const Wrapper = styled.div<StyledWrapperProps>`
   color: ${({ foundation, variant }) => (
     foundation?.theme?.[getColorFromColorVariantWithDefaultValue(variant, 'txt-black-darkest')]
   )};
-  
+
   text-decoration: none;
   cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
-  opacity: ${({ disabled }) => (disabled ? disabledOpacity : 1)};
+  opacity: ${({ disabled }) => (disabled ? 'var(--opacity-disabled)' : 1)};
 
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS(['background-color'])};
 

--- a/packages/bezier-react/src/components/ListItem/ListItem.styled.ts
+++ b/packages/bezier-react/src/components/ListItem/ListItem.styled.ts
@@ -7,8 +7,6 @@ import {
   styled,
 } from '~/src/foundation'
 
-
-
 import { Icon } from '~/src/components/Icon'
 
 import {

--- a/packages/bezier-react/src/constants/DisabledOpacity.ts
+++ b/packages/bezier-react/src/constants/DisabledOpacity.ts
@@ -1,3 +1,0 @@
-const disabledOpacity = 0.4
-
-export default disabledOpacity


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- #1106

## Summary
<!-- Please brief explanation of the changes made -->

Migrate `DisabledOpacity` constant to CSS variable

## Details
<!-- Please elaborate description of the changes -->

`DiabledOpacity` 상수를 `--opacity-disabled` CSS variable로 변경합니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- #1106 
