### PR TITLE
Add codemod for `Text` component interface

### DIFF
--- a/.changeset/early-tables-taste.md
+++ b/.changeset/early-tables-taste.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-codemod": minor
+---
+
+Add codemod to transform interface of `Text` component

--- a/packages/bezier-codemod/README.md
+++ b/packages/bezier-codemod/README.md
@@ -322,7 +322,7 @@ function Bar() {
 
 `v2-text-component-interface`
 
-Replace `Typography` enum with string literal and change properties related to margin to be shorthand. **Notice that this transforms all `Typography` enum in styled component, so `v2-typography-interpolation-to-css-variable` should be applied first.**
+Replace `Typography` enum with string literal and change properties related to margin to be shorthand.
 
 For example:
 

--- a/packages/bezier-codemod/README.md
+++ b/packages/bezier-codemod/README.md
@@ -258,7 +258,7 @@ export const Wrapper = styled(Button)``;
 
 ### Remove Alpha prefix from `AlphaStack` and add Legacy prefix to `Stack`
 
-`remove-alpha-from-alpha-stack`
+`v2-remove-alpha-from-alpha-stack`
 
 Deprecates current `Stack`, `HStack`, `VStack`, `StackItem`, `Spacer` components and supports `AlphaStack` instead, removing "Alpha" prefix.
 
@@ -316,4 +316,48 @@ function Bar() {
     </Stack>
   );
 }
