### PR TITLE
fix(smooth-corners): add a separator(,) to the shadow custom property

### DIFF
--- a/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.module.scss
+++ b/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.module.scss
@@ -21,7 +21,7 @@
   &:where([data-state="enabled"]) {
     @supports (background: paint(smooth-corners)) {
       --smooth-corners: var(--b-smooth-corners-box-border-radius);
-      --smooth-corners-shadow: var(--b-smooth-corners-box-shadow-offset-x) var(--b-smooth-corners-box-shadow-offset-y) var(--b-smooth-corners-box-shadow-blur-radius) var(--b-smooth-corners-box-shadow-spread-radius) var(--b-smooth-corners-box-shadow-color);
+      --smooth-corners-shadow: var(--b-smooth-corners-box-shadow-offset-x), var(--b-smooth-corners-box-shadow-offset-y), var(--b-smooth-corners-box-shadow-blur-radius), var(--b-smooth-corners-box-shadow-spread-radius), var(--b-smooth-corners-box-shadow-color);
       --smooth-corners-bg-color: var(--b-smooth-corners-box-background-color);
       --smooth-corners-padding: var(--b-smooth-corners-box-padding);
 

--- a/packages/bezier-react/src/features/SmoothCornersFeature/smoothCornersScript.ts
+++ b/packages/bezier-react/src/features/SmoothCornersFeature/smoothCornersScript.ts
@@ -36,16 +36,16 @@ class SmoothCorners {
 
     const result = this.computeSuperellipse(...sanitizedArgs)
 
-    this.superellipseCache.set(cacheKey, result);
+    this.superellipseCache.set(cacheKey, result)
 
-    return [...result];
+    return [...result]
   }
 
   sanitizeSuperellipseArgs(a, b, nX, nY) {
-    if (nX > 100) nX = 100
-    if (nY > 100) nY = 100
-    if (nX < 0.00000000001) nX = 0.00000000001
-    if (nY < 0.00000000001) nY = 0.00000000001
+    if (nX > 100) { nX = 100 }
+    if (nY > 100) { nY = 100 }
+    if (nX < 0.00000000001) { nX = 0.00000000001 }
+    if (nY < 0.00000000001) { nY = 0.00000000001 }
 
     return [a, b, nX, nY]
   }
@@ -60,7 +60,7 @@ class SmoothCorners {
       const sinT = Math.sin(t)
       return {
         x: Math.abs(cosT) ** nX2 * a * Math.sign(cosT),
-        y: Math.abs(sinT) ** nY2 * b * Math.sign(sinT)
+        y: Math.abs(sinT) ** nY2 * b * Math.sign(sinT),
       }
     }
 
@@ -83,15 +83,10 @@ class SmoothCorners {
       .get('--smooth-corners-padding')
       .toString()
 
-    const boxShadow = properties
+    const [offsetX, offsetY, blur, spread, color] = properties
       .get('--smooth-corners-shadow')
       .toString()
-      .split(/(?<=[^0-9]),/)
-      .map(shadow => (
-        shadow
-          .split(/(?<=[^,]) /)
-          .map(value => value.trim())
-      ))
+      .split(/,s*/)
 
     const halfWidth = geom.width / 2
     const halfHeight = geom.height / 2
@@ -115,51 +110,43 @@ class SmoothCorners {
       halfWidth - this.trimPX(padding),
       halfHeight - this.trimPX(padding),
       parseFloat(targetNX, 10),
-      parseFloat(targetNY, 10)
+      parseFloat(targetNY, 10),
     )
 
     ctx.setTransform(1, 0, 0, 1, halfWidth, halfHeight)
     ctx.beginPath()
 
-    boxShadow.forEach(([
-      offsetX,
-      offsetY,
-      blur,
-      spread,
-      color,
-    ]) => {
-      ctx.shadowColor = null
-      ctx.shadowOffsetX = 0
-      ctx.shadowOffsetY = 0
-      ctx.shadowBlur = 0
+    ctx.shadowColor = null
+    ctx.shadowOffsetX = 0
+    ctx.shadowOffsetY = 0
+    ctx.shadowBlur = 0
 
-      const trimedX = this.trimPX(offsetX) * 2
-      const trimedY = this.trimPX(offsetY) * 2
-      const trimedBlur = this.trimPX(blur)
-      const trimedSpread = this.trimPX(spread)
+    const trimedX = this.trimPX(offsetX) * 2
+    const trimedY = this.trimPX(offsetY) * 2
+    const trimedBlur = this.trimPX(blur)
+    const trimedSpread = this.trimPX(spread)
 
-      if (trimedBlur === 0) {
-        ctx.strokeStyle = color
-        ctx.lineWidth = trimedSpread * 2
+    if (trimedBlur === 0) {
+      ctx.strokeStyle = color
+      ctx.lineWidth = trimedSpread * 2
+    } else {
+      ctx.shadowColor = color
+      ctx.shadowOffsetX = trimedX
+      ctx.shadowOffsetY = trimedY
+      ctx.shadowBlur = trimedBlur * 2
+    }
+
+    smooth.forEach(({ x, y }, index) => {
+      if (index === 0) {
+        ctx.moveTo(x, y)
       } else {
-        ctx.shadowColor = color
-        ctx.shadowOffsetX = trimedX
-        ctx.shadowOffsetY = trimedY
-        ctx.shadowBlur = trimedBlur * 2
-      }
-
-      smooth.forEach(({ x, y }, index) => {
-        if (index === 0) {
-          ctx.moveTo(x, y)
-        } else {
-          ctx.lineTo(x, y)
-        }
-      })
-
-      if (trimedBlur === 0) {
-        ctx.stroke()
+        ctx.lineTo(x, y)
       }
     })
+
+    if (trimedBlur === 0) {
+      ctx.stroke()
+    }
 
     if (backgroundColor) {
       ctx.fillStyle = backgroundColor


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

Fixes #1955

## Summary
<!-- Please brief explanation of the changes made -->

Add a separator(,) to the shadow custom property

## Details
<!-- Please elaborate description of the changes -->

- shadow 커스텀 속성에 `,` 구분자를 추가합니다.
- shadow 커스텀 속성에서 그림자 속성들을 추출하는 로직을 수정합니다. 쉼표와 그 이후 0개 이상의 공백을 기준으로 속성들을 나눕니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
