### PR TITLE
Remove runtime overhead related with css variables

### DIFF
--- a/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.tsx
+++ b/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.tsx
@@ -9,7 +9,6 @@ import {
 } from '~/src/features'
 import {
   cssUrl,
-  cssVarName,
   cssVarValue,
   px,
 } from '~/src/utils/style'
@@ -17,8 +16,6 @@ import {
 import { type AlphaSmoothCornersBoxProps } from './AlphaSmoothCornersBox.types'
 
 import * as Styled from './AlphaSmoothCornersBox.styled'
-
-const cv = cssVarName('alpha-smooth-corners-box')
 
 /**
  * `AlphaSmoothCornersBox` is a simple `div` element with smooth corners.
@@ -50,21 +47,21 @@ export const AlphaSmoothCornersBox = forwardRef<HTMLElement, AlphaSmoothCornersB
 
   const style = useMemo(() => ({
     ...styleProp,
-    [cv('border-radius')]: borderRadius,
-    [cv('border-radius-type')]: typeof borderRadius,
-    [cv('shadow-offset-x')]: shadow?.offsetX,
-    [cv('shadow-offset-y')]: shadow?.offsetY,
-    [cv('shadow-blur-radius')]: px(shadow?.blurRadius ?? 0),
-    [cv('shadow-spread-radius')]: px(shadowSpreadRadius),
-    [cv('shadow-color')]: cssVarValue(shadow?.color),
+    '--b-alpha-smooth-corners-box-border-radius': borderRadius,
+    '--b-alpha-smooth-corners-box-border-radius-type': typeof borderRadius,
+    '--b-alpha-smooth-corners-box-shadow-offset-x': shadow?.offsetX,
+    '--b-alpha-smooth-corners-box-shadow-offset-y': shadow?.offsetY,
+    '--b-alpha-smooth-corners-box-shadow-blur-radius': px(shadow?.blurRadius ?? 0),
+    '--b-alpha-smooth-corners-box-shadow-spread-radius': px(shadowSpreadRadius),
+    '--b-alpha-smooth-corners-box-shadow-color': cssVarValue(shadow?.color),
     /**
      * NOTE: Calculate in javascript because it cannot access calculated values via CSS calc() in the paint worklet.
      * @see {@link ~/src/features/SmoothCorners/smoothCornersScript.ts}
      */
-    [cv('padding')]: px(shadowSpreadRadius * 2),
-    [cv('margin')]: px(margin ?? 0),
-    [cv('background-color')]: cssVarValue(backgroundColor),
-    [cv('background-image')]: cssUrl(backgroundImage),
+    '--b-alpha-smooth-corners-box-padding': px(shadowSpreadRadius * 2),
+    '--b-alpha-smooth-corners-box-margin': px(margin ?? 0),
+    '--b-alpha-smooth-corners-box-background-color': cssVarValue(backgroundColor),
+    '--b-alpha-smooth-corners-box-background-image': cssUrl(backgroundImage),
   }), [
     styleProp,
     borderRadius,

--- a/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.tsx
+++ b/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.tsx
@@ -9,7 +9,7 @@ import {
 } from '~/src/features'
 import {
   cssUrl,
-  cssVarValue,
+  cssVar,
   px,
 } from '~/src/utils/style'
 
@@ -53,14 +53,14 @@ export const AlphaSmoothCornersBox = forwardRef<HTMLElement, AlphaSmoothCornersB
     '--b-alpha-smooth-corners-box-shadow-offset-y': shadow?.offsetY,
     '--b-alpha-smooth-corners-box-shadow-blur-radius': px(shadow?.blurRadius ?? 0),
     '--b-alpha-smooth-corners-box-shadow-spread-radius': px(shadowSpreadRadius),
-    '--b-alpha-smooth-corners-box-shadow-color': cssVarValue(shadow?.color),
+    '--b-alpha-smooth-corners-box-shadow-color': cssVar(shadow?.color),
     /**
      * NOTE: Calculate in javascript because it cannot access calculated values via CSS calc() in the paint worklet.
      * @see {@link ~/src/features/SmoothCorners/smoothCornersScript.ts}
      */
     '--b-alpha-smooth-corners-box-padding': px(shadowSpreadRadius * 2),
     '--b-alpha-smooth-corners-box-margin': px(margin ?? 0),
-    '--b-alpha-smooth-corners-box-background-color': cssVarValue(backgroundColor),
+    '--b-alpha-smooth-corners-box-background-color': cssVar(backgroundColor),
     '--b-alpha-smooth-corners-box-background-image': cssUrl(backgroundImage),
   }), [
     styleProp,

--- a/packages/bezier-react/src/components/AlphaStack/AlphaStack.tsx
+++ b/packages/bezier-react/src/components/AlphaStack/AlphaStack.tsx
@@ -4,18 +4,13 @@ import React, {
   useMemo,
 } from 'react'
 
-import {
-  cssVarName,
-  px,
-} from '~/src/utils/style'
+import { px } from '~/src/utils/style'
 
 import { flex } from '~/src/components/Stack/util'
 
 import type { AlphaStackProps } from './AlphaStack.types'
 
 import * as Styled from './AlphaStack.styled'
-
-const cv = cssVarName('alpha-stack')
 
 /**
  * `AlphaStack` provides an abstraction of **flex layout** so that
@@ -53,10 +48,10 @@ export const AlphaStack = forwardRef(function AlphaStack(
 ) {
   const stackStyle = useMemo(() => ({
     ...style,
-    [cv('direction')]: direction === 'horizontal' ? 'row' : 'column',
-    [cv('justify')]: flex(justify),
-    [cv('align')]: flex(align),
-    [cv('spacing')]: px(spacing),
+    '--b-alpha-stack-direction': direction === 'horizontal' ? 'row' : 'column',
+    '--b-alpha-stack-justify': flex(justify),
+    '--b-alpha-stack-align': flex(align),
+    '--b-alpha-stack-spacing': px(spacing),
   } as React.CSSProperties),
   [
     align,

--- a/packages/bezier-react/src/components/Avatars/Avatar/Avatar.tsx
+++ b/packages/bezier-react/src/components/Avatars/Avatar/Avatar.tsx
@@ -5,10 +5,7 @@ import React, {
 
 import classNames from 'classnames'
 
-import {
-  cssVarName,
-  px,
-} from '~/src/utils/style'
+import { px } from '~/src/utils/style'
 import { isEmpty } from '~/src/utils/type'
 
 import { type BoxShadow } from '~/src/components/AlphaSmoothCornersBox'
@@ -27,8 +24,6 @@ import { AvatarSize } from './Avatar.types'
 import useProgressiveImage from './useProgressiveImage'
 
 import * as Styled from './Avatar.styled'
-
-const cv = cssVarName('avatar')
 
 const shadow: BoxShadow = {
   spreadRadius: 2,
@@ -96,7 +91,7 @@ export const Avatar = forwardRef(function Avatar({
   )
 
   const avatarStyle = useMemo(() => ({
-    [cv('status-gap')]: px(size >= AvatarSize.Size72 ? 4 : -2),
+    '--b-avatar-status-gap': px(size >= AvatarSize.Size72 ? 4 : -2),
   } as React.CSSProperties), [size])
 
   return (

--- a/packages/bezier-react/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/packages/bezier-react/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -10,10 +10,7 @@ import { Typography } from '~/src/foundation'
 
 import { isLastIndex } from '~/src/utils/array'
 import { noop } from '~/src/utils/function'
-import {
-  cssVarName,
-  px,
-} from '~/src/utils/style'
+import { px } from '~/src/utils/style'
 
 import {
   type AvatarProps,
@@ -34,8 +31,6 @@ import {
 } from './AvatarGroup.types'
 
 import * as Styled from './AvatarGroup.styled'
-
-const cv = cssVarName('avatar-group')
 
 const MAX_AVATAR_LIST_COUNT = 99
 
@@ -169,8 +164,8 @@ forwardedRef: React.Ref<HTMLDivElement>,
             { AvatarElement }
             <Styled.AvatarEllipsisCountWrapper
               style={{
-                [cv('ellipsis-mr')]: px(getProperEllipsisCountMarginRight(size)),
-                [cv('ellipsis-ml')]: px(Math.max(spacing, AVATAR_GROUP_DEFAULT_SPACING)),
+                '--b-avatar-group-ellipsis-mr': px(getProperEllipsisCountMarginRight(size)),
+                '--b-avatar-group-ellipsis-ml': px(Math.max(spacing, AVATAR_GROUP_DEFAULT_SPACING)),
               } as React.CSSProperties}
               onMouseEnter={onMouseEnterEllipsis}
               onMouseLeave={onMouseLeaveEllipsis}
@@ -209,8 +204,8 @@ forwardedRef: React.Ref<HTMLDivElement>,
       className={className}
       style={{
         ...style,
-        [cv('spacing')]: px(spacing),
-        [cv('size')]: px(size),
+        '--b-avatar-group-spacing': px(spacing),
+        '--b-avatar-group-size': px(size),
       } as React.CSSProperties}
       {...rest}
     >

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.tsx
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.tsx
@@ -7,10 +7,7 @@ import {
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
 
 import useId from '~/src/hooks/useId'
-import {
-  cssVarName,
-  px,
-} from '~/src/utils/style'
+import { px } from '~/src/utils/style'
 
 import { FormFieldSize } from '~/src/components/Forms'
 import useFormFieldProps from '~/src/components/Forms/useFormFieldProps'
@@ -22,8 +19,6 @@ import {
 } from './Checkbox.types'
 
 import * as Styled from './Checkbox.styled'
-
-const cv = cssVarName('checkbox')
 
 type CheckIconProps = {} | {
   style: React.CSSProperties
@@ -67,7 +62,7 @@ function CheckboxImpl<Checked extends CheckedState>({
   const id = useId(idProp ?? formFieldId, 'bezier-checkbox')
 
   const containerStyle = {
-    [cv('height')]: children ? px(FormFieldSize.M) : 'auto',
+    '--b-checkbox-height': children ? px(FormFieldSize.M) : 'auto',
   } as React.CSSProperties
 
   return (

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -9,10 +9,7 @@ import { Typography } from '~/src/foundation'
 
 import useId from '~/src/hooks/useId'
 import { splitByBezierComponentProps } from '~/src/utils/props'
-import {
-  cssVarName,
-  px,
-} from '~/src/utils/style'
+import { px } from '~/src/utils/style'
 import { isNil } from '~/src/utils/type'
 
 import { AlphaStack } from '~/src/components/AlphaStack'
@@ -32,8 +29,6 @@ import {
 import { FormControlContextProvider } from './FormControlContext'
 
 import * as Styled from './FormControl.styled'
-
-const cv = cssVarName('form-control')
 
 export const FORM_CONTROL_TEST_ID = 'bezier-react-form-control'
 
@@ -196,7 +191,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
 
   const containerStyle = useMemo(() => ({
     ...style,
-    [cv('left-label-wrapper-height')]: px(leftLabelWrapperHeight),
+    '--b-form-control-left-label-wrapper-height': px(leftLabelWrapperHeight),
   } as React.CSSProperties), [
     style,
     leftLabelWrapperHeight,

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -8,10 +8,7 @@ import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 import * as TabsPrimitive from '@radix-ui/react-tabs'
 import classNames from 'classnames'
 
-import {
-  cssVarName,
-  px,
-} from '~/src/utils/style'
+import { px } from '~/src/utils/style'
 import { isNumber } from '~/src/utils/type'
 
 import { Divider } from '~/src/components/Divider'
@@ -37,8 +34,6 @@ import {
 import { SegmentedControlIndicator } from './SegmentedControlIndicator'
 
 import * as Styled from './SegmentedControl.styled'
-
-const cv = cssVarName('segmented-control')
 
 function SegmentedControlItemListImpl<
   Type extends SegmentedControlType,
@@ -68,7 +63,7 @@ function SegmentedControlItemListImpl<
 
   const style = useMemo(() => ({
     ...styleProp,
-    [cv('width')]: isNumber(width) ? px(width) : width,
+    '--b-segmented-control-width': isNumber(width) ? px(width) : width,
   } as React.CSSProperties), [
     styleProp,
     width,

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControlIndicator.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 
-import {
-  cssVarName,
-  px,
-} from '~/src/utils/style'
+import { px } from '~/src/utils/style'
 
 import { DIVIDER_THICKNESS } from '~/src/components/Divider'
 
@@ -13,8 +10,6 @@ import {
 } from './SegmentedControlContext'
 
 import * as Styled from './SegmentedControl.styled'
-
-const cv = cssVarName('segmented-control-indicator')
 
 export const SEGMENTED_CONTROL_INDICATOR_TEST_ID = 'bezier-react-segmented-control-indicator'
 
@@ -31,10 +26,10 @@ export function SegmentedControlIndicator() {
   const containerHorizontalPadding = `${2 * containerPadding}px`
 
   const style = {
-    [cv('translateX')]: `calc(${selectedItemIndex * 100}% + ${selectedItemIndex * DIVIDER_THICKNESS}px)`,
-    [cv('width')]: `calc((100% - ${dividerTotalWidth} - ${containerHorizontalPadding}) / ${itemCount})`,
-    [cv('height')]: px(containerHeight - (2 * containerPadding)),
-    [cv('left')]: px(containerPadding),
+    '--b-segmented-control-indicator-translateX': `calc(${selectedItemIndex * 100}% + ${selectedItemIndex * DIVIDER_THICKNESS}px)`,
+    '--b-segmented-control-indicator-width': `calc((100% - ${dividerTotalWidth} - ${containerHorizontalPadding}) / ${itemCount})`,
+    '--b-segmented-control-indicator-height': px(containerHeight - (2 * containerPadding)),
+    '--b-segmented-control-indicator-left': px(containerPadding),
   } as React.CSSProperties
 
   return (

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -5,10 +5,7 @@ import React, {
 
 import * as SliderPrimitive from '@radix-ui/react-slider'
 
-import {
-  cssVarName,
-  px,
-} from '~/src/utils/style'
+import { px } from '~/src/utils/style'
 import { isNumber } from '~/src/utils/type'
 
 import {
@@ -20,8 +17,6 @@ import type SliderProps from './Slider.types'
 
 import * as Styled from './Slider.styled'
 
-const cv = cssVarName('slider')
-
 export const SLIDER_TEST_ID = 'bezier-react-slider'
 
 const SliderGuide = memo<Record<'min' | 'max' | 'value', number>>(function SliderGuide({
@@ -32,7 +27,7 @@ const SliderGuide = memo<Record<'min' | 'max' | 'value', number>>(function Slide
   return (
     <Styled.SliderGuide
       style={{
-        [cv('guide-left')]: `${(value / (max - min)) * 100}%`,
+        '--b-slider-guide-left': `${(value / (max - min)) * 100}%`,
       } as React.CSSProperties}
     />
   )
@@ -106,7 +101,7 @@ export const Slider = forwardRef<HTMLSpanElement, SliderProps>(function Slider({
     <Styled.SliderPrimitiveRoot
       style={{
         ...style,
-        [cv('width')]: isNumber(width) ? px(width) : width,
+        '--b-slider-width': isNumber(width) ? px(width) : width,
       }}
       data-testid={SLIDER_TEST_ID}
       ref={forwardedRef}

--- a/packages/bezier-react/src/components/Modals/Modal/ModalContent.tsx
+++ b/packages/bezier-react/src/components/Modals/Modal/ModalContent.tsx
@@ -10,10 +10,7 @@ import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { ZIndex } from '~/src/constants/ZIndex'
 import useMergeRefs from '~/src/hooks/useMergeRefs'
 import { useWindow } from '~/src/providers/WindowProvider'
-import {
-  cssVarName,
-  px,
-} from '~/src/utils/style'
+import { px } from '~/src/utils/style'
 import { isNumber } from '~/src/utils/type'
 
 import {
@@ -27,8 +24,6 @@ import {
 import { ModalClose } from './ModalHelpers'
 
 import * as Styled from './Modal.styled'
-
-const cv = cssVarName('modal')
 
 /**
  * `ModalContent` is a container of the modal content.
@@ -76,8 +71,8 @@ export const ModalContent = forwardRef(function ModalContent({
     })()
 
     return ({
-      [cv('z-index')]: zIndex,
-      [cv('collision-padding')]: padding,
+      '--b-modal-z-index': zIndex,
+      '--b-modal-collision-padding': padding,
     } as React.CSSProperties)
   }, [
     collisionPadding,
@@ -86,8 +81,8 @@ export const ModalContent = forwardRef(function ModalContent({
 
   const contentStyle = useMemo(() => ({
     ...style,
-    [cv('width')]: isNumber(width) ? px(width) : width,
-    [cv('height')]: isNumber(height) ? px(height) : height,
+    '--b-modal-width': isNumber(width) ? px(width) : width,
+    '--b-modal-height': isNumber(height) ? px(height) : height,
   } as React.CSSProperties), [
     style,
     width,

--- a/packages/bezier-react/src/components/Spinner/Spinner.tsx
+++ b/packages/bezier-react/src/components/Spinner/Spinner.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'
 
-import { cssVarValue } from '~/src/utils/style'
+import { cssVar } from '~/src/utils/style'
 
 import type SpinnerProps from './Spinner.types'
 import { SpinnerSize } from './Spinner.types'
@@ -27,7 +27,7 @@ const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(function Spinner({
       {...rest}
       ref={forwardedRef}
       style={{
-        '--b-spinner-color': cssVarValue(color),
+        '--b-spinner-color': cssVar(color),
         ...style,
       }}
       className={classNames(

--- a/packages/bezier-react/src/components/Spinner/Spinner.tsx
+++ b/packages/bezier-react/src/components/Spinner/Spinner.tsx
@@ -2,10 +2,7 @@ import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'
 
-import {
-  cssVarName,
-  cssVarValue,
-} from '~/src/utils/style'
+import { cssVarValue } from '~/src/utils/style'
 
 import type SpinnerProps from './Spinner.types'
 import { SpinnerSize } from './Spinner.types'
@@ -13,8 +10,6 @@ import { SpinnerSize } from './Spinner.types'
 import styles from './Spinner.module.scss'
 
 export const SPINNER_TEST_ID = 'bezier-react-spinner'
-
-const cv = cssVarName('spinner')
 
 const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(function Spinner({
   testId = SPINNER_TEST_ID,
@@ -32,7 +27,7 @@ const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(function Spinner({
       {...rest}
       ref={forwardedRef}
       style={{
-        [cv('color')]: cssVarValue(color),
+        '--b-spinner-color': cssVarValue(color),
         ...style,
       }}
       className={classNames(

--- a/packages/bezier-react/src/components/Status/Status.tsx
+++ b/packages/bezier-react/src/components/Status/Status.tsx
@@ -11,7 +11,7 @@ import {
 import type { SemanticNames } from '~/src/foundation'
 
 import {
-  cssVarValue,
+  cssVar,
   px,
 } from '~/src/utils/style'
 
@@ -59,7 +59,7 @@ export const Status = memo(forwardRef(function Status({
       style={{
         ...style,
         '--b-status-size': px(size),
-        '--b-status-bg-color': cssVarValue(backgroundColor),
+        '--b-status-bg-color': cssVar(backgroundColor),
         '--b-status-border-width': px(getStatusCircleBorderWidth(size)),
       }}
       {...rest}

--- a/packages/bezier-react/src/components/Status/Status.tsx
+++ b/packages/bezier-react/src/components/Status/Status.tsx
@@ -11,7 +11,6 @@ import {
 import type { SemanticNames } from '~/src/foundation'
 
 import {
-  cssVarName,
   cssVarValue,
   px,
 } from '~/src/utils/style'
@@ -25,8 +24,6 @@ import {
 } from './Status.types'
 
 import * as Styled from './Status.styled'
-
-const cv = cssVarName('status')
 
 const statusTypesWithIcon: Readonly<StatusType[]> = [
   StatusType.OnlineCrescent,
@@ -61,9 +58,9 @@ export const Status = memo(forwardRef(function Status({
       ref={forwardedRef}
       style={{
         ...style,
-        [cv('size')]: px(size),
-        [cv('bg-color')]: cssVarValue(backgroundColor),
-        [cv('border-width')]: px(getStatusCircleBorderWidth(size)),
+        '--b-status-size': px(size),
+        '--b-status-bg-color': cssVarValue(backgroundColor),
+        '--b-status-border-width': px(getStatusCircleBorderWidth(size)),
       }}
       {...rest}
     >

--- a/packages/bezier-react/src/components/Tabs/TabList.tsx
+++ b/packages/bezier-react/src/components/Tabs/TabList.tsx
@@ -3,10 +3,7 @@ import React, {
   useMemo,
 } from 'react'
 
-import {
-  cssVarName,
-  px,
-} from '~/src/utils/style'
+import { px } from '~/src/utils/style'
 
 import { TabListContextProvider } from './TabListContext'
 import {
@@ -15,8 +12,6 @@ import {
 } from './Tabs.types'
 
 import * as Styled from './TabList.styled'
-
-const cv = cssVarName('tabs')
 
 const heightBy = (size: TabSize) => {
   switch (size) {
@@ -48,7 +43,7 @@ export const TabList = forwardRef(function TabList({
         size={size}
         ref={forwardedRef}
         style={{
-          [cv('size')]: px(heightBy(size)),
+          '--b-tabs-size': px(heightBy(size)),
         } as React.CSSProperties}
         {...rest}
       >

--- a/packages/bezier-react/src/utils/props.ts
+++ b/packages/bezier-react/src/utils/props.ts
@@ -6,8 +6,8 @@ import {
 import { TokenPrefix } from '~/src/types/Token'
 
 import {
-  cssVarValue,
-  tokenCssVarValue,
+  cssVar,
+  tokenCssVar,
 } from './style'
 
 export const splitByBezierComponentProps = <
@@ -206,17 +206,17 @@ export const getLayoutStyle = <Props extends LayoutProps>({
     '--b-left': left,
     '--b-shrink': shrink,
     '--b-grow': grow,
-    '--b-bg-color': cssVarValue(bgColor),
-    '--b-border-color': cssVarValue(borderColor),
-    '--b-border-radius': tokenCssVarValue(borderRadius && `${TokenPrefix.Radius}-${borderRadius}`),
+    '--b-bg-color': cssVar(bgColor),
+    '--b-border-color': cssVar(borderColor),
+    '--b-border-radius': tokenCssVar(borderRadius && `${TokenPrefix.Radius}-${borderRadius}`),
     '--b-border-width': borderWidth,
     '--b-border-top-width': borderTopWidth,
     '--b-border-right-width': borderRightWidth,
     '--b-border-bottom-width': borderBottomWidth,
     '--b-border-left-width': borderLeftWidth,
     '--b-border-style': borderStyle,
-    '--b-elevation': tokenCssVarValue(elevation && `${TokenPrefix.Elevation}-${elevation}`),
-    '--b-z-index': tokenCssVarValue(zIndex && `${TokenPrefix.ZIndex}-${zIndex}`),
+    '--b-elevation': tokenCssVar(elevation && `${TokenPrefix.Elevation}-${elevation}`),
+    '--b-z-index': tokenCssVar(zIndex && `${TokenPrefix.ZIndex}-${zIndex}`),
     '--b-overflow': overflow,
     '--b-overflow-x': overflowX,
     '--b-overflow-y': overflowY,

--- a/packages/bezier-react/src/utils/style.ts
+++ b/packages/bezier-react/src/utils/style.ts
@@ -38,7 +38,7 @@ export function touchableHover(interpolation: InjectedInterpolation): InjectedIn
 
 export const px = <Value extends number | undefined>(value: Value) => (!isNil(value) ? `${value}px` as const : undefined)
 
-export function cssVarValue<
+export function cssVar<
   PropertyName extends string | undefined,
 >(propertyName: PropertyName) {
   /* eslint-disable no-nested-ternary */
@@ -48,10 +48,10 @@ export function cssVarValue<
   /* eslint-enable no-nested-ternary */
 }
 
