### PR TITLE
Change `FormFieldSize` enum to classname shared through component 

### DIFF
--- a/.changeset/good-dodos-obey.md
+++ b/.changeset/good-dodos-obey.md
@@ -1,0 +1,8 @@
+---
+"@channel.io/bezier-react": major
+---
+
+**Breaking Changes: Property updates in `FormControl`, `Select`, and `TextField` component**
+
+- `FormControl` component no longer supports `leftLabelWrapperHeight` props.
+- The size property of `Select` and `TextField` component changes from enum to string literal union type. Also, `SelectSize` and `TextFieldSize` enum are deprecated.

--- a/.changeset/good-dodos-obey.md
+++ b/.changeset/good-dodos-obey.md
@@ -5,4 +5,5 @@
 **Breaking Changes: Property updates in `FormControl`, `Select`, and `TextField` component**
 
 - `FormControl` component no longer supports `leftLabelWrapperHeight` props.
+- `FormControl` component now supports `size` props, which is passed as context to the child component such as `TextField` and `Select` and specified as the size property.
 - The size property of `Select` and `TextField` component changes from enum to string literal union type. Also, `SelectSize` and `TextFieldSize` enum are deprecated.

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.module.scss
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.module.scss
@@ -74,7 +74,7 @@
   }
 
   &:where(:has(.Label)) {
-    height: 36px;
+    height: var(--b-form-field-size);
   }
 }
 

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.tsx
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.tsx
@@ -15,6 +15,9 @@ import {
   IconSize,
 } from '~/src/components/Icon'
 
