### PR TITLE
Fix unused import in transition codemod

### DIFF
--- a/.changeset/famous-trees-wash.md
+++ b/.changeset/famous-trees-wash.md
@@ -1,0 +1,7 @@
+---
+"@channel.io/bezier-codemod": minor
+---
+
+Enhancement in `v2-foundation-to-css-variable-transition` codemod
+
+- It will properly remove import statement if it converts code where `TransitionDuration` is used.

--- a/packages/bezier-codemod/src/transforms/v2-foundation-to-css-variable/fixtures/transition1.input.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-foundation-to-css-variable/fixtures/transition1.input.tsx
@@ -1,23 +1,26 @@
-const BackIcon = styled(Icon)`
+import { AllIcon } from '@channel.io/bezier-icons'
+import { styled, TransitionDuration, css } from '@channel.io/bezier-react'
+
+export const BackIcon = styled(AllIcon)`
   ${({ foundation }) => foundation?.transition?.getTransitionsCSS('color')};
 `
 
-const Block = styled.div`
+export const Block = styled.div`
   ${({ foundation }) =>
     foundation?.transition.getTransitionsCSS(['background-color'])};
 `
 
-const Wrapper = styled.div`
+export const Wrapper = styled.div`
   ${({ foundation }) =>
     foundation?.transition.getTransitionsCSS(['background-color', 'color'])};
 `
 
-const Wrapper = styled.div`
+export const Wrapper1 = styled.div`
   ${({ hasTransition, foundation }) =>
     hasTransition && foundation?.transition.getTransitionsCSS(['background-color', 'color'])};
 `
 
-const Command = styled.div`
+export const Command = styled.div`
   ${({ disabled }) =>
     disabled &&
     css`
@@ -32,7 +35,7 @@ const Command = styled.div`
     `}
 `
 
-const div = styled.div`
+export const div = styled.div`
   ${({ foundation }) =>
   foundation?.transition?.getTransitionsCSS(
     'background-color',

--- a/packages/bezier-codemod/src/transforms/v2-foundation-to-css-variable/fixtures/transition1.output.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-foundation-to-css-variable/fixtures/transition1.output.tsx
@@ -1,21 +1,24 @@
-const BackIcon = styled(Icon)`
+import { AllIcon } from '@channel.io/bezier-icons'
+import { styled, css } from '@channel.io/bezier-react'
+
+export const BackIcon = styled(AllIcon)`
   transition: color var(--transition-s);
 `
 
-const Block = styled.div`
+export const Block = styled.div`
   transition: background-color var(--transition-s);
 `
 
-const Wrapper = styled.div`
+export const Wrapper = styled.div`
   transition: background-color var(--transition-s), color var(--transition-s);
 `
 
-const Wrapper = styled.div`
+export const Wrapper1 = styled.div`
   ${({ hasTransition, foundation }) =>
     hasTransition && foundation?.transition.getTransitionsCSS(['background-color', 'color'])};
 `
 
-const Command = styled.div`
+export const Command = styled.div`
   ${({ disabled }) =>
     disabled &&
     css`
@@ -25,6 +28,6 @@ const Command = styled.div`
     `}
 `
 
-const div = styled.div`
+export const div = styled.div`
   transition: background-color var(--transition-m);
 `

--- a/packages/bezier-codemod/src/transforms/v2-foundation-to-css-variable/transition.ts
+++ b/packages/bezier-codemod/src/transforms/v2-foundation-to-css-variable/transition.ts
@@ -38,6 +38,7 @@ const hasTransitionFoundation = (node: Node) => node.getText().includes('getTran
 const replaceTransitionsCSS = (sourceFile: SourceFile) => {
   sourceFile.forEachDescendant((node) => {
     if (Node.isTemplateExpression(node)) {
+      const oldSourceFile = sourceFile.getText()
       const transitionCallExpression = node
         .getDescendantsOfKind(SyntaxKind.CallExpression)
         .find(hasTransitionFoundation)
@@ -60,6 +61,10 @@ const replaceTransitionsCSS = (sourceFile: SourceFile) => {
               .replace(`\${${text}}\n` ?? '', transitionStyle),
           )
         })
+
+      if (oldSourceFile !== sourceFile.getText()) {
+        sourceFile.fixUnusedIdentifiers()
+      }
     }
   })
 }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox


## Summary
<!-- Please brief explanation of the changes made -->

- Transition codemod에서 TransitionDuration 을 css variable 로 변환 후 import 에서 제거하지 않는 버그가 있어서 이를 수정합니다. 코드 변환이 일어났을 때 `sourceFile.fixUnusedIdentifiers()`를 실행하면 됩니다. 

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

- No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- None
