### PR TITLE
Enhance margin, layout common css module

### DIFF
--- a/.changeset/tough-rats-drive.md
+++ b/.changeset/tough-rats-drive.md
@@ -2,4 +2,4 @@
 "@channel.io/bezier-react": minor
 ---
 
-Remove `overflow`, `borderStyle` prop from Layout props.
+Remove `borderStyle` prop from Layout props.

--- a/.changeset/tough-rats-drive.md
+++ b/.changeset/tough-rats-drive.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Remove `overflow`, `borderStyle` prop from Layout props.

--- a/packages/bezier-react/src/components/Avatars/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/Avatars/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
@@ -246,7 +246,7 @@ exports[`AvatarGroup Ellipsis type - Count Snapshot 1`] = `
     style="--b-avatar-group-ellipsis-mr: 5px; --b-avatar-group-ellipsis-ml: 4px;"
   >
     <span
-      class="margin Text typo-13 c5"
+      class="Text typo-13 margin c5"
       data-testid="bezier-react-text"
       foundation="[object Object]"
     >

--- a/packages/bezier-react/src/components/Box/Box.tsx
+++ b/packages/bezier-react/src/components/Box/Box.tsx
@@ -12,8 +12,6 @@ import {
   splitByMarginProps,
 } from '~/src/utils/props'
 
-import sharedStyles from '~/src/components/shared.module.scss'
-
 import { type BoxProps } from './Box.types'
 
 import styles from './Box.module.scss'
@@ -38,6 +36,9 @@ import styles from './Box.module.scss'
 export const Box = forwardRef<HTMLElement, BoxProps>(function Box(props, forwardedRef) {
   const [marginProps, marginRest] = splitByMarginProps(props)
   const [layoutProps, layoutRest] = splitByLayoutProps(marginRest)
+  const marginStyle = getMarginStyle(marginProps)
+  const layoutStyle = getLayoutStyle(layoutProps)
+
   const {
     children,
     style,
@@ -55,15 +56,15 @@ export const Box = forwardRef<HTMLElement, BoxProps>(function Box(props, forward
   return createElement(as, {
     ref: forwardedRef,
     style: {
-      ...getMarginStyle(marginProps),
-      ...getLayoutStyle(layoutProps),
+      ...marginStyle.style,
+      ...layoutStyle.style,
       ...style,
     },
     className: classNames(
-      sharedStyles.margin,
-      sharedStyles.layout,
       styles.Box,
       display && styles[`display-${display}`],
+      marginStyle.className,
+      layoutStyle.className,
       className,
     ),
     'data-testid': testId,

--- a/packages/bezier-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/bezier-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Button Test > Active Test > Active prop change Button to hover style 1`
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -172,7 +172,7 @@ exports[`Button Test > Disabled Test > Button can have disabled attribute 1`] = 
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -284,7 +284,7 @@ exports[`Button Test > Loading Test > Active prop change Button to hover style 1
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -384,7 +384,7 @@ exports[`Button Test > Reset CSS 1`] = `
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -483,7 +483,7 @@ exports[`Button Test > Size Test > with text > Size L - styleVariant: Floating 1
   >
     <span
       buttonsize="L"
-      class="margin Text typo-15 bold c2"
+      class="Text typo-15 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -575,7 +575,7 @@ exports[`Button Test > Size Test > with text > Size L 1`] = `
   >
     <span
       buttonsize="L"
-      class="margin Text typo-15 bold c2"
+      class="Text typo-15 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -674,7 +674,7 @@ exports[`Button Test > Size Test > with text > Size M - styleVariant: Floating 1
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -766,7 +766,7 @@ exports[`Button Test > Size Test > with text > Size M 1`] = `
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -865,7 +865,7 @@ exports[`Button Test > Size Test > with text > Size S - styleVariant: Floating 1
   >
     <span
       buttonsize="S"
-      class="margin Text typo-13 bold c2"
+      class="Text typo-13 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -957,7 +957,7 @@ exports[`Button Test > Size Test > with text > Size S 1`] = `
   >
     <span
       buttonsize="S"
-      class="margin Text typo-13 bold c2"
+      class="Text typo-13 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -1056,7 +1056,7 @@ exports[`Button Test > Size Test > with text > Size XL - styleVariant: Floating 
   >
     <span
       buttonsize="XL"
-      class="margin Text typo-18 bold c2"
+      class="Text typo-18 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -1148,7 +1148,7 @@ exports[`Button Test > Size Test > with text > Size XL 1`] = `
   >
     <span
       buttonsize="XL"
-      class="margin Text typo-18 bold c2"
+      class="Text typo-18 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -1247,7 +1247,7 @@ exports[`Button Test > Size Test > with text > Size XS - styleVariant: Floating 
   >
     <span
       buttonsize="XS"
-      class="margin Text typo-13 bold c2"
+      class="Text typo-13 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -1339,7 +1339,7 @@ exports[`Button Test > Size Test > with text > Size XS 1`] = `
   >
     <span
       buttonsize="XS"
-      class="margin Text typo-13 bold c2"
+      class="Text typo-13 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -1431,7 +1431,7 @@ exports[`Button Test > Size Test > with text > size prop not given, default size
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -1925,7 +1925,7 @@ exports[`Button Test > StyleVariant Test > Floating 1`] = `
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -2024,7 +2024,7 @@ exports[`Button Test > StyleVariant Test > FloatingAlt 1`] = `
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -2116,7 +2116,7 @@ exports[`Button Test > StyleVariant Test > Primary 1`] = `
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -2208,7 +2208,7 @@ exports[`Button Test > StyleVariant Test > Secondary 1`] = `
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >
@@ -2301,7 +2301,7 @@ exports[`Button Test > StyleVariant Test > Tertiary 1`] = `
   >
     <span
       buttonsize="M"
-      class="margin Text typo-14 bold c2"
+      class="Text typo-14 bold margin c2"
       data-testid="bezier-react-button-text"
       foundation="[object Object]"
     >

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 
 <div>
   <div
-    class="margin layout Stack display-flex direction-vertical"
+    class="Stack display-flex direction-vertical margin layout"
     data-testid="bezier-react-form-control"
     style="--b-form-control-left-label-wrapper-height: 36px;"
   >
@@ -130,7 +130,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       class="c0 c1"
     >
       <label
-        class="margin Text typo-13 bold c2"
+        class="Text typo-13 bold margin c2"
         data-testid="bezier-react-form-label"
         foundation="[object Object]"
         id="form-label"
@@ -142,14 +142,14 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
     <div
       aria-describedby="form-help-text"
       aria-labelledby="form-label"
-      class="margin layout Stack display-flex direction-vertical justify-start align-stretch wrap"
+      class="Stack display-flex direction-vertical justify-start align-stretch wrap margin layout"
       data-testid="bezier-react-form-group"
       id="form-group"
       role="group"
       style="--b-stack-spacing: 6px;"
     >
       <div
-        class="margin layout Stack display-flex direction-vertical"
+        class="Stack display-flex direction-vertical margin layout"
         data-testid="bezier-react-form-control"
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
@@ -157,7 +157,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
           class="c0 c1"
         >
           <label
-            class="margin Text typo-13 bold c2"
+            class="Text typo-13 bold margin c2"
             data-testid="bezier-react-form-label"
             for="field-:r3:"
             foundation="[object Object]"
@@ -182,7 +182,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         </div>
       </div>
       <div
-        class="margin layout Stack display-flex direction-vertical"
+        class="Stack display-flex direction-vertical margin layout"
         data-testid="bezier-react-form-control"
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
@@ -190,7 +190,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
           class="c0 c1"
         >
           <label
-            class="margin Text typo-13 bold c2"
+            class="Text typo-13 bold margin c2"
             data-testid="bezier-react-form-label"
             for="field-:r4:"
             foundation="[object Object]"
@@ -220,7 +220,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       class="c0 c7"
     >
       <p
-        class="margin Text typo-13 c8"
+        class="Text typo-13 margin c8"
         data-testid="bezier-react-form-helper-text"
         foundation="[object Object]"
         id="form-help-text"
@@ -396,7 +396,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       class="c0 c2"
     >
       <label
-        class="margin Text typo-14 bold c3"
+        class="Text typo-14 bold margin c3"
         data-testid="bezier-react-form-label"
         foundation="[object Object]"
         id="form-label"
@@ -408,14 +408,14 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
     <div
       aria-describedby="form-help-text"
       aria-labelledby="form-label"
-      class="margin layout Stack display-flex direction-vertical justify-start align-stretch wrap"
+      class="Stack display-flex direction-vertical justify-start align-stretch wrap margin layout"
       data-testid="bezier-react-form-group"
       id="form-group"
       role="group"
       style="--b-stack-spacing: 6px;"
     >
       <div
-        class="margin layout Stack display-flex direction-vertical"
+        class="Stack display-flex direction-vertical margin layout"
         data-testid="bezier-react-form-control"
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
@@ -423,7 +423,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
           class="c0 c4"
         >
           <label
-            class="margin Text typo-13 bold c3"
+            class="Text typo-13 bold margin c3"
             data-testid="bezier-react-form-label"
             for="field-:r6:"
             foundation="[object Object]"
@@ -448,7 +448,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         </div>
       </div>
       <div
-        class="margin layout Stack display-flex direction-vertical"
+        class="Stack display-flex direction-vertical margin layout"
         data-testid="bezier-react-form-control"
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
@@ -456,7 +456,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
           class="c0 c4"
         >
           <label
-            class="margin Text typo-13 bold c3"
+            class="Text typo-13 bold margin c3"
             data-testid="bezier-react-form-label"
             for="field-:r7:"
             foundation="[object Object]"
@@ -486,7 +486,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       class="c0 c9 c10"
     >
       <p
-        class="margin Text typo-13 c11"
+        class="Text typo-13 margin c11"
         data-testid="bezier-react-form-helper-text"
         foundation="[object Object]"
         id="form-help-text"
@@ -587,7 +587,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 }
 
 <div
-  class="margin layout Stack display-flex direction-vertical"
+  class="Stack display-flex direction-vertical margin layout"
   data-testid="bezier-react-form-control"
   style="--b-form-control-left-label-wrapper-height: 36px;"
 >
@@ -595,7 +595,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
     class="c0 c1"
   >
     <label
-      class="margin Text typo-13 bold c2"
+      class="Text typo-13 bold margin c2"
       data-testid="bezier-react-form-label"
       for="form"
       foundation="[object Object]"
@@ -623,7 +623,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
     class="c0 c6"
   >
     <p
-      class="margin Text typo-13 c7"
+      class="Text typo-13 margin c7"
       data-testid="bezier-react-form-helper-text"
       foundation="[object Object]"
       id="form-help-text"
@@ -759,7 +759,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
     class="c0 c2"
   >
     <label
-      class="margin Text typo-14 bold c3"
+      class="Text typo-14 bold margin c3"
       data-testid="bezier-react-form-label"
       for="form"
       foundation="[object Object]"
@@ -787,7 +787,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
     class="c0 c7 c8"
   >
     <p
-      class="margin Text typo-13 c9"
+      class="Text typo-13 margin c9"
       data-testid="bezier-react-form-helper-text"
       foundation="[object Object]"
       id="form-help-text"

--- a/packages/bezier-react/src/components/Forms/FormGroup/__snapshots__/FormGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormGroup/__snapshots__/FormGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`FormGroup > Snapshot > 1`] = `
 <div
-  class="margin layout Stack display-flex direction-vertical justify-start align-stretch wrap"
+  class="Stack display-flex direction-vertical justify-start align-stretch wrap margin layout"
   data-testid="bezier-react-form-group"
   role="group"
   style="--b-stack-spacing: 6px;"

--- a/packages/bezier-react/src/components/Forms/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`FormErrorMessage > Snapshot > 1`] = `
 
 <p
   aria-live="polite"
-  class="margin Text typo-13 c0"
+  class="Text typo-13 margin c0"
   data-testid="bezier-react-form-error-message"
   foundation="[object Object]"
   id="test"
@@ -25,7 +25,7 @@ exports[`FormHelperText > Snapshot > 1`] = `
 }
 
 <p