+// eslint-disable-next-line no-restricted-imports
+import formStyles from '../Form.module.scss'
+
 import {
   type CheckboxProps,
   type CheckedState,
@@ -66,7 +69,11 @@ function CheckboxImpl<Checked extends CheckedState>({
   const id = useId(idProp ?? formFieldId, 'bezier-checkbox')
 
   return (
-    <div className={styles.Container}>
+    <div className={classNames(
+      styles.Container,
+      formStyles['size-m'],
+    )}
+    >
       <CheckboxPrimitive.Root
         className={classNames(
           styles.Checkbox,

--- a/packages/bezier-react/src/components/Forms/Form.module.scss
+++ b/packages/bezier-react/src/components/Forms/Form.module.scss
@@ -5,10 +5,8 @@ $size-map: (
   xl: 54,
 );
 
-.Form {
-  @each $size, $value in $size-map {
-    &:where(.size-#{$size}) {
-      --b-form-field-size: #{$value}px;
-    }
+@each $size, $value in $size-map {
+  :where(.size-#{$size}) {
+    --b-form-field-size: #{$value}px;
   }
 }

--- a/packages/bezier-react/src/components/Forms/Form.module.scss
+++ b/packages/bezier-react/src/components/Forms/Form.module.scss
@@ -1,0 +1,14 @@
+$size-map: (
+  xs: 28,
+  m: 36,
+  l: 44,
+  xl: 54,
+);
+
+.Form {
+  @each $size, $value in $size-map {
+    &:where(.size-#{$size}) {
+      --b-form-field-size: #{$value}px;
+    }
+  }
+}

--- a/packages/bezier-react/src/components/Forms/Form.types.ts
+++ b/packages/bezier-react/src/components/Forms/Form.types.ts
@@ -3,7 +3,7 @@ import type {
   IdentifierProps,
 } from '~/src/types/ComponentProps'
 
-interface FormComponentOptions {
+interface FormComponentOwnProps {
   hasError?: boolean
   required?: boolean
   readOnly?: boolean
@@ -12,4 +12,6 @@ interface FormComponentOptions {
 export interface FormComponentProps extends
   DisableProps,
   Partial<IdentifierProps>,
-  FormComponentOptions {}
+  FormComponentOwnProps {}
+
+export type FormFieldSize = 'xl' | 'l' | 'm' | 'xs'

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.module.scss
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.module.scss
@@ -21,7 +21,7 @@
     align-items: center;
     align-self: start;
 
-    height: var(--b-form-control-left-label-wrapper-height);
+    height: var(--b-form-field-size);
   }
 }
 

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.stories.tsx
@@ -61,6 +61,7 @@ export const Primary: StoryObj<FormControlProps> = {
     disabled: false,
     readOnly: false,
     required: false,
+    size: 'm',
   },
 }
 
@@ -149,5 +150,6 @@ export const WithMultiForm: StoryObj<FormControlProps> = {
     disabled: false,
     readOnly: false,
     required: false,
+    size: 'm',
   },
 }

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.stories.tsx
@@ -57,7 +57,6 @@ export const Primary: StoryObj<FormControlProps> = {
   args: {
     id: 'form',
     labelPosition: 'top',
-    leftLabelWrapperHeight: undefined,
     hasError: false,
     disabled: false,
     readOnly: false,
@@ -146,7 +145,6 @@ export const WithMultiForm: StoryObj<FormControlProps> = {
 
   args: {
     labelPosition: 'top',
-    leftLabelWrapperHeight: undefined,
     hasError: false,
     disabled: false,
     readOnly: false,

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.test.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.test.tsx
@@ -23,7 +23,6 @@ describe('FormControl >', () => {
     props = {
       id: 'form',
       labelPosition: 'top',
-      leftLabelWrapperHeight: undefined,
       hasError: false,
       disabled: false,
       readOnly: false,

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -9,13 +9,12 @@ import classNames from 'classnames'
 
 import useId from '~/src/hooks/useId'
 import { splitByBezierComponentProps } from '~/src/utils/props'
-import { px } from '~/src/utils/style'
 import { isNil } from '~/src/utils/type'
 
 import { Stack } from '~/src/components/Stack'
 
 // eslint-disable-next-line no-restricted-imports
-import FormFieldSize from '../FormFieldSize'
+import formStyles from '../Form.module.scss'
 
 import {
   type ContainerProps,
@@ -75,7 +74,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
   id: idProp,
   testId = FORM_CONTROL_TEST_ID,
   labelPosition = 'top',
-  leftLabelWrapperHeight = FormFieldSize.M,
+  leftLabelWrapperHeight = 'm',
   style,
   children,
   ...rest
@@ -120,12 +119,18 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
   const getLabelProps = useCallback<LabelPropsGetter>(ownProps => ({
     id: labelId,
     htmlFor: fieldId,
-    className: classNames(styles.FormLabelWrapper, styles[`position-${labelPosition}`]),
+    className: classNames(
+      styles.FormLabelWrapper,
+      styles[`position-${labelPosition}`],
+      formStyles.Form,
+      formStyles[`size-${leftLabelWrapperHeight}`],
+    ),
     typo: labelPosition === 'top' ? '13' : '14',
     ...ownProps,
   }), [
     fieldId,
     labelId,
+    leftLabelWrapperHeight,
     labelPosition,
   ])
 
@@ -189,15 +194,6 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     formCommonProps,
   ])
 
-  // TODO: fix to className when FormFieldSize can be shared
-  const containerStyle = useMemo(() => ({
-    ...style,
-    '--b-form-control-left-label-wrapper-height': px(leftLabelWrapperHeight),
-  } as React.CSSProperties), [
-    style,
-    leftLabelWrapperHeight,
-  ])
-
   if (!children) { return null }
 
   return (
@@ -205,7 +201,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
       <Container
         {...bezierProps}
         ref={forwardedRef}
-        style={containerStyle}
+        style={style}
         testId={testId}
         labelPosition={labelPosition}
       >

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -121,7 +121,6 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     className: classNames(
       styles.FormLabelWrapper,
       styles[`position-${labelPosition}`],
-      formStyles.Form,
       formStyles['size-m'],
     ),
     typo: labelPosition === 'top' ? '13' : '14',

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -74,6 +74,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
   id: idProp,
   testId = FORM_CONTROL_TEST_ID,
   labelPosition = 'top',
+  size = 'm',
   style,
   children,
   ...rest
@@ -121,7 +122,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     className: classNames(
       styles.FormLabelWrapper,
       styles[`position-${labelPosition}`],
-      formStyles['size-m'],
+      formStyles[`size-${size}`],
     ),
     typo: labelPosition === 'top' ? '13' : '14',
     ...ownProps,
@@ -129,6 +130,7 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     fieldId,
     labelId,
     labelPosition,
+    size,
   ])
 
   const getFieldProps = useCallback<FieldPropsGetter>(ownProps => ({

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -135,12 +135,14 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
 
   const getFieldProps = useCallback<FieldPropsGetter>(ownProps => ({
     id: fieldId,
+    size,
     'aria-describedby': groupNode ? undefined : describerId,
     ...formCommonProps,
     ...ownProps,
   }), [
     fieldId,
     describerId,
+    size,
     formCommonProps,
     groupNode,
   ])

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.tsx
@@ -74,7 +74,6 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
   id: idProp,
   testId = FORM_CONTROL_TEST_ID,
   labelPosition = 'top',
-  leftLabelWrapperHeight = 'm',
   style,
   children,
   ...rest
@@ -123,14 +122,13 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
       styles.FormLabelWrapper,
       styles[`position-${labelPosition}`],
       formStyles.Form,
-      formStyles[`size-${leftLabelWrapperHeight}`],
+      formStyles['size-m'],
     ),
     typo: labelPosition === 'top' ? '13' : '14',
     ...ownProps,
   }), [
     fieldId,
     labelId,
-    leftLabelWrapperHeight,
     labelPosition,
   ])
 

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
@@ -2,9 +2,13 @@ import type {
   AlphaBezierComponentProps,
   ChildrenProps,
   IdentifierProps,
+  SizeProps,
 } from '~/src/types/ComponentProps'
 
-import type { FormComponentProps } from '~/src/components/Forms'
+import type {
+  FormComponentProps,
+  FormFieldSize,
+} from '~/src/components/Forms'
 
 type LabelPosition = 'top' | 'left'
 
@@ -61,5 +65,6 @@ export interface ContainerProps extends
 export interface FormControlProps extends
   AlphaBezierComponentProps,
   ChildrenProps,
+  SizeProps<FormFieldSize>,
   FormComponentProps,
   FormControlOwnProps {}

--- a/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
+++ b/packages/bezier-react/src/components/Forms/FormControl/FormControl.types.ts
@@ -4,15 +4,11 @@ import type {
   IdentifierProps,
 } from '~/src/types/ComponentProps'
 
-import type {
-  FormComponentProps,
-  FormFieldSize,
-} from '~/src/components/Forms'
+import type { FormComponentProps } from '~/src/components/Forms'
 
 type LabelPosition = 'top' | 'left'
 
 interface FormControlOwnProps {
-  leftLabelWrapperHeight?: FormFieldSize
   labelPosition?: LabelPosition
 }
 

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
     data-testid="bezier-react-form-control"
   >
     <label
-      class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
+      class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
       data-testid="bezier-react-form-label"
       id="form-label"
       style="--b-text-color: var(--txt-black-darkest);"
@@ -28,7 +28,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         data-testid="bezier-react-form-control"
       >
         <label
-          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
           data-testid="bezier-react-form-label"
           for="field-:r3:"
           id="field-:r3:-label"
@@ -37,7 +37,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
           First Inner Label
         </label>
         <div
-          class="TextFieldWrapper variant-primary size-m Form size-m"
+          class="TextFieldWrapper variant-primary size-m size-m"
           data-testid="bezier-react-text-input"
         >
           <input
@@ -54,7 +54,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         data-testid="bezier-react-form-control"
       >
         <label
-          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
           data-testid="bezier-react-form-label"
           for="field-:r4:"
           id="field-:r4:-label"
@@ -63,7 +63,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
           Second Inner Label
         </label>
         <div
-          class="TextFieldWrapper variant-primary size-m Form size-m"
+          class="TextFieldWrapper variant-primary size-m size-m"
           data-testid="bezier-react-text-input"
         >
           <input
@@ -96,7 +96,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
     data-testid="bezier-react-form-control"
   >
     <label
-      class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left Form size-m"
+      class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left size-m"
       data-testid="bezier-react-form-label"
       id="form-label"
       style="--b-text-color: var(--txt-black-darkest);"
@@ -117,7 +117,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         data-testid="bezier-react-form-control"
       >
         <label
-          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
           data-testid="bezier-react-form-label"
           for="field-:r6:"
           id="field-:r6:-label"
@@ -126,7 +126,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
           First Inner Label
         </label>
         <div
-          class="TextFieldWrapper variant-primary size-m Form size-m"
+          class="TextFieldWrapper variant-primary size-m size-m"
           data-testid="bezier-react-text-input"
         >
           <input
@@ -143,7 +143,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         data-testid="bezier-react-form-control"
       >
         <label
-          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
           data-testid="bezier-react-form-label"
           for="field-:r7:"
           id="field-:r7:-label"
@@ -152,7 +152,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
           Second Inner Label
         </label>
         <div
-          class="TextFieldWrapper variant-primary size-m Form size-m"
+          class="TextFieldWrapper variant-primary size-m size-m"
           data-testid="bezier-react-text-input"
         >
           <input
@@ -184,7 +184,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   data-testid="bezier-react-form-control"
 >
   <label
-    class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
+    class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
     data-testid="bezier-react-form-label"
     for="form"
     id="form-label"
@@ -193,7 +193,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
     Label
   </label>
   <div
-    class="TextFieldWrapper variant-primary size-m Form size-m"
+    class="TextFieldWrapper variant-primary size-m size-m"
     data-testid="bezier-react-text-input"
   >
     <input
@@ -222,7 +222,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   data-testid="bezier-react-form-control"
 >
   <label
-    class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left Form size-m"
+    class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left size-m"
     data-testid="bezier-react-form-label"
     for="form"
     id="form-label"
@@ -231,7 +231,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
     Label
   </label>
   <div
-    class="TextFieldWrapper variant-primary size-m Form size-m"
+    class="TextFieldWrapper variant-primary size-m size-m"
     data-testid="bezier-react-text-input"
   >
     <input

--- a/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/Forms/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -5,10 +5,9 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
   <div
     class="Stack display-flex direction-vertical margin layout"
     data-testid="bezier-react-form-control"
-    style="--b-form-control-left-label-wrapper-height: 36px;"
   >
     <label
-      class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+      class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
       data-testid="bezier-react-form-label"
       id="form-label"
       style="--b-text-color: var(--txt-black-darkest);"
@@ -27,10 +26,9 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       <div
         class="Stack display-flex direction-vertical margin layout"
         data-testid="bezier-react-form-control"
-        style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <label
-          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
           data-testid="bezier-react-form-label"
           for="field-:r3:"
           id="field-:r3:-label"
@@ -39,7 +37,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
           First Inner Label
         </label>
         <div
-          class="TextFieldWrapper variant-primary size-36"
+          class="TextFieldWrapper variant-primary size-m Form size-m"
           data-testid="bezier-react-text-input"
         >
           <input
@@ -54,10 +52,9 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       <div
         class="Stack display-flex direction-vertical margin layout"
         data-testid="bezier-react-form-control"
-        style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <label
-          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
           data-testid="bezier-react-form-label"
           for="field-:r4:"
           id="field-:r4:-label"
@@ -66,7 +63,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
           Second Inner Label
         </label>
         <div
-          class="TextFieldWrapper variant-primary size-36"
+          class="TextFieldWrapper variant-primary size-m Form size-m"
           data-testid="bezier-react-text-input"
         >
           <input
@@ -97,10 +94,9 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
   <div
     class="Grid"
     data-testid="bezier-react-form-control"
-    style="--b-form-control-left-label-wrapper-height: 36px;"
   >
     <label
-      class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left"
+      class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left Form size-m"
       data-testid="bezier-react-form-label"
       id="form-label"
       style="--b-text-color: var(--txt-black-darkest);"
@@ -119,10 +115,9 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       <div
         class="Stack display-flex direction-vertical margin layout"
         data-testid="bezier-react-form-control"
-        style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <label
-          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
           data-testid="bezier-react-form-label"
           for="field-:r6:"
           id="field-:r6:-label"
@@ -131,7 +126,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
           First Inner Label
         </label>
         <div
-          class="TextFieldWrapper variant-primary size-36"
+          class="TextFieldWrapper variant-primary size-m Form size-m"
           data-testid="bezier-react-text-input"
         >
           <input
@@ -146,10 +141,9 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       <div
         class="Stack display-flex direction-vertical margin layout"
         data-testid="bezier-react-form-control"
-        style="--b-form-control-left-label-wrapper-height: 36px;"
       >
         <label
-          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+          class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
           data-testid="bezier-react-form-label"
           for="field-:r7:"
           id="field-:r7:-label"
@@ -158,7 +152,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
           Second Inner Label
         </label>
         <div
-          class="TextFieldWrapper variant-primary size-36"
+          class="TextFieldWrapper variant-primary size-m Form size-m"
           data-testid="bezier-react-text-input"
         >
           <input
@@ -188,10 +182,9 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 <div
   class="Stack display-flex direction-vertical margin layout"
   data-testid="bezier-react-form-control"
-  style="--b-form-control-left-label-wrapper-height: 36px;"
 >
   <label
-    class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top"
+    class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top Form size-m"
     data-testid="bezier-react-form-label"
     for="form"
     id="form-label"
@@ -200,7 +193,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
     Label
   </label>
   <div
-    class="TextFieldWrapper variant-primary size-36"
+    class="TextFieldWrapper variant-primary size-m Form size-m"
     data-testid="bezier-react-text-input"
   >
     <input
@@ -227,10 +220,9 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
 <div
   class="Grid"
   data-testid="bezier-react-form-control"
-  style="--b-form-control-left-label-wrapper-height: 36px;"
 >
   <label
-    class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left"
+    class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left Form size-m"
     data-testid="bezier-react-form-label"
     for="form"
     id="form-label"
@@ -239,7 +231,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
     Label
   </label>
   <div
-    class="TextFieldWrapper variant-primary size-36"
+    class="TextFieldWrapper variant-primary size-m Form size-m"
     data-testid="bezier-react-text-input"
   >
     <input

--- a/packages/bezier-react/src/components/Forms/FormFieldSize.ts
+++ b/packages/bezier-react/src/components/Forms/FormFieldSize.ts
@@ -1,1 +1,0 @@
-export type FormFieldSize = 'xl' | 'l' | 'm' | 'xs'

--- a/packages/bezier-react/src/components/Forms/FormFieldSize.ts
+++ b/packages/bezier-react/src/components/Forms/FormFieldSize.ts
@@ -1,8 +1,1 @@
-enum FormFieldSize {
-  XL = 54,
-  L = 44,
-  M = 36,
-  XS = 28,
-}
-
-export default FormFieldSize
+export type FormFieldSize = 'xl' | 'l' | 'm' | 'xs'

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.module.scss
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.module.scss
@@ -14,6 +14,7 @@
 
   box-sizing: border-box;
   width: 100%;
+  height: var(--b-form-field-size);
   padding: 8px 12px;
 
   color: var(--txt-black-darkest);
@@ -23,22 +24,6 @@
   box-shadow: var(--input-box-shadow);
 
   transition: background-color var(--transition-s), box-shadow var(--transition-s);
-
-  &:where(.size-28) {
-    height: 28px;
-  }
-
-  &:where(.size-36) {
-    height: 36px;
-  }
-
-  &:where(.size-44) {
-    height: 44px;
-  }
-
-  &:where(.size-54) {
-    height: 54px;
-  }
 
   &.readonly {
     cursor: initial;

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.stories.tsx
@@ -6,27 +6,16 @@ import {
   type StoryFn,
 } from '@storybook/react'
 
-import { getObjectFromEnum } from '~/src/utils/story'
-
 import { Text } from '~/src/components/Text'
 
 import { Select } from './Select'
-import {
-  type SelectProps,
-  SelectSize,
-} from './Select.types'
+import { type SelectProps } from './Select.types'
 
 const meta: Meta<SelectProps & {
   wrapperSize: number
 }> = {
   component: Select,
   argTypes: {
-    size: {
-      control: {
-        type: 'radio',
-      },
-      options: getObjectFromEnum(SelectSize),
-    },
     wrapperSize: {
       control: {
         type: 'number',
@@ -58,6 +47,6 @@ export const Primary = {
     readOnly: false,
     withoutChevron: false,
     hasError: false,
-    size: SelectSize.M,
+    size: 'm',
   },
 }

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
@@ -45,7 +45,7 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
   children,
   style,
   className,
-  size = 'm',
+  size: sizeProps = 'm',
   defaultFocus = false,
   placeholder = '',
   leftContent,
@@ -73,11 +73,14 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
     disabled,
     readOnly,
     hasError,
+    size: formFieldSize,
     ...ownProps
   } = useFormFieldProps(rest)
 
   const containerRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
+
+  const size = formFieldSize ?? sizeProps
 
   const [isDropdownOpened, setIsDropdownOpened] = useState(false)
 

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
@@ -136,7 +136,6 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
       <button
         className={classNames(
           styles.SelectTrigger,
-          formStyles.Form,
           formStyles[`size-${size}`],
           hasError && styles.invalid,
           readOnly && styles.readonly,

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
@@ -80,7 +80,7 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
   const containerRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
 
-  const size = formFieldSize ?? sizeProps
+  const size = sizeProps ?? formFieldSize ?? 'm'
 
   const [isDropdownOpened, setIsDropdownOpened] = useState(false)
 

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
@@ -45,7 +45,7 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
   children,
   style,
   className,
-  size: sizeProps = 'm',
+  size: sizeProps,
   defaultFocus = false,
   placeholder = '',
   leftContent,

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.tsx
@@ -29,10 +29,12 @@ import {
 } from '~/src/components/Overlay'
 import { Text } from '~/src/components/Text'
 
+// eslint-disable-next-line no-restricted-imports
+import formStyles from '../../Form.module.scss'
+
 import {
   type SelectProps,
   type SelectRef,
-  SelectSize,
 } from './Select.types'
 
 import styles from './Select.module.scss'
@@ -43,7 +45,7 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
   children,
   style,
   className,
-  size = SelectSize.M,
+  size = 'm',
   defaultFocus = false,
   placeholder = '',
   leftContent,
@@ -134,7 +136,8 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
       <button
         className={classNames(
           styles.SelectTrigger,
-          size && styles[`size-${size}`],
+          formStyles.Form,
+          formStyles[`size-${size}`],
           hasError && styles.invalid,
           readOnly && styles.readonly,
           isDropdownOpened && styles.active,

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/Select.types.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/Select.types.ts
@@ -11,16 +11,11 @@ import type {
 } from '~/src/types/ComponentProps'
 import { type ZIndex } from '~/src/types/Token'
 
-import type { FormComponentProps } from '~/src/components/Forms'
-import { FormFieldSize } from '~/src/components/Forms'
+import {
+  type FormComponentProps,
+  type FormFieldSize,
+} from '~/src/components/Forms'
 import type { OverlayProps } from '~/src/components/Overlay'
-
-export enum SelectSize {
-  XL = FormFieldSize.XL,
-  L = FormFieldSize.L,
-  M = FormFieldSize.M,
-  S = FormFieldSize.XS,
-}
 
 export interface SelectRef {
   handleClickTrigger(event: React.MouseEvent): void
@@ -45,7 +40,7 @@ interface SelectOwnProps {
 export interface SelectProps extends
   AlphaBezierComponentProps,
   ChildrenProps,
-  SizeProps<SelectSize>,
+  SizeProps<FormFieldSize>,
   SideContentProps<BezierIcon | React.ReactNode, BezierIcon | React.ReactNode>,
   AdditionalTestIdProps<['trigger', 'triggerText', 'dropdown']>,
   AlphaAdditionalStylableProps<'dropdown'>,

--- a/packages/bezier-react/src/components/Forms/Inputs/Select/index.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/Select/index.ts
@@ -1,7 +1,5 @@
 export { Select } from './Select'
 
-export { SelectSize } from './Select.types'
-
 export type {
   SelectProps,
   SelectRef,

--- a/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.test.tsx
@@ -5,7 +5,7 @@ import { act } from '@testing-library/react'
 
 import { render } from '~/src/utils/test'
 
-import { COMMON_IME_CONTROL_KEYS } from '~/src/components/Forms/Inputs/constants/CommonImeControlKeys'
+import { COMMON_IME_CONTROL_KEYS } from '~/src/components/Forms'
 
 import { TextArea } from './TextArea'
 import type { TextAreaProps } from './TextArea.types'

--- a/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextArea/TextArea.tsx
@@ -9,7 +9,7 @@ import TextareaAutosize from 'react-textarea-autosize'
 
 import useMergeRefs from '~/src/hooks/useMergeRefs'
 
-import { COMMON_IME_CONTROL_KEYS } from '~/src/components/Forms/Inputs/constants/CommonImeControlKeys'
+import { COMMON_IME_CONTROL_KEYS } from '~/src/components/Forms'
 import useFormFieldProps from '~/src/components/Forms/useFormFieldProps'
 import useKeyboardActionLockerWhileComposing from '~/src/components/Forms/useKeyboardActionLockerWhileComposing'
 

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.module.scss
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.module.scss
@@ -49,14 +49,11 @@
     background-color: var(--bg-black-lightest);
   }
 
-
-  &:where(.size-44) {
-    & .TextFieldInput {
-      @include typography.size(16);
-    }
+  &:where(.size-l) .TextFieldInput {
+    @include typography.size(16);
   }
 
-  &:where(.size-54) {
+  &:where(.size-xl) {
     border-radius: var(--radius-12);
 
     & .TextFieldInput {

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.module.scss
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.module.scss
@@ -43,29 +43,20 @@
   border-radius: var(--radius-8);
 
   transition: border-color var(--transition-s), box-shadow var(--transition-s);
+  height: var(--b-form-field-size);
 
   &:where(.variant-secondary) {
     background-color: var(--bg-black-lightest);
   }
 
-  &:where(.size-28) {
-    height: 28px;
-  }
-
-  &:where(.size-36) {
-    height: 36px;
-  }
 
   &:where(.size-44) {
-    height: 44px;
-
     & .TextFieldInput {
       @include typography.size(16);
     }
   }
 
   &:where(.size-54) {
-    height: 54px;
     border-radius: var(--radius-12);
 
     & .TextFieldInput {

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.module.scss
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.module.scss
@@ -37,13 +37,13 @@
   align-items: center;
 
   box-sizing: border-box;
+  height: var(--b-form-field-size);
   padding: 0 12px;
 
   background-color: var(--bg-grey-lightest);
   border-radius: var(--radius-8);
 
   transition: border-color var(--transition-s), box-shadow var(--transition-s);
-  height: var(--b-form-field-size);
 
   &:where(.variant-secondary) {
     background-color: var(--bg-black-lightest);

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.stories.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.stories.tsx
@@ -16,7 +16,6 @@ import { TextField } from './TextField'
 import {
   type TextFieldProps,
   type TextFieldRef,
-  TextFieldSize,
   TextFieldVariant,
 } from './TextField.types'
 
@@ -62,7 +61,7 @@ export const Primary = {
 
   args: {
     variant: TextFieldVariant.Primary,
-    size: TextFieldSize.M,
+    size: 'm',
     disabled: false,
     readOnly: false,
     allowClear: true,
@@ -71,14 +70,7 @@ export const Primary = {
     maxLength: 10,
     placeholder: 'this is placeholder',
   },
-
   argTypes: {
-    size: {
-      control: {
-        type: 'radio', // type 'select' is automatically inferred when 'options' is defined
-      },
-      options: getObjectFromEnum(TextFieldSize),
-    },
     variant: {
       control: {
         type: 'radio',

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.test.tsx
@@ -9,7 +9,7 @@ import userEvent from '@testing-library/user-event'
 
 import { render } from '~/src/utils/test'
 
-import { COMMON_IME_CONTROL_KEYS } from '~/src/components/Forms/Inputs/constants/CommonImeControlKeys'
+import { COMMON_IME_CONTROL_KEYS } from '~/src/components/Forms'
 
 import {
   TEXT_INPUT_CLEAR_ICON_TEST_ID,

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
@@ -169,7 +169,7 @@ function TextFieldRightContent({
 
 export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextField({
   type,
-  size: sizeProps = 'm',
+  size: sizeProps,
   testId = TEXT_INPUT_TEST_ID,
   autoFocus,
   autoComplete = 'off',

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
@@ -19,8 +19,10 @@ import {
   isNil,
 } from '~/src/utils/type'
 
-import { type FormFieldSize } from '~/src/components/Forms/FormFieldSize'
-import { COMMON_IME_CONTROL_KEYS } from '~/src/components/Forms/Inputs/constants/CommonImeControlKeys'
+import {
+  COMMON_IME_CONTROL_KEYS,
+  type FormFieldSize,
+} from '~/src/components/Forms'
 import useFormFieldProps from '~/src/components/Forms/useFormFieldProps'
 import useKeyboardActionLockerWhileComposing from '~/src/components/Forms/useKeyboardActionLockerWhileComposing'
 import {

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
@@ -169,7 +169,7 @@ function TextFieldRightContent({
 
 export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextField({
   type,
-  size = 'm',
+  size: sizeProps = 'm',
   testId = TEXT_INPUT_TEST_ID,
   autoFocus,
   autoComplete = 'off',
@@ -202,6 +202,7 @@ export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextF
     disabled,
     readOnly,
     hasError,
+    size: formFieldSize,
     ...ownProps
   } = useFormFieldProps(rest)
 
@@ -211,6 +212,7 @@ export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextF
   const normalizedValue = isNil(value) ? undefined : toString(value)
   const activeInput = !disabled && !readOnly
   const activeClear = activeInput && allowClear && !isEmpty(normalizedValue)
+  const size = formFieldSize ?? sizeProps
 
   const inputRef = useRef<HTMLInputElement | null>(null)
 

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
@@ -362,7 +362,6 @@ export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextF
         styles.TextFieldWrapper,
         styles[`variant-${variant}`],
         styles[`size-${size}`],
-        formStyles.Form,
         formStyles[`size-${size}`],
         wrapperClassName,
       )}

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
@@ -361,6 +361,7 @@ export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextF
       className={classNames(
         styles.TextFieldWrapper,
         styles[`variant-${variant}`],
+        styles[`size-${size}`],
         formStyles.Form,
         formStyles[`size-${size}`],
         wrapperClassName,

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
@@ -47,6 +47,10 @@ import styles from './TextField.module.scss'
 export const TEXT_INPUT_TEST_ID = 'bezier-react-text-input'
 export const TEXT_INPUT_CLEAR_ICON_TEST_ID = 'bezier-react-text-input-clear-icon'
 
+/**
+ * FIXME: This mapping constant was defined for UI consistency,
+ * and it should be removed with size attribute
+ */
 const INPUT_LENGTH_BY_SIZE: Record<FormFieldSize, number> = {
   xs: 28,
   m: 36,

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
@@ -212,7 +212,7 @@ export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextF
   const normalizedValue = isNil(value) ? undefined : toString(value)
   const activeInput = !disabled && !readOnly
   const activeClear = activeInput && allowClear && !isEmpty(normalizedValue)
-  const size = formFieldSize ?? sizeProps
+  const size = sizeProps ?? formFieldSize ?? 'm'
 
   const inputRef = useRef<HTMLInputElement | null>(null)
 

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.tsx
@@ -19,6 +19,7 @@ import {
   isNil,
 } from '~/src/utils/type'
 
+import { type FormFieldSize } from '~/src/components/Forms/FormFieldSize'
 import { COMMON_IME_CONTROL_KEYS } from '~/src/components/Forms/Inputs/constants/CommonImeControlKeys'
 import useFormFieldProps from '~/src/components/Forms/useFormFieldProps'
 import useKeyboardActionLockerWhileComposing from '~/src/components/Forms/useKeyboardActionLockerWhileComposing'
@@ -27,12 +28,14 @@ import {
   IconSize,
 } from '~/src/components/Icon'
 
+// eslint-disable-next-line no-restricted-imports
+import formStyles from '../../Form.module.scss'
+
 import {
   type SelectionRangeDirections,
   type TextFieldItemProps,
   type TextFieldProps,
   type TextFieldRef,
-  TextFieldSize,
   TextFieldType,
   TextFieldVariant,
 } from './TextField.types'
@@ -41,6 +44,13 @@ import styles from './TextField.module.scss'
 
 export const TEXT_INPUT_TEST_ID = 'bezier-react-text-input'
 export const TEXT_INPUT_CLEAR_ICON_TEST_ID = 'bezier-react-text-input-clear-icon'
+
+const INPUT_LENGTH_BY_SIZE: Record<FormFieldSize, number> = {
+  xs: 28,
+  m: 36,
+  l: 44,
+  xl: 54,
+}
 
 function TextFieldLeftContent({
   children,
@@ -153,7 +163,7 @@ function TextFieldRightContent({
 
 export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextField({
   type,
-  size = TextFieldSize.M,
+  size = 'm',
   testId = TEXT_INPUT_TEST_ID,
   autoFocus,
   autoComplete = 'off',
@@ -349,7 +359,8 @@ export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextF
       className={classNames(
         styles.TextFieldWrapper,
         styles[`variant-${variant}`],
-        styles[`size-${size}`],
+        formStyles.Form,
+        formStyles[`size-${size}`],
         wrapperClassName,
       )}
       data-testid={testId}
@@ -376,7 +387,7 @@ export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextF
          * Invalid size attribute
          * FIXME: https://github.com/channel-io/bezier-react/issues/1053
          */
-        size={size}
+        size={INPUT_LENGTH_BY_SIZE[size]}
         autoComplete={autoComplete}
         readOnly={readOnly}
         disabled={disabled}

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.types.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.types.ts
@@ -12,7 +12,7 @@ import type {
 } from '~/src/types/ComponentProps'
 
 import type { FormComponentProps } from '~/src/components/Forms'
-import { FormFieldSize } from '~/src/components/Forms'
+import { type FormFieldSize } from '~/src/components/Forms/FormFieldSize'
 
 export enum TextFieldType {
   Search = 'search',
@@ -23,16 +23,6 @@ export enum TextFieldType {
   Url = 'url',
   Hidden = 'hidden',
   Number = 'number',
-}
-
-/**
- * FIXME: Change to string literal type
- */
-export enum TextFieldSize {
-  XL = FormFieldSize.XL,
-  L = FormFieldSize.L,
-  M = FormFieldSize.M,
-  XS = FormFieldSize.XS,
 }
 
 export type SelectionRangeDirections = 'forward' | 'backward' | 'none'
@@ -80,7 +70,7 @@ export interface TextFieldProps extends
   AlphaBezierComponentProps,
   AlphaAdditionalStylableProps<['wrapper', 'leftWrapper', 'rightWrapper']>,
   FormComponentProps,
-  SizeProps<TextFieldSize>,
+  SizeProps<FormFieldSize>,
   VariantProps<TextFieldVariant>,
   SideContentProps<TextFieldItemProps, TextFieldItemProps | TextFieldItemProps[]>,
   Omit<React.InputHTMLAttributes<HTMLInputElement>, OmittedInputHTMLAttributes>,

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.types.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.types.ts
@@ -11,8 +11,10 @@ import type {
   VariantProps,
 } from '~/src/types/ComponentProps'
 
-import type { FormComponentProps } from '~/src/components/Forms'
-import { type FormFieldSize } from '~/src/components/Forms/FormFieldSize'
+import type {
+  FormComponentProps,
+  FormFieldSize,
+} from '~/src/components/Forms'
 
 export enum TextFieldType {
   Search = 'search',

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/index.ts
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/index.ts
@@ -1,7 +1,6 @@
 export { TextField } from './TextField'
 
 export {
-  TextFieldSize,
   TextFieldType,
   TextFieldVariant,
 } from './TextField.types'

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.module.scss
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.module.scss
@@ -97,7 +97,7 @@ $inner-indicator-size: 8px;
   }
 
   &:where(:has(.Label)) {
-    height: 36px;
+    height: var(--b-form-field-size);
   }
 }
 

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.tsx
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.tsx
@@ -9,6 +9,9 @@ import useFormFieldProps from '~/src/components/Forms/useFormFieldProps'
 import { Stack } from '~/src/components/Stack'
 import { Text } from '~/src/components/Text'
 
+// eslint-disable-next-line no-restricted-imports
+import formStyles from '../Form.module.scss'
+
 import {
   type RadioGroupProps,
   type RadioProps,
@@ -73,6 +76,7 @@ function RadioImpl<Value extends string>({
     <RadioGroupPrimitive.Item
       className={classNames(
         styles.RadioGroupItem,
+        formStyles['size-m'],
         className,
       )}
       ref={forwardedRef}

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -136,6 +136,7 @@ const SegmentedControlItemList = forwardRef(SegmentedControlItemListImpl) as <
 
 function SegmentedControlRadioGroupImpl<Value extends string>({
   children,
+  size,
   ...rest
 }: SegmentedControlRadioGroupProps<Value>, forwardedRef: React.Ref<HTMLDivElement>) {
   const { hasError, ...ownProps } = useFormFieldProps(rest)
@@ -143,6 +144,7 @@ function SegmentedControlRadioGroupImpl<Value extends string>({
     <SegmentedControlItemList
       ref={forwardedRef}
       {...ownProps}
+      size={size}
     >
       { children }
     </SegmentedControlItemList>

--- a/packages/bezier-react/src/components/Forms/index.ts
+++ b/packages/bezier-react/src/components/Forms/index.ts
@@ -1,12 +1,9 @@
-import type { FormComponentProps } from './Form.types'
-import FormFieldSize from './FormFieldSize'
 import useFormFieldProps from './useFormFieldProps'
 import useKeyboardActionLockerWhileComposing from './useKeyboardActionLockerWhileComposing'
 
-export type { FormComponentProps }
-export * from './Inputs/constants/CommonImeControlKeys'
+export type { FormComponentProps, FormFieldSize } from './Form.types'
+export { COMMON_IME_CONTROL_KEYS } from './Inputs/constants/CommonImeControlKeys'
 export {
-  FormFieldSize,
   useFormFieldProps,
   useKeyboardActionLockerWhileComposing,
 }

--- a/packages/bezier-react/src/components/Forms/useFormFieldProps.ts
+++ b/packages/bezier-react/src/components/Forms/useFormFieldProps.ts
@@ -1,12 +1,16 @@
 import { useMemo } from 'react'
 
+import { type SizeProps } from '~/src/types/ComponentProps'
 import { ariaAttr } from '~/src/utils/dom'
 
-import type { FormComponentProps } from '~/src/components/Forms/Form.types'
+import type {
+  FormComponentProps,
+  FormFieldSize,
+} from '~/src/components/Forms/Form.types'
 import { useFormControlContext } from '~/src/components/Forms/FormControl'
 
 // TODO: 테스트 추가
-function useFormFieldProps<Props extends FormComponentProps>(props?: Props) {
+function useFormFieldProps<Props extends FormComponentProps & SizeProps<FormFieldSize>>(props?: Props) {
   const contextValue = useFormControlContext()
 
   const formFieldProps = useMemo(() => {
@@ -17,6 +21,7 @@ function useFormFieldProps<Props extends FormComponentProps>(props?: Props) {
       readOnly = false,
       required = false,
       hasError = false,
+      size = undefined,
       ...rest
     } = mergedProps
 
@@ -26,6 +31,7 @@ function useFormFieldProps<Props extends FormComponentProps>(props?: Props) {
       'aria-invalid': ariaAttr(hasError),
       'aria-required': ariaAttr(required),
       'aria-readonly': ariaAttr(readOnly),
+      size,
       disabled,
       hasError,
       required,

--- a/packages/bezier-react/src/features/SmoothCornersFeature/smoothCornersScript.ts
+++ b/packages/bezier-react/src/features/SmoothCornersFeature/smoothCornersScript.ts
@@ -95,6 +95,7 @@ class SmoothCorners {
       .get('--smooth-corners')
       .toString()
 
+    console.log("padding: ", padding)
     const targetWidth = geom.width - (2 * this.trimPX(padding))
     const targetHeight = geom.height - (2 * this.trimPX(padding))
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary
<!-- Please brief explanation of the changes made -->

- 기존에 `FormFieldSize` 로 정의되는 enum 을 string literal union 으로 변경하고, 공통 스타일을 classname 으로 변경해서 `Select`, `TextField` 컴포넌트에서 공유하도록 합니다.  

## Details
<!-- Please elaborate description of the changes -->

- `FormControl` 컴포넌트의 leftLabelWrapperHeight 속성을 deprecate 합니다. 데스크에서 사용처가 없는 것을 확인했습니다. 
- `TextFieldSize`, `SelectSize` export 를 제거합니다. 


### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

- Yes

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- None
