### PR TITLE
feat(navigators): rename `leftIcon` property of `NavItem` and `NavGroup` to `leftContent`

### DIFF
--- a/.changeset/gentle-shirts-grow.md
+++ b/.changeset/gentle-shirts-grow.md
@@ -1,0 +1,7 @@
+---
+"@channel.io/bezier-react": major
+---
+
+**Breaking Changes: Property updates in `NavGroup` and `NavItem` component**
+
+`leftIcon` renamed to `leftContent`. Changed to improve consistency of interface property names across libraries.

--- a/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.stories.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.stories.tsx
@@ -56,7 +56,7 @@ export const Primary: StoryObj<NavGroupProps> = {
     active: false,
     name: 'general',
     content: '일반 설정',
-    leftIcon: SettingsIcon,
+    leftContent: SettingsIcon,
     rightContent: (
       <Icon source={DotIcon} size={IconSize.XS} color="bgtxt-orange-normal" />
     ),

--- a/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.test.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.test.tsx
@@ -21,7 +21,7 @@ describe('NavGroup Test >', () => {
 
   beforeEach(() => {
     props = {
-      leftIcon: DotIcon,
+      leftContent: DotIcon,
       name: 'general',
       content: 'test-content',
       rightContent: <Icon source={DotIcon} size={IconSize.XS} color="bgtxt-orange-normal" />,

--- a/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.tsx
@@ -23,21 +23,19 @@ import styles from './NavGroup.module.scss'
 export const NAV_GROUP_TEST_ID = 'bezier-react-nav-group'
 export const NAV_GROUP_LEFT_ICON_TEST_ID = 'bezier-react-nav-group-left-icon'
 
-export const NavGroup = forwardRef<HTMLButtonElement, NavGroupProps>(function NavGroup(props, forwardedRef) {
-  const {
-    testId = NAV_GROUP_TEST_ID,
-    name,
-    className,
-    children,
-    content,
-    rightContent,
-    leftIcon,
-    open,
-    active,
-    onClick = noop,
-    ...rest
-  } = props
-
+export const NavGroup = forwardRef<HTMLButtonElement, NavGroupProps>(function NavGroup({
+  testId = NAV_GROUP_TEST_ID,
+  name,
+  className,
+  children,
+  content,
+  rightContent,
+  leftContent,
+  open,
+  active,
+  onClick = noop,
+  ...rest
+}, forwardedRef) {
   const handleClickItem = (e?: React.MouseEvent) => {
     onClick(e, name)
   }
@@ -70,7 +68,7 @@ export const NavGroup = forwardRef<HTMLButtonElement, NavGroupProps>(function Na
         <div className={commonStyles.LeftIconWrapper}>
           <Icon
             testId={NAV_GROUP_LEFT_ICON_TEST_ID}
-            source={leftIcon}
+            source={leftContent}
             size={IconSize.S}
             color={active ? 'bgtxt-blue-normal' : 'txt-black-dark'}
           />

--- a/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.types.ts
+++ b/packages/bezier-react/src/components/Navigator/NavGroup/NavGroup.types.ts
@@ -10,7 +10,6 @@ import type {
 
 interface NavGroupOwnProps {
   open?: boolean
-  leftIcon: BezierIcon
   name: string
   onClick?: (e?: React.MouseEvent, name?: string) => void
 }
@@ -19,6 +18,7 @@ export interface NavGroupProps extends
   AlphaBezierComponentProps,
   ChildrenProps,
   ContentProps,
+  Required<Pick<SideContentProps<BezierIcon>, 'leftContent'>>,
   Pick<SideContentProps, 'rightContent'>,
   Pick<ActivatableProps, 'active'>,
   Omit<React.HTMLAttributes<HTMLButtonElement>, 'onClick' | 'content'>,

--- a/packages/bezier-react/src/components/Navigator/NavItem/NavItem.stories.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavItem/NavItem.stories.tsx
@@ -34,7 +34,7 @@ export const Primary: StoryObj<NavItemProps> = {
     name: 'general',
     content: '일반 설정',
     href: 'https://google.com',
-    leftIcon: undefined,
+    leftContent: undefined,
     rightContent: (
       <Icon
         source={ErrorFilledIcon}

--- a/packages/bezier-react/src/components/Navigator/NavItem/NavItem.test.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavItem/NavItem.test.tsx
@@ -16,7 +16,7 @@ describe('NavItem Test >', () => {
 
   beforeEach(() => {
     props = {
-      leftIcon: DotIcon,
+      leftContent: DotIcon,
       name: 'general',
       content: 'test-content',
     }

--- a/packages/bezier-react/src/components/Navigator/NavItem/NavItem.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavItem/NavItem.tsx
@@ -28,22 +28,20 @@ export const NAV_ITEM_LEFT_ICON_TEST_ID = 'bezier-react-nav-item-left-icon'
  * />
  * ```
  */
-export const NavItem = forwardRef<HTMLAnchorElement, NavItemProps>(function NavItem(props, forwardedRef) {
-  const {
-    testId = NAV_ITEM_TEST_ID,
-    name,
-    style,
-    className,
-    content,
-    href,
-    target = '_self',
-    rightContent,
-    leftIcon,
-    active,
-    onClick = noop,
-    ...rest
-  } = props
-
+export const NavItem = forwardRef<HTMLAnchorElement, NavItemProps>(function NavItem({
+  testId = NAV_ITEM_TEST_ID,
+  name,
+  style,
+  className,
+  content,
+  href,
+  target = '_self',
+  rightContent,
+  leftContent,
+  active,
+  onClick = noop,
+  ...rest
+}, forwardedRef) {
   const handleClickItem = (e?: React.MouseEvent) => {
     onClick(e, name)
   }
@@ -69,10 +67,10 @@ export const NavItem = forwardRef<HTMLAnchorElement, NavItemProps>(function NavI
         {...rest}
       >
         <div className={styles.LeftIconWrapper}>
-          { leftIcon && (
+          { leftContent && (
             <Icon
               testId={NAV_ITEM_LEFT_ICON_TEST_ID}
-              source={leftIcon}
+              source={leftContent}
               size={IconSize.S}
               color={active ? 'bgtxt-blue-normal' : 'txt-black-dark'}
             />

--- a/packages/bezier-react/src/components/Navigator/NavItem/NavItem.types.ts
+++ b/packages/bezier-react/src/components/Navigator/NavItem/NavItem.types.ts
@@ -9,7 +9,6 @@ import type {
 } from '~/src/types/ComponentProps'
 
 interface NavItemOwnProps {
-  leftIcon?: BezierIcon
   name: string
   target?: HTMLAnchorElement['target']
   onClick?: (e?: React.MouseEvent, name?: string) => void
@@ -19,7 +18,7 @@ export interface NavItemProps extends
   AlphaBezierComponentProps,
   ContentProps,
   LinkProps,
-  Pick<SideContentProps, 'rightContent'>,
+  SideContentProps<BezierIcon, React.ReactNode>,
   Pick<ActivatableProps, 'active'>,
   Omit<React.HTMLAttributes<HTMLAnchorElement>, 'onClick' | 'content'>,
   NavItemOwnProps {}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- Fixes #1929

## Summary
<!-- Please brief explanation of the changes made -->

Rename `leftIcon` property of `NavItem` and `NavGroup` to `leftContent`

## Details
<!-- Please elaborate description of the changes -->

이슈로 갈음합니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

Yes