-  class="margin Text typo-13 c0"
+  class="Text typo-13 margin c0"
   data-testid="bezier-react-form-helper-text"
   foundation="[object Object]"
   id="test"

--- a/packages/bezier-react/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`FormLabel > Snapshot > 1`] = `
 }
 
 <label
-  class="margin Text typo-13 bold c0"
+  class="Text typo-13 bold margin c0"
   data-testid="bezier-react-form-label"
   foundation="[object Object]"
   style="--b-text-color: var(--txt-black-darkest);"

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`Select Test > Default Style > Snapshot > 1`] = `
       class="c2"
     >
       <span
-        class="margin Text typo-14 truncated"
+        class="Text typo-14 truncated margin"
         data-testid="bezier-react-select-trigger-text"
         style="--b-text-color: var(--txt-black-darkest);"
       >
@@ -231,7 +231,7 @@ exports[`Select Test > rightContent > Snapshot > 1`] = `
       class="c2"
     >
       <span
-        class="margin Text typo-14 truncated"
+        class="Text typo-14 truncated margin"
         data-testid="bezier-react-select-trigger-text"
         style="--b-text-color: var(--txt-black-darkest);"
       >

--- a/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
+++ b/packages/bezier-react/src/components/KeyValueListItem/__snapshots__/KeyValueListItem.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`KeyValueListItem Snapshot > 1`] = `
         />
       </svg>
       <div
