### PR TITLE
fix(bezier-tokens): add the missing `bg-header-float` semantic color token

### DIFF
--- a/.changeset/hot-parrots-shop.md
+++ b/.changeset/hot-parrots-shop.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-tokens": minor
+---
+
+Add the missing `bg-header-float` semantic color token.

--- a/packages/bezier-tokens/src/semantic/dark-theme/color.json
+++ b/packages/bezier-tokens/src/semantic/dark-theme/color.json
@@ -26,10 +26,10 @@
       "value": "{grey.800-80}"
     },
     "header": {
-      "value": "{grey.800}",
-      "float": {
-        "value": "{grey.800-80}"
-      }
+      "value": "{grey.800}"
+    },
+    "header-float": {
+      "value": "{grey.800-80}"
     },
     "lounge": {
       "value": "{grey.800-90}"

--- a/packages/bezier-tokens/src/semantic/light-theme/color.json
+++ b/packages/bezier-tokens/src/semantic/light-theme/color.json
@@ -26,10 +26,10 @@
       "value": "{grey.100-80}"
     },
     "header": {
-      "value": "{white.100}",
-      "float": {
-        "value": "{white.90}"
-      }
+      "value": "{white.100}"
+    },
+    "header-float": {
+      "value": "{white.90}"
     },
     "lounge": {
       "value": "{grey.100-90}"


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- #1820

## Summary
<!-- Please brief explanation of the changes made -->

add the missing `bg-header-float` semantic color token

## Details
<!-- Please elaborate description of the changes -->

- #1820 변경사항 중 일부를 cherry-pick 합니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
