### PR TITLE
feat(Overlay.stories): fix not working containerWidth/Height and add targetProps to control target's position in Overlay Storybook

### DIFF
--- a/.changeset/tender-donkeys-promise.md
+++ b/.changeset/tender-donkeys-promise.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix not working containerProps and add targetProps to control target's position in Overlay.stories

--- a/.changeset/tender-donkeys-promise.md
+++ b/.changeset/tender-donkeys-promise.md
@@ -1,5 +1,0 @@
----
-"@channel.io/bezier-react": patch
----
-
-Fix not working containerProps and add targetProps to control target's position in Overlay.stories

--- a/packages/bezier-react/src/components/Overlay/Overlay.stories.tsx
+++ b/packages/bezier-react/src/components/Overlay/Overlay.stories.tsx
@@ -18,6 +18,9 @@ import { OverlayPosition } from './Overlay.types'
 const meta: Meta<OverlayProps & {
   containerWidth: number
   containerHeight: number
+} & {
+  targetTop: number
+  targetLeft: number
 }> = {
   component: Overlay,
   argTypes: {
@@ -76,6 +79,22 @@ const meta: Meta<OverlayProps & {
         step: 20,
       },
     },
+    targetTop: {
+      control: {
+        type: 'range',
+        min: 100,
+        max: 1000,
+        step: 20,
+      },
+    },
+    targetLeft: {
+      control: {
+        type: 'range',
+        min: 100,
+        max: 1000,
+        step: 20,
+      },
+    },
   },
 }
 export default meta
@@ -83,6 +102,11 @@ export default meta
 interface ContainerProps {
   containerWidth?: number
   containerHeight?: number
+}
+
+interface TargetProps {
+  targetTop?: number
+  targetLeft?: number
 }
 
 const Container = styled.div<ContainerProps>`
@@ -99,10 +123,10 @@ const Wrapper = styled.div`
   height: 100%;
 `
 
-const Target = styled.div`
+const Target = styled.div<TargetProps>`
   position: absolute;
-  top: 200px;
-  left: 200px;
+  top: ${({ targetTop }) => targetTop ?? 200}px;
+  left: ${({ targetLeft }) => targetLeft ?? 200}px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -128,10 +152,12 @@ const ScrollContent = styled.div`
   color: white;
 `
 
-const OverlayTemplate: React.FC<OverlayProps & ContainerProps> = ({
+const OverlayTemplate: React.FC<OverlayProps & ContainerProps & TargetProps> = ({
   children,
-  width: containerWidth,
-  height: containerHeight,
+  containerWidth,
+  containerHeight,
+  targetTop,
+  targetLeft,
   ...rests
 }) => {
   const containerRef = useRef<any>(null)
@@ -144,7 +170,11 @@ const OverlayTemplate: React.FC<OverlayProps & ContainerProps> = ({
       ref={containerRef}
     >
       <Wrapper>
-        <Target ref={targetRef}>
+        <Target
+          targetTop={targetTop}
+          targetLeft={targetLeft}
+          ref={targetRef}
+        >
           target
         </Target>
         <Overlay

--- a/packages/bezier-react/src/components/Overlay/Overlay.stories.tsx
+++ b/packages/bezier-react/src/components/Overlay/Overlay.stories.tsx
@@ -81,14 +81,14 @@ const meta: Meta<OverlayProps & {
 export default meta
 
 interface ContainerProps {
-  width?: number
-  height?: number
+  containerWidth?: number
+  containerHeight?: number
 }
 
 const Container = styled.div<ContainerProps>`
   position: relative;
-  width: ${({ width }) => width ?? 600}px;
-  height: ${({ height }) => height ?? 500}px;
+  width: ${({ containerWidth }) => containerWidth ?? 600}px;
+  height: ${({ containerHeight }) => containerHeight ?? 500}px;
   overflow: hidden;
   border: 1px solid ${props => props.foundation?.theme?.['bg-black-dark']};
 `
@@ -139,8 +139,8 @@ const OverlayTemplate: React.FC<OverlayProps & ContainerProps> = ({
 
   return (
     <Container
-      width={containerWidth}
-      height={containerHeight}
+      containerWidth={containerWidth}
+      containerHeight={containerHeight}
       ref={containerRef}
     >
       <Wrapper>


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

closes #1799 

## Summary
<!-- Please brief explanation of the changes made -->

Overlay Storybook 에서 container 크기 조절을 위한 containerProps가 동작하지 않던 문제를 해결하고, target의 위치를 위한 targetProps를 추가합니다.

## Details
<!-- Please elaborate description of the changes -->

문제 원인은 props를 containerWidth, containerHeight로 넘겨주는데, 받는 쪽에서 width, height로 받고 있어서 동작하지 않았습니다. conatinerWidth, containerHeight로 받도록 수정하였습니다.

targetProps는 containerProps와 동일한 방법으로 조절하도록 추가하였습니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

없습니다.

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

[채널톡](https://desk.channel.io/root/groups/WebBezier-124831/657bef5ea1193bf10d53)