-        class="margin Text typo-12 bold truncated c6"
+        class="Text typo-12 bold truncated margin c6"
         data-testid="bezier-react-text"
         foundation="[object Object]"
         style="--b-text-color: var(--txt-black-dark);"

--- a/packages/bezier-react/src/components/LegacyTooltip/__snapshots__/LegacyTooltip.test.tsx.snap
+++ b/packages/bezier-react/src/components/LegacyTooltip/__snapshots__/LegacyTooltip.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Tooltip test > Tooltip with contentInterpolation prop 1`] = `
         class="c3"
       >
         <span
-          class="margin Text typo-14"
+          class="Text typo-14 margin"
           data-testid="bezier-react-text"
         >
           Hovered
@@ -136,7 +136,7 @@ exports[`Tooltip test > Tooltip with default props 1`] = `
         class="c3"
       >
         <span
-          class="margin Text typo-14"
+          class="Text typo-14 margin"
           data-testid="bezier-react-text"
         >
           Hovered

--- a/packages/bezier-react/src/components/ListItem/__snapshots__/ListItem.test.tsx.snap
+++ b/packages/bezier-react/src/components/ListItem/__snapshots__/ListItem.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`ListItem Snapshot > 1`] = `
         class="c3"
       >
         <span
-          class="margin Text typo-14"
+          class="Text typo-14 margin"
           data-testid="bezier-react-text"
         >
           this is content

--- a/packages/bezier-react/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`NavGroup Test > Snapshot > Active 1`] = `
     </svg>
   </div>
   <span
-    class="margin Text typo-14 truncated"
+    class="Text typo-14 truncated margin"
     data-testid="bezier-react-text"
   >
     test-content
@@ -285,7 +285,7 @@ exports[`NavGroup Test > Snapshot > Not active 1`] = `
     </svg>
   </div>
   <span
-    class="margin Text typo-14 truncated"
+    class="Text typo-14 truncated margin"
     data-testid="bezier-react-text"
   >
     test-content

--- a/packages/bezier-react/src/components/Navigator/NavItem/__snapshots__/NavItem.test.tsx.snap
+++ b/packages/bezier-react/src/components/Navigator/NavItem/__snapshots__/NavItem.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`NavItem Test > Snapshot > Active 1`] = `
     </svg>
   </div>
   <span
-    class="margin Text typo-14 truncated"
+    class="Text typo-14 truncated margin"
     data-testid="bezier-react-text"
   >
     test-content
@@ -183,7 +183,7 @@ exports[`NavItem Test > Snapshot > Not active 1`] = `
     </svg>
   </div>
   <span
-    class="margin Text typo-14 truncated"
+    class="Text typo-14 truncated margin"
     data-testid="bezier-react-text"
   >
     test-content

--- a/packages/bezier-react/src/components/Stack/Stack.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack.tsx
@@ -13,8 +13,6 @@ import {
 } from '~/src/utils/props'
 import { cssDimension } from '~/src/utils/style'
 