+```
+
+### Change interface of `Text`
+
+`v2-text-component-interface`
+
+Replace `Typography` enum with string literal and change properties related to margin to be shorthand. **Notice that this transforms all `Typography` enum in styled component, so `v2-typography-interpolation-to-css-variable` should be applied first.**
+
+For example:
+
+```tsx
+import { Text, styled, Typography } from "@channel.io/bezier-react";
+
+function Foo() {
+  return (
+    <Text typo={Typography.Size13} marginLeft={4}>
+      title
+    </Text>
+  );
+}
+
+const Title = styled(Text).attrs({
+  typo: Typography.Size13,
+  marginLeft: 4,
+})``;
+```
+
+Transforms into:
+
+```tsx
+import { Text, styled } from "@channel.io/bezier-react";
+
+function Foo() {
+  return (
+    <Text typo="13" ml={4}>
+      title
+    </Text>
+  );
+}
+
+const Title = styled(Text).attrs({
+  typo: "13",
+  ml: 4,
+})``;
 ```

--- a/packages/bezier-codemod/src/App.tsx
+++ b/packages/bezier-codemod/src/App.tsx
@@ -30,6 +30,7 @@ import foundationToCssVariableTransition from './transforms/v2-foundation-to-css
 import styledToStyledComponents from './transforms/v2-import-styled-from-styled-components/transform.js'
 import inputInterpolationToCssVariable from './transforms/v2-input-interpolation-to-css-variable/transform.js'
 import removeAlphaFromAlphaStack from './transforms/v2-remove-alpha-from-alpha-stack/transform.js'
+import textComponentInterface from './transforms/v2-text-component-interface/transform.js'
 import typographyInterpolationToCssVariable from './transforms/v2-typography-interpolation-to-css-variable/transform.js'
 import zIndexInterpolationToCssVariable from './transforms/v2-z-index-interpolation-to-css-variable/transform.js'
 
@@ -55,6 +56,7 @@ enum Option {
   V2StyledToStyledComponents = 'v2-styled-to-styled-components',
   V2RemoveAlphaFromAlphaStack = 'v2-remove-alpha-from-alpha-stack',
   V2ZIndexInterpolationToCssVariable = 'v2-z-index-interpolation-to-css-variable',
+  V2TextComponentInterface = 'v2-text-component-interface',
   Exit = 'Exit',
 }
 
@@ -75,6 +77,7 @@ const transformMap = {
   [Option.V2StyledToStyledComponents]: styledToStyledComponents,
   [Option.V2RemoveAlphaFromAlphaStack]: removeAlphaFromAlphaStack,
   [Option.V2ZIndexInterpolationToCssVariable]: zIndexInterpolationToCssVariable,
+  [Option.V2TextComponentInterface]: textComponentInterface,
 }
 
 const options = (Object.keys(transformMap) as Option[]).map((transformName) => ({

--- a/packages/bezier-codemod/src/shared/enum.ts
+++ b/packages/bezier-codemod/src/shared/enum.ts
@@ -11,7 +11,7 @@ type Member = string
 type Value = string
 export type EnumTransformMap = Record<Name, Record<Member, Value>>
 
-export const transformEnumTostringLiteralInBezier = (sourceFile: SourceFile, enumTransforms: EnumTransformMap) => {
+export const transformEnumToStringLiteralInBezier = (sourceFile: SourceFile, enumTransforms: EnumTransformMap) => {
   const transformedEnumNames: string[] = []
 
   Object

--- a/packages/bezier-codemod/src/shared/enum.ts
+++ b/packages/bezier-codemod/src/shared/enum.ts
@@ -11,7 +11,7 @@ type Member = string
 type Value = string
 export type EnumTransformMap = Record<Name, Record<Member, Value>>
 
-export const transformEnumMemberToStringLiteral = (sourceFile: SourceFile, enumTransforms: EnumTransformMap) => {
+export const transformEnumTostringLiteralInBezier = (sourceFile: SourceFile, enumTransforms: EnumTransformMap) => {
   const transformedEnumNames: string[] = []
 
   Object

--- a/packages/bezier-codemod/src/transforms/enum-member-to-string-literal/transform.ts
+++ b/packages/bezier-codemod/src/transforms/enum-member-to-string-literal/transform.ts
@@ -2,7 +2,7 @@ import { type SourceFile } from 'ts-morph'
 
 import {
   type EnumTransformMap,
-  transformEnumMemberToStringLiteral,
+  transformEnumTostringLiteralInBezier,
 } from '../../shared/enum.js'
 
 const ENUM_TRANSFORM_MAP: EnumTransformMap = {
@@ -18,7 +18,7 @@ const ENUM_TRANSFORM_MAP: EnumTransformMap = {
 }
 
 function enumMemberToStringLiteral(sourceFile: SourceFile): true | void {
-  return transformEnumMemberToStringLiteral(sourceFile, ENUM_TRANSFORM_MAP)
+  return transformEnumTostringLiteralInBezier(sourceFile, ENUM_TRANSFORM_MAP)
 }
 
 export default enumMemberToStringLiteral

--- a/packages/bezier-codemod/src/transforms/enum-member-to-string-literal/transform.ts
+++ b/packages/bezier-codemod/src/transforms/enum-member-to-string-literal/transform.ts
@@ -2,7 +2,7 @@ import { type SourceFile } from 'ts-morph'
 
 import {
   type EnumTransformMap,
-  transformEnumTostringLiteralInBezier,
+  transformEnumToStringLiteralInBezier,
 } from '../../shared/enum.js'
 
 const ENUM_TRANSFORM_MAP: EnumTransformMap = {
@@ -18,7 +18,7 @@ const ENUM_TRANSFORM_MAP: EnumTransformMap = {
 }
 
 function enumMemberToStringLiteral(sourceFile: SourceFile): true | void {
-  return transformEnumTostringLiteralInBezier(sourceFile, ENUM_TRANSFORM_MAP)
+  return transformEnumToStringLiteralInBezier(sourceFile, ENUM_TRANSFORM_MAP)
 }
 
 export default enumMemberToStringLiteral

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-attrs.input.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-attrs.input.tsx
@@ -1,0 +1,12 @@
+import { Text, Typography, styled } from '@channel.io/bezier-react'
+
+export const Title = styled(Text).attrs({
+  typo: Typography.Size11,
+  marginAll: 1,
+  marginTop: 2,
+  marginRight: 3,
+  marginBottom: 4,
+  marginLeft: 5,
+  marginHorizontal: 6,
+  marginVertical: 7,
+})``

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-attrs.output.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-attrs.output.tsx
@@ -1,0 +1,12 @@
+import { Text, styled } from '@channel.io/bezier-react'
+
+export const Title = styled(Text).attrs({
+  typo: '11',
+  m: 1,
+  mt: 2,
+  mr: 3,
+  mb: 4,
+  ml: 5,
+  mx: 6,
+  my: 7,
+})``

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-attrs.output.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-attrs.output.tsx
@@ -1,7 +1,7 @@
 import { Text, styled } from '@channel.io/bezier-react'
 
 export const Title = styled(Text).attrs({
-  typo: '11',
+  typo: "11",
   m: 1,
   mt: 2,
   mr: 3,

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-props.input.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-props.input.tsx
@@ -1,0 +1,18 @@
+import { Text, Typography } from '@channel.io/bezier-react'
+
+export function Component () {
+  return (
+    <Text 
+      typo={Typography.Size14}
+      marginAll={1}
+      marginTop={3}
+      marginRight={3}
+      marginBottom={3}
+      marginLeft={2}
+      marginHorizontal={3}
+      marginVertical={3}
+    >
+      text
+    </Text>
+  )
+}

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-props.output.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-props.output.tsx
@@ -1,0 +1,18 @@
+import { Text } from '@channel.io/bezier-react'
+
+export function Component () {
+  return (
+    <Text 
+      typo='14'
+      m={1}
+      mt={3}
+      mr={3}
+      mb={3}
+      ml={2}
+      mx={3}
+      my={3}
+    >
+      text
+    </Text>
+  )
+}

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-props.output.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-props.output.tsx
@@ -3,7 +3,7 @@ import { Text } from '@channel.io/bezier-react'
 export function Component () {
   return (
     <Text 
-      typo='14'
+      typo="14"
       m={1}
       mt={3}
       mr={3}

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-with-interpolation.input.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-with-interpolation.input.tsx
@@ -1,0 +1,16 @@
+import { Text, Typography, styled } from '@channel.io/bezier-react'
+
+export const Title = styled(Text).attrs({
+  typo: Typography.Size11,
+  marginAll: 1,
+  marginTop: 2,
+  marginRight: 3,
+  marginBottom: 4,
+  marginLeft: 5,
+  marginHorizontal: 6,
+  marginVertical: 7,
+})``
+
+export const Subtitle = styled(Text)`
+  ${Typography.Size11};
+`

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-with-interpolation.output.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/fixtures/text-component-with-interpolation.output.tsx
@@ -1,0 +1,16 @@
+import { Text, Typography, styled } from '@channel.io/bezier-react'
+
+export const Title = styled(Text).attrs({
+  typo: "11",
+  m: 1,
+  mt: 2,
+  mr: 3,
+  mb: 4,
+  ml: 5,
+  mx: 6,
+  my: 7,
+})``
+
+export const Subtitle = styled(Text)`
+  ${Typography.Size11};
+`

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/transform.test.ts
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/transform.test.ts
@@ -1,0 +1,13 @@
+import { testTransformFunction } from '../../utils/test.js'
+
+import textTransform from './transform.js'
+
+describe('Text component transform', () => {
+  it('should transform typography enum to string literal and margin properties to be shorthand', () => {
+    testTransformFunction(__dirname, 'text-component-props', textTransform)
+  })
+
+  it('should transform properties in attrs object of styled component', () => {
+    testTransformFunction(__dirname, 'text-component-attrs', textTransform)
+  })
+})

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/transform.test.ts
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/transform.test.ts
@@ -10,4 +10,8 @@ describe('Text component transform', () => {
   it('should transform properties in attrs object of styled component', () => {
     testTransformFunction(__dirname, 'text-component-attrs', textTransform)
   })
+
+  it('should transform properties only in attrs object of styled component', () => {
+    testTransformFunction(__dirname, 'text-component-with-interpolation', textTransform)
+  })
 })

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/transform.ts
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/transform.ts
@@ -1,46 +1,74 @@
 import { type SourceFile } from 'ts-morph'
 
 import {
-  changePropsName,
-  transformAttrProperty,
+  type ComponentTransformMap,
+  changeAttrProperty,
+  changeComponentProp,
 } from '../../utils/component.js'
-import { transformEnumMemberToStringLiteral } from '../enum-member-to-string-literal/transform.js'
 
-const MARGIN_TRANSFORM_MAP = {
+const MARGIN_TRANSFORM_MAP: ComponentTransformMap = {
   Text: {
-    marginAll: 'm',
-    marginTop: 'mt',
-    marginRight: 'mr',
-    marginBottom: 'mb',
-    marginLeft: 'ml',
-    marginHorizontal: 'mx',
-    marginVertical: 'my',
+    keyMapper: {
+      marginAll: 'm',
+      marginTop: 'mt',
+      marginRight: 'mr',
+      marginBottom: 'mb',
+      marginLeft: 'ml',
+      marginHorizontal: 'mx',
+      marginVertical: 'my',
+    },
+    valueMapper: {
+      'Typography.Size11': '"11"',
+      'Typography.Size12': '"12"',
+      'Typography.Size13': '"13"',
+      'Typography.Size14': '"14"',
+      'Typography.Size15': '"15"',
+      'Typography.Size16': '"16"',
+      'Typography.Size17': '"17"',
+      'Typography.Size18': '"18"',
+      'Typography.Size22': '"22"',
+      'Typography.Size24': '"24"',
+      'Typography.Size30': '"30"',
+      'Typography.Size36': '"36"',
+    },
   },
 }
 
-const TYPOGRAPHY_ENUM_TRANSFORM_MAP = {
-  Typography: {
-    Size11: '11',
-    Size12: '12',
-    Size13: '13',
-    Size14: '14',
-    Size15: '15',
-    Size16: '16',
-    Size17: '17',
-    Size18: '18',
-    Size22: '22',
-    Size24: '24',
-    Size30: '30',
-    Size36: '36',
+const TYPOGRAPHY_MAP: ComponentTransformMap = {
+  Text: {
+    keyMapper: {
+      marginAll: 'm',
+      marginTop: 'mt',
+      marginRight: 'mr',
+      marginBottom: 'mb',
+      marginLeft: 'ml',
+      marginHorizontal: 'mx',
+      marginVertical: 'my',
+    },
+    valueMapper: {
+      '{Typography.Size11}': '"11"',
+      '{Typography.Size12}': '"12"',
+      '{Typography.Size13}': '"13"',
+      '{Typography.Size14}': '"14"',
+      '{Typography.Size15}': '"15"',
+      '{Typography.Size16}': '"16"',
+      '{Typography.Size17}': '"17"',
+      '{Typography.Size18}': '"18"',
+      '{Typography.Size22}': '"22"',
+      '{Typography.Size24}': '"24"',
+      '{Typography.Size30}': '"30"',
+      '{Typography.Size36}': '"36"',
+    },
   },
 }
 
 const transformTextComponentProps = (sourceFile: SourceFile) => {
   const oldSourceFileText = sourceFile.getText()
 
-  transformEnumMemberToStringLiteral(sourceFile, TYPOGRAPHY_ENUM_TRANSFORM_MAP)
-  changePropsName(sourceFile, MARGIN_TRANSFORM_MAP)
-  transformAttrProperty(sourceFile, MARGIN_TRANSFORM_MAP)
+  changeComponentProp(sourceFile, TYPOGRAPHY_MAP)
+  changeAttrProperty(sourceFile, MARGIN_TRANSFORM_MAP)
+
+  sourceFile.fixUnusedIdentifiers()
 
   return oldSourceFileText !== sourceFile.getText()
 }

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/transform.ts
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/transform.ts
@@ -6,7 +6,7 @@ import {
   changeComponentProp,
 } from '../../utils/component.js'
 
-const MARGIN_TRANSFORM_MAP: ComponentTransformMap = {
+const STYLED_ATTRS_TRANSFORM_MAP: ComponentTransformMap = {
   Text: {
     keyMapper: {
       marginAll: 'm',
@@ -34,7 +34,7 @@ const MARGIN_TRANSFORM_MAP: ComponentTransformMap = {
   },
 }
 
-const TYPOGRAPHY_MAP: ComponentTransformMap = {
+const JSX_PROP_TRANSFORM_MAP: ComponentTransformMap = {
   Text: {
     keyMapper: {
       marginAll: 'm',
@@ -65,8 +65,8 @@ const TYPOGRAPHY_MAP: ComponentTransformMap = {
 const transformTextComponentProps = (sourceFile: SourceFile) => {
   const oldSourceFileText = sourceFile.getText()
 
-  changeComponentProp(sourceFile, TYPOGRAPHY_MAP)
-  changeAttrProperty(sourceFile, MARGIN_TRANSFORM_MAP)
+  changeComponentProp(sourceFile, JSX_PROP_TRANSFORM_MAP)
+  changeAttrProperty(sourceFile, STYLED_ATTRS_TRANSFORM_MAP)
 
   sourceFile.fixUnusedIdentifiers()
 

--- a/packages/bezier-codemod/src/transforms/v2-text-component-interface/transform.ts
+++ b/packages/bezier-codemod/src/transforms/v2-text-component-interface/transform.ts
@@ -1,0 +1,48 @@
+import { type SourceFile } from 'ts-morph'
+
+import {
+  changePropsName,
+  transformAttrProperty,
+} from '../../utils/component.js'
+import { transformEnumMemberToStringLiteral } from '../enum-member-to-string-literal/transform.js'
+
+const MARGIN_TRANSFORM_MAP = {
+  Text: {
+    marginAll: 'm',
+    marginTop: 'mt',
+    marginRight: 'mr',
+    marginBottom: 'mb',
+    marginLeft: 'ml',
+    marginHorizontal: 'mx',
+    marginVertical: 'my',
+  },
+}
+
+const TYPOGRAPHY_ENUM_TRANSFORM_MAP = {
+  Typography: {
+    Size11: '11',
+    Size12: '12',
+    Size13: '13',
+    Size14: '14',
+    Size15: '15',
+    Size16: '16',
+    Size17: '17',
+    Size18: '18',
+    Size22: '22',
+    Size24: '24',
+    Size30: '30',
+    Size36: '36',
+  },
+}
+
+const transformTextComponentProps = (sourceFile: SourceFile) => {
+  const oldSourceFileText = sourceFile.getText()
+
+  transformEnumMemberToStringLiteral(sourceFile, TYPOGRAPHY_ENUM_TRANSFORM_MAP)
+  changePropsName(sourceFile, MARGIN_TRANSFORM_MAP)
+  transformAttrProperty(sourceFile, MARGIN_TRANSFORM_MAP)
+
+  return oldSourceFileText !== sourceFile.getText()
+}
+
+export default transformTextComponentProps

--- a/packages/bezier-codemod/src/transforms/v2-z-index-interpolation-to-css-variable/transform.ts
+++ b/packages/bezier-codemod/src/transforms/v2-z-index-interpolation-to-css-variable/transform.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-template-curly-in-string */
 import { type SourceFile } from 'ts-morph'
 
-import { transformEnumMemberToStringLiteral } from '../../shared/enum.js'
+import { transformEnumTostringLiteralInBezier } from '../../shared/enum.js'
 import { interpolationTransform } from '../../shared/interpolation.js'
 import { removeUnusedNamedImport } from '../../utils/import.js'
 
-const cssVariableByInterpolation = {
+const CSS_VARIABLE_TRANSFORM_MAP = {
   'ZIndex.Hide': 'var(--z-index-hidden);',
   'ZIndex.Auto': 'var(--z-index-auto);',
   'ZIndex.Base': 'var(--z-index-base);',
@@ -17,22 +17,24 @@ const cssVariableByInterpolation = {
   'ZIndex.Important': 'var(--z-index-important);',
 }
 
+const ENUM_TRANSFORM_MAP = {
+  ZIndex: {
+    Hide: 'var(--z-index-hidden)',
+    Base: 'var(--z-index-base)',
+    Float: 'var(--z-index-float)',
+    Overlay: 'var(--z-index-overlay)',
+    Modal: 'var(--z-index-modal)',
+    Toast: 'var(--z-index-toast)',
+    Tooltip: 'var(--z-index-tooltip)',
+    Important: 'var(--z-index-important)',
+  },
+}
+
 const replaceZIndexInterpolation = (sourceFile: SourceFile) => {
   const oldSourceFileText = sourceFile.getText()
 
-  interpolationTransform(sourceFile, cssVariableByInterpolation)
-  transformEnumMemberToStringLiteral(sourceFile, {
-    ZIndex: {
-      Hide: 'var(--z-index-hidden)',
-      Base: 'var(--z-index-base)',
-      Float: 'var(--z-index-float)',
-      Overlay: 'var(--z-index-overlay)',
-      Modal: 'var(--z-index-modal)',
-      Toast: 'var(--z-index-toast)',
-      Tooltip: 'var(--z-index-tooltip)',
-      Important: 'var(--z-index-important)',
-    },
-  })
+  interpolationTransform(sourceFile, CSS_VARIABLE_TRANSFORM_MAP)
+  transformEnumTostringLiteralInBezier(sourceFile, ENUM_TRANSFORM_MAP)
 
   const isChanged = sourceFile.getText() !== oldSourceFileText
   if (isChanged) {

--- a/packages/bezier-codemod/src/transforms/v2-z-index-interpolation-to-css-variable/transform.ts
+++ b/packages/bezier-codemod/src/transforms/v2-z-index-interpolation-to-css-variable/transform.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import { type SourceFile } from 'ts-morph'
 
-import { transformEnumTostringLiteralInBezier } from '../../shared/enum.js'
+import { transformEnumToStringLiteralInBezier } from '../../shared/enum.js'
 import { interpolationTransform } from '../../shared/interpolation.js'
 import { removeUnusedNamedImport } from '../../utils/import.js'
 
@@ -34,7 +34,7 @@ const replaceZIndexInterpolation = (sourceFile: SourceFile) => {
   const oldSourceFileText = sourceFile.getText()
 
   interpolationTransform(sourceFile, CSS_VARIABLE_TRANSFORM_MAP)
-  transformEnumTostringLiteralInBezier(sourceFile, ENUM_TRANSFORM_MAP)
+  transformEnumToStringLiteralInBezier(sourceFile, ENUM_TRANSFORM_MAP)
 
   const isChanged = sourceFile.getText() !== oldSourceFileText
   if (isChanged) {

--- a/packages/bezier-codemod/src/utils/component.ts
+++ b/packages/bezier-codemod/src/utils/component.ts
@@ -1,0 +1,34 @@
+import {
+  type JsxAttribute,
+  type JsxOpeningElement,
+  type JsxSelfClosingElement,
+  type SourceFile,
+  SyntaxKind,
+} from 'ts-morph'
+
+type Component = string
+type PropsFrom = string
+type PropsTo = string
+type ComponentPropTransformMap = Record<Component, Record<PropsFrom, PropsTo>>
+
+const getName = (node: JsxSelfClosingElement | JsxOpeningElement) => node.getTagNameNode().getText()
+
+const renameProps = (node: JsxAttribute, to: string) => {
+  node.set({ name: to, initializer: node.getInitializer()?.getText() })
+}
+
+export const changePropsName = (sourceFile: SourceFile, componentPropTransformMap: ComponentPropTransformMap) => {
+  const componentNames = new Set(Object.keys(componentPropTransformMap));
+
+  ([SyntaxKind.JsxSelfClosingElement, SyntaxKind.JsxOpeningElement] as const)
+    .flatMap((v) => sourceFile.getDescendantsOfKind(v))
+    .filter((node) => componentNames.has(getName(node)))
+    .forEach((jsxElement) => {
+      for (const [propsFrom, propsTo] of Object.entries(componentPropTransformMap[getName(jsxElement)])) {
+        const attribute = jsxElement.getAttribute(propsFrom) as JsxAttribute | undefined
+        if (attribute) {
+          renameProps(attribute, propsTo)
+        }
+      }
+    })
+}

--- a/packages/bezier-codemod/src/utils/component.ts
+++ b/packages/bezier-codemod/src/utils/component.ts
@@ -2,14 +2,15 @@ import {
   type JsxAttribute,
   type JsxOpeningElement,
   type JsxSelfClosingElement,
+  type PropertyAssignment,
   type SourceFile,
   SyntaxKind,
 } from 'ts-morph'
 
 type Component = string
-type PropsFrom = string
-type PropsTo = string
-type ComponentPropTransformMap = Record<Component, Record<PropsFrom, PropsTo>>
+type From = string
+type To = string
+type ComponentTransformMap = Record<Component, Record<From, To>>
 
 const getName = (node: JsxSelfClosingElement | JsxOpeningElement) => node.getTagNameNode().getText()
 
@@ -17,7 +18,7 @@ const renameProps = (node: JsxAttribute, to: string) => {
   node.set({ name: to, initializer: node.getInitializer()?.getText() })
 }
 
-export const changePropsName = (sourceFile: SourceFile, componentPropTransformMap: ComponentPropTransformMap) => {
+export const changePropsName = (sourceFile: SourceFile, componentPropTransformMap: ComponentTransformMap) => {
   const componentNames = new Set(Object.keys(componentPropTransformMap));
 
   ([SyntaxKind.JsxSelfClosingElement, SyntaxKind.JsxOpeningElement] as const)
@@ -31,4 +32,27 @@ export const changePropsName = (sourceFile: SourceFile, componentPropTransformMa
         }
       }
     })
+}
+
+export const renameSingleProperty = (node: PropertyAssignment, to: string) => {
+  node.getFirstChild()?.replaceWithText(to)
+}
+
+export const transformAttrProperty = (sourceFile: SourceFile, transformMap: Record<string, Record<string, string>>) => {
+  for (const component of Object.keys(transformMap)) {
+    const fromProps = new Set(Object.keys(transformMap[component]))
+
+    sourceFile
+      .getDescendantsOfKind(SyntaxKind.TaggedTemplateExpression)
+      .filter((node) => node.getText().startsWith(`styled(${component})`))
+      .flatMap((node) => node.getDescendantsOfKind(SyntaxKind.PropertyAssignment))
+      .forEach((node) => {
+        const prop = node.getFirstChild()?.getText()
+        if (!prop || !fromProps.has(prop)) {
+          return
+        }
+
+        renameSingleProperty(node, transformMap[component][prop])
+      })
+  }
 }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- Fixes https://github.com/channel-io/bezier-react/issues/1816

## Summary
<!-- Please brief explanation of the changes made -->

- `Text` 컴포넌트의 인터페이스를 변경하기 위한 codemod 를 추가합니다. 아래와 같이 변환됩니다.
- https://github.com/channel-io/bezier-react/pull/1844 base, from a1f267f17a8d6fced227575d6f39c60914ee9896 

```tsx
// As-is
import { Text, Typography } from '@channel.io/bezier-react'

<Text 
  typo={Typography.Size14}
  marginHorizontal={6}
>
  some text
</Text>

// To-be
import { Text } from '@channel.io/bezier-react'

<Text 
  typo="14"
  mx={6}
>
  some text
</Text>

// As-is
import { Text, styled, Typography } from '@channel.io/bezier-react'

const Title = styled(Text).attrs({
  typo: Typography.Size11,
  marginHorizontal: 6,
})``

// To-be
import { Text, styled } from '@channel.io/bezier-react'

const Title = styled(Text).attrs({
  typo: '11',
  mxl: 6,
})``
```

## Details
<!-- Please elaborate description of the changes -->

- 컴포넌트의 prop 을 변경하는 유틸과 styled component 안에서 .attrs 뒤에 나오는 객체를 변경하는 유틸을 추가했습니다. 

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

- No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- https://github.com/channel-io/bezier-react/issues/1816
