### PR TITLE
Migrate `FormHelperText`, `FormErrorMessage`, and `FormLabel` component with scss

### DIFF
--- a/.changeset/funny-peaches-report.md
+++ b/.changeset/funny-peaches-report.md
@@ -2,6 +2,6 @@
 "@channel.io/bezier-react": major
 ---
 
-Changes in `FormLabel`, `FormHelperText`, and `FormErrorMessage`
+**Breaking Changes: Property updates in `FormLabel`, `FormHelperText`, and `FormErrorMessage` component**
 
-- They no longer supports `as` and `interpolation` props.
+No longer support `as` and `interpolation` property. Replace any usage of `interpolation` property with appropriate `style` or `className` implementations.

--- a/.changeset/funny-peaches-report.md
+++ b/.changeset/funny-peaches-report.md
@@ -1,0 +1,7 @@
+---
+"@channel.io/bezier-react": major
+---
+
+Changes in `FormLabel`, `FormHelperText`, and `FormErrorMessage`
+
+- They no longer supports `as` and `interpolation` props.

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.module.scss
@@ -1,0 +1,26 @@
+.FormLabelWrapper {
+  &:where(.position-top) {
+    padding: 0 2px;
+    margin-bottom: 4px;
+  }
+
+  &:where(.position-left) {
+    display: flex;
+    grid-row: 1 / 1;
+    grid-column: 1 / 1;
+    align-items: center;
+    align-self: start;
+    height: var(--b-form-control-left-label-wrapper-height);
+  }
+}
+
+.FormHelperTextWrapper {
+  padding: 0 2px;
+  margin-top: 4px;
+
+  &:where(.position-left) {
+    grid-row: 2 / 2;
+    grid-column: 2;
+  }
+}
+

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.module.scss
@@ -1,26 +1,27 @@
 .FormLabelWrapper {
   &:where(.position-top) {
-    padding: 0 2px;
     margin-bottom: 4px;
+    padding: 0 2px;
   }
 
   &:where(.position-left) {
     display: flex;
-    grid-row: 1 / 1;
     grid-column: 1 / 1;
+    grid-row: 1 / 1;
     align-items: center;
     align-self: start;
+
     height: var(--b-form-control-left-label-wrapper-height);
   }
 }
 
 .FormHelperTextWrapper {
-  padding: 0 2px;
   margin-top: 4px;
+  padding: 0 2px;
 
   &:where(.position-left) {
-    grid-row: 2 / 2;
     grid-column: 2;
+    grid-row: 2 / 2;
   }
 }
 

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.styled.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.styled.ts
@@ -9,34 +9,10 @@ const Box = styled.div<InterpolationProps>`
   ${({ interpolation }) => interpolation}
 `
 
-export const TopLabelWrapper = styled(Box)`
-  padding: 0 2px;
-  margin-bottom: 4px;
-`
-
-export const TopHelperTextWrapper = styled(Box)`
-  padding: 0 2px;
-  margin-top: 4px;
-`
-
 export const Grid = styled(Box)`
   display: grid;
   grid-template-rows: repeat(2, auto);
   grid-template-columns: ${LEFT_LABEL_MIN_WIDTH}px 1fr;
   grid-column-gap: 12px;
   align-items: center;
-`
-
-export const LeftLabelWrapper = styled(Box)`
-  display: flex;
-  grid-row: 1 / 1;
-  grid-column: 1 / 1;
-  align-items: center;
-  align-self: start;
-  height: var(--b-form-control-left-label-wrapper-height);
-`
-
-export const LeftHelperTextWrapper = styled(TopHelperTextWrapper)`
-  grid-row: 2 / 2;
-  grid-column: 2;
 `

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -113,7 +113,6 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     id: labelId,
     htmlFor: fieldId,
     labelPosition,