-import sharedStyles from '~/src/components/shared.module.scss'
-
 import type {
   HStackProps,
   StackProps,
@@ -41,6 +39,9 @@ import styles from './Stack.module.scss'
 export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, forwardedRef) {
   const [marginProps, marginRest] = splitByMarginProps(props)
   const [layoutProps, layoutRest] = splitByLayoutProps(marginRest)
+  const marginStyle = getMarginStyle(marginProps)
+  const layoutStyle = getLayoutStyle(layoutProps)
+
   const {
     children,
     style,
@@ -61,13 +62,11 @@ export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, f
     ref: forwardedRef,
     style: {
       '--b-stack-spacing': cssDimension(spacing),
-      ...getMarginStyle(marginProps),
-      ...getLayoutStyle(layoutProps),
+      ...marginStyle.style,
+      ...layoutStyle.style,
       ...style,
     },
     className: classNames(
-      sharedStyles.margin,
-      sharedStyles.layout,
       styles.Stack,
       display && styles[`display-${display}`],
       direction && styles[`direction-${direction}`],
@@ -75,6 +74,8 @@ export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, f
       align && styles[`align-${align}`],
       reverse && styles.reverse,
       wrap && styles.wrap,
+      marginStyle.className,
+      layoutStyle.className,
       className,
     ),
     'data-testid': testId,

--- a/packages/bezier-react/src/components/Text/Text.tsx
+++ b/packages/bezier-react/src/components/Text/Text.tsx
@@ -11,8 +11,6 @@ import {
 } from '~/src/utils/props'
 import { tokenCssVar } from '~/src/utils/style'
 
-import sharedStyles from '~/src/components/shared.module.scss'
-
 import { type TextProps } from './Text.types'
 
 import styles from './Text.module.scss'
@@ -33,6 +31,8 @@ import styles from './Text.module.scss'
  */
 export const Text = forwardRef<HTMLElement, TextProps>(function Text(props, forwardedRef) {
   const [marginProps, marginRest] = splitByMarginProps(props)
+  const marginStyle = getMarginStyle(marginProps)
+
   const {
     children,
     style,
@@ -47,21 +47,22 @@ export const Text = forwardRef<HTMLElement, TextProps>(function Text(props, forw
     align,
     ...rest
   } = marginRest
+
   return createElement(as, {
     ref: forwardedRef,
     style: {
       '--b-text-color': tokenCssVar(color),
-      ...getMarginStyle(marginProps),
+      ...marginStyle.style,
       ...style,
     },
     className: classNames(
-      sharedStyles.margin,
       styles.Text,
       styles[`typo-${typo}`],
       bold && styles.bold,
       italic && styles.italic,
       truncated && styles.truncated,
       align && styles[`align-${align}`],
+      marginStyle.className,
       className,
     ),
     'data-testid': testId,

--- a/packages/bezier-react/src/styles/components/layout.module.scss
+++ b/packages/bezier-react/src/styles/components/layout.module.scss
@@ -77,6 +77,22 @@
       flex-grow: 1;
     }
 
+    &.overflow-visible {
+      overflow: visible;
+    }
+
+    &.overflow-hidden {
+      overflow: hidden;
+    }
+
+    &.overflow-scroll {
+      overflow: scroll;
+    }
+
+    &.overflow-auto {
+      overflow: auto;
+    }
+
     &.overflow-x-visible {
       overflow-x: visible;
     }

--- a/packages/bezier-react/src/styles/components/layout.module.scss
+++ b/packages/bezier-react/src/styles/components/layout.module.scss
@@ -1,16 +1,4 @@
 @layer components {
-  .margin {
-    --b-margin: 0;
-    --b-margin-x: var(--b-margin);
-    --b-margin-y: var(--b-margin);
-    --b-margin-top: var(--b-margin-y);
-    --b-margin-right: var(--b-margin-x);
-    --b-margin-bottom: var(--b-margin-y);
-    --b-margin-left: var(--b-margin-x);
-
-    margin: var(--b-margin-top) var(--b-margin-right) var(--b-margin-bottom) var(--b-margin-left);
-  }
-
   .layout {
     --b-padding: 0;
     --b-padding-x: var(--b-padding);
@@ -25,14 +13,11 @@
     --b-max-height: initial;
     --b-min-width: initial;
     --b-min-height: initial;
-    --b-position: initial;
     --b-inset: auto;
     --b-top: var(--b-inset);
     --b-right: var(--b-inset);
     --b-bottom: var(--b-inset);
     --b-left: var(--b-inset);
-    --b-shrink: initial;
-    --b-grow: initial;
     --b-bg-color: initial;
     --b-border-color: initial;
     --b-border-radius: initial;
@@ -41,12 +26,8 @@
     --b-border-right-width: var(--b-border-width);
     --b-border-bottom-width: var(--b-border-width);
     --b-border-left-width: var(--b-border-width);
-    --b-border-style: solid;
     --b-elevation: initial;
     --b-z-index: initial;
-    --b-overflow: initial;
-    --b-overflow-x: var(--b-overflow);
-    --b-overflow-y: var(--b-overflow);
 
     padding: var(--b-padding-top) var(--b-padding-right) var(--b-padding-bottom) var(--b-padding-left);
     width: var(--b-width);
@@ -55,17 +36,77 @@
     max-height: var(--b-max-height);
     min-width: var(--b-min-width);
     min-height: var(--b-min-height);
-    position: var(--b-position);
     inset: var(--b-top) var(--b-right) var(--b-bottom) var(--b-left);
-    flex-shrink: var(--b-shrink);
-    flex-grow: var(--b-grow);
     background-color: var(--b-bg-color);
     border-color: var(--b-border-color);
     border-radius: var(--b-border-radius);
+    border-style: solid;
     border-width: var(--b-border-top-width) var(--b-border-right-width) var(--b-border-bottom-width) var(--b-border-left-width);
-    border-style: var(--b-border-style);
     box-shadow: var(--b-elevation);
     z-index: var(--b-z-index);
-    overflow: var(--b-overflow-x) var(--b-overflow-y);
+
+    &.position-relative {
+      position: relative;
+    }
+
+    &.position-absolute {
+      position: absolute;
+    }
+
+    &.position-fixed {
+      position: fixed;
+    }
+
+    &.position-sticky {
+      position: sticky;
+    }
+
+    &.shrink-0 {
+      flex-shrink: 0;
+    }
+
+    &.shrink-1 {
+      flex-shrink: 1;
+    }
+
+    &.grow-0 {
+      flex-grow: 0;
+    }
+
+    &.grow-1 {
+      flex-grow: 1;
+    }
+
+    &.overflow-x-visible {
+      overflow-x: visible;
+    }
+
+    &.overflow-x-hidden {
+      overflow-x: hidden;
+    }
+
+    &.overflow-x-scroll {
+      overflow-x: scroll;
+    }
+
+    &.overflow-x-auto {
+      overflow-x: auto;
+    }
+
+    &.overflow-y-visible {
+      overflow-y: visible;
+    }
+
+    &.overflow-y-hidden {
+      overflow-y: hidden;
+    }
+
+    &.overflow-y-scroll {
+      overflow-y: scroll;
+    }
+
+    &.overflow-y-auto {
+      overflow-y: auto;
+    }
   }
 }

--- a/packages/bezier-react/src/styles/components/margin.module.scss
+++ b/packages/bezier-react/src/styles/components/margin.module.scss
@@ -1,0 +1,13 @@
+@layer components {
+  .margin {
+    --b-margin: 0;
+    --b-margin-x: var(--b-margin);
+    --b-margin-y: var(--b-margin);
+    --b-margin-top: var(--b-margin-y);
+    --b-margin-right: var(--b-margin-x);
+    --b-margin-bottom: var(--b-margin-y);
+    --b-margin-left: var(--b-margin-x);
+
+    margin: var(--b-margin-top) var(--b-margin-right) var(--b-margin-bottom) var(--b-margin-left);
+  }
+}

--- a/packages/bezier-react/src/types/ComponentProps.ts
+++ b/packages/bezier-react/src/types/ComponentProps.ts
@@ -178,14 +178,14 @@ export interface LayoutProps {
   minWidth?: CSSProperties['minWidth']
   maxHeight?: CSSProperties['maxHeight']
   minHeight?: CSSProperties['minHeight']
-  position?: CSSProperties['position']
+  position?: 'absolute' | 'fixed' | 'relative' | 'sticky'
   inset?: CSSProperties['inset']
   top?: CSSProperties['top']
   right?: CSSProperties['right']
   bottom?: CSSProperties['bottom']
   left?: CSSProperties['left']
-  shrink?: CSSProperties['flexShrink']
-  grow?: CSSProperties['flexGrow']
+  shrink?: 0 | 1
+  grow?: 0 | 1
   bgColor?: BackgroundSemanticColor | BackgroundTextSemanticColor
   borderColor?: BorderSemanticColor
   borderRadius?: Radius
@@ -194,10 +194,8 @@ export interface LayoutProps {
   borderRightWidth?: CSSProperties['borderRightWidth']
   borderBottomWidth?: CSSProperties['borderBottomWidth']
   borderLeftWidth?: CSSProperties['borderLeftWidth']
-  borderStyle?: CSSProperties['borderStyle']
   elevation?: Elevation
   zIndex?: ZIndex
-  overflow?: CSSProperties['overflow']
-  overflowX?: CSSProperties['overflowX']
-  overflowY?: CSSProperties['overflowY']
+  overflowX?: 'auto' | 'hidden' | 'scroll' | 'visible'
+  overflowY?: 'auto' | 'hidden' | 'scroll' | 'visible'
 }

--- a/packages/bezier-react/src/types/ComponentProps.ts
+++ b/packages/bezier-react/src/types/ComponentProps.ts
@@ -161,6 +161,11 @@ export interface MarginProps {
   ml?: CSSProperties['marginLeft']
 }
 
+type Position = 'absolute' | 'fixed' | 'relative' | 'sticky'
+type Overflow = 'auto' | 'hidden' | 'scroll' | 'visible'
+type Shrink = 0 | 1
+type Grow = 0 | 1
+
 /**
  * TODO: Add JSDoc
  */
@@ -178,14 +183,14 @@ export interface LayoutProps {
   minWidth?: CSSProperties['minWidth']
   maxHeight?: CSSProperties['maxHeight']
   minHeight?: CSSProperties['minHeight']
-  position?: 'absolute' | 'fixed' | 'relative' | 'sticky'
+  position?: Position
   inset?: CSSProperties['inset']
   top?: CSSProperties['top']
   right?: CSSProperties['right']
   bottom?: CSSProperties['bottom']
   left?: CSSProperties['left']
-  shrink?: 0 | 1
-  grow?: 0 | 1
+  shrink?: Shrink
+  grow?: Grow
   bgColor?: BackgroundSemanticColor | BackgroundTextSemanticColor
   borderColor?: BorderSemanticColor
   borderRadius?: Radius
@@ -196,6 +201,7 @@ export interface LayoutProps {
   borderLeftWidth?: CSSProperties['borderLeftWidth']
   elevation?: Elevation
   zIndex?: ZIndex
-  overflowX?: 'auto' | 'hidden' | 'scroll' | 'visible'
-  overflowY?: 'auto' | 'hidden' | 'scroll' | 'visible'
+  overflow?: Overflow
+  overflowX?: Overflow
+  overflowY?: Overflow
 }

--- a/packages/bezier-react/src/utils/props.ts
+++ b/packages/bezier-react/src/utils/props.ts
@@ -94,6 +94,7 @@ export const splitByLayoutProps = <Props extends LayoutProps>({
   borderLeftWidth,
   elevation,
   zIndex,
+  overflow,
   overflowX,
   overflowY,
   ...rest
@@ -130,6 +131,7 @@ export const splitByLayoutProps = <Props extends LayoutProps>({
       borderLeftWidth,
       elevation,
       zIndex,
+      overflow,
       overflowX,
       overflowY,
     },
@@ -191,6 +193,7 @@ export const getLayoutStyle = <Props extends LayoutProps>({
   borderLeftWidth,
   elevation,
   zIndex,
+  overflow,
   overflowX,
   overflowY,
 }: Props) => (
@@ -230,6 +233,7 @@ export const getLayoutStyle = <Props extends LayoutProps>({
         position && layoutStyles[`position-${position}`],
         isNumber(shrink) && layoutStyles[`shrink-${shrink}`],
         isNumber(grow) && layoutStyles[`grow-${grow}`],
+        overflow && layoutStyles[`overflow-${overflow}`],
         overflowX && layoutStyles[`overflow-x-${overflowX}`],
         overflowY && layoutStyles[`overflow-y-${overflowY}`],
       ),

--- a/packages/bezier-react/src/utils/props.ts
+++ b/packages/bezier-react/src/utils/props.ts
@@ -138,7 +138,7 @@ export const splitByLayoutProps = <Props extends LayoutProps>({
     rest,
   ]
 
-export const getMarginStyle = <Props extends MarginProps>({
+export const getMarginStyle = ({
   m,
   mx,
   my,
@@ -146,22 +146,22 @@ export const getMarginStyle = <Props extends MarginProps>({
   mr,
   mb,
   ml,
-}: Props) => (
-    {
-      style: {
-        '--b-margin': cssDimension(m),
-        '--b-margin-x': cssDimension(mx),
-        '--b-margin-y': cssDimension(my),
-        '--b-margin-top': cssDimension(mt),
-        '--b-margin-right': cssDimension(mr),
-        '--b-margin-bottom': cssDimension(mb),
-        '--b-margin-left': cssDimension(ml),
-      },
-      className: marginStyles.margin,
-    }
-  )
+}: MarginProps) => (
+  {
+    style: {
+      '--b-margin': cssDimension(m),
+      '--b-margin-x': cssDimension(mx),
+      '--b-margin-y': cssDimension(my),
+      '--b-margin-top': cssDimension(mt),
+      '--b-margin-right': cssDimension(mr),
+      '--b-margin-bottom': cssDimension(mb),
+      '--b-margin-left': cssDimension(ml),
+    },
+    className: marginStyles.margin,
+  }
+)
 
-export const getLayoutStyle = <Props extends LayoutProps>({
+export const getLayoutStyle = ({
   p,
   px,
   py,
@@ -196,46 +196,46 @@ export const getLayoutStyle = <Props extends LayoutProps>({
   overflow,
   overflowX,
   overflowY,
-}: Props) => (
-    {
-      style: {
-        '--b-padding': cssDimension(p),
-        '--b-padding-x': cssDimension(px),
-        '--b-padding-y': cssDimension(py),
-        '--b-padding-top': cssDimension(pt),
-        '--b-padding-right': cssDimension(pr),
-        '--b-padding-bottom': cssDimension(pb),
-        '--b-padding-left': cssDimension(pl),
-        '--b-width': cssDimension(width),
-        '--b-height': cssDimension(height),
-        '--b-max-width': cssDimension(maxWidth),
-        '--b-min-width': cssDimension(minWidth),
-        '--b-max-height': cssDimension(maxHeight),
-        '--b-min-height': cssDimension(minHeight),
-        '--b-inset': cssDimension(inset),
-        '--b-top': cssDimension(top),
-        '--b-right': cssDimension(right),
-        '--b-bottom': cssDimension(bottom),
-        '--b-left': cssDimension(left),
-        '--b-bg-color': cssVar(bgColor),
-        '--b-border-color': cssVar(borderColor),
-        '--b-border-radius': tokenCssVar(borderRadius && `${TokenPrefix.Radius}-${borderRadius}`),
-        '--b-border-width': cssDimension(borderWidth),
-        '--b-border-top-width': cssDimension(borderTopWidth),
-        '--b-border-right-width': cssDimension(borderRightWidth),
-        '--b-border-bottom-width': cssDimension(borderBottomWidth),
-        '--b-border-left-width': cssDimension(borderLeftWidth),
-        '--b-elevation': tokenCssVar(elevation && `${TokenPrefix.Elevation}-${elevation}`),
-        '--b-z-index': tokenCssVar(zIndex && `${TokenPrefix.ZIndex}-${zIndex}`),
-      },
-      className: classNames(
-        layoutStyles.layout,
-        position && layoutStyles[`position-${position}`],
-        isNumber(shrink) && layoutStyles[`shrink-${shrink}`],
-        isNumber(grow) && layoutStyles[`grow-${grow}`],
-        overflow && layoutStyles[`overflow-${overflow}`],
-        overflowX && layoutStyles[`overflow-x-${overflowX}`],
-        overflowY && layoutStyles[`overflow-y-${overflowY}`],
-      ),
-    }
-  )
+}: LayoutProps) => (
+  {
+    style: {
+      '--b-padding': cssDimension(p),
+      '--b-padding-x': cssDimension(px),
+      '--b-padding-y': cssDimension(py),
+      '--b-padding-top': cssDimension(pt),
+      '--b-padding-right': cssDimension(pr),
+      '--b-padding-bottom': cssDimension(pb),
+      '--b-padding-left': cssDimension(pl),
+      '--b-width': cssDimension(width),
+      '--b-height': cssDimension(height),
+      '--b-max-width': cssDimension(maxWidth),
+      '--b-min-width': cssDimension(minWidth),
+      '--b-max-height': cssDimension(maxHeight),
+      '--b-min-height': cssDimension(minHeight),
+      '--b-inset': cssDimension(inset),
+      '--b-top': cssDimension(top),
+      '--b-right': cssDimension(right),
+      '--b-bottom': cssDimension(bottom),
+      '--b-left': cssDimension(left),
+      '--b-bg-color': cssVar(bgColor),
+      '--b-border-color': cssVar(borderColor),
+      '--b-border-radius': tokenCssVar(borderRadius && `${TokenPrefix.Radius}-${borderRadius}`),
+      '--b-border-width': cssDimension(borderWidth),
+      '--b-border-top-width': cssDimension(borderTopWidth),
+      '--b-border-right-width': cssDimension(borderRightWidth),
+      '--b-border-bottom-width': cssDimension(borderBottomWidth),
+      '--b-border-left-width': cssDimension(borderLeftWidth),
+      '--b-elevation': tokenCssVar(elevation && `${TokenPrefix.Elevation}-${elevation}`),
+      '--b-z-index': tokenCssVar(zIndex && `${TokenPrefix.ZIndex}-${zIndex}`),
+    },
+    className: classNames(
+      layoutStyles.layout,
+      position && layoutStyles[`position-${position}`],
+      isNumber(shrink) && layoutStyles[`shrink-${shrink}`],
+      isNumber(grow) && layoutStyles[`grow-${grow}`],
+      overflow && layoutStyles[`overflow-${overflow}`],
+      overflowX && layoutStyles[`overflow-x-${overflowX}`],
+      overflowY && layoutStyles[`overflow-y-${overflowY}`],
+    ),
+  }
+)

--- a/packages/bezier-react/src/utils/props.ts
+++ b/packages/bezier-react/src/utils/props.ts
@@ -1,3 +1,5 @@
+import classNames from 'classnames'
+
 import {
   type BezierComponentProps,
   type LayoutProps,
@@ -5,11 +7,18 @@ import {
 } from '~/src/types/ComponentProps'
 import { TokenPrefix } from '~/src/types/Token'
 
+// NOTE: 'typescript-plugin-css-modules' does not support path alias
+/* eslint-disable no-restricted-imports */
+import layoutStyles from '../styles/components/layout.module.scss'
+import marginStyles from '../styles/components/margin.module.scss'
+/* eslint-enable no-restricted-imports */
+
 import {
   cssDimension,
   cssVar,
   tokenCssVar,
 } from './style'
+import { isNumber } from './type'
 
 export const splitByBezierComponentProps = <
   Props extends BezierComponentProps,
@@ -83,10 +92,8 @@ export const splitByLayoutProps = <Props extends LayoutProps>({
   borderRightWidth,
   borderBottomWidth,
   borderLeftWidth,
-  borderStyle,
   elevation,
   zIndex,
-  overflow,
   overflowX,
   overflowY,
   ...rest
@@ -121,10 +128,8 @@ export const splitByLayoutProps = <Props extends LayoutProps>({
       borderRightWidth,
       borderBottomWidth,
       borderLeftWidth,
-      borderStyle,
       elevation,
       zIndex,
-      overflow,
       overflowX,
       overflowY,
     },
@@ -139,15 +144,20 @@ export const getMarginStyle = <Props extends MarginProps>({
   mr,
   mb,
   ml,
-}: Props) => ({
-    '--b-margin': cssDimension(m),
-    '--b-margin-x': cssDimension(mx),
-    '--b-margin-y': cssDimension(my),
-    '--b-margin-top': cssDimension(mt),
-    '--b-margin-right': cssDimension(mr),
-    '--b-margin-bottom': cssDimension(mb),
-    '--b-margin-left': cssDimension(ml),
-  })
+}: Props) => (
+    {
+      style: {
+        '--b-margin': cssDimension(m),
+        '--b-margin-x': cssDimension(mx),
+        '--b-margin-y': cssDimension(my),
+        '--b-margin-top': cssDimension(mt),
+        '--b-margin-right': cssDimension(mr),
+        '--b-margin-bottom': cssDimension(mb),
+        '--b-margin-left': cssDimension(ml),
+      },
+      className: marginStyles.margin,
+    }
+  )
 
 export const getLayoutStyle = <Props extends LayoutProps>({
   p,
@@ -179,46 +189,49 @@ export const getLayoutStyle = <Props extends LayoutProps>({
   borderRightWidth,
   borderBottomWidth,
   borderLeftWidth,
-  borderStyle,
   elevation,
   zIndex,
-  overflow,
   overflowX,
   overflowY,
-}: Props) => ({
-    '--b-padding': cssDimension(p),
-    '--b-padding-x': cssDimension(px),
-    '--b-padding-y': cssDimension(py),
-    '--b-padding-top': cssDimension(pt),
-    '--b-padding-right': cssDimension(pr),
-    '--b-padding-bottom': cssDimension(pb),
-    '--b-padding-left': cssDimension(pl),
-    '--b-width': cssDimension(width),
-    '--b-height': cssDimension(height),
-    '--b-max-width': cssDimension(maxWidth),
-    '--b-min-width': cssDimension(minWidth),
-    '--b-max-height': cssDimension(maxHeight),
-    '--b-min-height': cssDimension(minHeight),
-    '--b-position': position,
-    '--b-inset': cssDimension(inset),
-    '--b-top': cssDimension(top),
-    '--b-right': cssDimension(right),
-    '--b-bottom': cssDimension(bottom),
-    '--b-left': cssDimension(left),
-    '--b-shrink': shrink,
-    '--b-grow': grow,
-    '--b-bg-color': cssVar(bgColor),
-    '--b-border-color': cssVar(borderColor),
-    '--b-border-radius': tokenCssVar(borderRadius && `${TokenPrefix.Radius}-${borderRadius}`),
-    '--b-border-width': cssDimension(borderWidth),
-    '--b-border-top-width': cssDimension(borderTopWidth),
-    '--b-border-right-width': cssDimension(borderRightWidth),
-    '--b-border-bottom-width': cssDimension(borderBottomWidth),
-    '--b-border-left-width': cssDimension(borderLeftWidth),
-    '--b-border-style': borderStyle,
-    '--b-elevation': tokenCssVar(elevation && `${TokenPrefix.Elevation}-${elevation}`),
-    '--b-z-index': tokenCssVar(zIndex && `${TokenPrefix.ZIndex}-${zIndex}`),
-    '--b-overflow': overflow,
-    '--b-overflow-x': overflowX,
-    '--b-overflow-y': overflowY,
-  })
+}: Props) => (
+    {
+      style: {
+        '--b-padding': cssDimension(p),
+        '--b-padding-x': cssDimension(px),
+        '--b-padding-y': cssDimension(py),
+        '--b-padding-top': cssDimension(pt),
+        '--b-padding-right': cssDimension(pr),
+        '--b-padding-bottom': cssDimension(pb),
+        '--b-padding-left': cssDimension(pl),
+        '--b-width': cssDimension(width),
+        '--b-height': cssDimension(height),
+        '--b-max-width': cssDimension(maxWidth),
+        '--b-min-width': cssDimension(minWidth),
+        '--b-max-height': cssDimension(maxHeight),
+        '--b-min-height': cssDimension(minHeight),
+        '--b-inset': cssDimension(inset),
+        '--b-top': cssDimension(top),
+        '--b-right': cssDimension(right),
+        '--b-bottom': cssDimension(bottom),
+        '--b-left': cssDimension(left),
+        '--b-bg-color': cssVar(bgColor),
+        '--b-border-color': cssVar(borderColor),
+        '--b-border-radius': tokenCssVar(borderRadius && `${TokenPrefix.Radius}-${borderRadius}`),
+        '--b-border-width': cssDimension(borderWidth),
+        '--b-border-top-width': cssDimension(borderTopWidth),
+        '--b-border-right-width': cssDimension(borderRightWidth),
+        '--b-border-bottom-width': cssDimension(borderBottomWidth),
+        '--b-border-left-width': cssDimension(borderLeftWidth),
+        '--b-elevation': tokenCssVar(elevation && `${TokenPrefix.Elevation}-${elevation}`),
+        '--b-z-index': tokenCssVar(zIndex && `${TokenPrefix.ZIndex}-${zIndex}`),
+      },
+      className: classNames(
+        layoutStyles.layout,
+        position && layoutStyles[`position-${position}`],
+        isNumber(shrink) && layoutStyles[`shrink-${shrink}`],
+        isNumber(grow) && layoutStyles[`grow-${grow}`],
+        overflowX && layoutStyles[`overflow-x-${overflowX}`],
+        overflowY && layoutStyles[`overflow-y-${overflowY}`],
+      ),
+    }
+  )


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

공용 Margin css module과 Layout 컴포넌트 공용 css module을 개선합니다.

## Details
<!-- Please elaborate description of the changes -->

1.디자인 토큰을 사용하지 않고 2. dimension value를 사용하지 않는, 적은 수의 키워드만 값으로 사용할 수 있는 CSS 속성들의 타입을 명확하게 좁히고 이를 inline style 대신 class로 스타일링하도록 개선했습니다. 불필요한 스타일 계산을 최소화하기 위함입니다.

- 디자인 토큰도 갯수가 정해져있으므로 모두 class를 정의해둘 수 있지만(`.color-txt-black-darkest { color: var(--txt-black-darkest')}`), 이렇게 되면 토큰 스펙 변경에 따라 클래스명도 함께 변경해주어여하니 사람이 직접 추적해야하는 곳이 너무 많아지므로... 약간의 성능을 잃더라도 중앙 집중식 관리(bezier-tokens를 통한)의 이점을 챙기는 편이 더 좋다고 판단했습니다. CSS 파일 용량도 무시 못하게 올라가기도 합니다.
- 이 방식을 채택하자면 차라리 지금이라도 tailwind 처럼 utility class 기반 + 사용처에서 CSS를 build하는 방향으로 가는 게 맞는데, 디자인 시스템 라이브러리에서 이런 방향이 맞는지 모르겠습니다. 라이브러리 사용처에 특정 기술의 사용을 강요하다보면 또 styled-components와 같은 전철을 밟게 될 거 같다는 두려움이 있어요.
- radix UI Theme를 참고하여 `shrink`, `grow` prop의 타입을 `0 | 1` 로 좁혔습니다. 마찬가지로 class를 정적으로 생성해두기 위함입니다. 채널 데스크 기준, LegacyStack의 사용례를 봤을 때 두 값만으로 99%이상 커버되므로 문제 없을거라고 판단했습니다.
- 코드를 더 들여다보니 우리 디자인에서 사용하는 `border-style` 이 `solid` 고정이라 필요없다는 사실을 알았습니다. 제거합니다.

변경 이후 사용처에서 스타일링하려면 inline style + classname 두 가지의 조합이 필수적인데, 이를 각 사용처인 컴포넌트에서 처리해주기보다 props 유틸에 포함하는 게 좋다고 판단했습니다(DRY). components 디렉터리 하위에 위치하고 있던 shared.module.scss를 공용 styles 디렉터리의 components 하위로 옮겨서 props 유틸에서 import하도록 했습니다. 이 편이 더 좋은 구성인 거 같아요.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No (alpha)

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- https://www.radix-ui.com/themes/docs/components/box