### PR TITLE
Add missed `inputPlaceholderStyle` migration logic to codemod

### DIFF
--- a/.changeset/sour-dogs-sin.md
+++ b/.changeset/sour-dogs-sin.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-codemod": minor
+---
+
+Add ` inputPlaceholderStyle` migration logic to `v2-input-interpolation-to-css-variable` codemod

--- a/.changeset/sour-dogs-sin.md
+++ b/.changeset/sour-dogs-sin.md
@@ -2,4 +2,4 @@
 "@channel.io/bezier-codemod": minor
 ---
 
-Add ` inputPlaceholderStyle` migration logic to `v2-input-interpolation-to-css-variable` codemod
+Add `inputPlaceholderStyle` migration logic to `v2-input-interpolation-to-css-variable` codemod

--- a/packages/bezier-codemod/README.md
+++ b/packages/bezier-codemod/README.md
@@ -163,6 +163,10 @@ const Wrapper = styled.div`
   ${inputWrapperStyle};
 
   ${({ focus }) => focus && focusedInputWrapperStyle};
+
+  ${erroredInputWrapperStyle};
+
+  ${inputPlaceholderStyle};
 `;
 ```
 
@@ -179,6 +183,12 @@ const Wrapper = styled.div`
     css`
       box-shadow: var(--input-box-shadow-focused);
     `};
+
+  box-shadow: var(--input-box-shadow-invalid);
+
+  &::placeholder {
+    color: var(--txt-black-dark);
+  }
 `;
 ```
 

--- a/packages/bezier-codemod/src/transforms/v2-input-interpolation-to-css-variable/fixtures/input-interpolation.input.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-input-interpolation-to-css-variable/fixtures/input-interpolation.input.tsx
@@ -3,6 +3,7 @@ import {
   inputWrapperStyle, 
   focusedInputWrapperStyle, 
   erroredInputWrapperStyle,
+  inputPlaceholderStyle,
 } from '@channel.io/bezier-react'
 
 const Wrapper = styled.div`
@@ -28,4 +29,8 @@ const Wrapper = styled.div`
 
 const Wrapper = styled.div`
   ${erroredInputWrapperStyle};
+`
+
+const Wrapper = styled.div`
+  ${inputPlaceholderStyle};
 `

--- a/packages/bezier-codemod/src/transforms/v2-input-interpolation-to-css-variable/fixtures/input-interpolation.output.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-input-interpolation-to-css-variable/fixtures/input-interpolation.output.tsx
@@ -30,3 +30,7 @@ const Wrapper = styled.div`
 const Wrapper = styled.div`
   box-shadow: var(--input-box-shadow-invalid);
 `
+
+const Wrapper = styled.div`
+  &::placeholder { color: var(--txt-black-dark); };
+`

--- a/packages/bezier-codemod/src/transforms/v2-input-interpolation-to-css-variable/transform.ts
+++ b/packages/bezier-codemod/src/transforms/v2-input-interpolation-to-css-variable/transform.ts
@@ -12,6 +12,7 @@ const cssVariableByInterpolation = {
   inputWrapperStyle: 'box-shadow: var(--input-box-shadow);',
   focusedInputWrapperStyle: 'box-shadow: var(--input-box-shadow-focused);',
   erroredInputWrapperStyle: 'box-shadow: var(--input-box-shadow-invalid);',
+  inputPlaceholderStyle: '&::placeholder { color: var(--txt-black-dark); }',
 }
 
 const replaceInputInterpolation = (sourceFile: SourceFile) => {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- https://github.com/channel-io/bezier-react/issues/1778

## Summary
<!-- Please brief explanation of the changes made -->

- `inputPlaceholderStyle` mixin 에 대한 변환 로직을 codemod 에 추가하고 README를 업데이트 했습니다. 

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

- No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- None