-    typo: labelPosition === 'top' ? '13' : '14',
     ...ownProps,
   }), [
     fieldId,

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -112,10 +112,8 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
   const getLabelProps = useCallback<LabelPropsGetter>(ownProps => ({
     id: labelId,
     htmlFor: fieldId,
+    labelPosition,
     typo: labelPosition === 'top' ? '13' : '14',
-    Wrapper: labelPosition === 'top'
-      ? Styled.TopLabelWrapper
-      : Styled.LeftLabelWrapper,
     ...ownProps,
   }), [
     fieldId,
@@ -139,9 +137,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     id: helperTextId,
     visible: isNil(formCommonProps?.hasError) || !formCommonProps?.hasError,
     ref: setHelperTextNode,
-    Wrapper: labelPosition === 'top'
-      ? Styled.TopHelperTextWrapper
-      : Styled.LeftHelperTextWrapper,
+    labelPosition,
     ...ownProps,
   }), [
     helperTextId,
@@ -153,9 +149,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     id: errorMessageId,
     visible: isNil(formCommonProps?.hasError) || formCommonProps?.hasError,
     ref: setErrorMessageNode,
-    Wrapper: labelPosition === 'top'
-      ? Styled.TopHelperTextWrapper
-      : Styled.LeftHelperTextWrapper,
+    labelPosition,
     ...ownProps,
   }), [
     errorMessageId,

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -115,7 +115,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
   const getLabelProps = useCallback<LabelPropsGetter>(ownProps => ({
     id: labelId,
     htmlFor: fieldId,
-    classNameFromControl: classNames(styles.FormLabelWrapper, styles[`position-${labelPosition}`]),
+    className: classNames(styles.FormLabelWrapper, styles[`position-${labelPosition}`]),
     typo: labelPosition === 'top' ? '13' : '14',
     ...ownProps,
   }), [
@@ -140,7 +140,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     id: helperTextId,
     visible: isNil(formCommonProps?.hasError) || !formCommonProps?.hasError,
     ref: setHelperTextNode,
-    classNameFromControl: classNames(styles.FormHelperTextWrapper, labelPosition === 'left' && styles['position-left']),
+    className: classNames(styles.FormHelperTextWrapper, labelPosition === 'left' && styles['position-left']),
     ...ownProps,
   }), [
     helperTextId,
@@ -152,7 +152,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     id: errorMessageId,
     visible: isNil(formCommonProps?.hasError) || formCommonProps?.hasError,
     ref: setErrorMessageNode,
-    classNameFromControl: classNames(styles.FormHelperTextWrapper, labelPosition === 'left' && styles['position-left']),
+    className: classNames(styles.FormHelperTextWrapper, labelPosition === 'left' && styles['position-left']),
     ...ownProps,
   }), [
     errorMessageId,

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -5,6 +5,8 @@ import React, {
   useState,
 } from 'react'
 
+import classNames from 'classnames'
+
 import useId from '~/src/hooks/useId'
 import { splitByBezierComponentProps } from '~/src/utils/props'
 import { px } from '~/src/utils/style'
@@ -26,6 +28,7 @@ import {
 } from './FormControl.types'
 import { FormControlContextProvider } from './FormControlContext'
 
+import styles from './FormControl.module.scss'
 import * as Styled from './FormControl.styled'
 
 export const FORM_CONTROL_TEST_ID = 'bezier-react-form-control'
@@ -112,7 +115,8 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
   const getLabelProps = useCallback<LabelPropsGetter>(ownProps => ({
     id: labelId,
     htmlFor: fieldId,
-    labelPosition,
+    classNameFromControl: classNames(styles.FormLabelWrapper, styles[`position-${labelPosition}`]),
+    typo: labelPosition === 'top' ? '13' : '14',
     ...ownProps,
   }), [
     fieldId,
@@ -136,7 +140,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     id: helperTextId,
     visible: isNil(formCommonProps?.hasError) || !formCommonProps?.hasError,
     ref: setHelperTextNode,
-    labelPosition,
+    classNameFromControl: classNames(styles.FormHelperTextWrapper, labelPosition === 'left' && styles['position-left']),
     ...ownProps,
   }), [
     helperTextId,
@@ -148,7 +152,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     id: errorMessageId,
     visible: isNil(formCommonProps?.hasError) || formCommonProps?.hasError,
     ref: setErrorMessageNode,
-    labelPosition,
+    classNameFromControl: classNames(styles.FormHelperTextWrapper, labelPosition === 'left' && styles['position-left']),
     ...ownProps,
   }), [
     errorMessageId,

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
@@ -10,8 +10,13 @@ import type {
   FormFieldSize,
 } from '~/src/components/Forms'
 
+type LabelPosition = 'top' | 'left'
+
+interface LabelPositionProps {
+  labelPosition?: LabelPosition
+}
+
 interface FormControlOptions {
-  labelPosition?: 'top' | 'left'
   leftLabelWrapperHeight?: FormFieldSize
 }
 
@@ -22,10 +27,6 @@ export interface FormControlAriaProps {
   'aria-describedby'?: string
 }
 
-interface WrapperProps {
-  Wrapper: React.FunctionComponent<ChildrenProps>
-}
-
 interface CallbackRefProps {
   ref: (node: HTMLElement | null) => void
 }
@@ -34,11 +35,11 @@ type PropsGetter<ExtraReturnType = {}> = <Props = {}>(props: Props) => Props & F
 
 export type GroupPropsGetter = PropsGetter<CallbackRefProps & FormControlAriaProps>
 
-export type LabelPropsGetter = PropsGetter<WrapperProps>
+export type LabelPropsGetter = PropsGetter<LabelPositionProps>
 
 export type FieldPropsGetter = PropsGetter<Omit<FormControlAriaProps, 'aria-labelledby'>>
 
-export type HelperTextPropsGetter = PropsGetter<WrapperProps & CallbackRefProps & {
+export type HelperTextPropsGetter = PropsGetter<LabelPositionProps & CallbackRefProps & {
   visible: boolean
 }>
 
@@ -59,10 +60,11 @@ export interface FormControlContextValue extends FormComponentProps {
 export interface ContainerProps extends
   AlphaBezierComponentProps,
   ChildrenProps,
-  Pick<FormControlOptions, 'labelPosition'> {}
+  LabelPositionProps {}
 
 export interface FormControlProps extends
   BezierComponentProps,
   ChildrenProps,
   FormComponentProps,
+  LabelPositionProps,
   FormControlOptions {}

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
@@ -12,12 +12,13 @@ import type {
 
 type LabelPosition = 'top' | 'left'
 
-interface LabelPositionProps {
+interface FormControlOptions {
+  leftLabelWrapperHeight?: FormFieldSize
   labelPosition?: LabelPosition
 }
 
-interface FormControlOptions {
-  leftLabelWrapperHeight?: FormFieldSize
+interface FormControlClassNameProps {
+  classNameFromControl: string
 }
 
 export interface FormControlContextCommonValue extends Partial<IdentifierProps> {}
@@ -35,11 +36,11 @@ type PropsGetter<ExtraReturnType = {}> = <Props = {}>(props: Props) => Props & F
 
 export type GroupPropsGetter = PropsGetter<CallbackRefProps & FormControlAriaProps>
 
-export type LabelPropsGetter = PropsGetter<LabelPositionProps>
+export type LabelPropsGetter = PropsGetter<FormControlClassNameProps>
 
 export type FieldPropsGetter = PropsGetter<Omit<FormControlAriaProps, 'aria-labelledby'>>
 
-export type HelperTextPropsGetter = PropsGetter<LabelPositionProps & CallbackRefProps & {
+export type HelperTextPropsGetter = PropsGetter<FormControlClassNameProps & CallbackRefProps & {
   visible: boolean
 }>
 
@@ -60,11 +61,10 @@ export interface FormControlContextValue extends FormComponentProps {
 export interface ContainerProps extends
   AlphaBezierComponentProps,
   ChildrenProps,
-  LabelPositionProps {}
+  Pick<FormControlOptions, 'labelPosition'> {}
 
 export interface FormControlProps extends
   BezierComponentProps,
   ChildrenProps,
   FormComponentProps,
-  LabelPositionProps,
   FormControlOptions {}

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
@@ -18,7 +18,7 @@ interface FormControlOptions {
 }
 
 interface FormControlClassNameProps {
-  classNameFromControl: string
+  className: string
 }
 
 export interface FormControlContextCommonValue extends Partial<IdentifierProps> {}

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -1,32 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormControl > Snapshot > With multiple field 1`] = `
-.c0 {
-  position: relative;
-}
-
-.c1 {
-  padding: 0 2px;
-  margin-bottom: 4px;
-}
-
-.c7 {
-  padding: 0 2px;
-  margin-top: 4px;
-}
-
-.c8 {
-  display: block;
-  text-align: left;
-}
-
 .c2 {
-  display: block;
-  text-align: left;
-  word-break: break-word;
-}
-
-.c5 {
   width: 100%;
   height: 100%;
   padding: 0;
@@ -39,23 +14,23 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   color: #000000D9;
 }
 
-.c5::-webkit-input-placeholder {
+.c2::-webkit-input-placeholder {
   color: #00000066;
 }
 
-.c5::-moz-placeholder {
+.c2::-moz-placeholder {
   color: #00000066;
 }
 
-.c5:-ms-input-placeholder {
+.c2:-ms-input-placeholder {
   color: #00000066;
 }
 
-.c5::placeholder {
+.c2::placeholder {
   color: #00000066;
 }
 
-.c3 {
+.c0 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -82,12 +57,12 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   transition-property: border-color,box-shadow;
 }
 
-.c3 .c4 {
+.c0 .c1 {
   font-size: 1.4rem;
   line-height: 1.8rem;
 }
 
-.c6 {
+.c3 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -115,7 +90,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   transition-property: border-color,box-shadow;
 }
 
-.c6 .c4 {
+.c3 .c1 {
   font-size: 1.4rem;
   line-height: 1.8rem;
 }
@@ -127,12 +102,11 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
     style="--b-form-control-left-label-wrapper-height: 36px;"
   >
     <div
-      class="c0 c1"
+      class="FormLabel top-position"
     >
       <label
-        class="Text typo-13 bold margin c2"
+        class="Text typo-13 bold align-left margin LabelText"
         data-testid="bezier-react-form-label"
-        foundation="[object Object]"
         id="form-label"
         style="--b-text-color: var(--txt-black-darkest);"
       >
@@ -154,13 +128,12 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="c0 c1"
+          class="FormLabel top-position"
         >
           <label
-            class="Text typo-13 bold margin c2"
+            class="Text typo-13 bold align-left margin LabelText"
             data-testid="bezier-react-form-label"
             for="field-:r3:"
-            foundation="[object Object]"
             id="field-:r3:-label"
             style="--b-text-color: var(--txt-black-darkest);"
           >
@@ -168,13 +141,13 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
           </label>
         </div>
         <div
-          class="c3"
+          class="c0"
           data-testid="bezier-react-text-input"
           size="36"
         >
           <input
             autocomplete="off"
-            class="c4 c5"
+            class="c1 c2"
             id="field-:r3:"
             size="36"
             value=""
@@ -187,13 +160,12 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="c0 c1"
+          class="FormLabel top-position"
         >
           <label
-            class="Text typo-13 bold margin c2"
+            class="Text typo-13 bold align-left margin LabelText"
             data-testid="bezier-react-form-label"
             for="field-:r4:"
-            foundation="[object Object]"
             id="field-:r4:-label"
             style="--b-text-color: var(--txt-black-darkest);"
           >
@@ -201,14 +173,14 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
           </label>
         </div>
         <div
-          class="c6"
+          class="c3"
           data-testid="bezier-react-text-input"
           size="36"
         >
           <input
             aria-invalid="true"
             autocomplete="off"
-            class="c4 c5"
+            class="c1 c2"
             id="field-:r4:"
             size="36"
             value=""
@@ -217,17 +189,16 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       </div>
     </div>
     <div
-      class="c0 c7"
+      class="HelperTextWrapper top-position"
     >
-      <p
-        class="Text typo-13 margin c8"
+      <span
+        class="Text typo-13 align-left margin HelperText"
         data-testid="bezier-react-form-helper-text"
-        foundation="[object Object]"
         id="form-help-text"
         style="--b-text-color: var(--txt-black-dark);"
       >
         Description
-      </p>
+      </span>
     </div>
   </div>
 </div>
@@ -236,16 +207,6 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 exports[`FormControl > Snapshot > With multiple field and left label position 1`] = `
 .c0 {
   position: relative;
-}
-
-.c4 {
-  padding: 0 2px;
-  margin-bottom: 4px;
-}
-
-.c9 {
-  padding: 0 2px;
-  margin-top: 4px;
 }
 
 .c1 {
@@ -259,40 +220,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   align-items: center;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  grid-row: 1 / 1;
-  grid-column: 1 / 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-align-self: start;
-  -ms-flex-item-align: start;
-  align-self: start;
-  height: var(--b-form-control-left-label-wrapper-height);
-}
-
-.c10 {
-  grid-row: 2 / 2;
-  grid-column: 2;
-}
-
-.c11 {
-  display: block;
-  text-align: left;
-}
-
-.c3 {
-  display: block;
-  text-align: left;
-  word-break: break-word;
-}
-
-.c7 {
+.c4 {
   width: 100%;
   height: 100%;
   padding: 0;
@@ -305,23 +233,23 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   color: #000000D9;
 }
 
-.c7::-webkit-input-placeholder {
+.c4::-webkit-input-placeholder {
   color: #00000066;
 }
 
-.c7::-moz-placeholder {
+.c4::-moz-placeholder {
   color: #00000066;
 }
 
-.c7:-ms-input-placeholder {
+.c4:-ms-input-placeholder {
   color: #00000066;
 }
 
-.c7::placeholder {
+.c4::placeholder {
   color: #00000066;
 }
 
-.c5 {
+.c2 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -348,12 +276,12 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   transition-property: border-color,box-shadow;
 }
 
-.c5 .c6 {
+.c2 .c3 {
   font-size: 1.4rem;
   line-height: 1.8rem;
 }
 
-.c8 {
+.c5 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -381,7 +309,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   transition-property: border-color,box-shadow;
 }
 
-.c8 .c6 {
+.c5 .c3 {
   font-size: 1.4rem;
   line-height: 1.8rem;
 }
@@ -393,12 +321,11 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
     style="--b-form-control-left-label-wrapper-height: 36px;"
   >
     <div
-      class="c0 c2"
+      class="FormLabel left-position"
     >
       <label
-        class="Text typo-14 bold margin c3"
+        class="Text typo-14 bold align-left margin LabelText"
         data-testid="bezier-react-form-label"
-        foundation="[object Object]"
         id="form-label"
         style="--b-text-color: var(--txt-black-darkest);"
       >
@@ -420,13 +347,12 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="c0 c4"
+          class="FormLabel top-position"
         >
           <label
-            class="Text typo-13 bold margin c3"
+            class="Text typo-13 bold align-left margin LabelText"
             data-testid="bezier-react-form-label"
             for="field-:r6:"
-            foundation="[object Object]"
             id="field-:r6:-label"
             style="--b-text-color: var(--txt-black-darkest);"
           >
@@ -434,13 +360,13 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
           </label>
         </div>
         <div
-          class="c5"
+          class="c2"
           data-testid="bezier-react-text-input"
           size="36"
         >
           <input
             autocomplete="off"
-            class="c6 c7"
+            class="c3 c4"
             id="field-:r6:"
             size="36"
             value=""
@@ -453,13 +379,12 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="c0 c4"
+          class="FormLabel top-position"
         >
           <label
-            class="Text typo-13 bold margin c3"
+            class="Text typo-13 bold align-left margin LabelText"
             data-testid="bezier-react-form-label"
             for="field-:r7:"
-            foundation="[object Object]"
             id="field-:r7:-label"
             style="--b-text-color: var(--txt-black-darkest);"
           >
@@ -467,14 +392,14 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
           </label>
         </div>
         <div
-          class="c8"
+          class="c5"
           data-testid="bezier-react-text-input"
           size="36"
         >
           <input
             aria-invalid="true"
             autocomplete="off"
-            class="c6 c7"
+            class="c3 c4"
             id="field-:r7:"
             size="36"
             value=""
@@ -483,49 +408,23 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       </div>
     </div>
     <div
-      class="c0 c9 c10"
+      class="HelperTextWrapper left-position"
     >
-      <p
-        class="Text typo-13 margin c11"
+      <span
+        class="Text typo-13 align-left margin HelperText"
         data-testid="bezier-react-form-helper-text"
-        foundation="[object Object]"
         id="form-help-text"
         style="--b-text-color: var(--txt-black-dark);"
       >
         Description
-      </p>
+      </span>
     </div>
   </div>
 </div>
 `;
 
 exports[`FormControl > Snapshot > With single field 1`] = `
-.c0 {
-  position: relative;
-}
-
-.c1 {
-  padding: 0 2px;
-  margin-bottom: 4px;
-}
-
-.c6 {
-  padding: 0 2px;
-  margin-top: 4px;
-}
-
-.c7 {
-  display: block;
-  text-align: left;
-}
-
 .c2 {
-  display: block;
-  text-align: left;
-  word-break: break-word;
-}
-
-.c5 {
   width: 100%;
   height: 100%;
   padding: 0;
@@ -538,23 +437,23 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   color: #000000D9;
 }
 
-.c5::-webkit-input-placeholder {
+.c2::-webkit-input-placeholder {
   color: #00000066;
 }
 
-.c5::-moz-placeholder {
+.c2::-moz-placeholder {
   color: #00000066;
 }
 
-.c5:-ms-input-placeholder {
+.c2:-ms-input-placeholder {
   color: #00000066;
 }
 
-.c5::placeholder {
+.c2::placeholder {
   color: #00000066;
 }
 
-.c3 {
+.c0 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -581,7 +480,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   transition-property: border-color,box-shadow;
 }
 
-.c3 .c4 {
+.c0 .c1 {
   font-size: 1.4rem;
   line-height: 1.8rem;
 }
@@ -592,13 +491,12 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   style="--b-form-control-left-label-wrapper-height: 36px;"
 >
   <div
-    class="c0 c1"
+    class="FormLabel top-position"
   >
     <label
-      class="Text typo-13 bold margin c2"
+      class="Text typo-13 bold align-left margin LabelText"
       data-testid="bezier-react-form-label"
       for="form"
-      foundation="[object Object]"
       id="form-label"
       style="--b-text-color: var(--txt-black-darkest);"
     >
@@ -606,31 +504,30 @@ exports[`FormControl > Snapshot > With single field 1`] = `
     </label>
   </div>
   <div
-    class="c3"
+    class="c0"
     data-testid="bezier-react-text-input"
     size="36"
   >
     <input
       aria-describedby="form-help-text"
       autocomplete="off"
-      class="c4 c5"
+      class="c1 c2"
       id="form"
       size="36"
       value=""
     />
   </div>
   <div
-    class="c0 c6"
+    class="HelperTextWrapper top-position"
   >
-    <p
-      class="Text typo-13 margin c7"
+    <span
+      class="Text typo-13 align-left margin HelperText"
       data-testid="bezier-react-form-helper-text"
-      foundation="[object Object]"
       id="form-help-text"
       style="--b-text-color: var(--txt-black-dark);"
     >
       Description
-    </p>
+    </span>
   </div>
 </div>
 `;
@@ -638,11 +535,6 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 exports[`FormControl > Snapshot > With single field and left label position 1`] = `
 .c0 {
   position: relative;
-}
-
-.c7 {
-  padding: 0 2px;
-  margin-top: 4px;
 }
 
 .c1 {
@@ -656,40 +548,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   align-items: center;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  grid-row: 1 / 1;
-  grid-column: 1 / 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-align-self: start;
-  -ms-flex-item-align: start;
-  align-self: start;
-  height: var(--b-form-control-left-label-wrapper-height);
-}
-
-.c8 {
-  grid-row: 2 / 2;
-  grid-column: 2;
-}
-
-.c9 {
-  display: block;
-  text-align: left;
-}
-
-.c3 {
-  display: block;
-  text-align: left;
-  word-break: break-word;
-}
-
-.c6 {
+.c4 {
   width: 100%;
   height: 100%;
   padding: 0;
@@ -702,23 +561,23 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   color: #000000D9;
 }
 
-.c6::-webkit-input-placeholder {
+.c4::-webkit-input-placeholder {
   color: #00000066;
 }
 
-.c6::-moz-placeholder {
+.c4::-moz-placeholder {
   color: #00000066;
 }
 
-.c6:-ms-input-placeholder {
+.c4:-ms-input-placeholder {
   color: #00000066;
 }
 
-.c6::placeholder {
+.c4::placeholder {
   color: #00000066;
 }
 
-.c4 {
+.c2 {
   position: relative;
   box-sizing: border-box;
   display: -webkit-box;
@@ -745,7 +604,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   transition-property: border-color,box-shadow;
 }
 
-.c4 .c5 {
+.c2 .c3 {
   font-size: 1.4rem;
   line-height: 1.8rem;
 }
@@ -756,13 +615,12 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   style="--b-form-control-left-label-wrapper-height: 36px;"
 >
   <div
-    class="c0 c2"
+    class="FormLabel left-position"
   >
     <label
-      class="Text typo-14 bold margin c3"
+      class="Text typo-14 bold align-left margin LabelText"
       data-testid="bezier-react-form-label"
       for="form"
-      foundation="[object Object]"
       id="form-label"
       style="--b-text-color: var(--txt-black-darkest);"
     >
@@ -770,31 +628,30 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
     </label>
   </div>
   <div
-    class="c4"
+    class="c2"
     data-testid="bezier-react-text-input"
     size="36"
   >
     <input
       aria-describedby="form-help-text"
       autocomplete="off"
-      class="c5 c6"
+      class="c3 c4"
       id="form"
       size="36"
       value=""
     />
   </div>
   <div
-    class="c0 c7 c8"
+    class="HelperTextWrapper left-position"
   >
-    <p
-      class="Text typo-13 margin c9"
+    <span
+      class="Text typo-13 align-left margin HelperText"
       data-testid="bezier-react-form-helper-text"
-      foundation="[object Object]"
       id="form-help-text"
       style="--b-text-color: var(--txt-black-dark);"
     >
       Description
-    </p>
+    </span>
   </div>
 </div>
 `;

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
     style="--b-form-control-left-label-wrapper-height: 36px;"
   >
     <div
-      class="FormLabel top-position"
+      class="FormLabel position-top"
     >
       <label
         class="Text typo-13 bold align-left margin LabelText"
@@ -128,7 +128,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="FormLabel top-position"
+          class="FormLabel position-top"
         >
           <label
             class="Text typo-13 bold align-left margin LabelText"
@@ -160,7 +160,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="FormLabel top-position"
+          class="FormLabel position-top"
         >
           <label
             class="Text typo-13 bold align-left margin LabelText"
@@ -189,16 +189,16 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       </div>
     </div>
     <div
-      class="HelperTextWrapper top-position"
+      class="HelperTextWrapper position-top"
     >
-      <span
+      <p
         class="Text typo-13 align-left margin HelperText"
         data-testid="bezier-react-form-helper-text"
         id="form-help-text"
         style="--b-text-color: var(--txt-black-dark);"
       >
         Description
-      </span>
+      </p>
     </div>
   </div>
 </div>
@@ -321,7 +321,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
     style="--b-form-control-left-label-wrapper-height: 36px;"
   >
     <div
-      class="FormLabel left-position"
+      class="FormLabel position-left"
     >
       <label
         class="Text typo-14 bold align-left margin LabelText"
@@ -347,7 +347,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="FormLabel top-position"
+          class="FormLabel position-top"
         >
           <label
             class="Text typo-13 bold align-left margin LabelText"
@@ -379,7 +379,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="FormLabel top-position"
+          class="FormLabel position-top"
         >
           <label
             class="Text typo-13 bold align-left margin LabelText"
@@ -408,16 +408,16 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       </div>
     </div>
     <div
-      class="HelperTextWrapper left-position"
+      class="HelperTextWrapper position-left"
     >
-      <span
+      <p
         class="Text typo-13 align-left margin HelperText"
         data-testid="bezier-react-form-helper-text"
         id="form-help-text"
         style="--b-text-color: var(--txt-black-dark);"
       >
         Description
-      </span>
+      </p>
     </div>
   </div>
 </div>
@@ -491,7 +491,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   style="--b-form-control-left-label-wrapper-height: 36px;"
 >
   <div
-    class="FormLabel top-position"
+    class="FormLabel position-top"
   >
     <label
       class="Text typo-13 bold align-left margin LabelText"
@@ -518,16 +518,16 @@ exports[`FormControl > Snapshot > With single field 1`] = `
     />
   </div>
   <div
-    class="HelperTextWrapper top-position"
+    class="HelperTextWrapper position-top"
   >
-    <span
+    <p
       class="Text typo-13 align-left margin HelperText"
       data-testid="bezier-react-form-helper-text"
       id="form-help-text"
       style="--b-text-color: var(--txt-black-dark);"
     >
       Description
-    </span>
+    </p>
   </div>
 </div>
 `;
@@ -615,7 +615,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   style="--b-form-control-left-label-wrapper-height: 36px;"
 >
   <div
-    class="FormLabel left-position"
+    class="FormLabel position-left"
   >
     <label
       class="Text typo-14 bold align-left margin LabelText"
@@ -642,16 +642,16 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
     />
   </div>
   <div
-    class="HelperTextWrapper left-position"
+    class="HelperTextWrapper position-left"
   >
-    <span
+    <p
       class="Text typo-13 align-left margin HelperText"
       data-testid="bezier-react-form-helper-text"
       id="form-help-text"
       style="--b-text-color: var(--txt-black-dark);"
     >
       Description
-    </span>
+    </p>
   </div>
 </div>
 `;

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
     style="--b-form-control-left-label-wrapper-height: 36px;"
   >
     <div
-      class="FormLabel position-top"
+      class="FormLabelWrapper position-top"
     >
       <label
         class="Text typo-13 bold align-left margin LabelText"
@@ -128,7 +128,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="FormLabel position-top"
+          class="FormLabelWrapper position-top"
         >
           <label
             class="Text typo-13 bold align-left margin LabelText"
@@ -160,7 +160,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="FormLabel position-top"
+          class="FormLabelWrapper position-top"
         >
           <label
             class="Text typo-13 bold align-left margin LabelText"
@@ -189,10 +189,10 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       </div>
     </div>
     <div
-      class="HelperTextWrapper position-top"
+      class="FormHelperTextWrapper"
     >
       <p
-        class="Text typo-13 align-left margin HelperText"
+        class="Text typo-13 align-left margin FormHelperText"
         data-testid="bezier-react-form-helper-text"
         id="form-help-text"
         style="--b-text-color: var(--txt-black-dark);"
@@ -321,7 +321,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
     style="--b-form-control-left-label-wrapper-height: 36px;"
   >
     <div
-      class="FormLabel position-left"
+      class="FormLabelWrapper position-left"
     >
       <label
         class="Text typo-14 bold align-left margin LabelText"
@@ -347,7 +347,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="FormLabel position-top"
+          class="FormLabelWrapper position-top"
         >
           <label
             class="Text typo-13 bold align-left margin LabelText"
@@ -379,7 +379,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <div
-          class="FormLabel position-top"
+          class="FormLabelWrapper position-top"
         >
           <label
             class="Text typo-13 bold align-left margin LabelText"
@@ -408,10 +408,10 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       </div>
     </div>
     <div
-      class="HelperTextWrapper position-left"
+      class="FormHelperTextWrapper position-left"
     >
       <p
-        class="Text typo-13 align-left margin HelperText"
+        class="Text typo-13 align-left margin FormHelperText"
         data-testid="bezier-react-form-helper-text"
         id="form-help-text"
         style="--b-text-color: var(--txt-black-dark);"
@@ -491,7 +491,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   style="--b-form-control-left-label-wrapper-height: 36px;"
 >
   <div
-    class="FormLabel position-top"
+    class="FormLabelWrapper position-top"
   >
     <label
       class="Text typo-13 bold align-left margin LabelText"
@@ -518,10 +518,10 @@ exports[`FormControl > Snapshot > With single field 1`] = `
     />
   </div>
   <div
-    class="HelperTextWrapper position-top"
+    class="FormHelperTextWrapper"
   >
     <p
-      class="Text typo-13 align-left margin HelperText"
+      class="Text typo-13 align-left margin FormHelperText"
       data-testid="bezier-react-form-helper-text"
       id="form-help-text"
       style="--b-text-color: var(--txt-black-dark);"
@@ -615,7 +615,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   style="--b-form-control-left-label-wrapper-height: 36px;"
 >
   <div
-    class="FormLabel position-left"
+    class="FormLabelWrapper position-left"
   >
     <label
       class="Text typo-14 bold align-left margin LabelText"
@@ -642,10 +642,10 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
     />
   </div>
   <div
-    class="HelperTextWrapper position-left"
+    class="FormHelperTextWrapper position-left"
   >
     <p
-      class="Text typo-13 align-left margin HelperText"
+      class="Text typo-13 align-left margin FormHelperText"
       data-testid="bezier-react-form-helper-text"
       id="form-help-text"
       style="--b-text-color: var(--txt-black-dark);"

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -101,18 +101,14 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
     data-testid="bezier-react-form-control"
     style="--b-form-control-left-label-wrapper-height: 36px;"
   >
-    <div
-      class="FormLabelWrapper position-top"
+    <label
+      class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+      data-testid="bezier-react-form-label"
+      id="form-label"
+      style="--b-text-color: var(--txt-black-darkest);"
     >
-      <label
-        class="Text typo-13 bold align-left margin LabelText"
-        data-testid="bezier-react-form-label"
-        id="form-label"
-        style="--b-text-color: var(--txt-black-darkest);"
-      >
-        Label
-      </label>
-    </div>
+      Label
+    </label>
     <div
       aria-describedby="form-help-text"
       aria-labelledby="form-label"
@@ -127,19 +123,15 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         data-testid="bezier-react-form-control"
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
-        <div
-          class="FormLabelWrapper position-top"
+        <label
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+          data-testid="bezier-react-form-label"
+          for="field-:r3:"
+          id="field-:r3:-label"
+          style="--b-text-color: var(--txt-black-darkest);"
         >
-          <label
-            class="Text typo-13 bold align-left margin LabelText"
-            data-testid="bezier-react-form-label"
-            for="field-:r3:"
-            id="field-:r3:-label"
-            style="--b-text-color: var(--txt-black-darkest);"
-          >
-            First Inner Label
-          </label>
-        </div>
+          First Inner Label
+        </label>
         <div
           class="c0"
           data-testid="bezier-react-text-input"
@@ -159,19 +151,15 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         data-testid="bezier-react-form-control"
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
-        <div
-          class="FormLabelWrapper position-top"
+        <label
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+          data-testid="bezier-react-form-label"
+          for="field-:r4:"
+          id="field-:r4:-label"
+          style="--b-text-color: var(--txt-black-darkest);"
         >
-          <label
-            class="Text typo-13 bold align-left margin LabelText"
-            data-testid="bezier-react-form-label"
-            for="field-:r4:"
-            id="field-:r4:-label"
-            style="--b-text-color: var(--txt-black-darkest);"
-          >
-            Second Inner Label
-          </label>
-        </div>
+          Second Inner Label
+        </label>
         <div
           class="c3"
           data-testid="bezier-react-text-input"
@@ -188,18 +176,14 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="FormHelperTextWrapper"
+    <p
+      class="Text typo-13 align-left margin FormHelperText FormHelperTextWrapper"
+      data-testid="bezier-react-form-helper-text"
+      id="form-help-text"
+      style="--b-text-color: var(--txt-black-dark);"
     >
-      <p
-        class="Text typo-13 align-left margin FormHelperText"
-        data-testid="bezier-react-form-helper-text"
-        id="form-help-text"
-        style="--b-text-color: var(--txt-black-dark);"
-      >
-        Description
-      </p>
-    </div>
+      Description
+    </p>
   </div>
 </div>
 `;
@@ -320,18 +304,14 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
     data-testid="bezier-react-form-control"
     style="--b-form-control-left-label-wrapper-height: 36px;"
   >
-    <div
-      class="FormLabelWrapper position-left"
+    <label
+      class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left"
+      data-testid="bezier-react-form-label"
+      id="form-label"
+      style="--b-text-color: var(--txt-black-darkest);"
     >
-      <label
-        class="Text typo-14 bold align-left margin LabelText"
-        data-testid="bezier-react-form-label"
-        id="form-label"
-        style="--b-text-color: var(--txt-black-darkest);"
-      >
-        Label
-      </label>
-    </div>
+      Label
+    </label>
     <div
       aria-describedby="form-help-text"
       aria-labelledby="form-label"
@@ -346,19 +326,15 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         data-testid="bezier-react-form-control"
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
-        <div
-          class="FormLabelWrapper position-top"
+        <label
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+          data-testid="bezier-react-form-label"
+          for="field-:r6:"
+          id="field-:r6:-label"
+          style="--b-text-color: var(--txt-black-darkest);"
         >
-          <label
-            class="Text typo-13 bold align-left margin LabelText"
-            data-testid="bezier-react-form-label"
-            for="field-:r6:"
-            id="field-:r6:-label"
-            style="--b-text-color: var(--txt-black-darkest);"
-          >
-            First Inner Label
-          </label>
-        </div>
+          First Inner Label
+        </label>
         <div
           class="c2"
           data-testid="bezier-react-text-input"
@@ -378,19 +354,15 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         data-testid="bezier-react-form-control"
         style="--b-form-control-left-label-wrapper-height: 36px;"
       >
-        <div
-          class="FormLabelWrapper position-top"
+        <label
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+          data-testid="bezier-react-form-label"
+          for="field-:r7:"
+          id="field-:r7:-label"
+          style="--b-text-color: var(--txt-black-darkest);"
         >
-          <label
-            class="Text typo-13 bold align-left margin LabelText"
-            data-testid="bezier-react-form-label"
-            for="field-:r7:"
-            id="field-:r7:-label"
-            style="--b-text-color: var(--txt-black-darkest);"
-          >
-            Second Inner Label
-          </label>
-        </div>
+          Second Inner Label
+        </label>
         <div
           class="c5"
           data-testid="bezier-react-text-input"
@@ -407,18 +379,14 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         </div>
       </div>
     </div>
-    <div
-      class="FormHelperTextWrapper position-left"
+    <p
+      class="Text typo-13 align-left margin FormHelperText FormHelperTextWrapper position-left"
+      data-testid="bezier-react-form-helper-text"
+      id="form-help-text"
+      style="--b-text-color: var(--txt-black-dark);"
     >
-      <p
-        class="Text typo-13 align-left margin FormHelperText"
-        data-testid="bezier-react-form-helper-text"
-        id="form-help-text"
-        style="--b-text-color: var(--txt-black-dark);"
-      >
-        Description
-      </p>
-    </div>
+      Description
+    </p>
   </div>
 </div>
 `;
@@ -490,19 +458,15 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   data-testid="bezier-react-form-control"
   style="--b-form-control-left-label-wrapper-height: 36px;"
 >
-  <div
-    class="FormLabelWrapper position-top"
+  <label
+    class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+    data-testid="bezier-react-form-label"
+    for="form"
+    id="form-label"
+    style="--b-text-color: var(--txt-black-darkest);"
   >
-    <label
-      class="Text typo-13 bold align-left margin LabelText"
-      data-testid="bezier-react-form-label"
-      for="form"
-      id="form-label"
-      style="--b-text-color: var(--txt-black-darkest);"
-    >
-      Label
-    </label>
-  </div>
+    Label
+  </label>
   <div
     class="c0"
     data-testid="bezier-react-text-input"
@@ -517,18 +481,14 @@ exports[`FormControl > Snapshot > With single field 1`] = `
       value=""
     />
   </div>
-  <div
-    class="FormHelperTextWrapper"
+  <p
+    class="Text typo-13 align-left margin FormHelperText FormHelperTextWrapper"
+    data-testid="bezier-react-form-helper-text"
+    id="form-help-text"
+    style="--b-text-color: var(--txt-black-dark);"
   >
-    <p
-      class="Text typo-13 align-left margin FormHelperText"
-      data-testid="bezier-react-form-helper-text"
-      id="form-help-text"
-      style="--b-text-color: var(--txt-black-dark);"
-    >
-      Description
-    </p>
-  </div>
+    Description
+  </p>
 </div>
 `;
 
@@ -614,19 +574,15 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   data-testid="bezier-react-form-control"
   style="--b-form-control-left-label-wrapper-height: 36px;"
 >
-  <div
-    class="FormLabelWrapper position-left"
+  <label
+    class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left"
+    data-testid="bezier-react-form-label"
+    for="form"
+    id="form-label"
+    style="--b-text-color: var(--txt-black-darkest);"
   >
-    <label
-      class="Text typo-14 bold align-left margin LabelText"
-      data-testid="bezier-react-form-label"
-      for="form"
-      id="form-label"
-      style="--b-text-color: var(--txt-black-darkest);"
-    >
-      Label
-    </label>
-  </div>
+    Label
+  </label>
   <div
     class="c2"
     data-testid="bezier-react-text-input"
@@ -641,17 +597,13 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
       value=""
     />
   </div>
-  <div
-    class="FormHelperTextWrapper position-left"
+  <p
+    class="Text typo-13 align-left margin FormHelperText FormHelperTextWrapper position-left"
+    data-testid="bezier-react-form-helper-text"
+    id="form-help-text"
+    style="--b-text-color: var(--txt-black-dark);"
   >
-    <p
-      class="Text typo-13 align-left margin FormHelperText"
-      data-testid="bezier-react-form-helper-text"
-      id="form-help-text"
-      style="--b-text-color: var(--txt-black-dark);"
-    >
-      Description
-    </p>
-  </div>
+    Description
+  </p>
 </div>
 `;

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.module.scss
@@ -1,0 +1,3 @@
+.HelperText {
+  display: block;
+}

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.module.scss
@@ -1,13 +1,3 @@
-.HelperText {
+.FormHelperText {
   display: block;
-}
-
-.HelperTextWrapper {
-  padding: 0 2px;
-  margin-top: 4px;
-
-  &:where(.position-left) {
-    grid-row: 2 / 2;
-    grid-column: 2;
-  }
 }

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.module.scss
@@ -6,7 +6,7 @@
   padding: 0 2px;
   margin-top: 4px;
 
-  &:where(.left-position) {
+  &:where(.position-left) {
     grid-row: 2 / 2;
     grid-column: 2;
   }

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.module.scss
@@ -1,3 +1,14 @@
 .HelperText {
   display: block;
 }
+
+.HelperTextWrapper {
+  position: relative;
+  padding: 0 2px;
+  margin-top: 4px;
+
+  &:where(.left-position) {
+    grid-row: 2 / 2;
+    grid-column: 2;
+  }
+}

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.module.scss
@@ -3,7 +3,6 @@
 }
 
 .HelperTextWrapper {
-  position: relative;
   padding: 0 2px;
   margin-top: 4px;
 

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.styled.ts
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.styled.ts
@@ -1,8 +1,0 @@
-import { styled } from '~/src/foundation'
-
-import { Text } from '~/src/components/Text'
-
-export const HelperText = styled(Text)`
-  display: block;
-  text-align: left;
-`

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -20,7 +20,7 @@ import styles from './FormHelperText.module.scss'
 export const FORM_HELPER_TEXT_TEST_ID = 'bezier-react-form-helper-text'
 export const FORM_ERROR_MESSAGE_TEST_ID = 'bezier-react-form-error-message'
 
-const BaseHelperText = forwardRef<HTMLParamElement, BaseHelperTextProps>(({
+const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(({
   type,
   typo = '13',
   children,
@@ -67,7 +67,7 @@ const BaseHelperText = forwardRef<HTMLParamElement, BaseHelperTextProps>(({
   )
 })
 
-export const FormHelperText = forwardRef<HTMLParamElement, FormHelperTextProps>(({
+export const FormHelperText = forwardRef<HTMLSpanElement, FormHelperTextProps>(({
   testId = FORM_HELPER_TEXT_TEST_ID,
   color = 'txt-black-dark',
   children,
@@ -84,7 +84,7 @@ export const FormHelperText = forwardRef<HTMLParamElement, FormHelperTextProps>(
   </BaseHelperText>
 ))
 
-export const FormErrorMessage = forwardRef<HTMLParamElement, FormErrorMessageProps>(({
+export const FormErrorMessage = forwardRef<HTMLSpanElement, FormErrorMessageProps>(({
   testId = FORM_ERROR_MESSAGE_TEST_ID,
   color = 'bgtxt-orange-normal',
   children,

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -24,7 +24,6 @@ export const FORM_HELPER_TEXT_TEST_ID = 'bezier-react-form-helper-text'
 export const FORM_ERROR_MESSAGE_TEST_ID = 'bezier-react-form-error-message'
 
 const BaseHelperText = forwardRef(({
-  as = 'p',
   type,
   typo = '13',
   children,

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -73,11 +73,11 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function
 
 /**
  * `FormHelperText` is a component to show the description of the input element.
- * It should be used with `FormControl` component.
+ * `FormControl` component can handle its layout by `position` props.
  *
  * @example
  * ```tsx
- * <FormControl>
+ * <FormControl position="top">
  *   <FormLabel>
  *     Password
  *   </FormLabel>

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -17,19 +17,15 @@ import type {
 
 import styles from './FormHelperText.module.scss'
 
-type ForwardedRef = React.Ref<HTMLParamElement>
-
 export const FORM_HELPER_TEXT_TEST_ID = 'bezier-react-form-helper-text'
 export const FORM_ERROR_MESSAGE_TEST_ID = 'bezier-react-form-error-message'
 
-const BaseHelperText = forwardRef(({
+const BaseHelperText = forwardRef<HTMLParamElement, BaseHelperTextProps>(({
   type,
   typo = '13',
   children,
   ...rest
-}: BaseHelperTextProps,
-forwardedRef: ForwardedRef,
-) => {
+}, forwardedRef) => {
   const contextValue = useFormControlContext()
   const getProps = type === 'info'
     ? contextValue?.getHelperTextProps
@@ -71,14 +67,12 @@ forwardedRef: ForwardedRef,
   )
 })
 
-export const FormHelperText = forwardRef(({
+export const FormHelperText = forwardRef<HTMLParamElement, FormHelperTextProps>(({
   testId = FORM_HELPER_TEXT_TEST_ID,
   color = 'txt-black-dark',
   children,
   ...rest
-}: FormHelperTextProps,
-forwardedRef: ForwardedRef,
-) => (
+}, forwardedRef) => (
   <BaseHelperText
     {...rest}
     type="info"
@@ -90,14 +84,12 @@ forwardedRef: ForwardedRef,
   </BaseHelperText>
 ))
 
-export const FormErrorMessage = forwardRef(({
+export const FormErrorMessage = forwardRef<HTMLParamElement, FormErrorMessageProps>(({
   testId = FORM_ERROR_MESSAGE_TEST_ID,
   color = 'bgtxt-orange-normal',
   children,
   ...rest
-}: FormErrorMessageProps,
-forwardedRef: ForwardedRef,
-) => (
+}, forwardedRef) => (
   <BaseHelperText
     {...rest}
     aria-live="polite"

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -20,12 +20,14 @@ import styles from './FormHelperText.module.scss'
 export const FORM_HELPER_TEXT_TEST_ID = 'bezier-react-form-helper-text'
 export const FORM_ERROR_MESSAGE_TEST_ID = 'bezier-react-form-error-message'
 
-const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(({
-  type,
-  typo = '13',
-  children,
-  ...rest
-}, forwardedRef) => {
+const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function BaseHelperText(props, forwardedRef) {
+  const {
+    type,
+    typo = '13',
+    children,
+    ...rest
+  } = props
+
   const contextValue = useFormControlContext()
   const getProps = type === 'info'
     ? contextValue?.getHelperTextProps
@@ -67,37 +69,45 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(({
   )
 })
 
-export const FormHelperText = forwardRef<HTMLSpanElement, FormHelperTextProps>(({
-  testId = FORM_HELPER_TEXT_TEST_ID,
-  color = 'txt-black-dark',
-  children,
-  ...rest
-}, forwardedRef) => (
-  <BaseHelperText
-    {...rest}
-    type="info"
-    ref={forwardedRef}
-    testId={testId}
-    color={color}
-  >
-    { children }
-  </BaseHelperText>
-))
+export const FormHelperText = forwardRef<HTMLSpanElement, FormHelperTextProps>(function FormHelperText(props, forwardedRef) {
+  const {
+    testId = FORM_HELPER_TEXT_TEST_ID,
+    color = 'txt-black-dark',
+    children,
+    ...rest
+  } = props
 
-export const FormErrorMessage = forwardRef<HTMLSpanElement, FormErrorMessageProps>(({
-  testId = FORM_ERROR_MESSAGE_TEST_ID,
-  color = 'bgtxt-orange-normal',
-  children,
-  ...rest
-}, forwardedRef) => (
-  <BaseHelperText
-    {...rest}
-    aria-live="polite"
-    type="error"
-    ref={forwardedRef}
-    testId={testId}
-    color={color}
-  >
-    { children }
-  </BaseHelperText>
-))
+  return (
+    <BaseHelperText
+      {...rest}
+      type="info"
+      ref={forwardedRef}
+      testId={testId}
+      color={color}
+    >
+      { children }
+    </BaseHelperText>
+  )
+})
+
+export const FormErrorMessage = forwardRef<HTMLSpanElement, FormErrorMessageProps>(function FormErrorMessage(props, forwardedRef) {
+  const {
+    testId = FORM_ERROR_MESSAGE_TEST_ID,
+    color = 'bgtxt-orange-normal',
+    children,
+    ...rest
+  } = props
+
+  return (
+    <BaseHelperText
+      {...rest}
+      aria-live="polite"
+      type="error"
+      ref={forwardedRef}
+      testId={testId}
+      color={color}
+    >
+      { children }
+    </BaseHelperText>
+  )
+})

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -3,6 +3,8 @@ import React, {
   useMemo,
 } from 'react'
 
+import classNames from 'classnames'
+
 import useMergeRefs from '~/src/hooks/useMergeRefs'
 import { noop } from '~/src/utils/function'
 import { isEmpty } from '~/src/utils/type'
@@ -39,12 +41,12 @@ forwardedRef: ForwardedRef,
   const {
     visible,
     ref,
-    Wrapper,
+    labelPosition,
     ...ownProps
   } = getProps?.(rest) ?? {
     visible: true,
     ref: noop,
-    Wrapper: React.Fragment,
+    labelPosition: 'top',
     ...rest,
   }
 
@@ -60,7 +62,12 @@ forwardedRef: ForwardedRef,
   if (!shouldRendered) { return null }
 
   return (
-    <Wrapper>
+    <div
+      className={classNames(
+        styles.HelperTextWrapper,
+        styles[`${labelPosition}-position`],
+      )}
+    >
       <Text
         {...ownProps}
         ref={mergedRef}
@@ -70,7 +77,7 @@ forwardedRef: ForwardedRef,
       >
         { children }
       </Text>
-    </Wrapper>
+    </div>
   )
 })
 

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -53,7 +53,7 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function
     <div
       className={classNames(
         styles.HelperTextWrapper,
-        styles[`${labelPosition}-position`],
+        styles[`position-${labelPosition}`],
       )}
     >
       <Text

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -1,5 +1,7 @@
 import React, { forwardRef } from 'react'
 
+import classNames from 'classnames'
+
 import useMergeRefs from '~/src/hooks/useMergeRefs'
 import { noop } from '~/src/utils/function'
 import { isEmpty } from '~/src/utils/type'
@@ -34,7 +36,7 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function
   const {
     visible,
     ref,
-    classNameFromControl,
+    className: formControlClassName,
     ...ownProps
   } = getProps?.(rest) ?? {
     visible: true,
@@ -47,27 +49,20 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function
 
   if (isEmpty(children) || !visible) { return null }
 
-  const TextElement = (
+  return (
     <Text
-      {...ownProps}
       ref={mergedRef}
       as="p"
-      className={styles.FormHelperText}
+      className={classNames(
+        styles.FormHelperText,
+        formControlClassName,
+      )}
       typo={typo}
       align="left"
+      {...ownProps}
     >
       { children }
     </Text>
-  )
-
-  return (
-    classNameFromControl ? (
-      <div className={classNameFromControl}>
-        { TextElement }
-      </div>
-    ) : (
-      TextElement
-    )
   )
 })
 

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -59,6 +59,7 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function
       <Text
         {...ownProps}
         ref={mergedRef}
+        as="p"
         className={styles.HelperText}
         typo={typo}
         align="left"

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -8,6 +8,7 @@ import { noop } from '~/src/utils/function'
 import { isEmpty } from '~/src/utils/type'
 
 import { useFormControlContext } from '~/src/components/Forms/FormControl'
+import { Text } from '~/src/components/Text'
 
 import type {
   BaseHelperTextProps,
@@ -15,7 +16,7 @@ import type {
   FormHelperTextProps,
 } from './FormHelperText.types'
 
-import * as Styled from './FormHelperText.styled'
+import styles from './FormHelperText.module.scss'
 
 type ForwardedRef = React.Ref<HTMLParamElement>
 
@@ -61,14 +62,15 @@ forwardedRef: ForwardedRef,
 
   return (
     <Wrapper>
-      <Styled.HelperText
+      <Text
         {...ownProps}
         ref={mergedRef}
-        forwardedAs={as}
+        className={styles.HelperText}
         typo={typo}
+        align="left"
       >
         { children }
-      </Styled.HelperText>
+      </Text>
     </Wrapper>
   )
 })

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -1,7 +1,4 @@
-import React, {
-  forwardRef,
-  useMemo,
-} from 'react'
+import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'
 
@@ -52,14 +49,7 @@ forwardedRef: ForwardedRef,
 
   const mergedRef = useMergeRefs(ref, forwardedRef)
 
-  const shouldRendered = useMemo(() => (
-    !isEmpty(children) && visible
-  ), [
-    visible,
-    children,
-  ])
-
-  if (!shouldRendered) { return null }
+  if (isEmpty(children) || !visible) { return null }
 
   return (
     <div

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -1,7 +1,5 @@
 import React, { forwardRef } from 'react'
 
-import classNames from 'classnames'
-
 import useMergeRefs from '~/src/hooks/useMergeRefs'
 import { noop } from '~/src/utils/function'
 import { isEmpty } from '~/src/utils/type'
@@ -36,12 +34,12 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function
   const {
     visible,
     ref,
-    labelPosition,
+    classNameFromControl,
     ...ownProps
   } = getProps?.(rest) ?? {
     visible: true,
     ref: noop,
-    labelPosition: 'top',
+    classNameFromControl: undefined,
     ...rest,
   }
 
@@ -49,24 +47,27 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function
 
   if (isEmpty(children) || !visible) { return null }
 
-  return (
-    <div
-      className={classNames(
-        styles.HelperTextWrapper,
-        styles[`position-${labelPosition}`],
-      )}
+  const TextElement = (
+    <Text
+      {...ownProps}
+      ref={mergedRef}
+      as="p"
+      className={styles.FormHelperText}
+      typo={typo}
+      align="left"
     >
-      <Text
-        {...ownProps}
-        ref={mergedRef}
-        as="p"
-        className={styles.HelperText}
-        typo={typo}
-        align="left"
-      >
-        { children }
-      </Text>
-    </div>
+      { children }
+    </Text>
+  )
+
+  return (
+    classNameFromControl ? (
+      <div className={classNameFromControl}>
+        { TextElement }
+      </div>
+    ) : (
+      TextElement
+    )
   )
 })
 

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -70,6 +70,23 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function
   )
 })
 
+/**
+ * `FormHelperText` is a component to show the description of the input element.
+ * It should be used with `FormControl` component.
+ *
+ * @example
+ * ```tsx
+ * <FormControl>
+ *   <FormLabel>
+ *     Password
+ *   </FormLabel>
+ *   <TextField />
+ *   <FormHelperText>
+ *     Please use at least 6 characters
+ *   </FormHelperText>
+ * </FormControl>
+ * ```
+ */
 export const FormHelperText = forwardRef<HTMLSpanElement, FormHelperTextProps>(function FormHelperText(props, forwardedRef) {
   const {
     testId = FORM_HELPER_TEXT_TEST_ID,
@@ -91,6 +108,23 @@ export const FormHelperText = forwardRef<HTMLSpanElement, FormHelperTextProps>(f
   )
 })
 
+/**
+ * `FormErrorMessage` is a component to show error message when form values are invalid.
+ * It should be used with `FormControl` component.
+ *
+ * @example
+ * ```tsx
+ * <FormControl>
+ *   <FormLabel>
+ *     Password
+ *   </FormLabel>
+ *   <TextField />
+ *   <FormErrorMessage>
+ *     Password should be at least 6 characters
+ *   </FormErrorMessage>
+ * </FormControl>
+ * ```
+ */
 export const FormErrorMessage = forwardRef<HTMLSpanElement, FormErrorMessageProps>(function FormErrorMessage(props, forwardedRef) {
   const {
     testId = FORM_ERROR_MESSAGE_TEST_ID,

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.types.ts
@@ -2,6 +2,7 @@ import {
   type AlphaBezierComponentProps,
   type ChildrenProps,
   type IdentifierProps,
+  type MarginProps,
 } from '~/src/types/ComponentProps'
 
 import { type TextProps } from '~/src/components/Text'
@@ -14,7 +15,7 @@ export interface BaseHelperTextProps extends
   AlphaBezierComponentProps,
   ChildrenProps,
   Partial<IdentifierProps>,
-  Omit<TextProps, 'as'>,
+  Omit<TextProps, keyof MarginProps>,
   BaseHelperTextOwnProps {}
 
 export interface FormHelperTextProps extends Omit<BaseHelperTextProps, 'type'> {}

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.types.ts
@@ -1,5 +1,5 @@
 import {
-  type BezierComponentProps,
+  type AlphaBezierComponentProps,
   type ChildrenProps,
   type IdentifierProps,
 } from '~/src/types/ComponentProps'
@@ -11,7 +11,7 @@ interface BaseHelperTextOptions {
 }
 
 export interface BaseHelperTextProps extends
-  BezierComponentProps,
+  AlphaBezierComponentProps,
   ChildrenProps,
   Partial<IdentifierProps>,
   Omit<TextProps, 'as'>,

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.types.ts
@@ -6,7 +6,7 @@ import {
 
 import { type TextProps } from '~/src/components/Text'
 
-interface BaseHelperTextOptions {
+interface BaseHelperTextOwnProps {
   type: 'info' | 'error'
 }
 
@@ -15,7 +15,7 @@ export interface BaseHelperTextProps extends
   ChildrenProps,
   Partial<IdentifierProps>,
   Omit<TextProps, 'as'>,
-  BaseHelperTextOptions {}
+  BaseHelperTextOwnProps {}
 
 export interface FormHelperTextProps extends Omit<BaseHelperTextProps, 'type'> {}
 

--- a/packages/bezier-react/src/components/Forms/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
@@ -1,36 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormErrorMessage > Snapshot > 1`] = `
-.c0 {
-  display: block;
-  text-align: left;
-}
-
-<p
+<span
   aria-live="polite"
-  class="Text typo-13 margin c0"
+  class="Text typo-13 align-left margin HelperText"
   data-testid="bezier-react-form-error-message"
-  foundation="[object Object]"
   id="test"
   style="--b-text-color: var(--bgtxt-orange-normal);"
 >
   Lorem ipsum
-</p>
+</span>
 `;
 
 exports[`FormHelperText > Snapshot > 1`] = `
-.c0 {
-  display: block;
-  text-align: left;
-}
-
-<p
-  class="Text typo-13 margin c0"
+<span
+  class="Text typo-13 align-left margin HelperText"
   data-testid="bezier-react-form-helper-text"
-  foundation="[object Object]"
   id="test"
   style="--b-text-color: var(--txt-black-dark);"
 >
   Lorem ipsum
-</p>
+</span>
 `;

--- a/packages/bezier-react/src/components/Forms/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FormErrorMessage > Snapshot > 1`] = `
 <p
   aria-live="polite"
-  class="Text typo-13 align-left margin HelperText"
+  class="Text typo-13 align-left margin FormHelperText"
   data-testid="bezier-react-form-error-message"
   id="test"
   style="--b-text-color: var(--bgtxt-orange-normal);"
@@ -14,7 +14,7 @@ exports[`FormErrorMessage > Snapshot > 1`] = `
 
 exports[`FormHelperText > Snapshot > 1`] = `
 <p
-  class="Text typo-13 align-left margin HelperText"
+  class="Text typo-13 align-left margin FormHelperText"
   data-testid="bezier-react-form-helper-text"
   id="test"
   style="--b-text-color: var(--txt-black-dark);"

--- a/packages/bezier-react/src/components/Forms/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormErrorMessage > Snapshot > 1`] = `
-<span
+<p
   aria-live="polite"
   class="Text typo-13 align-left margin HelperText"
   data-testid="bezier-react-form-error-message"
@@ -9,16 +9,16 @@ exports[`FormErrorMessage > Snapshot > 1`] = `
   style="--b-text-color: var(--bgtxt-orange-normal);"
 >
   Lorem ipsum
-</span>
+</p>
 `;
 
 exports[`FormHelperText > Snapshot > 1`] = `
-<span
+<p
   class="Text typo-13 align-left margin HelperText"
   data-testid="bezier-react-form-helper-text"
   id="test"
   style="--b-text-color: var(--txt-black-dark);"
 >
   Lorem ipsum
-</span>
+</p>
 `;

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.module.scss
@@ -1,10 +1,10 @@
 .FormLabel {
-  &:where(.top-position) {
+  &:where(.position-top) {
     padding: 0 2px;
     margin-bottom: 4px;
   }
 
-  &:where(.left-position) {
+  &:where(.position-left) {
     display: flex;
     grid-row: 1 / 1;
     grid-column: 1 / 1;

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.module.scss
@@ -1,0 +1,17 @@
+.FormLabel {
+  position: relative;
+
+  &:where(.top-position) {
+    padding: 0 2px;
+    margin-bottom: 4px;
+  }
+
+  &:where(.left-position) {
+    display: flex;
+    grid-row: 1 / 1;
+    grid-column: 1 / 1;
+    align-items: center;
+    align-self: start;
+    height: var(--b-form-control-left-label-wrapper-height);
+  }
+}

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.module.scss
@@ -1,6 +1,4 @@
 .FormLabel {
-  position: relative;
-
   &:where(.top-position) {
     padding: 0 2px;
     margin-bottom: 4px;

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.module.scss
@@ -1,19 +1,3 @@
-.FormLabel {
-  &:where(.position-top) {
-    padding: 0 2px;
-    margin-bottom: 4px;
-  }
-
-  &:where(.position-left) {
-    display: flex;
-    grid-row: 1 / 1;
-    grid-column: 1 / 1;
-    align-items: center;
-    align-self: start;
-    height: var(--b-form-control-left-label-wrapper-height);
-  }
-}
-
 .LabelText {
   display: block;
   word-break: break-word;

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.module.scss
@@ -15,3 +15,8 @@
     height: var(--b-form-control-left-label-wrapper-height);
   }
 }
+
+.LabelText {
+  display: block;
+  word-break: break-word;
+}

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.stories.tsx
@@ -3,8 +3,8 @@ import type {
   StoryObj,
 } from '@storybook/react'
 
-import FormLabel from './FormLabel'
-import type FormLabelProps from './FormLabel.types'
+import { FormLabel } from './FormLabel'
+import { type FormLabelProps } from './FormLabel.types'
 
 const meta: Meta<typeof FormLabel> = {
   component: FormLabel,

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.styled.ts
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.styled.ts
@@ -1,9 +1,0 @@
-import { styled } from '~/src/foundation'
-
-import { Text } from '~/src/components/Text'
-
-export const Label = styled(Text)`
-  display: block;
-  text-align: left;
-  word-break: break-word;
-`

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.test.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.test.tsx
@@ -4,8 +4,11 @@ import { render } from '~/src/utils/test'
 
 import Help, { HELP_TEST_ID } from '~/src/components/Help/Help'
 
-import FormLabel, { FORM_LABEL_TEST_ID } from './FormLabel'
-import type FormLabelProps from './FormLabel.types'
+import {
+  FORM_LABEL_TEST_ID,
+  FormLabel,
+} from './FormLabel'
+import { type FormLabelProps } from './FormLabel.types'
 
 describe('FormLabel >', () => {
   let props: FormLabelProps

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -1,7 +1,5 @@
 import React, { forwardRef } from 'react'
 
-import classNames from 'classnames'
-
 import { isEmpty } from '~/src/utils/type'
 
 import { useFormControlContext } from '~/src/components/Forms/FormControl'
@@ -44,8 +42,13 @@ export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function F
   } = props
 
   const contextValue = useFormControlContext()
-  const { labelPosition, ...ownProps } = contextValue?.getLabelProps(rest) ?? {
-    labelPosition: 'top',
+  const {
+    typo,
+    classNameFromControl,
+    ...ownProps
+  } = contextValue?.getLabelProps(rest) ?? {
+    typo: '13',
+    classNameFromControl: undefined,
     ...rest,
   }
 
@@ -58,7 +61,7 @@ export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function F
       as="label"
       align="left"
       bold={bold}
-      typo={labelPosition === 'top' ? '13' : '14'}
+      typo={typo}
       color={color}
     >
       { children }
@@ -85,26 +88,24 @@ export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function F
 
   if (isEmpty(children)) { return null }
 
+  const LabelElement = !HelpComponent
+    ? LabelComponent
+    : (
+      <LegacyHStack align="center" spacing={6}>
+        <LegacyStackItem shrink weight={1}>
+          { LabelComponent }
+        </LegacyStackItem>
+        <LegacyStackItem>
+          { HelpComponent }
+        </LegacyStackItem>
+      </LegacyHStack>
+    )
+
   return (
-    <div className={
-      classNames(
-        styles.FormLabel,
-        styles[`position-${labelPosition}`],
-      )
-    }
-    >
-      { !HelpComponent
-        ? LabelComponent
-        : (
-          <LegacyHStack align="center" spacing={6}>
-            <LegacyStackItem shrink weight={1}>
-              { LabelComponent }
-            </LegacyStackItem>
-            <LegacyStackItem>
-              { HelpComponent }
-            </LegacyStackItem>
-          </LegacyHStack>
-        ) }
-    </div>
+    classNameFromControl ? (
+      <div className={classNameFromControl}>
+        { LabelElement }
+      </div>
+    ) : LabelElement
   )
 })

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -3,6 +3,8 @@ import React, {
   useMemo,
 } from 'react'
 
+import classNames from 'classnames'
+
 import { isEmpty } from '~/src/utils/type'
 
 import { useFormControlContext } from '~/src/components/Forms/FormControl'
@@ -15,6 +17,7 @@ import {
 
 import type FormLabelProps from './FormLabel.types'
 
+import styles from './FormLabel.module.scss'
 import * as Styled from './FormLabel.styled'
 
 export const FORM_LABEL_TEST_ID = 'bezier-react-form-label'
@@ -32,8 +35,8 @@ forwardedRef: React.Ref<HTMLLabelElement>,
 ) {
   const contextValue = useFormControlContext()
 
-  const { Wrapper, typo, ...ownProps } = contextValue?.getLabelProps(rest) ?? {
-    Wrapper: React.Fragment,
+  const { labelPosition, typo, ...ownProps } = contextValue?.getLabelProps(rest) ?? {
+    labelPosition: 'top',
     typo: '13',
     ...rest,
   }
@@ -82,7 +85,13 @@ forwardedRef: React.Ref<HTMLLabelElement>,
   if (isEmpty(children)) { return null }
 
   return (
-    <Wrapper>
+    <div className={
+      classNames(
+        styles.FormLabel,
+        styles[`${labelPosition}-position`],
+      )
+    }
+    >
       { !HelpComponent
         ? LabelComponent
         : (
@@ -95,7 +104,7 @@ forwardedRef: React.Ref<HTMLLabelElement>,
             </LegacyStackItem>
           </LegacyHStack>
         ) }
-    </Wrapper>
+    </div>
   )
 }
 

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -14,18 +14,17 @@ import {
   LegacyHStack,
   LegacyStackItem,
 } from '~/src/components/LegacyStack'
+import { Text } from '~/src/components/Text'
 
 import type FormLabelProps from './FormLabel.types'
 
 import styles from './FormLabel.module.scss'
-import * as Styled from './FormLabel.styled'
 
 export const FORM_LABEL_TEST_ID = 'bezier-react-form-label'
 
 function FormLabel({
   testId = FORM_LABEL_TEST_ID,
   help,
-  as = 'label',
   bold = true,
   color = 'txt-black-darkest',
   children,
@@ -42,19 +41,19 @@ forwardedRef: React.Ref<HTMLLabelElement>,
   }
 
   const LabelComponent = useMemo(() => (
-    <Styled.Label
+    <Text
       {...ownProps}
+      className={styles.LabelText}
       ref={forwardedRef}
       testId={testId}
-      forwardedAs={as}
+      align="left"
       bold={bold}
       typo={typo}
       color={color}
     >
       { children }
-    </Styled.Label>
+    </Text>
   ), [
-    as,
     typo,
     bold,
     color,

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -1,7 +1,4 @@
-import React, {
-  forwardRef,
-  useMemo,
-} from 'react'
+import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'
 
@@ -40,7 +37,7 @@ forwardedRef: React.Ref<HTMLLabelElement>,
     ...rest,
   }
 
-  const LabelComponent = useMemo(() => (
+  const LabelComponent = (
     <Text
       {...ownProps}
       className={styles.LabelText}
@@ -53,17 +50,9 @@ forwardedRef: React.Ref<HTMLLabelElement>,
     >
       { children }
     </Text>
-  ), [
-    typo,
-    bold,
-    color,
-    testId,
-    children,
-    forwardedRef,
-    ownProps,
-  ])
+  )
 
-  const HelpComponent = useMemo(() => {
+  const HelpComponent = (() => {
     if (isEmpty(help)) { return null }
 
     if (React.isValidElement(help)) {
@@ -79,7 +68,7 @@ forwardedRef: React.Ref<HTMLLabelElement>,
         { help }
       </Help>
     )
-  }, [help])
+  })()
 
   if (isEmpty(children)) { return null }
 

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -75,7 +75,7 @@ export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function F
     <div className={
       classNames(
         styles.FormLabel,
-        styles[`${labelPosition}-position`],
+        styles[`position-${labelPosition}`],
       )
     }
     >

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -31,9 +31,8 @@ forwardedRef: React.Ref<HTMLLabelElement>,
 ) {
   const contextValue = useFormControlContext()
 
-  const { labelPosition, typo, ...ownProps } = contextValue?.getLabelProps(rest) ?? {
+  const { labelPosition, ...ownProps } = contextValue?.getLabelProps(rest) ?? {
     labelPosition: 'top',
-    typo: '13',
     ...rest,
   }
 
@@ -45,7 +44,7 @@ forwardedRef: React.Ref<HTMLLabelElement>,
       testId={testId}
       align="left"
       bold={bold}
-      typo={typo}
+      typo={labelPosition === 'top' ? '13' : '14'}
       color={color}
     >
       { children }

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -19,11 +19,11 @@ export const FORM_LABEL_TEST_ID = 'bezier-react-form-label'
 
 /**
  * `FormLabel` is a component to show label.
- * It should be used with `FormControl` component.
+ * `FormControl` component can handle its layout by `position` props.
  *
  * @example
  * ```tsx
- * <FormControl>
+ * <FormControl position="top">
  *   <FormLabel>
  *     Name
  *   </FormLabel>

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -19,6 +19,20 @@ import styles from './FormLabel.module.scss'
 
 export const FORM_LABEL_TEST_ID = 'bezier-react-form-label'
 
+/**
+ * `FormLabel` is a component to show label.
+ * It should be used with `FormControl` component.
+ *
+ * @example
+ * ```tsx
+ * <FormControl>
+ *   <FormLabel>
+ *     Name
+ *   </FormLabel>
+ *   <TextField />
+ * </FormControl>
+ * ```
+ */
 export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function FormLabel(props, forwardedRef) {
   const {
     testId = FORM_LABEL_TEST_ID,

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -44,11 +44,11 @@ export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function F
   const contextValue = useFormControlContext()
   const {
     typo,
-    classNameFromControl,
+    className: classNameFromControl,
     ...ownProps
   } = contextValue?.getLabelProps(rest) ?? {
     typo: '13',
-    classNameFromControl: undefined,
+    className: undefined,
     ...rest,
   }
 

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -41,6 +41,7 @@ export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function F
       className={styles.LabelText}
       ref={forwardedRef}
       testId={testId}
+      as="label"
       align="left"
       bold={bold}
       typo={labelPosition === 'top' ? '13' : '14'}

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -13,24 +13,23 @@ import {
 } from '~/src/components/LegacyStack'
 import { Text } from '~/src/components/Text'
 
-import type FormLabelProps from './FormLabel.types'
+import { type FormLabelProps } from './FormLabel.types'
 
 import styles from './FormLabel.module.scss'
 
 export const FORM_LABEL_TEST_ID = 'bezier-react-form-label'
 
-function FormLabel({
-  testId = FORM_LABEL_TEST_ID,
-  help,
-  bold = true,
-  color = 'txt-black-darkest',
-  children,
-  ...rest
-}: FormLabelProps,
-forwardedRef: React.Ref<HTMLLabelElement>,
-) {
-  const contextValue = useFormControlContext()
+export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function FormLabel(props, forwardedRef) {
+  const {
+    testId = FORM_LABEL_TEST_ID,
+    help,
+    bold = true,
+    color = 'txt-black-darkest',
+    children,
+    ...rest
+  } = props
 
+  const contextValue = useFormControlContext()
   const { labelPosition, ...ownProps } = contextValue?.getLabelProps(rest) ?? {
     labelPosition: 'top',
     ...rest,
@@ -93,6 +92,4 @@ forwardedRef: React.Ref<HTMLLabelElement>,
         ) }
     </div>
   )
-}
-
-export default forwardRef(FormLabel)
+})

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -1,5 +1,7 @@
 import React, { forwardRef } from 'react'
 
+import classNames from 'classnames'
+
 import { isEmpty } from '~/src/utils/type'
 
 import { useFormControlContext } from '~/src/components/Forms/FormControl'
@@ -43,30 +45,13 @@ export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function F
 
   const contextValue = useFormControlContext()
   const {
-    typo,
-    className: classNameFromControl,
+    className: formControlClassName,
     ...ownProps
   } = contextValue?.getLabelProps(rest) ?? {
     typo: '13',
     className: undefined,
     ...rest,
   }
-
-  const LabelComponent = (
-    <Text
-      {...ownProps}
-      className={styles.LabelText}
-      ref={forwardedRef}
-      testId={testId}
-      as="label"
-      align="left"
-      bold={bold}
-      typo={typo}
-      color={color}
-    >
-      { children }
-    </Text>
-  )
 
   const HelpComponent = (() => {
     if (isEmpty(help)) { return null }
@@ -86,26 +71,37 @@ export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function F
     )
   })()
 
+  const LabelComponent = (
+    <Text
+      className={classNames(
+        styles.LabelText,
+        !HelpComponent && formControlClassName,
+      )}
+      ref={forwardedRef}
+      testId={testId}
+      as="label"
+      align="left"
+      bold={bold}
+      color={color}
+      {...ownProps}
+    >
+      { children }
+    </Text>
+  )
+
   if (isEmpty(children)) { return null }
 
-  const LabelElement = !HelpComponent
-    ? LabelComponent
-    : (
-      <LegacyHStack align="center" spacing={6}>
-        <LegacyStackItem shrink weight={1}>
-          { LabelComponent }
-        </LegacyStackItem>
-        <LegacyStackItem>
-          { HelpComponent }
-        </LegacyStackItem>
-      </LegacyHStack>
-    )
-
   return (
-    classNameFromControl ? (
-      <div className={classNameFromControl}>
-        { LabelElement }
-      </div>
-    ) : LabelElement
-  )
+    !HelpComponent
+      ? LabelComponent
+      : (
+        <LegacyHStack align="center" spacing={6} className={HelpComponent && formControlClassName}>
+          <LegacyStackItem shrink weight={1}>
+            { LabelComponent }
+          </LegacyStackItem>
+          <LegacyStackItem>
+            { HelpComponent }
+          </LegacyStackItem>
+        </LegacyHStack>
+      ))
 })

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.types.ts
@@ -11,7 +11,7 @@ interface FormLabelOwnProps {
   help?: React.ReactNode
 }
 
-export default interface FormLabelProps extends
+export interface FormLabelProps extends
   AlphaBezierComponentProps,
   ChildrenProps,
   Omit<TextProps, 'as'>,

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.types.ts
@@ -2,6 +2,7 @@ import {
   type AlphaBezierComponentProps,
   type ChildrenProps,
   type IdentifierProps,
+  type MarginProps,
 } from '~/src/types/ComponentProps'
 
 import { type TextProps } from '~/src/components/Text'
@@ -14,6 +15,6 @@ interface FormLabelOwnProps {
 export interface FormLabelProps extends
   AlphaBezierComponentProps,
   ChildrenProps,
-  Omit<TextProps, 'as'>,
+  Omit<TextProps, keyof MarginProps>,
   Partial<IdentifierProps>,
   FormLabelOwnProps {}

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.types.ts
@@ -1,19 +1,19 @@
 import {
-  type BezierComponentProps,
+  type AlphaBezierComponentProps,
   type ChildrenProps,
   type IdentifierProps,
 } from '~/src/types/ComponentProps'
 
 import { type TextProps } from '~/src/components/Text'
 
-interface FormLabelOptions {
+interface FormLabelOwnProps {
   htmlFor?: string
   help?: React.ReactNode
 }
 
 export default interface FormLabelProps extends
-  BezierComponentProps,
+  AlphaBezierComponentProps,
   ChildrenProps,
   Omit<TextProps, 'as'>,
   Partial<IdentifierProps>,
-  FormLabelOptions {}
+  FormLabelOwnProps {}

--- a/packages/bezier-react/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormLabel/__snapshots__/FormLabel.test.tsx.snap
@@ -1,16 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormLabel > Snapshot > 1`] = `
-.c0 {
-  display: block;
-  text-align: left;
-  word-break: break-word;
-}
-
 <label
-  class="Text typo-13 bold margin c0"
+  class="Text typo-13 bold align-left margin LabelText"
   data-testid="bezier-react-form-label"
-  foundation="[object Object]"
   style="--b-text-color: var(--txt-black-darkest);"
 >
   label

--- a/packages/bezier-react/src/components/Forms/FormLabel/index.ts
+++ b/packages/bezier-react/src/components/Forms/FormLabel/index.ts
@@ -1,2 +1,2 @@
-export { default as FormLabel } from './FormLabel'
-export type { default as FormLabelProps } from './FormLabel.types'
+export { FormLabel } from './FormLabel'
+export type { FormLabelProps } from './FormLabel.types'


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- #1733 

## Summary
<!-- Please brief explanation of the changes made -->

- `FormHelperText`, `FormErrorMessage`, `FormLabel`컴포넌트를 scss로 마이그레이션 하고 `as`, `interpolation`속성을 인터페이스에서 제거합니다. 

## Details
<!-- Please elaborate description of the changes -->
- 각각의 컴포넌트를 scss로 마이그레이션할 때, `FormControl.styled.ts`에 있던 스타일 코드를 각 컴포넌트의 .module.scss로 이동시켰습니다. 또한 context로서 Wrapper컴포넌트를 주던 것을 `labelPosition`만 주고 각 컴포넌트의 .module.scss에서 스타일링 하도록 변경했습니다. `FornControl.module.scss`에서 스타일링 코드를 작성하고 각 컴포넌트에서는 여기에 있는 className을 사용하게 할 수도 있었는데, 컴포넌트간의 의존성을 만드는 것이 좋지 않아보여서 이렇게 했습니다.

- Ref타입으로 deprecated된 HTMLParamElement을 쓰던 것을 적절한 타입으로 변경합니다.

- 컴포넌트의 레이아웃이 `labelPosition`에 영향을 받기 때문에 일부러 `MarginProps`는 인터페이스로 노출하지 않았습니다. 

- 지금은 `Text`의 속성을 그대로 노출하고 있는데, 사실상 고정된 스타일(color, typo)를 사용하고 있기 때문에 이런 속성역시 제거해야되나 고민됩니다. 어떻게 생각하시는지 궁금합니다 @sungik-choi 

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

- Yes, `FormHelperText`, `FormErrorMessage`, `FormLabel` no longer supports `as` and `interpolation` props.

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- https://developer.mozilla.org/en-US/docs/Web/API/HTMLParamElement
