### PR TITLE
refactor(banner): remove postcss build warning

### DIFF
--- a/packages/bezier-react/src/components/Banner/Banner.module.scss
+++ b/packages/bezier-react/src/components/Banner/Banner.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: row;
   gap: 6px;
-  align-items: start;
+  align-items: flex-start;
   min-width: 200px;
   padding: 12px;
   border-radius: var(--radius-12);


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

<img width="821" alt="스크린샷 2024-01-12 오후 9 30 45" src="https://github.com/channel-io/bezier-react/assets/58209009/37ee5c75-3d63-46eb-b7f4-0c31e73a6534">

`flex-start` 대신 `start` 를 사용하여 발생한 빌드 경고를 수정합니다.
