### PR TITLE
Use `:where` pseudo class to `Text`, `Stack` components

### DIFF
--- a/packages/bezier-react/src/components/Stack/Stack.module.scss
+++ b/packages/bezier-react/src/components/Stack/Stack.module.scss
@@ -5,71 +5,71 @@
     box-sizing: border-box;
     gap: var(--b-stack-spacing);
 
-    &.display-flex {
+   &:where(.display-flex) {
       display: flex;
     }
 
-    &.display-inline-flex {
+   &:where(.display-inline-flex) {
       display: inline-flex;
     }
 
-    &.direction-horizontal {
+   &:where(.direction-horizontal) {
       flex-direction: row;
 
-      &.reverse {
+     &:where(.reverse) {
         flex-direction: row-reverse;
       }
     }
 
-    &.direction-vertical {
+   &:where(.direction-vertical) {
       flex-direction: column;
 
-      &.reverse {
+     &:where(.reverse) {
         flex-direction: column-reverse;
       }
     }
 
-    &.justify-start {
+   &:where(.justify-start) {
       justify-content: flex-start;
     }
 
-    &.justify-end {
+   &:where(.justify-end) {
       justify-content: flex-end;
     }
 
-    &.justify-center {
+   &:where(.justify-center) {
       justify-content: center;
     }
 
-    &.justify-stretch {
+   &:where(.justify-stretch) {
       justify-content: stretch;
     }
 
-    &.justify-between {
+   &:where(.justify-between) {
       justify-content: space-between;
     }
 
-    &.align-start {
+   &:where(.align-start) {
       align-items: flex-start;
     }
 
-    &.align-end {
+   &:where(.align-end) {
       align-items: flex-end;
     }
 
-    &.align-center {
+   &:where(.align-center) {
       align-items: center;
     }
 
-    &.align-stretch {
+   &:where(.align-stretch) {
       align-items: stretch;
     }
 
-    &.align-baseline {
+   &:where(.align-baseline) {
       align-items: baseline;
     }
 
-    &.wrap {
+   &:where(.wrap) {
       flex-wrap: wrap;
     }
   }

--- a/packages/bezier-react/src/components/Stack/Stack.stories.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack.stories.tsx
@@ -9,6 +9,7 @@ import {
 import { range } from '~/src/utils/number'
 
 import { Box } from '~/src/components/Box'
+import { Text } from '~/src/components/Text'
 
 import { Stack } from './Stack'
 
@@ -18,7 +19,7 @@ const meta = {
 
 type Story = StoryObj<typeof meta>
 
-function DecorativeBox() {
+function DecorativeBox({ children }) {
   return (
     <Box
       width={50}
@@ -27,14 +28,22 @@ function DecorativeBox() {
       borderRadius="8"
       borderWidth={1}
       borderColor="bdr-black-light"
-    />
+    >
+      <Text>
+        { children }
+      </Text>
+    </Box>
   )
 }
 
 const Template: StoryFn<typeof Stack> = (args) => (
-  <Stack {...args}>
+  <Stack
+    {...args}
+    borderColor="bdr-black-dark"
+    borderWidth={1}
+  >
     { range(4).map((i) => (
-      <DecorativeBox key={`item-${i}`} />
+      <DecorativeBox key={`item-${i}`}>{ i + 1 }</DecorativeBox>
     )) }
   </Stack>
 )
@@ -43,6 +52,12 @@ export const Primary: Story = {
   render: Template,
   args: {
     direction: 'horizontal',
+    justify: 'start',
+    align: 'start',
+    reverse: false,
+    wrap: true,
+    width: 300,
+    height: 300,
     spacing: 6,
   },
 }

--- a/packages/bezier-react/src/components/Text/Text.module.scss
+++ b/packages/bezier-react/src/components/Text/Text.module.scss
@@ -7,95 +7,95 @@
     font-weight: var(--font-weight-400);
     transition: color var(--transition-s);
 
-    &.bold {
+    &:where(.bold) {
       font-weight: var(--font-weight-700);
     }
 
-    &.italic {
+    &:where(.italic) {
       font-style: italic;
     }
 
-    &.truncated {
+    &:where(.truncated) {
       display: block;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
     }
 
-    &.align-left {
+    &:where(.align-left) {
       text-align: left;
     }
 
-    &.align-center {
+    &:where(.align-center) {
       text-align: center;
     }
 
-    &.align-right {
+    &:where(.align-right) {
       text-align: right;
     }
 
-    &.typo-11 {
+    &:where(.typo-11) {
       font-size: var(--typography-size-11-font-size);
       line-height: var(--typography-size-11-line-height);
     }
 
-    &.typo-12 {
+    &:where(.typo-12) {
       font-size: var(--typography-size-12-font-size);
       line-height: var(--typography-size-12-line-height);
     }
 
-    &.typo-13 {
+    &:where(.typo-13) {
       font-size: var(--typography-size-13-font-size);
       line-height: var(--typography-size-13-line-height);
     }
 
-    &.typo-14 {
+    &:where(.typo-14) {
       font-size: var(--typography-size-14-font-size);
       line-height: var(--typography-size-14-line-height);
     }
 
-    &.typo-15 {
+    &:where(.typo-15) {
       font-size: var(--typography-size-15-font-size);
       line-height: var(--typography-size-15-line-height);
       letter-spacing: var(--typography-size-15-letter-spacing);
     }
 
-    &.typo-16 {
+    &:where(.typo-16) {
       font-size: var(--typography-size-16-font-size);
       line-height: var(--typography-size-16-line-height);
       letter-spacing: var(--typography-size-16-letter-spacing);
     }
 
-    &.typo-17 {
+    &:where(.typo-17) {
       font-size: var(--typography-size-17-font-size);
       line-height: var(--typography-size-17-line-height);
       letter-spacing: var(--typography-size-17-letter-spacing);
     }
 
-    &.typo-18 {
+    &:where(.typo-18) {
       font-size: var(--typography-size-18-font-size);
       line-height: var(--typography-size-18-line-height);
     }
 
-    &.typo-22 {
+    &:where(.typo-22) {
       font-size: var(--typography-size-22-font-size);
       line-height: var(--typography-size-22-line-height);
       letter-spacing: var(--typography-size-22-letter-spacing);
     }
 
-    &.typo-24 {
+    &:where(.typo-24) {
       font-size: var(--typography-size-24-font-size);
       line-height: var(--typography-size-24-line-height);
       letter-spacing: var(--typography-size-24-letter-spacing);
     }
 
-    &.typo-30 {
+    &:where(.typo-30) {
       font-size: var(--typography-size-30-font-size);
       line-height: var(--typography-size-30-line-height);
       letter-spacing: var(--typography-size-30-letter-spacing);
     }
 
-    &.typo-36 {
+    &:where(.typo-36) {
       font-size: var(--typography-size-36-font-size);
       line-height: var(--typography-size-36-line-height);
       letter-spacing: var(--typography-size-36-letter-spacing);

--- a/packages/bezier-react/src/components/Text/Text.stories.tsx
+++ b/packages/bezier-react/src/components/Text/Text.stories.tsx
@@ -22,8 +22,11 @@ const Template: StoryFn<TextProps> = ({ children, ...rest }) => (
 export const Primary: StoryObj<typeof Text> = {
   render: Template,
   args: {
+    bold: false,
+    italic: false,
     color: 'txt-black-darkest',
     children: 'Hello, Channel!',
+    typo: '15',
   },
 }
 

--- a/packages/bezier-react/src/stories/ComponentConvention/PropsInterface.stories.mdx
+++ b/packages/bezier-react/src/stories/ComponentConvention/PropsInterface.stories.mdx
@@ -8,7 +8,7 @@ import {
   PersonIcon,
   SearchIcon,
   TagIcon,
-  UserNameIcon,
+  UsernameIcon,
 } from '@channel.io/bezier-icons'
 import { css, Themes, Typography } from '~/src/foundation'
 import { Badge, Tag, TagBadgeVariant } from '~/src/components/TagBadge'
@@ -501,10 +501,10 @@ Form 내에서 사용되는 필드가 구현할 수 있는 인터페이스입니
 
 <Canvas>
   <Story name="FormComponentProps:TextFieldProps.idle">
-    <TextField leftContent={<Icon source={UserNameIcon} />} value="channel" />
+    <TextField leftContent={<Icon source={UsernameIcon} />} value="channel" />
   </Story>
   <Story name="FormComponentProps:TextFieldProps.hasError">
-    <TextField leftContent={<Icon source={UserNameIcon} />} value="channel" hasError />
+    <TextField leftContent={<Icon source={UsernameIcon} />} value="channel" hasError />
   </Story>
 </Canvas>
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- https://github.com/channel-io/bezier-react/issues/1865

## Summary
<!-- Please brief explanation of the changes made -->

- `Text`, `Stack` 컴포넌트 스타일링의 css 우선순위를 낮추기 위해 :where 셀렉터를 사용합니다.
- 컴포넌트 스토리북에 args 를 추가합니다. 

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

- No

