### PR TITLE
Enchance to add `@layer components` at-rule in CSS post-processing

### DIFF
--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -107,6 +107,7 @@
     "jest-styled-components": "^7.1.1",
     "lightningcss": "^1.22.1",
     "paths.macro": "^3.0.1",
+    "postcss": "^8.4.33",
     "postcss-preset-env": "^9.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -106,6 +106,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest-styled-components": "^7.1.1",
     "lightningcss": "^1.22.1",
+    "minimatch": "^9.0.3",
     "paths.macro": "^3.0.1",
     "postcss": "^8.4.33",
     "postcss-preset-env": "^9.3.0",

--- a/packages/bezier-react/postcss-auto-layer.mjs
+++ b/packages/bezier-react/postcss-auto-layer.mjs
@@ -9,7 +9,7 @@ const postcssAutoLayer = (opts = {}) => ({
     const filePath = result.opts.from
     if (filePath && minimatch(filePath, opts.path)) {
       const layer = new AtRule({ name: 'layer', params: opts.name })
-      root.nodes.forEach(node => { layer.append(node) })
+      root.nodes.forEach(node => { layer.append(node.clone()) })
       root.removeAll().append(layer)
     }
   },

--- a/packages/bezier-react/postcss-auto-layer.mjs
+++ b/packages/bezier-react/postcss-auto-layer.mjs
@@ -1,0 +1,20 @@
+import { minimatch } from 'minimatch'
+
+/**
+ * @type {import('postcss').PluginCreator<{ name: string, path: string }>}
+ */
+const postcssAutoLayer = (opts = {}) => ({
+  postcssPlugin: 'postcss-auto-layer',
+  Once(root, { result, AtRule }) {
+    const filePath = result.opts.from
+    if (filePath && minimatch(filePath, opts.path)) {
+      const layer = new AtRule({ name: 'layer', params: opts.name })
+      root.nodes.forEach(node => { layer.append(node) })
+      root.removeAll().append(layer)
+    }
+  },
+})
+
+postcssAutoLayer.postcss = true
+
+export default postcssAutoLayer

--- a/packages/bezier-react/postcss-auto-layer.mjs
+++ b/packages/bezier-react/postcss-auto-layer.mjs
@@ -1,7 +1,14 @@
 import { minimatch } from 'minimatch'
 
 /**
- * @type {import('postcss').PluginCreator<{ name: string, path: string }>}
+ * @typedef {Object} Options
+ * @property {string} name The name of the layer.
+ * @property {string} path The path to the file to wrap in a layer.
+ */
+
+/**
+ * PostCSS plugin to automatically wrap the root node in a CSS layer at rule.
+ * @type {import('postcss').PluginCreator<Options>}
  */
 const postcssAutoLayer = (opts = {}) => ({
   postcssPlugin: 'postcss-auto-layer',

--- a/packages/bezier-react/rollup.config.mjs
+++ b/packages/bezier-react/rollup.config.mjs
@@ -16,6 +16,8 @@ import nodeExternals from 'rollup-plugin-node-externals'
 import postcss from 'rollup-plugin-postcss'
 import { visualizer } from 'rollup-plugin-visualizer'
 
+import postcssAutoLayer from './postcss-auto-layer.mjs'
+
 const pkg = JSON.parse(
   readFileSync(fileURLToPath(new URL('./package.json', import.meta.url))),
 )
@@ -78,6 +80,10 @@ const generateConfig = ({
       plugins: [
         autoprefixer(),
         postcssPresetEnv(),
+        postcssAutoLayer({
+          name: 'components',
+          path: '**/components/**/*.module.scss',
+        }),
       ],
     }),
     /**

--- a/packages/bezier-react/src/components/Avatars/Avatar/Avatar.module.scss
+++ b/packages/bezier-react/src/components/Avatars/Avatar/Avatar.module.scss
@@ -1,87 +1,85 @@
-@layer components {
-  .Avatar {
-    position: relative;
-    display: block;
-    flex: none;
+.Avatar {
+  position: relative;
+  display: block;
+  flex: none;
 
-    &:where(.disabled) {
-      pointer-events: none;
-      opacity: var(--opacity-disabled);
-    }
-
-    &:where(.size-20) {
-      width: 20px;
-      height: 20px;
-    }
-
-    &:where(.size-24) {
-      width: 24px;
-      height: 24px;
-    }
-
-    &:where(.size-30) {
-      width: 30px;
-      height: 30px;
-    }
-
-    &:where(.size-36) {
-      width: 36px;
-      height: 36px;
-    }
-
-    &:where(.size-42) {
-      width: 42px;
-      height: 42px;
-    }
-
-    &:where(.size-48) {
-      width: 48px;
-      height: 48px;
-    }
-
-    &:where(.size-72) {
-      width: 72px;
-      height: 72px;
-    }
-
-    &:where(.size-90) {
-      width: 90px;
-      height: 90px;
-    }
-
-    &:where(.size-120) {
-      width: 120px;
-      height: 120px;
-    }
+  &:where(.disabled) {
+    pointer-events: none;
+    opacity: var(--opacity-disabled);
   }
 
-  .AvatarImage {
-    --b-avatar-status-gap: -2px;
-    --b-avatar-computed-status-gap: var(--b-avatar-status-gap);
-
-    position: relative;
-    box-sizing: content-box;
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    outline: none;
-    
-    &:where(.big-size) {
-      --b-avatar-status-gap: 4px;
-    }
-
-    &:where(.bordered[data-state="enabled"]) {
-      --b-avatar-computed-status-gap: calc(var(--b-avatar-status-gap) + (2 * var(--b-alpha-smooth-corners-box-shadow-spread-radius)));
-    }
+  &:where(.size-20) {
+    width: 20px;
+    height: 20px;
   }
 
-  .StatusWrapper {
-    position: absolute;
-    right: var(--b-avatar-computed-status-gap);
-    bottom: var(--b-avatar-computed-status-gap);
-    display: flex;
+  &:where(.size-24) {
+    width: 24px;
+    height: 24px;
   }
+
+  &:where(.size-30) {
+    width: 30px;
+    height: 30px;
+  }
+
+  &:where(.size-36) {
+    width: 36px;
+    height: 36px;
+  }
+
+  &:where(.size-42) {
+    width: 42px;
+    height: 42px;
+  }
+
+  &:where(.size-48) {
+    width: 48px;
+    height: 48px;
+  }
+
+  &:where(.size-72) {
+    width: 72px;
+    height: 72px;
+  }
+
+  &:where(.size-90) {
+    width: 90px;
+    height: 90px;
+  }
+
+  &:where(.size-120) {
+    width: 120px;
+    height: 120px;
+  }
+}
+
+.AvatarImage {
+  --b-avatar-status-gap: -2px;
+  --b-avatar-computed-status-gap: var(--b-avatar-status-gap);
+
+  position: relative;
+  box-sizing: content-box;
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  outline: none;
+
+  &:where(.big-size) {
+    --b-avatar-status-gap: 4px;
+  }
+
+  &:where(.bordered[data-state="enabled"]) {
+    --b-avatar-computed-status-gap: calc(var(--b-avatar-status-gap) + (2 * var(--b-alpha-smooth-corners-box-shadow-spread-radius)));
+  }
+}
+
+.StatusWrapper {
+  position: absolute;
+  right: var(--b-avatar-computed-status-gap);
+  bottom: var(--b-avatar-computed-status-gap);
+  display: flex;
 }

--- a/packages/bezier-react/src/components/Avatars/AvatarGroup/AvatarGroup.module.scss
+++ b/packages/bezier-react/src/components/Avatars/AvatarGroup/AvatarGroup.module.scss
@@ -1,82 +1,80 @@
-@layer components {
-  .AvatarGroup {
-    --b-avatar-group-spacing: 0;
-    --b-avatar-group-size: 0;
+.AvatarGroup {
+  --b-avatar-group-spacing: 0;
+  --b-avatar-group-size: 0;
 
-    position: relative;
-    z-index: var(--z-index-base);
-    display: flex;
+  position: relative;
+  z-index: var(--z-index-base);
+  display: flex;
 
-    & > * + * {
-      margin-left: var(--b-avatar-group-spacing);
-    }
+  & > * + * {
+    margin-left: var(--b-avatar-group-spacing);
+  }
+}
+
+.AvatarEllipsisIconWrapper {
+  position: relative;
+}
+
+.AvatarEllipsisIcon {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: var(--z-index-floating);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  outline: none;
+}
+
+.AvatarEllipsisCountWrapper {
+  --b-avatar-group-ellipsis-pr: 0;
+  --b-avatar-group-ellipsis-ml: 0;
+
+  &:where(.size-20) {
+    --b-avatar-group-ellipsis-pr: 4px;
   }
 
-  .AvatarEllipsisIconWrapper {
-    position: relative;
+  &:where(.size-24) {
+    --b-avatar-group-ellipsis-pr: 5px;
   }
 
-  .AvatarEllipsisIcon {
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: var(--z-index-floating);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    outline: none;
+  &:where(.size-30) {
+    --b-avatar-group-ellipsis-pr: 6px;
   }
 
-  .AvatarEllipsisCountWrapper {
-    --b-avatar-group-ellipsis-pr: 0;
-    --b-avatar-group-ellipsis-ml: 0;
-
-    &:where(.size-20) {
-      --b-avatar-group-ellipsis-pr: 4px;
-    }
-
-    &:where(.size-24) {
-      --b-avatar-group-ellipsis-pr: 5px;
-    }
-
-    &:where(.size-30) {
-      --b-avatar-group-ellipsis-pr: 6px;
-    }
-
-    &:where(.size-36) {
-      --b-avatar-group-ellipsis-pr: 6px;
-    }
-
-    &:where(.size-42) {
-      --b-avatar-group-ellipsis-pr: 6px;
-    }
-
-    &:where(.size-48) {
-      --b-avatar-group-ellipsis-pr: 6px;
-    }
-
-    &:where(.size-72) {
-      --b-avatar-group-ellipsis-pr: 6px;
-    }
-
-    &:where(.size-90) {
-      --b-avatar-group-ellipsis-pr: 6px;
-    }
-
-    &:where(.size-120) {
-      --b-avatar-group-ellipsis-pr: 6px;
-    }
-
-    padding-right: var(--b-avatar-group-ellipsis-pr);
-    margin-left: var(--b-avatar-group-ellipsis-ml);
+  &:where(.size-36) {
+    --b-avatar-group-ellipsis-pr: 6px;
   }
 
-  .AvatarEllipsisCount {
-    position: relative;
-    display: flex;
-    align-items: center;
-    height: var(--b-avatar-group-size);
+  &:where(.size-42) {
+    --b-avatar-group-ellipsis-pr: 6px;
   }
+
+  &:where(.size-48) {
+    --b-avatar-group-ellipsis-pr: 6px;
+  }
+
+  &:where(.size-72) {
+    --b-avatar-group-ellipsis-pr: 6px;
+  }
+
+  &:where(.size-90) {
+    --b-avatar-group-ellipsis-pr: 6px;
+  }
+
+  &:where(.size-120) {
+    --b-avatar-group-ellipsis-pr: 6px;
+  }
+
+  padding-right: var(--b-avatar-group-ellipsis-pr);
+  margin-left: var(--b-avatar-group-ellipsis-ml);
+}
+
+.AvatarEllipsisCount {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: var(--b-avatar-group-size);
 }

--- a/packages/bezier-react/src/components/Box/Box.module.scss
+++ b/packages/bezier-react/src/components/Box/Box.module.scss
@@ -1,17 +1,15 @@
-@layer components {
-  .Box {
-    box-sizing: border-box;
+.Box {
+  box-sizing: border-box;
 
-    &:where(.display-block) {
-      display: block;
-    }
+  &:where(.display-block) {
+    display: block;
+  }
 
-    &:where(.display-inline-block) {
-      display: inline-block;
-    }
+  &:where(.display-inline-block) {
+    display: inline-block;
+  }
 
-    &:where(.display-inline) {
-      display: inline;
-    }
+  &:where(.display-inline) {
+    display: inline;
   }
 }

--- a/packages/bezier-react/src/components/Center/Center.module.scss
+++ b/packages/bezier-react/src/components/Center/Center.module.scss
@@ -1,14 +1,12 @@
-@layer components {
-  .Center {
-    align-items: center;
-    justify-content: center;
+.Center {
+  align-items: center;
+  justify-content: center;
 
-    &:where(.display-flex) {
-      display: flex;
-    }
+  &:where(.display-flex) {
+    display: flex;
+  }
 
-    &:where(.display-inline-flex) {
-      display: inline-flex;
-    }
+  &:where(.display-inline-flex) {
+    display: inline-flex;
   }
 }

--- a/packages/bezier-react/src/components/Divider/Divider.module.scss
+++ b/packages/bezier-react/src/components/Divider/Divider.module.scss
@@ -1,53 +1,51 @@
-@layer components {
-  .Divider {
-    --b-divider-indent-size: 6px;
+.Divider {
+  --b-divider-indent-size: 6px;
 
-    border-radius: var(--radius-1);
-    background-color: var(--bdr-black-light);
+  border-radius: var(--radius-1);
+  background-color: var(--bdr-black-light);
 
-    &:where(.horizontal) {
-      width: calc(100% - 2 * var(--b-divider-indent-size));
-      height: var(--b-divider-thickness);
-      margin: var(--b-divider-indent-size);
+  &:where(.horizontal) {
+    width: calc(100% - 2 * var(--b-divider-indent-size));
+    height: var(--b-divider-thickness);
+    margin: var(--b-divider-indent-size);
 
-      &:where(.without-indent) {
-        width: 100%;
-        margin: 0;
-      }
-      &:where(.without-side-indent) {
-        width: 100%;
-        margin-left: 0;
-        margin-right: 0;
-      }
-      &:where(.without-parallel-indent) {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
+    &:where(.without-indent) {
+      width: 100%;
+      margin: 0;
     }
-
-    &:where(.vertical) {
-      width: var(--b-divider-thickness);
-      height: calc(100% - 2 * var(--b-divider-indent-size));
-      margin: var(--b-divider-indent-size);
-
-      &:where(.without-indent) {
-        height: 100%;
-        margin: 0;
-      }
-      &:where(.without-side-indent) {
-        height: 100%;
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-      &:where(.without-parallel-indent) {
-        margin-left: 0;
-        margin-right: 0;
-      }
+    &:where(.without-side-indent) {
+      width: 100%;
+      margin-left: 0;
+      margin-right: 0;
+    }
+    &:where(.without-parallel-indent) {
+      margin-top: 0;
+      margin-bottom: 0;
     }
   }
 
-  /* NOTE: For access from outside the component */
-  .variables {
-    --b-divider-thickness: 1px;
+  &:where(.vertical) {
+    width: var(--b-divider-thickness);
+    height: calc(100% - 2 * var(--b-divider-indent-size));
+    margin: var(--b-divider-indent-size);
+
+    &:where(.without-indent) {
+      height: 100%;
+      margin: 0;
+    }
+    &:where(.without-side-indent) {
+      height: 100%;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+    &:where(.without-parallel-indent) {
+      margin-left: 0;
+      margin-right: 0;
+    }
   }
+}
+
+/* NOTE: For access from outside the component */
+.variables {
+  --b-divider-thickness: 1px;
 }

--- a/packages/bezier-react/src/components/Emoji/Emoji.module.scss
+++ b/packages/bezier-react/src/components/Emoji/Emoji.module.scss
@@ -10,23 +10,21 @@ $emoji-sizes: '16', '20', '24', '30', '36', '42', '48', '60', '72', '90', '120';
   background-clip: content-box;
 }
 
-@layer components {
-  .Emoji {
-    --b-emoji-size: initial;
+.Emoji {
+  --b-emoji-size: initial;
 
-    position: relative;
-    box-sizing: content-box;
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    justify-content: center;
-    @include dimension.square(var(--b-emoji-size));
-    @include emoji-background(var(--b-emoji-size));
+  position: relative;
+  box-sizing: content-box;
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  @include dimension.square(var(--b-emoji-size));
+  @include emoji-background(var(--b-emoji-size));
 
-    @each $size in $emoji-sizes {
-      &:where(.size-#{$size}) {
-        --b-emoji-size: #{$size}px;
-      }
+  @each $size in $emoji-sizes {
+    &:where(.size-#{$size}) {
+      --b-emoji-size: #{$size}px;
     }
   }
 }

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.module.scss
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.module.scss
@@ -1,151 +1,149 @@
-@layer components {
-  .SegmentedControl {
-    --b-segmented-control-width: initial;
-    --b-segmented-control-item-index: -1;
-    --b-segmented-control-item-count: 0;
+.SegmentedControl {
+  --b-segmented-control-width: initial;
+  --b-segmented-control-item-index: -1;
+  --b-segmented-control-item-count: 0;
 
-    --b-segmented-control-height: initial;
-    --b-segmented-control-padding: initial;
+  --b-segmented-control-height: initial;
+  --b-segmented-control-padding: initial;
 
-    position: relative;
-    z-index: var(--z-index-base);
-    box-sizing: border-box;
-    width: var(--b-segmented-control-width);
-    height: var(--b-segmented-control-height);
-    padding: var(--b-segmented-control-padding);
-    background-color: var(--bg-black-lighter);
+  position: relative;
+  z-index: var(--z-index-base);
+  box-sizing: border-box;
+  width: var(--b-segmented-control-width);
+  height: var(--b-segmented-control-height);
+  padding: var(--b-segmented-control-padding);
+  background-color: var(--bg-black-lighter);
 
-    &:where(.size-xs) {
-      --b-segmented-control-height: 24px;
-      --b-segmented-control-padding: 1px;
+  &:where(.size-xs) {
+    --b-segmented-control-height: 24px;
+    --b-segmented-control-padding: 1px;
+    border-radius: var(--radius-6);
+
+    & :where(.SegmentedControlItem, .SegmentedControlIndicator) {
+      border-radius: 5px;
+    }
+
+    & :where(.SegmentedControlItem) {
+      padding: 1px 0;
+    }
+  }
+
+  &:where(.size-s) {
+    --b-segmented-control-height: 28px;
+    --b-segmented-control-padding: 2px;
+    border-radius: var(--radius-8);
+
+    & :where(.SegmentedControlItem, .SegmentedControlIndicator) {
+      border-radius: 5px;
+    }
+
+    & :where(.SegmentedControlItem) {
+      padding: 2px 0;
+    }
+  }
+
+  &:where(.size-m) {
+    --b-segmented-control-height: 36px;
+    --b-segmented-control-padding: 2px;
+    border-radius: var(--radius-8);
+
+    & :where(.SegmentedControlItem, .SegmentedControlIndicator) {
       border-radius: var(--radius-6);
-
-      & :where(.SegmentedControlItem, .SegmentedControlIndicator) {
-        border-radius: 5px;
-      }
-
-      & :where(.SegmentedControlItem) {
-        padding: 1px 0;
-      }
     }
 
-    &:where(.size-s) {
-      --b-segmented-control-height: 28px;
-      --b-segmented-control-padding: 2px;
-      border-radius: var(--radius-8);
-
-      & :where(.SegmentedControlItem, .SegmentedControlIndicator) {
-        border-radius: 5px;
-      }
-
-      & :where(.SegmentedControlItem) {
-        padding: 2px 0;
-      }
-    }
-
-    &:where(.size-m) {
-      --b-segmented-control-height: 36px;
-      --b-segmented-control-padding: 2px;
-      border-radius: var(--radius-8);
-
-      & :where(.SegmentedControlItem, .SegmentedControlIndicator) {
-        border-radius: var(--radius-6);
-      }
-
-      & :where(.SegmentedControlItem) {
-        padding: 6px 0;
-      }
-    }
-
-    &:where(.size-l) {
-      --b-segmented-control-height: 44px;
-      --b-segmented-control-padding: 4px;
-      border-radius: var(--radius-12);
-
-      & :where(.SegmentedControlItem, .SegmentedControlIndicator) {
-        border-radius: var(--radius-8);
-      }
-
-      & :where(.SegmentedControlItem) {
-        padding: 8px 0;
-      }
-    }
-
-    &:where([data-disabled]) {
-      opacity: var(--opacity-disabled);
-
-      & :where(.SegmentedControlItem, .SegmentedControlIndicator) {
-        cursor: not-allowed;
-      }
+    & :where(.SegmentedControlItem) {
+      padding: 6px 0;
     }
   }
 
-  .SegmentedControlIndicator {
-    position: absolute;
-    top: 50%;
-    left: var(--b-segmented-control-padding);
-    width: calc((100% - ((var(--b-segmented-control-item-count) - 1) * var(--b-divider-thickness)) - (var(--b-segmented-control-padding) * 2)) / var(--b-segmented-control-item-count));
-    height: calc(var(--b-segmented-control-height) - (var(--b-segmented-control-padding) * 2));
-    background-color: var(--bg-white-high);
-    box-shadow: var(--ev-1);
-    transform: translateX(calc((var(--b-segmented-control-item-index) * 100%) + var(--b-segmented-control-item-index) * var(--b-divider-thickness))) translateY(-50%);
-    transition: transform var(--transition-s);
+  &:where(.size-l) {
+    --b-segmented-control-height: 44px;
+    --b-segmented-control-padding: 4px;
+    border-radius: var(--radius-12);
+
+    & :where(.SegmentedControlItem, .SegmentedControlIndicator) {
+      border-radius: var(--radius-8);
+    }
+
+    & :where(.SegmentedControlItem) {
+      padding: 8px 0;
+    }
   }
 
-  .SegmentedControlItem {
-    position: relative;
-    display: flex;
-    flex: 1;
-    align-items: center;
-    justify-content: center;
-    min-width: 0;
-    transition: background-color var(--transition-s);
+  &:where([data-disabled]) {
+    opacity: var(--opacity-disabled);
 
-    &:where([data-checked]) {
-      color: var(--txt-black-darkest);
-      cursor: default;
-    }
-
-    &:where(:not([data-checked])) {
-      color: var(--txt-black-dark);
-      cursor: pointer;
-    }
-
-    &:where(:disabled) {
+    & :where(.SegmentedControlItem, .SegmentedControlIndicator) {
       cursor: not-allowed;
     }
+  }
+}
 
-    /* NOTE: Focus indicator */
-    &::after {
-      position: absolute;
-      top: 0;
-      left: 0;
-      z-index: var(--z-index-floating);
-      display: block;
-      width: 100%;
-      height: 100%;
-      content: '';
-      border-radius: inherit;
-      transition: box-shadow var(--transition-m);
-    }
+.SegmentedControlIndicator {
+  position: absolute;
+  top: 50%;
+  left: var(--b-segmented-control-padding);
+  width: calc((100% - ((var(--b-segmented-control-item-count) - 1) * var(--b-divider-thickness)) - (var(--b-segmented-control-padding) * 2)) / var(--b-segmented-control-item-count));
+  height: calc(var(--b-segmented-control-height) - (var(--b-segmented-control-padding) * 2));
+  background-color: var(--bg-white-high);
+  box-shadow: var(--ev-1);
+  transform: translateX(calc((var(--b-segmented-control-item-index) * 100%) + var(--b-segmented-control-item-index) * var(--b-divider-thickness))) translateY(-50%);
+  transition: transform var(--transition-s);
+}
 
-    &:where(:focus-visible) {
-      &::after {
-        box-shadow: var(--input-box-shadow-focused);
-      }
-    }
+.SegmentedControlItem {
+  position: relative;
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  transition: background-color var(--transition-s);
 
-    &:where(:not([data-checked]):not(&:disabled):hover) {
-      background-color: var(--bg-black-light);
-    }
+  &:where([data-checked]) {
+    color: var(--txt-black-darkest);
+    cursor: default;
   }
 
-  .SegmentedControlItemContainer {
+  &:where(:not([data-checked])) {
+    color: var(--txt-black-dark);
+    cursor: pointer;
+  }
+
+  &:where(:disabled) {
+    cursor: not-allowed;
+  }
+
+  /* NOTE: Focus indicator */
+  &::after {
+    position: absolute;
+    top: 0;
+    left: 0;
     z-index: var(--z-index-floating);
-    overflow: hidden;
+    display: block;
+    width: 100%;
+    height: 100%;
+    content: '';
+    border-radius: inherit;
+    transition: box-shadow var(--transition-m);
   }
 
-  .SegmentedControlItemLabel {
-    padding: 1px 4px;
+  &:where(:focus-visible) {
+    &::after {
+      box-shadow: var(--input-box-shadow-focused);
+    }
   }
+
+  &:where(:not([data-checked]):not(&:disabled):hover) {
+    background-color: var(--bg-black-light);
+  }
+}
+
+.SegmentedControlItemContainer {
+  z-index: var(--z-index-floating);
+  overflow: hidden;
+}
+
+.SegmentedControlItemLabel {
+  padding: 1px 4px;
 }

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.module.scss
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.module.scss
@@ -1,80 +1,78 @@
-@layer components {
-  .Slider {
-    --b-slider-width: initial;
-    --b-slider-thumb-size: 20px;
+.Slider {
+  --b-slider-width: initial;
+  --b-slider-thumb-size: 20px;
 
-    position: relative;
-    display: flex;
-    align-items: center;
-    width: var(--b-slider-width);
-    height: var(--b-slider-thumb-size);
-    touch-action: none;
-    cursor: pointer;
-    user-select: none;
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: var(--b-slider-width);
+  height: var(--b-slider-thumb-size);
+  touch-action: none;
+  cursor: pointer;
+  user-select: none;
 
-    &[data-disabled] {
-      cursor: not-allowed;
-      opacity: var(--opacity-disabled);
-    }
-
-    transition: opacity var(--transition-s);
+  &[data-disabled] {
+    cursor: not-allowed;
+    opacity: var(--opacity-disabled);
   }
 
-  .SliderPrimitiveTrack {
-    position: relative;
-    flex: 1;
-    height: 6px;
-    background-color: var(--bg-black-dark);
-    border-radius: var(--radius-3);
-    border-radius: 3px;
+  transition: opacity var(--transition-s);
+}
+
+.SliderPrimitiveTrack {
+  position: relative;
+  flex: 1;
+  height: 6px;
+  background-color: var(--bg-black-dark);
+  border-radius: var(--radius-3);
+  border-radius: 3px;
+}
+
+.SliderPrimitiveRange {
+  position: absolute;
+  height: 100%;
+  background-color: var(--bgtxt-green-normal);
+  border-radius: var(--radius-3);
+}
+
+.GuideContainer {
+  --b-slider-guide-height: 8px;
+
+  position: absolute;
+  top: calc(-1 * (var(--b-slider-guide-height) + 3px));
+  left: calc(var(--b-slider-thumb-size) / 2);
+  width: calc(100% - var(--b-slider-thumb-size));
+}
+
+.SliderGuide {
+  --b-slider-guide-left: 0;
+
+  position: absolute;
+  top: 0;
+  left: var(--b-slider-guide-left);
+  width: 2px;
+  height: var(--b-slider-guide-height);
+  background-color: var(--bg-black-light);
+  border-radius: 1px;
+  transform: translateX(-50%);
+}
+
+.SliderThumb {
+  display: block;
+  width: var(--b-slider-thumb-size);
+  height: var(--b-slider-thumb-size);
+  border-radius: var(--radius-12);
+
+  box-shadow: var(--ev-2);
+  background-color: var(--bgtxt-absolute-white-dark);
+
+  &:hover {
+    box-shadow: var(--ev-3);
   }
 
-  .SliderPrimitiveRange {
-    position: absolute;
-    height: 100%;
-    background-color: var(--bgtxt-green-normal);
-    border-radius: var(--radius-3);
+  &:focus-visible {
+    box-shadow: var(--input-box-shadow-focused);
   }
 
-  .GuideContainer {
-    --b-slider-guide-height: 8px;
-
-    position: absolute;
-    top: calc(-1 * (var(--b-slider-guide-height) + 3px));
-    left: calc(var(--b-slider-thumb-size) / 2);
-    width: calc(100% - var(--b-slider-thumb-size));
-  }
-
-  .SliderGuide {
-    --b-slider-guide-left: 0;
-
-    position: absolute;
-    top: 0;
-    left: var(--b-slider-guide-left);
-    width: 2px;
-    height: var(--b-slider-guide-height);
-    background-color: var(--bg-black-light);
-    border-radius: 1px;
-    transform: translateX(-50%);
-  }
-
-  .SliderThumb {
-    display: block;
-    width: var(--b-slider-thumb-size);
-    height: var(--b-slider-thumb-size);
-    border-radius: var(--radius-12);
-
-    box-shadow: var(--ev-2);
-    background-color: var(--bgtxt-absolute-white-dark);
-
-    &:hover {
-      box-shadow: var(--ev-3);
-    }
-
-    &:focus-visible {
-      box-shadow: var(--input-box-shadow-focused);
-    }
-
-    transition: box-shadow var(--transition-s);
-  }
+  transition: box-shadow var(--transition-s);
 }

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.module.scss
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.module.scss
@@ -1,64 +1,62 @@
-@layer components {
-  .Switch {
-    --b-switch-width: auto;
-    --b-switch-height: auto;
-    --b-switch-thumb-size: initial;
+.Switch {
+  --b-switch-width: auto;
+  --b-switch-height: auto;
+  --b-switch-thumb-size: initial;
 
-    position: relative;
-    width: var(--b-switch-width);
-    height: var(--b-switch-height);
-    cursor: pointer;
-    overflow: hidden;
-    border-radius: var(--radius-12);
-    background-color: var(--bg-black-dark);
-    transition: background-color var(--transition-s), opacity var(--transition-s);
+  position: relative;
+  width: var(--b-switch-width);
+  height: var(--b-switch-height);
+  cursor: pointer;
+  overflow: hidden;
+  border-radius: var(--radius-12);
+  background-color: var(--bg-black-dark);
+  transition: background-color var(--transition-s), opacity var(--transition-s);
 
-    &:where(.size-s) {
-      --b-switch-width: 30px;
-      --b-switch-height: 20px;
-      --b-switch-thumb-size: 14px;
-    }
+  &:where(.size-s) {
+    --b-switch-width: 30px;
+    --b-switch-height: 20px;
+    --b-switch-thumb-size: 14px;
+  }
 
-    &:where(.size-m) {
-      --b-switch-width: 36px;
-      --b-switch-height: 24px;
-      --b-switch-thumb-size: 18px;
-    }
+  &:where(.size-m) {
+    --b-switch-width: 36px;
+    --b-switch-height: 24px;
+    --b-switch-thumb-size: 18px;
+  }
 
-    &:where(&[data-state='checked']) {
-      background-color: var(--bgtxt-green-normal);
+  &:where(&[data-state='checked']) {
+    background-color: var(--bgtxt-green-normal);
 
-      &:hover {
-        background-color: var(--bgtxt-green-dark);
-      }
-    }
-
-    &:disabled {
-      cursor: not-allowed;
-      opacity: var(--opacity-disabled);
-    }
-
-    &:focus-visible {
-      box-shadow: var(--input-box-shadow-focused);
+    &:hover {
+      background-color: var(--bgtxt-green-dark);
     }
   }
 
-  .SwitchThumb {
-    --b-switch-thumb-padding: 3px;
+  &:disabled {
+    cursor: not-allowed;
+    opacity: var(--opacity-disabled);
+  }
 
-    position: absolute;
-    top: var(--b-switch-thumb-padding);
-    left: var(--b-switch-thumb-padding);
-    width: var(--b-switch-thumb-size);
-    height: var(--b-switch-thumb-size);
-    overflow: hidden;
-    border-radius: var(--radius-12);
-    box-shadow: var(--ev-2);
-    background-color: var(--bgtxt-absolute-white-dark);
-    transition: transform var(--transition-s);
+  &:focus-visible {
+    box-shadow: var(--input-box-shadow-focused);
+  }
+}
 
-    &:where(&[data-state='checked']) {
-      transform: translateX(calc(var(--b-switch-width) - var(--b-switch-thumb-size) - (var(--b-switch-thumb-padding) * 2)));
-    }
+.SwitchThumb {
+  --b-switch-thumb-padding: 3px;
+
+  position: absolute;
+  top: var(--b-switch-thumb-padding);
+  left: var(--b-switch-thumb-padding);
+  width: var(--b-switch-thumb-size);
+  height: var(--b-switch-thumb-size);
+  overflow: hidden;
+  border-radius: var(--radius-12);
+  box-shadow: var(--ev-2);
+  background-color: var(--bgtxt-absolute-white-dark);
+  transition: transform var(--transition-s);
+
+  &:where(&[data-state='checked']) {
+    transform: translateX(calc(var(--b-switch-width) - var(--b-switch-thumb-size) - (var(--b-switch-thumb-padding) * 2)));
   }
 }

--- a/packages/bezier-react/src/components/Help/Help.module.scss
+++ b/packages/bezier-react/src/components/Help/Help.module.scss
@@ -1,11 +1,9 @@
-@layer components {
-  .Help {
-    line-height: 0;
-    
-    &:not([data-state="closed"]) {
-      > .Icon {
-        color: var(--txt-black-darkest);
-      }
+.Help {
+  line-height: 0;
+
+  &:not([data-state="closed"]) {
+    > .Icon {
+      color: var(--txt-black-darkest);
     }
   }
 }

--- a/packages/bezier-react/src/components/Icon/Icon.module.scss
+++ b/packages/bezier-react/src/components/Icon/Icon.module.scss
@@ -1,9 +1,7 @@
-@layer components {
-  .Icon {
-    --b-icon-color: inherit;
+.Icon {
+  --b-icon-color: inherit;
 
-    flex: 0 0 auto;
-    color: var(--b-icon-color);
-    transition: color var(--transition-s);
-  }
+  flex: 0 0 auto;
+  color: var(--b-icon-color);
+  transition: color var(--transition-s);
 }

--- a/packages/bezier-react/src/components/Spinner/Spinner.module.scss
+++ b/packages/bezier-react/src/components/Spinner/Spinner.module.scss
@@ -1,55 +1,53 @@
 @use "../../styles/mixins/dimension";
 
-@layer components {
-  @keyframes spin {
-    0% {
-      transform: rotate(0deg);
-    }
-
-    100% {
-      transform: rotate(360deg);
-    }
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
   }
 
-  .Spinner {
-    --b-spinner-color: inherit;
+  100% {
+    transform: rotate(360deg);
+  }
+}
 
-    display: inline-block;
-    border-style: solid;
-    border-top-color: transparent;
-    border-right-color: var(--b-spinner-color);
-    border-bottom-color: var(--b-spinner-color);
-    border-left-color: var(--b-spinner-color);
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
+.Spinner {
+  --b-spinner-color: inherit;
 
-    &:where(.size-xl) {
-      @include dimension.square(50px);
-      border-width: 4px;
-    }
+  display: inline-block;
+  border-style: solid;
+  border-top-color: transparent;
+  border-right-color: var(--b-spinner-color);
+  border-bottom-color: var(--b-spinner-color);
+  border-left-color: var(--b-spinner-color);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
 
-    &:where(.size-l, .size-m) {
-      border-width: 3px;
-    }
+  &:where(.size-xl) {
+    @include dimension.square(50px);
+    border-width: 4px;
+  }
 
-    &:where(.size-l) {
-      @include dimension.square(24px);
-    }
+  &:where(.size-l, .size-m) {
+    border-width: 3px;
+  }
 
-    &:where(.size-m) {
-      @include dimension.square(20px);
-    }
+  &:where(.size-l) {
+    @include dimension.square(24px);
+  }
 
-    &:where(.size-s, .size-xs) {
-      border-width: 2px;
-    }
+  &:where(.size-m) {
+    @include dimension.square(20px);
+  }
 
-    &:where(.size-s) {
-      @include dimension.square(16px);
-    }
+  &:where(.size-s, .size-xs) {
+    border-width: 2px;
+  }
 
-    &:where(.size-xs) {
-      @include dimension.square(12px);
-    }
+  &:where(.size-s) {
+    @include dimension.square(16px);
+  }
+
+  &:where(.size-xs) {
+    @include dimension.square(12px);
   }
 }

--- a/packages/bezier-react/src/components/Stack/Stack.module.scss
+++ b/packages/bezier-react/src/components/Stack/Stack.module.scss
@@ -1,75 +1,73 @@
-@layer components {
-  .Stack {
-    --b-stack-spacing: initial;
+.Stack {
+  --b-stack-spacing: initial;
 
-    gap: var(--b-stack-spacing);
+  gap: var(--b-stack-spacing);
 
-   &:where(.display-flex) {
-      display: flex;
+  &:where(.display-flex) {
+    display: flex;
+  }
+
+  &:where(.display-inline-flex) {
+    display: inline-flex;
+  }
+
+  &:where(.direction-horizontal) {
+    flex-direction: row;
+
+    &:where(.reverse) {
+      flex-direction: row-reverse;
     }
+  }
 
-   &:where(.display-inline-flex) {
-      display: inline-flex;
+  &:where(.direction-vertical) {
+    flex-direction: column;
+
+    &:where(.reverse) {
+      flex-direction: column-reverse;
     }
+  }
 
-   &:where(.direction-horizontal) {
-      flex-direction: row;
+  &:where(.justify-start) {
+    justify-content: flex-start;
+  }
 
-     &:where(.reverse) {
-        flex-direction: row-reverse;
-      }
-    }
+  &:where(.justify-end) {
+    justify-content: flex-end;
+  }
 
-   &:where(.direction-vertical) {
-      flex-direction: column;
+  &:where(.justify-center) {
+    justify-content: center;
+  }
 
-     &:where(.reverse) {
-        flex-direction: column-reverse;
-      }
-    }
+  &:where(.justify-stretch) {
+    justify-content: stretch;
+  }
 
-   &:where(.justify-start) {
-      justify-content: flex-start;
-    }
+  &:where(.justify-between) {
+    justify-content: space-between;
+  }
 
-   &:where(.justify-end) {
-      justify-content: flex-end;
-    }
+  &:where(.align-start) {
+    align-items: flex-start;
+  }
 
-   &:where(.justify-center) {
-      justify-content: center;
-    }
+  &:where(.align-end) {
+    align-items: flex-end;
+  }
 
-   &:where(.justify-stretch) {
-      justify-content: stretch;
-    }
+  &:where(.align-center) {
+    align-items: center;
+  }
 
-   &:where(.justify-between) {
-      justify-content: space-between;
-    }
+  &:where(.align-stretch) {
+    align-items: stretch;
+  }
 
-   &:where(.align-start) {
-      align-items: flex-start;
-    }
+  &:where(.align-baseline) {
+    align-items: baseline;
+  }
 
-   &:where(.align-end) {
-      align-items: flex-end;
-    }
-
-   &:where(.align-center) {
-      align-items: center;
-    }
-
-   &:where(.align-stretch) {
-      align-items: stretch;
-    }
-
-   &:where(.align-baseline) {
-      align-items: baseline;
-    }
-
-   &:where(.wrap) {
-      flex-wrap: wrap;
-    }
+  &:where(.wrap) {
+    flex-wrap: wrap;
   }
 }

--- a/packages/bezier-react/src/components/Status/Status.module.scss
+++ b/packages/bezier-react/src/components/Status/Status.module.scss
@@ -1,45 +1,43 @@
 @use '../../styles/mixins/position';
 
-@layer components {
-  .Status {
-    --b-status-size: 0;
-    --b-status-border-width: 0;
-    --b-status-bg-color: inherit;
+.Status {
+  --b-status-size: 0;
+  --b-status-border-width: 0;
+  --b-status-bg-color: inherit;
 
-    position: relative;
-    z-index: var(--z-index-base);
-    box-sizing: content-box;
+  position: relative;
+  z-index: var(--z-index-base);
+  box-sizing: content-box;
+  width: var(--b-status-size);
+  height: var(--b-status-size);
+  background-color: var(--bg-white-high);
+  border: var(--b-status-border-width) solid var(--bg-white-high);
+  border-radius: 50%;
+
+  &::after {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: block;
     width: var(--b-status-size);
     height: var(--b-status-size);
-    background-color: var(--bg-white-high);
-    border: var(--b-status-border-width) solid var(--bg-white-high);
+    content: '';
+    background-color: var(--b-status-bg-color);
     border-radius: 50%;
-  
-    &::after {
-      position: absolute;
-      top: 0;
-      left: 0;
-      display: block;
-      width: var(--b-status-size);
-      height: var(--b-status-size);
-      content: '';
-      background-color: var(--b-status-bg-color);
-      border-radius: 50%;
-    }
-
-    &:where(.size-m) {
-      --b-status-size: 8px;
-      --b-status-border-width: 2px;
-    }
-
-    &:where(.size-l) {
-      --b-status-size: 14px;
-      --b-status-border-width: 3px;
-    }
   }
 
-  .Icon {
-    @include position.center();
-    z-index: var(--z-index-floating);
+  &:where(.size-m) {
+    --b-status-size: 8px;
+    --b-status-border-width: 2px;
   }
+
+  &:where(.size-l) {
+    --b-status-size: 14px;
+    --b-status-border-width: 3px;
+  }
+}
+
+.Icon {
+  @include position.center();
+  z-index: var(--z-index-floating);
 }

--- a/packages/bezier-react/src/components/TagBadge/Badge/Badge.module.scss
+++ b/packages/bezier-react/src/components/TagBadge/Badge/Badge.module.scss
@@ -1,76 +1,74 @@
-@layer components {
-  .Badge {
-    background-color: var(--b-tag-badge-background-color);
-    color: var(--b-tag-badge-color);
+.Badge {
+  background-color: var(--b-tag-badge-background-color);
+  color: var(--b-tag-badge-color);
 
-    &:where(.variant-Default) {
-      --b-tag-badge-background-color: var(--bg-black-lighter);
-      --b-tag-badge-color: var(--txt-black-darkest);
-    }
+  &:where(.variant-Default) {
+    --b-tag-badge-background-color: var(--bg-black-lighter);
+    --b-tag-badge-color: var(--txt-black-darkest);
+  }
 
-    &:where(.variant-MonochromeLight) {
-      --b-tag-badge-background-color: var(--bg-black-lighter);
-      --b-tag-badge-color: var(--txt-black-dark);
-    }
+  &:where(.variant-MonochromeLight) {
+    --b-tag-badge-background-color: var(--bg-black-lighter);
+    --b-tag-badge-color: var(--txt-black-dark);
+  }
 
-    &:where(.variant-MonochromeDark) {
-      --b-tag-badge-background-color: var(--bg-black-darker);
-      --b-tag-badge-color: var(--bgtxt-absolute-white-dark);
-    }
+  &:where(.variant-MonochromeDark) {
+    --b-tag-badge-background-color: var(--bg-black-darker);
+    --b-tag-badge-color: var(--bgtxt-absolute-white-dark);
+  }
 
-    &:where(.variant-Blue) {
-      --b-tag-badge-background-color: var(--bgtxt-blue-lighter);
-      --b-tag-badge-color: var(--bgtxt-blue-normal);
-    }
+  &:where(.variant-Blue) {
+    --b-tag-badge-background-color: var(--bgtxt-blue-lighter);
+    --b-tag-badge-color: var(--bgtxt-blue-normal);
+  }
 
-    &:where(.variant-Cobalt) {
-      --b-tag-badge-background-color: var(--bgtxt-cobalt-lighter);
-      --b-tag-badge-color: var(--bgtxt-cobalt-normal);
-    }
+  &:where(.variant-Cobalt) {
+    --b-tag-badge-background-color: var(--bgtxt-cobalt-lighter);
+    --b-tag-badge-color: var(--bgtxt-cobalt-normal);
+  }
 
-    &:where(.variant-Teal) {
-      --b-tag-badge-background-color: var(--bgtxt-teal-lighter);
-      --b-tag-badge-color: var(--bgtxt-teal-normal);
-    }
+  &:where(.variant-Teal) {
+    --b-tag-badge-background-color: var(--bgtxt-teal-lighter);
+    --b-tag-badge-color: var(--bgtxt-teal-normal);
+  }
 
-    &:where(.variant-Green) {
-      --b-tag-badge-background-color: var(--bgtxt-green-lighter);
-      --b-tag-badge-color: var(--bgtxt-green-normal);
-    }
+  &:where(.variant-Green) {
+    --b-tag-badge-background-color: var(--bgtxt-green-lighter);
+    --b-tag-badge-color: var(--bgtxt-green-normal);
+  }
 
-    &:where(.variant-Olive) {
-      --b-tag-badge-background-color: var(--bgtxt-olive-lighter);
-      --b-tag-badge-color: var(--bgtxt-olive-normal);
-    }
+  &:where(.variant-Olive) {
+    --b-tag-badge-background-color: var(--bgtxt-olive-lighter);
+    --b-tag-badge-color: var(--bgtxt-olive-normal);
+  }
 
-    &:where(.variant-Pink) {
-      --b-tag-badge-background-color: var(--bgtxt-pink-lighter);
-      --b-tag-badge-color: var(--bgtxt-pink-normal);
-    }
+  &:where(.variant-Pink) {
+    --b-tag-badge-background-color: var(--bgtxt-pink-lighter);
+    --b-tag-badge-color: var(--bgtxt-pink-normal);
+  }
 
-    &:where(.variant-Navy) {
-      --b-tag-badge-background-color: var(--bgtxt-navy-lighter);
-      --b-tag-badge-color: var(--bgtxt-navy-normal);
-    }
+  &:where(.variant-Navy) {
+    --b-tag-badge-background-color: var(--bgtxt-navy-lighter);
+    --b-tag-badge-color: var(--bgtxt-navy-normal);
+  }
 
-    &:where(.variant-Yellow) {
-      --b-tag-badge-background-color: var(--bgtxt-yellow-lighter);
-      --b-tag-badge-color: var(--bgtxt-yellow-normal);
-    }
+  &:where(.variant-Yellow) {
+    --b-tag-badge-background-color: var(--bgtxt-yellow-lighter);
+    --b-tag-badge-color: var(--bgtxt-yellow-normal);
+  }
 
-    &:where(.variant-Orange) {
-      --b-tag-badge-background-color: var(--bgtxt-orange-lighter);
-      --b-tag-badge-color: var(--bgtxt-orange-normal);
-    }
+  &:where(.variant-Orange) {
+    --b-tag-badge-background-color: var(--bgtxt-orange-lighter);
+    --b-tag-badge-color: var(--bgtxt-orange-normal);
+  }
 
-    &:where(.variant-Red) {
-      --b-tag-badge-background-color: var(--bgtxt-red-lighter);
-      --b-tag-badge-color: var(--bgtxt-red-normal);
-    }
+  &:where(.variant-Red) {
+    --b-tag-badge-background-color: var(--bgtxt-red-lighter);
+    --b-tag-badge-color: var(--bgtxt-red-normal);
+  }
 
-    &:where(.variant-Purple) {
-      --b-tag-badge-background-color: var(--bgtxt-purple-lighter);
-      --b-tag-badge-color: var(--bgtxt-purple-normal);
-    }
+  &:where(.variant-Purple) {
+    --b-tag-badge-background-color: var(--bgtxt-purple-lighter);
+    --b-tag-badge-color: var(--bgtxt-purple-normal);
   }
 }

--- a/packages/bezier-react/src/components/TagBadge/Tag/Tag.module.scss
+++ b/packages/bezier-react/src/components/TagBadge/Tag/Tag.module.scss
@@ -1,16 +1,14 @@
-@layer components {
-  .Tag {
-    /**
-    * TODO
-    * @see {@link https://github.com/channel-io/bezier-react/issues/1879}
-    * share background style logic with `Badge` after removing `color` props
-    */
-    --b-tag-badge-background-color: inherit;
+.Tag {
+  /**
+  * TODO
+  * @see {@link https://github.com/channel-io/bezier-react/issues/1879}
+  * share background style logic with `Badge` after removing `color` props
+  */
+  --b-tag-badge-background-color: inherit;
 
-    background-color: var(--b-tag-badge-background-color);
-  }
+  background-color: var(--b-tag-badge-background-color);
+}
 
-  .CloseIcon {
-    cursor: pointer;
-  }
+.CloseIcon {
+  cursor: pointer;
 }

--- a/packages/bezier-react/src/components/TagBadge/TagBadgeCommon/TagBadge.module.scss
+++ b/packages/bezier-react/src/components/TagBadge/TagBadgeCommon/TagBadge.module.scss
@@ -1,17 +1,15 @@
-@layer components {
-  .TagBadge {
-    display: flex;
-    align-items: center;
-    overflow: hidden;
+.TagBadge {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
 
-    &:where(.size-xs) {
-      padding: 1px 2px;
-      border-radius: var(--radius-4);
-    }
+  &:where(.size-xs) {
+    padding: 1px 2px;
+    border-radius: var(--radius-4);
+  }
 
-    &:where(.size-s, .size-m, .size-l) {
-      padding: 1px 4px;
-      border-radius: var(--radius-6);
-    }
+  &:where(.size-s, .size-m, .size-l) {
+    padding: 1px 4px;
+    border-radius: var(--radius-6);
   }
 }

--- a/packages/bezier-react/src/components/Text/Text.module.scss
+++ b/packages/bezier-react/src/components/Text/Text.module.scss
@@ -1,120 +1,118 @@
-@layer components {
-  .Text {
-    --b-text-color: inherit;
-    --b-text-line-clamp: 1;
-    --b-text-line-height: initial; 
-    --b-text-font-size: initial;
-    --b-text-letter-spacing: initial;
+.Text {
+  --b-text-color: inherit;
+  --b-text-line-clamp: 1;
+  --b-text-line-height: initial;
+  --b-text-font-size: initial;
+  --b-text-letter-spacing: initial;
 
-    color: var(--b-text-color);
-    font-style: normal;
-    font-weight: var(--font-weight-400);
-    font-size: var(--b-text-font-size);
-    line-height: var(--b-text-line-height);
-    letter-spacing: var(--b-text-letter-spacing);
-    transition: color var(--transition-s);
+  color: var(--b-text-color);
+  font-style: normal;
+  font-weight: var(--font-weight-400);
+  font-size: var(--b-text-font-size);
+  line-height: var(--b-text-line-height);
+  letter-spacing: var(--b-text-letter-spacing);
+  transition: color var(--transition-s);
 
-    &:where(.bold) {
-      font-weight: var(--font-weight-700);
-    }
+  &:where(.bold) {
+    font-weight: var(--font-weight-700);
+  }
 
-    &:where(.italic) {
-      font-style: italic;
-    }
+  &:where(.italic) {
+    font-style: italic;
+  }
 
-    &:where(.truncated) {
-      display: block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+  &:where(.truncated) {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
-    &:where(.multi-line-truncated) {
-      display: -webkit-box;
-      max-height: calc(var(--b-text-line-clamp) * var(--b-text-line-height));
-      overflow: hidden;
-      text-overflow: ellipsis;
-      -webkit-box-orient: vertical;
-      -webkit-line-clamp: var(--b-text-line-clamp);
-    }
+  &:where(.multi-line-truncated) {
+    display: -webkit-box;
+    max-height: calc(var(--b-text-line-clamp) * var(--b-text-line-height));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: var(--b-text-line-clamp);
+  }
 
-    &:where(.align-left) {
-      text-align: left;
-    }
+  &:where(.align-left) {
+    text-align: left;
+  }
 
-    &:where(.align-center) {
-      text-align: center;
-    }
+  &:where(.align-center) {
+    text-align: center;
+  }
 
-    &:where(.align-right) {
-      text-align: right;
-    }
+  &:where(.align-right) {
+    text-align: right;
+  }
 
-    &:where(.typo-11) {
-      --b-text-font-size: var(--typography-size-11-font-size);
-      --b-text-line-height: var(--typography-size-11-line-height);
-    }
+  &:where(.typo-11) {
+    --b-text-font-size: var(--typography-size-11-font-size);
+    --b-text-line-height: var(--typography-size-11-line-height);
+  }
 
-    &:where(.typo-12) {
-      --b-text-font-size: var(--typography-size-12-font-size);
-      --b-text-line-height: var(--typography-size-12-line-height);
-    }
+  &:where(.typo-12) {
+    --b-text-font-size: var(--typography-size-12-font-size);
+    --b-text-line-height: var(--typography-size-12-line-height);
+  }
 
-    &:where(.typo-13) {
-      --b-text-font-size: var(--typography-size-13-font-size);
-      --b-text-line-height: var(--typography-size-13-line-height);
-    }
+  &:where(.typo-13) {
+    --b-text-font-size: var(--typography-size-13-font-size);
+    --b-text-line-height: var(--typography-size-13-line-height);
+  }
 
-    &:where(.typo-14) {
-      --b-text-font-size: var(--typography-size-14-font-size);
-      --b-text-line-height: var(--typography-size-14-line-height);
-    }
+  &:where(.typo-14) {
+    --b-text-font-size: var(--typography-size-14-font-size);
+    --b-text-line-height: var(--typography-size-14-line-height);
+  }
 
-    &:where(.typo-15) {
-      --b-text-font-size: var(--typography-size-15-font-size);
-      --b-text-letter-spacing: var(--typography-size-15-letter-spacing);
-      --b-text-line-height: var(--typography-size-15-line-height);
-    }
+  &:where(.typo-15) {
+    --b-text-font-size: var(--typography-size-15-font-size);
+    --b-text-letter-spacing: var(--typography-size-15-letter-spacing);
+    --b-text-line-height: var(--typography-size-15-line-height);
+  }
 
-    &:where(.typo-16) {
-      --b-text-font-size: var(--typography-size-16-font-size);
-      --b-text-letter-spacing: var(--typography-size-16-letter-spacing);
-      --b-text-line-height: var(--typography-size-16-line-height);
-    }
+  &:where(.typo-16) {
+    --b-text-font-size: var(--typography-size-16-font-size);
+    --b-text-letter-spacing: var(--typography-size-16-letter-spacing);
+    --b-text-line-height: var(--typography-size-16-line-height);
+  }
 
-    &:where(.typo-17) {
-      --b-text-font-size: var(--typography-size-17-font-size);
-      --b-text-letter-spacing: var(--typography-size-17-letter-spacing);
-      --b-text-line-height: var(--typography-size-17-line-height);
-    }
+  &:where(.typo-17) {
+    --b-text-font-size: var(--typography-size-17-font-size);
+    --b-text-letter-spacing: var(--typography-size-17-letter-spacing);
+    --b-text-line-height: var(--typography-size-17-line-height);
+  }
 
-    &:where(.typo-18) {
-      --b-text-font-size: var(--typography-size-18-font-size);
-      --b-text-line-height: var(--typography-size-18-line-height);
-    }
+  &:where(.typo-18) {
+    --b-text-font-size: var(--typography-size-18-font-size);
+    --b-text-line-height: var(--typography-size-18-line-height);
+  }
 
-    &:where(.typo-22) {
-      --b-text-font-size: var(--typography-size-22-font-size);
-      --b-text-letter-spacing: var(--typography-size-22-letter-spacing);
-      --b-text-line-height: var(--typography-size-22-line-height);
-    }
+  &:where(.typo-22) {
+    --b-text-font-size: var(--typography-size-22-font-size);
+    --b-text-letter-spacing: var(--typography-size-22-letter-spacing);
+    --b-text-line-height: var(--typography-size-22-line-height);
+  }
 
-    &:where(.typo-24) {
-      --b-text-font-size: var(--typography-size-24-font-size);
-      --b-text-letter-spacing: var(--typography-size-24-letter-spacing);
-      --b-text-line-height: var(--typography-size-24-line-height);
-    }
+  &:where(.typo-24) {
+    --b-text-font-size: var(--typography-size-24-font-size);
+    --b-text-letter-spacing: var(--typography-size-24-letter-spacing);
+    --b-text-line-height: var(--typography-size-24-line-height);
+  }
 
-    &:where(.typo-30) {
-      --b-text-font-size: var(--typography-size-30-font-size);
-      --b-text-letter-spacing: var(--typography-size-30-letter-spacing);
-      --b-text-line-height: var(--typography-size-30-line-height);
-    }
+  &:where(.typo-30) {
+    --b-text-font-size: var(--typography-size-30-font-size);
+    --b-text-letter-spacing: var(--typography-size-30-letter-spacing);
+    --b-text-line-height: var(--typography-size-30-line-height);
+  }
 
-    &:where(.typo-36) {
-      --b-text-font-size: var(--typography-size-36-font-size);
-      --b-text-letter-spacing: var(--typography-size-36-letter-spacing);
-      --b-text-line-height: var(--typography-size-36-line-height);
-    }
+  &:where(.typo-36) {
+    --b-text-font-size: var(--typography-size-36-font-size);
+    --b-text-letter-spacing: var(--typography-size-36-letter-spacing);
+    --b-text-line-height: var(--typography-size-36-line-height);
   }
 }

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.module.scss
@@ -1,30 +1,28 @@
-@layer components {
-  .Tooltip {
-    z-index: var(--z-index-tooltip);
+.Tooltip {
+  z-index: var(--z-index-tooltip);
 
-    box-sizing: border-box;
-    width: max-content;
-    max-width: 260px;
-    height: max-content;
-    padding: 5px 8px;
-    word-break: normal;
-    word-wrap: break-word;
+  box-sizing: border-box;
+  width: max-content;
+  max-width: 260px;
+  height: max-content;
+  padding: 5px 8px;
+  word-break: normal;
+  word-wrap: break-word;
 
-    background-color: var(--bg-white-low);
-    overflow: hidden;
-    border-radius: var(--radius-8);
-    box-shadow: var(--ev-3);
-  }
+  background-color: var(--bg-white-low);
+  overflow: hidden;
+  border-radius: var(--radius-8);
+  box-shadow: var(--ev-3);
+}
 
-  .TooltipContainer {
-    overflow: hidden;
-  }
+.TooltipContainer {
+  overflow: hidden;
+}
 
-  .TooltipContent {
-    white-space: pre-wrap;
-  }
+.TooltipContent {
+  white-space: pre-wrap;
+}
 
-  .Icon {
-    padding: 1px;
-  }
+.Icon {
+  padding: 1px;
 }

--- a/packages/bezier-react/src/styles/components/layout.module.scss
+++ b/packages/bezier-react/src/styles/components/layout.module.scss
@@ -1,129 +1,127 @@
-@layer components {
-  .layout {
-    --b-padding: 0;
-    --b-padding-x: var(--b-padding);
-    --b-padding-y: var(--b-padding);
-    --b-padding-top: var(--b-padding-y);
-    --b-padding-right: var(--b-padding-x);
-    --b-padding-bottom: var(--b-padding-y);
-    --b-padding-left: var(--b-padding-x);
-    --b-width: initial;
-    --b-height: initial;
-    --b-max-width: initial;
-    --b-max-height: initial;
-    --b-min-width: initial;
-    --b-min-height: initial;
-    --b-inset: auto;
-    --b-top: var(--b-inset);
-    --b-right: var(--b-inset);
-    --b-bottom: var(--b-inset);
-    --b-left: var(--b-inset);
-    --b-background-color: initial;
-    --b-border-color: initial;
-    --b-border-radius: initial;
-    --b-border-width: 0;
-    --b-border-top-width: var(--b-border-width);
-    --b-border-right-width: var(--b-border-width);
-    --b-border-bottom-width: var(--b-border-width);
-    --b-border-left-width: var(--b-border-width);
-    --b-elevation: initial;
-    --b-z-index: initial;
+.layout {
+  --b-padding: 0;
+  --b-padding-x: var(--b-padding);
+  --b-padding-y: var(--b-padding);
+  --b-padding-top: var(--b-padding-y);
+  --b-padding-right: var(--b-padding-x);
+  --b-padding-bottom: var(--b-padding-y);
+  --b-padding-left: var(--b-padding-x);
+  --b-width: initial;
+  --b-height: initial;
+  --b-max-width: initial;
+  --b-max-height: initial;
+  --b-min-width: initial;
+  --b-min-height: initial;
+  --b-inset: auto;
+  --b-top: var(--b-inset);
+  --b-right: var(--b-inset);
+  --b-bottom: var(--b-inset);
+  --b-left: var(--b-inset);
+  --b-background-color: initial;
+  --b-border-color: initial;
+  --b-border-radius: initial;
+  --b-border-width: 0;
+  --b-border-top-width: var(--b-border-width);
+  --b-border-right-width: var(--b-border-width);
+  --b-border-bottom-width: var(--b-border-width);
+  --b-border-left-width: var(--b-border-width);
+  --b-elevation: initial;
+  --b-z-index: initial;
 
-    box-sizing: border-box;
-    padding: var(--b-padding-top) var(--b-padding-right) var(--b-padding-bottom) var(--b-padding-left);
-    width: var(--b-width);
-    height: var(--b-height);
-    max-width: var(--b-max-width);
-    max-height: var(--b-max-height);
-    min-width: var(--b-min-width);
-    min-height: var(--b-min-height);
-    inset: var(--b-top) var(--b-right) var(--b-bottom) var(--b-left);
-    background-color: var(--b-background-color);
-    border-color: var(--b-border-color);
-    border-radius: var(--b-border-radius);
-    border-style: solid;
-    border-width: var(--b-border-top-width) var(--b-border-right-width) var(--b-border-bottom-width) var(--b-border-left-width);
-    box-shadow: var(--b-elevation);
-    z-index: var(--b-z-index);
+  box-sizing: border-box;
+  padding: var(--b-padding-top) var(--b-padding-right) var(--b-padding-bottom) var(--b-padding-left);
+  width: var(--b-width);
+  height: var(--b-height);
+  max-width: var(--b-max-width);
+  max-height: var(--b-max-height);
+  min-width: var(--b-min-width);
+  min-height: var(--b-min-height);
+  inset: var(--b-top) var(--b-right) var(--b-bottom) var(--b-left);
+  background-color: var(--b-background-color);
+  border-color: var(--b-border-color);
+  border-radius: var(--b-border-radius);
+  border-style: solid;
+  border-width: var(--b-border-top-width) var(--b-border-right-width) var(--b-border-bottom-width) var(--b-border-left-width);
+  box-shadow: var(--b-elevation);
+  z-index: var(--b-z-index);
 
-    &:where(.position-relative) {
-      position: relative;
-    }
+  &:where(.position-relative) {
+    position: relative;
+  }
 
-    &:where(.position-absolute) {
-      position: absolute;
-    }
+  &:where(.position-absolute) {
+    position: absolute;
+  }
 
-    &:where(.position-fixed) {
-      position: fixed;
-    }
+  &:where(.position-fixed) {
+    position: fixed;
+  }
 
-    &:where(.position-sticky) {
-      position: sticky;
-    }
+  &:where(.position-sticky) {
+    position: sticky;
+  }
 
-    &:where(.shrink-0) {
-      flex-shrink: 0;
-    }
+  &:where(.shrink-0) {
+    flex-shrink: 0;
+  }
 
-    &:where(.shrink-1) {
-      flex-shrink: 1;
-    }
+  &:where(.shrink-1) {
+    flex-shrink: 1;
+  }
 
-    &:where(.grow-0) {
-      flex-grow: 0;
-    }
+  &:where(.grow-0) {
+    flex-grow: 0;
+  }
 
-    &:where(.grow-1) {
-      flex-grow: 1;
-    }
+  &:where(.grow-1) {
+    flex-grow: 1;
+  }
 
-    &:where(.overflow-visible) {
-      overflow: visible;
-    }
+  &:where(.overflow-visible) {
+    overflow: visible;
+  }
 
-    &:where(.overflow-hidden) {
-      overflow: hidden;
-    }
+  &:where(.overflow-hidden) {
+    overflow: hidden;
+  }
 
-    &:where(.overflow-scroll) {
-      overflow: scroll;
-    }
+  &:where(.overflow-scroll) {
+    overflow: scroll;
+  }
 
-    &:where(.overflow-auto) {
-      overflow: auto;
-    }
+  &:where(.overflow-auto) {
+    overflow: auto;
+  }
 
-    &:where(.overflow-x-visible) {
-      overflow-x: visible;
-    }
+  &:where(.overflow-x-visible) {
+    overflow-x: visible;
+  }
 
-    &:where(.overflow-x-hidden) {
-      overflow-x: hidden;
-    }
+  &:where(.overflow-x-hidden) {
+    overflow-x: hidden;
+  }
 
-    &:where(.overflow-x-scroll) {
-      overflow-x: scroll;
-    }
+  &:where(.overflow-x-scroll) {
+    overflow-x: scroll;
+  }
 
-    &:where(.overflow-x-auto) {
-      overflow-x: auto;
-    }
+  &:where(.overflow-x-auto) {
+    overflow-x: auto;
+  }
 
-    &:where(.overflow-y-visible) {
-      overflow-y: visible;
-    }
+  &:where(.overflow-y-visible) {
+    overflow-y: visible;
+  }
 
-    &:where(.overflow-y-hidden) {
-      overflow-y: hidden;
-    }
+  &:where(.overflow-y-hidden) {
+    overflow-y: hidden;
+  }
 
-    &:where(.overflow-y-scroll) {
-      overflow-y: scroll;
-    }
+  &:where(.overflow-y-scroll) {
+    overflow-y: scroll;
+  }
 
-    &:where(.overflow-y-auto) {
-      overflow-y: auto;
-    }
+  &:where(.overflow-y-auto) {
+    overflow-y: auto;
   }
 }

--- a/packages/bezier-react/src/styles/components/margin.module.scss
+++ b/packages/bezier-react/src/styles/components/margin.module.scss
@@ -1,13 +1,11 @@
-@layer components {
-  .margin {
-    --b-margin: 0;
-    --b-margin-x: var(--b-margin);
-    --b-margin-y: var(--b-margin);
-    --b-margin-top: var(--b-margin-y);
-    --b-margin-right: var(--b-margin-x);
-    --b-margin-bottom: var(--b-margin-y);
-    --b-margin-left: var(--b-margin-x);
+.margin {
+  --b-margin: 0;
+  --b-margin-x: var(--b-margin);
+  --b-margin-y: var(--b-margin);
+  --b-margin-top: var(--b-margin-y);
+  --b-margin-right: var(--b-margin-x);
+  --b-margin-bottom: var(--b-margin-y);
+  --b-margin-left: var(--b-margin-x);
 
-    margin: var(--b-margin-top) var(--b-margin-right) var(--b-margin-bottom) var(--b-margin-left);
-  }
+  margin: var(--b-margin-top) var(--b-margin-right) var(--b-margin-bottom) var(--b-margin-left);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,6 +2978,7 @@ __metadata:
     jest-styled-components: ^7.1.1
     lightningcss: ^1.22.1
     paths.macro: ^3.0.1
+    postcss: ^8.4.33
     postcss-preset-env: ^9.3.0
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -17767,6 +17768,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.7":
+  version: 3.3.7
+  resolution: "nanoid@npm:3.3.7"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: d36c427e530713e4ac6567d488b489a36582ef89da1d6d4e3b87eded11eb10d7042a877958c6f104929809b2ab0bafa17652b076cdf84324aa75b30b722204f2
+  languageName: node
+  linkType: hard
+
 "natural-compare-lite@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare-lite@npm:1.4.0"
@@ -19714,6 +19724,17 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: 814e2126dacfea313588eda09cc99a9b4c26ec55c059188aa7a916d20d26d483483106dc5ff9e560731b59f45c5bb91b945dfadc670aed875cc90ddbbf4e787d
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.33":
+  version: 8.4.33
+  resolution: "postcss@npm:8.4.33"
+  dependencies:
+    nanoid: ^3.3.7
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 6f98b2af4b76632a3de20c4f47bf0e984a1ce1a531cf11adcb0b1d63a6cbda0aae4165e578b66c32ca4879038e3eaad386a6be725a8fb4429c78e3c1ab858fe9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2977,6 +2977,7 @@ __metadata:
     identity-obj-proxy: ^3.0.0
     jest-styled-components: ^7.1.1
     lightningcss: ^1.22.1
+    minimatch: ^9.0.3
     paths.macro: ^3.0.1
     postcss: ^8.4.33
     postcss-preset-env: ^9.3.0


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- Fixes #1884

## Summary
<!-- Please brief explanation of the changes made -->

Enchance to add `@layer components` at-rule in CSS post-processing

## Details
<!-- Please elaborate description of the changes -->

- 커스텀 PostCSS plugin을 통해 CSS를 갈아끼우는 방식으로 구현했습니다. 구현은 단순합니다.
- 불필요해진 *.module.scss의 `@layer components` at-rule을 제거했습니다.
- `*.module.scss` + `components` 디렉토리 내부에 위치한 파일만 처리하도록 구현했습니다. 여기엔 layout, margin props도 포함되니 이후 디렉터리명 변경에 유의해야합니다.
- 이전/이후 빌드된 CSS 파일이 동일한 것을 확인했습니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- https://postcss.org/docs/writing-a-postcss-plugin
- 공식 홈페이지는 CJS인데, ESM으로 만들기 위해 참고: https://github.com/postcss/postcss/issues/1771