### PR TITLE
Remove constant for toastContainer positioning for ch-web-desk

### DIFF
--- a/.changeset/thick-actors-kneel.md
+++ b/.changeset/thick-actors-kneel.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": major
+---
+
+Add offset Props for positioning the toastContainer to ToastProviderAdjust the default position of toastContainer to left, bottom 0Inject the GNB_WIDTH value as default into the offset object of ToastProvider to ensure the same behavior as before

--- a/packages/bezier-react/src/components/Toast/Toast.stories.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.stories.tsx
@@ -80,7 +80,7 @@ const meta: Meta<ToastProps & {
     },
     enableLeftSpacing: {
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
     },
   },

--- a/packages/bezier-react/src/components/Toast/Toast.stories.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.stories.tsx
@@ -40,6 +40,7 @@ import useToast from './useToast'
 
 const meta: Meta<ToastProps & {
   autoDismissTimeout: number
+  enableLeftSpacing: boolean
 }> = {
   component: ToastElement,
   argTypes: {
@@ -75,6 +76,11 @@ const meta: Meta<ToastProps & {
         min: 1000,
         max: 6000,
         step: 100,
+      },
+    },
+    enableLeftSpacing: {
+      control: {
+        type: 'radio',
       },
     },
   },

--- a/packages/bezier-react/src/components/Toast/Toast.stories.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.stories.tsx
@@ -40,7 +40,6 @@ import useToast from './useToast'
 
 const meta: Meta<ToastProps & {
   autoDismissTimeout: number
-  enableLeftSpacing: boolean
 }> = {
   component: ToastElement,
   argTypes: {
@@ -76,11 +75,6 @@ const meta: Meta<ToastProps & {
         min: 1000,
         max: 6000,
         step: 100,
-      },
-    },
-    enableLeftSpacing: {
-      control: {
-        type: 'radio',
       },
     },
   },

--- a/packages/bezier-react/src/components/Toast/Toast.stories.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.stories.tsx
@@ -80,7 +80,7 @@ const meta: Meta<ToastProps & {
     },
     enableLeftSpacing: {
       control: {
-        type: 'radio',
+        type: 'boolean',
       },
     },
   },

--- a/packages/bezier-react/src/components/Toast/Toast.styled.ts
+++ b/packages/bezier-react/src/components/Toast/Toast.styled.ts
@@ -36,7 +36,7 @@ export const Container = styled.div<ToastContainerProps>`
   padding: 16px;
   overflow: hidden;
   pointer-events: none;
-  ${({ placement }) => getPlacement(placement)}
+  ${({ placement, enableLeftSpacing }) => getPlacement(placement, enableLeftSpacing)}
 `
 
 interface StyledToastProps extends Pick<ToastElementProps,

--- a/packages/bezier-react/src/components/Toast/Toast.styled.ts
+++ b/packages/bezier-react/src/components/Toast/Toast.styled.ts
@@ -36,7 +36,7 @@ export const Container = styled.div<ToastContainerProps>`
   padding: 16px;
   overflow: hidden;
   pointer-events: none;
-  ${({ placement, enableLeftSpacing }) => getPlacement(placement, enableLeftSpacing)}
+  ${({ placement }) => getPlacement(placement)}
 `
 
 interface StyledToastProps extends Pick<ToastElementProps,

--- a/packages/bezier-react/src/components/Toast/Toast.styled.ts
+++ b/packages/bezier-react/src/components/Toast/Toast.styled.ts
@@ -36,7 +36,7 @@ export const Container = styled.div<ToastContainerProps>`
   padding: 16px;
   overflow: hidden;
   pointer-events: none;
-  ${({ placement }) => getPlacement(placement)}
+  ${({ placement, offset }) => getPlacement({ placement, offset })}
 `
 
 interface StyledToastProps extends Pick<ToastElementProps,

--- a/packages/bezier-react/src/components/Toast/Toast.types.ts
+++ b/packages/bezier-react/src/components/Toast/Toast.types.ts
@@ -75,7 +75,6 @@ export default interface ToastElementProps extends
 
 export interface ToastProviderProps {
   autoDismissTimeout?: number
-  enableLeftSpacing?: boolean
   container?: HTMLElement | null
   children?: ReactNode[] | ReactNode
 }