-export function tokenCssVarValue<
+export function tokenCssVar<
   PropertyName extends FlattenAllToken | undefined,
 >(propertyName: PropertyName) {
-  return cssVarValue(propertyName)
+  return cssVar(propertyName)
 }
 
 export function cssUrl(url: string | undefined) {

--- a/packages/bezier-react/src/utils/style.ts
+++ b/packages/bezier-react/src/utils/style.ts
@@ -2,10 +2,7 @@ import { css } from '~/src/foundation'
 
 import { type InjectedInterpolation } from '~/src/types/Foundation'
 import { type FlattenAllToken } from '~/src/types/Token'
-import {
-  isEmpty,
-  isNil,
-} from '~/src/utils/type'
+import { isNil } from '~/src/utils/type'
 
 export function gap(spacing: number): InjectedInterpolation {
   return css`
@@ -40,13 +37,6 @@ export function touchableHover(interpolation: InjectedInterpolation): InjectedIn
 }
 
 export const px = <Value extends number | undefined>(value: Value) => (!isNil(value) ? `${value}px` as const : undefined)
-
-export const cssVarName = <ComponentName extends string>(componentName?: ComponentName) =>
-  <PropertyName extends string>(propertyName: PropertyName) => (
-    isEmpty(componentName)
-      ? `--b-${propertyName}` as const
-      : `--b-${componentName}-${propertyName}` as const
-  )
 
 export function cssVarValue<
   PropertyName extends string | undefined,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

Remove runtime overhead related with css variables

## Details
<!-- Please elaborate description of the changes -->

- 단순 문자열을 반환하는 함수인데 불필요하게 함수로 분리할 필요가 없다고 판단하여 제거합니다
  - 오버헤드를 없애자면 빌드 타임에 cv() -> 해당하는 문자열로 변경해줘도 되지만, 굳이 필요한가 싶어서 기존처럼 단순 string으로 변경했습니다
- cssVarValue -> cssVar로 이름 단순화

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

없음
