### PR TITLE
fix(bezier-tokens): fix invalid letter spacing token values

### DIFF
--- a/.changeset/purple-dodos-move.md
+++ b/.changeset/purple-dodos-move.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-tokens": minor
+---
+
+Fix invalid letter spacing token values

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -18,14 +18,7 @@ export const CSSTransforms = {
     transitive: true,
     matcher: (token) =>
       token.attributes?.category === 'font' && token.type === 'dimension',
-    transformer: ({ value }: { value: string }, options) => {
-      const extractedNumber = extractNumber(value)
-      const isNegative = value.trim().startsWith('-')
-      const numberValue =
-        parseFloat(extractedNumber ?? '') /
-        ((options && options.basePxFontSize) || 16)
-      return `${isNegative ? -numberValue : numberValue}rem`
-    },
+    transformer: ({ value }: { value: string }, options) => `${parseFloat(extractNumber(value) ?? '') / ((options && options.basePxFontSize) || 16)}rem`,
   },
   fontFamily: {
     name: 'custom/css/font/family',

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -1,6 +1,6 @@
 export const toCamelCase = (str: string) =>
   str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (_, char) => char.toUpperCase())
 
-export const extractNumber = (str: string) => str.match(/\d+/g)?.join('')
+export const extractNumber = (str: string) => str.match(/-?\d+(\.\d+)?/g)?.join('')
 
 export const toCSSDimension = (value: string) => (/^0[a-zA-Z]+$/.test(value) ? 0 : value)


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

letter spacing 관련 토큰 값이 잘못 변환되던 문제를 수정합니다.

## Details
<!-- Please elaborate description of the changes -->

기존 `extractNumber` 정규식이 숫자만 매칭했기 때문에, 소숫점이 포함된 letter spacing 토큰이 소숫점을 무시한채로 필터링되었습니다.
예컨대 `0.1` 이 `01` 로 필터링이 되면서, parseFloat에 의해 `1` 로 변환이 되었고 결과적으로 10배 높은 값으로 변환되었습니다.

올바르게 동작할 수 있도록 정규식을 개선합니다. 이제 부호와 소숫점 모두 포함하여 필터링할 수 있게 됩니다. 

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

<img width="795" alt="image" src="https://github.com/channel-io/bezier-react/assets/58209009/fe99b93c-77aa-4073-b4eb-46d7068b9a9d">