@@ -126,7 +125,6 @@ export interface ToastContextType {
 export type ToastContainerProps = {
   children?: ReactNode[]
   placement: ToastPlacement
-  enableLeftSpacing: boolean
 }
 
 export interface ToastControllerProps extends ToastElementProps {

--- a/packages/bezier-react/src/components/Toast/Toast.types.ts
+++ b/packages/bezier-react/src/components/Toast/Toast.types.ts
@@ -75,6 +75,7 @@ export default interface ToastElementProps extends
 
 export interface ToastProviderProps {
   autoDismissTimeout?: number
+  enableLeftSpacing?: boolean
   container?: HTMLElement | null
   children?: ReactNode[] | ReactNode
 }
@@ -125,6 +126,7 @@ export interface ToastContextType {
 export type ToastContainerProps = {
   children?: ReactNode[]
   placement: ToastPlacement
+  enableLeftSpacing: boolean
 }
 
 export interface ToastControllerProps extends ToastElementProps {

--- a/packages/bezier-react/src/components/Toast/Toast.types.ts
+++ b/packages/bezier-react/src/components/Toast/Toast.types.ts
@@ -73,8 +73,15 @@ export default interface ToastElementProps extends
   Required<ContentProps<ToastContent>>,
   ToastElementOptions {}
 
+export type Offset = {
+  left?: number
+  right?: number
+  bottom?: number
+}
+
 export interface ToastProviderProps {
   autoDismissTimeout?: number
+  offset?: Offset
   container?: HTMLElement | null
   children?: ReactNode[] | ReactNode
 }
@@ -125,6 +132,7 @@ export interface ToastContextType {
 export type ToastContainerProps = {
   children?: ReactNode[]
   placement: ToastPlacement
+  offset?: Offset
 }
 
 export interface ToastControllerProps extends ToastElementProps {

--- a/packages/bezier-react/src/components/Toast/ToastProvider.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastProvider.tsx
@@ -23,6 +23,7 @@ import useToastProviderValues from './useToastContextValues'
 
 function ToastProvider({
   autoDismissTimeout = 3000,
+  enableLeftSpacing = true,
   container: givenContainer,
   children = [],
 }: ToastProviderProps) {
@@ -41,6 +42,7 @@ function ToastProvider({
     <ToastContainer
       key={placement}
       placement={placement}
+      enableLeftSpacing={enableLeftSpacing}
     >
       { toasts.map(({
         autoDismiss,
@@ -78,6 +80,7 @@ function ToastProvider({
   ), [
     autoDismissTimeout,
     dismiss,
+    enableLeftSpacing,
   ])
 
   return (

--- a/packages/bezier-react/src/components/Toast/ToastProvider.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastProvider.tsx
@@ -23,7 +23,6 @@ import useToastProviderValues from './useToastContextValues'
 
 function ToastProvider({
   autoDismissTimeout = 3000,
-  enableLeftSpacing = true,
   container: givenContainer,
   children = [],
 }: ToastProviderProps) {
@@ -42,7 +41,6 @@ function ToastProvider({
     <ToastContainer
       key={placement}
       placement={placement}
-      enableLeftSpacing={enableLeftSpacing}
     >
       { toasts.map(({
         autoDismiss,
@@ -80,7 +78,6 @@ function ToastProvider({
   ), [
     autoDismissTimeout,
     dismiss,
-    enableLeftSpacing,
   ])
 
   return (

--- a/packages/bezier-react/src/components/Toast/ToastProvider.tsx
+++ b/packages/bezier-react/src/components/Toast/ToastProvider.tsx
@@ -21,9 +21,20 @@ import ToastController from './ToastController'
 import ToastElement from './ToastElement'
 import useToastProviderValues from './useToastContextValues'
 
+/**
+ * @deprecated
+ * FIXME: Styling dependent on specific applications.
+ */
+const GNB_WIDTH = 68
+
 function ToastProvider({
   autoDismissTimeout = 3000,
   container: givenContainer,
+  offset = {
+    left: GNB_WIDTH,
+    right: 0,
+    bottom: 0,
+  },
   children = [],
 }: ToastProviderProps) {
   const { rootElement } = useWindow()
@@ -41,6 +52,7 @@ function ToastProvider({
     <ToastContainer
       key={placement}
       placement={placement}
+      offset={offset}
     >
       { toasts.map(({
         autoDismiss,
@@ -78,6 +90,7 @@ function ToastProvider({
   ), [
     autoDismissTimeout,
     dismiss,
+    offset,
   ])
 
   return (

--- a/packages/bezier-react/src/components/Toast/utils.ts
+++ b/packages/bezier-react/src/components/Toast/utils.ts
@@ -36,7 +36,7 @@ function getIconColor(appearance: ToastAppearance): ToastIconColor {
   }
 }
 
-function getPlacement(placement: ToastPlacement, enableLeftSpacing: boolean) {
+function getPlacement(placement: ToastPlacement) {
   switch (placement) {
     case ToastPlacement.BottomRight:
       return css`
@@ -47,7 +47,7 @@ function getPlacement(placement: ToastPlacement, enableLeftSpacing: boolean) {
     default:
       return css`
         bottom: 0;
-        left: ${enableLeftSpacing ? GNB_WIDTH : 0}px;
+        left: ${GNB_WIDTH}px;
       `
   }
 }

--- a/packages/bezier-react/src/components/Toast/utils.ts
+++ b/packages/bezier-react/src/components/Toast/utils.ts
@@ -36,7 +36,7 @@ function getIconColor(appearance: ToastAppearance): ToastIconColor {
   }
 }
 
-function getPlacement(placement: ToastPlacement) {
+function getPlacement(placement: ToastPlacement, enableLeftSpacing: boolean) {
   switch (placement) {
     case ToastPlacement.BottomRight:
       return css`
@@ -47,7 +47,7 @@ function getPlacement(placement: ToastPlacement) {
     default:
       return css`
         bottom: 0;
-        left: ${GNB_WIDTH}px;
+        left: ${enableLeftSpacing ? GNB_WIDTH : 0}px;
       `
   }
 }

--- a/packages/bezier-react/src/components/Toast/utils.ts
+++ b/packages/bezier-react/src/components/Toast/utils.ts
@@ -16,12 +16,6 @@ import {
   type ToastPresetType,
 } from './Toast.types'
 
-/**
- * @deprecated
- * FIXME: Styling dependent on specific applications.
- */
-const GNB_WIDTH = 68
-
 function getIconColor(appearance: ToastAppearance): ToastIconColor {
   switch (appearance) {
     case ToastAppearance.Success:
@@ -47,7 +41,7 @@ function getPlacement(placement: ToastPlacement) {
     default:
       return css`
         bottom: 0;
-        left: ${GNB_WIDTH}px;
+        left: 0;
       `
   }
 }

--- a/packages/bezier-react/src/components/Toast/utils.ts
+++ b/packages/bezier-react/src/components/Toast/utils.ts
@@ -9,18 +9,13 @@ import {
 import { css } from '~/src/foundation'
 
 import {
+  type Offset,
   ToastAppearance,
   ToastIconColor,
   ToastPlacement,
   ToastPreset,
   type ToastPresetType,
 } from './Toast.types'
-
-/**
- * @deprecated
- * FIXME: Styling dependent on specific applications.
- */
-const GNB_WIDTH = 68
 
 function getIconColor(appearance: ToastAppearance): ToastIconColor {
   switch (appearance) {
@@ -36,18 +31,23 @@ function getIconColor(appearance: ToastAppearance): ToastIconColor {
   }
 }
 
-function getPlacement(placement: ToastPlacement) {
+interface GetPlacementProps {
+  placement: ToastPlacement
+  offset?: Offset
+}
+
+function getPlacement({ placement, offset }:GetPlacementProps) {
   switch (placement) {
     case ToastPlacement.BottomRight:
       return css`
-          right: 0;
-          bottom: 0;
+          right:  ${offset?.right !== undefined ? offset.right : 0}px;
+          bottom: ${offset?.bottom !== undefined ? offset.bottom : 0}px;
         `
     case ToastPlacement.BottomLeft:
     default:
       return css`
-        bottom: 0;
-        left: ${GNB_WIDTH}px;
+        bottom: ${offset?.bottom !== undefined ? offset.bottom : 0}px;
+        left: ${offset?.left !== undefined ? offset.left : 0}px;
       `
   }
 }

--- a/packages/bezier-react/src/components/Toast/utils.ts
+++ b/packages/bezier-react/src/components/Toast/utils.ts
@@ -16,6 +16,12 @@ import {
   type ToastPresetType,
 } from './Toast.types'
 
+/**
+ * @deprecated
+ * FIXME: Styling dependent on specific applications.
+ */
+const GNB_WIDTH = 68
+
 function getIconColor(appearance: ToastAppearance): ToastIconColor {
   switch (appearance) {
     case ToastAppearance.Success:
@@ -41,7 +47,7 @@ function getPlacement(placement: ToastPlacement) {
     default:
       return css`
         bottom: 0;
-        left: 0;
+        left: ${GNB_WIDTH}px;
       `
   }
 }


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox


## Summary
<!-- Please brief explanation of the changes made -->
toastContainer가 web-desk의 GNB 만큼의 좌측 여백을 확보하던 스타일링을 제거합니다

## Details
<!-- Please elaborate description of the changes -->
이제 toast의 표시 위치가 toastContainer (default: document.body)의 좌/우 하단에 위치하게 됩니다
`ToastProvider`에 enableLeftSpacing props를 추가합니다
- 기본값은 true (기존처럼 좌측에 GNB_WIDTH만큼의 offset을 추가
- false시 container의 `left:0` 포지셔닝을 잡습니다

## Preview (example)
|as-is|to-be|
|---|---|
|![asis](https://github.com/channel-io/bezier-react/assets/55074799/9433631e-22d0-47af-a9ce-516b68c1da58)|![tobe](https://github.com/channel-io/bezier-react/assets/55074799/135b6354-e9b7-45f3-979a-434087ff9503)|



### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
Yes
만약 좌하단의 여백을 기존 동작처럼 유지하고 싶다면
1. document.body 하위에 container를 위치하고
2. container의 position을 원하는 만큼 변경해야 합니다 (as-is left:68px)
