### PR TITLE
Add & Apply eslint-plugin-jsdoc

### DIFF
--- a/packages/bezier-react/.eslintrc.js
+++ b/packages/bezier-react/.eslintrc.js
@@ -1,51 +1,67 @@
+/**
+ * @type {import('eslint').Linter.Config}
+ */
 module.exports = {
   root: true,
-  extends: ['bezier'],
+  plugins: ['jsdoc'],
+  extends: [
+    'bezier',
+    'plugin:jsdoc/recommended-typescript-error',
+  ],
   parserOptions: {
     tsconfigRootDir: __dirname,
     project: './tsconfig.eslint.json',
   },
   rules: {
-    'sort-imports': [
-      'error',
-      {
-        ignoreDeclarationSort: true,
-      },
-    ],
-    'import/order': [
-      'error',
-      {
-        'newlines-between': 'always',
-        alphabetize: { order: 'asc' },
-        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
-        pathGroupsExcludedImportTypes: ['react', 'react-dom'],
-        pathGroups: [
-          {
-            pattern: 'react',
-            group: 'external',
-            position: 'before',
-          },
-          {
-            pattern: 'react-dom',
-            group: 'external',
-            position: 'before',
-          },
-          {
-            pattern: '~/src/components/**',
-            group: 'internal',
-            position: 'after',
-          },
-          {
-            pattern: './**/*.scss',
-            group: 'sibling',
-            position: 'after',
-          },
-        ],
-      },
+    'sort-imports': ['error', {
+      ignoreDeclarationSort: true,
+    }],
+    'import/order': ['error', {
+      'newlines-between': 'always',
+      alphabetize: { order: 'asc' },
+      groups: [
+        'builtin',
+        'external',
+        'internal',
+        'parent',
+        'sibling',
+        'index',
+      ],
+      pathGroupsExcludedImportTypes: [
+        'react',
+        'react-dom',
+      ],
+      pathGroups: [{
+        pattern: 'react',
+        group: 'external',
+        position: 'before',
+      }, {
+        pattern: 'react-dom',
+        group: 'external',
+        position: 'before',
+      }, {
+        pattern: '~/src/components/**',
+        group: 'internal',
+        position: 'after',
+      }, {
+        pattern: './**/*.scss',
+        group: 'sibling',
+        position: 'after',
+      }] },
     ],
     'max-classes-per-file': 'off',
     'react/jsx-props-no-spreading': 'off',
     'react/no-array-index-key': 'warn',
     '@typescript-eslint/naming-convention': 'off',
+    'jsdoc/require-jsdoc': 'off',
+    'jsdoc/require-returns': 'off',
+    'jsdoc/require-param': 'off',
+    'jsdoc/check-param-names': 'off',
+    /**
+     * NOTE: To allow @type tag in configuration files
+     */
+    'jsdoc/check-tag-names': ['error', {
+      typed: false,
+    }],
   },
 }

--- a/packages/bezier-react/.storybook/main.ts
+++ b/packages/bezier-react/.storybook/main.ts
@@ -34,8 +34,6 @@ export default {
 
   typescript: {
     /**
-     * @note
-     *
      * `react-docgen-typescript-plugin` introduces significant overhead
      * when HMR is enabled, so we enable it only in production.
      */

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -100,6 +100,7 @@
     "chromatic": "^7.0.0",
     "core-js": "^3.32.2",
     "eslint-config-bezier": "workspace:*",
+    "eslint-plugin-jsdoc": "^48.0.4",
     "eslint-plugin-storybook": "^0.6.13",
     "identity-obj-proxy": "^3.0.0",
     "lightningcss": "^1.22.1",

--- a/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.tsx
+++ b/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.tsx
@@ -18,7 +18,6 @@ import styles from './AlphaSmoothCornersBox.module.scss'
 /**
  * `AlphaSmoothCornersBox` is a simple `div` element with smooth corners.
  * It is available by enabling the `SmoothCornersFeature`.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/AppProvider/AppProvider.tsx
+++ b/packages/bezier-react/src/components/AppProvider/AppProvider.tsx
@@ -11,7 +11,6 @@ import { type AppProviderProps } from './AppProvider.types'
 
 /**
  * `AppProvider` is a required wrapper component that provides context for the app.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/AppProvider/AppProvider.types.ts
+++ b/packages/bezier-react/src/components/AppProvider/AppProvider.types.ts
@@ -9,14 +9,14 @@ interface AppProviderOwnProps {
    */
   themeName?: ThemeName
   /**
-     * List of features to enable for the app.
-     * @default []
-     */
+   * List of features to enable for the app.
+   * @default []
+   */
   features?: Feature[]
   /**
-     * Window object to use for the app.
-     * @default window
-     */
+   * Window object to use for the app.
+   * @default window
+   */
   window?: Window
 }
 

--- a/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
+++ b/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
@@ -14,7 +14,6 @@ import { type AutoFocusProps } from './AutoFocus.types'
  * `AutoFocus` is a component that automatically focuses its child element when they are added to the document.
  * It is useful when you want to focus on a specific element when the component is mounted.
  * It doesn't render any DOM node.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Avatars/Avatar/Avatar.tsx
+++ b/packages/bezier-react/src/components/Avatars/Avatar/Avatar.tsx
@@ -38,7 +38,6 @@ export const STATUS_WRAPPER_TEST_ID = 'bezier-react-status-wrapper'
 
 /**
  * `Avatar` is a component for representing some profile image.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/packages/bezier-react/src/components/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -69,7 +69,6 @@ function getProperTypoSize(avatarSize: AvatarSize) {
 
 /**
  * `AvatarGroup` is a component for grouping `Avatar` components
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Avatars/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/bezier-react/src/components/Avatars/AvatarGroup/AvatarGroup.types.ts
@@ -24,16 +24,13 @@ interface AvatarGroupOwnProps {
 
   /**
    * Spacing between the avatars.
-   *
-   * @note Spacing could be negative, which will make the avatars overlap each other.
-   *
+   * Spacing could be negative, which will make the avatars overlap each other.
    * @default 4
    */
   spacing?: number
 
   /**
    * Controls how the ellipsis is displayed.
-   *
    * @default AvatarGroupEllipsisType.Icon
    */
   ellipsisType?: AvatarGroupEllipsisType

--- a/packages/bezier-react/src/components/Avatars/CheckableAvatar/CheckableAvatar.tsx
+++ b/packages/bezier-react/src/components/Avatars/CheckableAvatar/CheckableAvatar.tsx
@@ -19,7 +19,6 @@ import styles from './CheckableAvatar.module.scss'
 
 /**
  * `CheckableAvatar` is a checkbox component that looks like `Avatar`.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Banner/Banner.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.tsx
@@ -62,7 +62,6 @@ const externalLinkRenderer: RenderLinkFunc = ({
 
 /**
  * `Banner` is a component you use when you want to communicate instructions, warnings, recommendations, and other information well.
- *
  * @example
  * ```tsx
  * <Banner

--- a/packages/bezier-react/src/components/Banner/Banner.types.ts
+++ b/packages/bezier-react/src/components/Banner/Banner.types.ts
@@ -39,7 +39,6 @@ interface BannerOwnProps {
 
   /**
    * Whether to display link at the end of banner content.
-   *
    * @default false
    */
   hasLink?: boolean
@@ -49,7 +48,6 @@ interface BannerOwnProps {
    *
    * This will be displayed as bold, underline text at the end of content.
    *
-   * @remarks
    * `hasLink` props should be given `true` to enable the link.
    */
   linkText?: string
@@ -60,14 +58,12 @@ interface BannerOwnProps {
    * By default, the link will be opened in a new tab. (`target="_blank"`)
    * To specify a different behavior, use `renderLink` prop to render the link as a custom component.
    *
-   * @remarks
    * `hasLink` props should be given `true` to enable the link.
    */
   linkTo?: string
 
   /**
    * Specifies how to render the link.
-   *
    * @default
    * renders link as an `<a>` tag with `target="_blank"` attribute.
    */

--- a/packages/bezier-react/src/components/Box/Box.tsx
+++ b/packages/bezier-react/src/components/Box/Box.tsx
@@ -18,7 +18,6 @@ import styles from './Box.module.scss'
 
 /**
  * `Box` is a primitive layout component. It provides an easy way to access design tokens.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Button/Button.types.ts
+++ b/packages/bezier-react/src/components/Button/Button.types.ts
@@ -48,7 +48,6 @@ interface ButtonOwnProps {
    *
    * You may want to set `type` to `submit` to the button
    * which is used as a submit button in `<form>` component.
-   *
    * @default 'button'
    */
   type?: 'button' | 'reset' | 'submit'
@@ -62,7 +61,6 @@ interface ButtonOwnProps {
 
   /**
    * If `loading` is true, spinner will be shown, replacing the content.
-   *
    * @default false
    */
   loading?: boolean
@@ -71,21 +69,18 @@ interface ButtonOwnProps {
    * If `active` is true, the button will be styled as if it is hovered.
    *
    * You may want to use this prop for a button which opens dropdown, etc.
-   *
    * @default false
    */
   active?: boolean
 
   /**
    * The style variant.
-   *
    * @default ButtonStyleVariant.Primary
    */
   styleVariant?: ButtonStyleVariant
 
   /**
    * The color variant.
-   *
    * @default ButtonColorVariant.Blue
    */
   colorVariant?: ButtonColorVariant

--- a/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.tsx
@@ -6,7 +6,6 @@ import type { ButtonGroupProps } from './ButtonGroup.types'
 
 /**
  * `ButtonGroup` is a component that groups buttons together.
- *
  * @example
  * ```tsx
  * <ButtonGroup>

--- a/packages/bezier-react/src/components/Center/Center.tsx
+++ b/packages/bezier-react/src/components/Center/Center.tsx
@@ -15,7 +15,6 @@ import styles from './Center.module.scss'
 
 /**
  * `Center` is a layout component that centers its child within itself.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/bezier-react/src/components/ConfirmModal/ConfirmModal.tsx
@@ -27,7 +27,6 @@ import {
  * `ConfirmModal` is a context of the ConfirmModal-related components. It doesn't render any DOM node.
  * It controls the visibility of the entire component and provides
  * handlers and accessibility properties to ConfirmModal-related components.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Divider/Divider.tsx
+++ b/packages/bezier-react/src/components/Divider/Divider.tsx
@@ -11,7 +11,6 @@ export const DIVIDER_TEST_ID = 'bezier-react-divider'
 
 /**
  * `Divider` is a component to visually or semantically separate content.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Divider/Divider.types.ts
+++ b/packages/bezier-react/src/components/Divider/Divider.types.ts
@@ -7,7 +7,6 @@ interface DividerOwnProps {
    * If true, the divider will be rendered without side padding,
    * which stands for the padding on the left and right sides of the horizontal divider,
    * and the top and bottom sides of the vertical divider.
-   *
    * @default false
    */
   withoutSideIndent?: boolean
@@ -16,14 +15,12 @@ interface DividerOwnProps {
    * If true, the divider will be rendered without parallel padding,
    * which stands for the padding on the top and bottom sides of the horizontal divider,
    * and the left and right sides of the vertical divider.
-   *
    * @default false
    */
   withoutParallelIndent?: boolean
 
   /**
    * If true, the divider will be rendered without padding,
-   *
    * @default false
    */
   withoutIndent?: boolean

--- a/packages/bezier-react/src/components/Emoji/Emoji.tsx
+++ b/packages/bezier-react/src/components/Emoji/Emoji.tsx
@@ -18,7 +18,6 @@ export const EMOJI_TEST_ID = 'bezier-react-emoji'
 
 /**
  * `Emoji` is a component for representing emoji with variant size.
- *
  * @example
  * ```tsx
  * <Emoji

--- a/packages/bezier-react/src/components/FeatureProvider/FeatureProvider.tsx
+++ b/packages/bezier-react/src/components/FeatureProvider/FeatureProvider.tsx
@@ -24,7 +24,6 @@ const [
 
 /**
  * `FeatureProvider` is a component that activates features and provides.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.tsx
+++ b/packages/bezier-react/src/components/Forms/Checkbox/Checkbox.tsx
@@ -108,7 +108,6 @@ function CheckboxImpl<Checked extends CheckedState>({
 /**
  * `Checkbox` is a control that allows the user to toggle between checked and not checked.
  * It can be used with labels or standalone.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/Forms/FormHelperText/FormHelperText.tsx
@@ -69,7 +69,6 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function
 /**
  * `FormHelperText` is a component to show the description of the input element.
  * `FormControl` component can handle its layout by `position` props.
- *
  * @example
  * ```tsx
  * <FormControl position="top">
@@ -107,7 +106,6 @@ export const FormHelperText = forwardRef<HTMLSpanElement, FormHelperTextProps>(f
 /**
  * `FormErrorMessage` is a component to show error message when form values are invalid.
  * It should be used with `FormControl` component.
- *
  * @example
  * ```tsx
  * <FormControl>

--- a/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/Forms/FormLabel/FormLabel.tsx
@@ -22,7 +22,6 @@ export const FORM_LABEL_TEST_ID = 'bezier-react-form-label'
 /**
  * `FormLabel` is a component to show label.
  * `FormControl` component can handle its layout by `position` props.
- *
  * @example
  * ```tsx
  * <FormControl position="top">

--- a/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.test.tsx
+++ b/packages/bezier-react/src/components/Forms/Inputs/TextField/TextField.test.tsx
@@ -235,7 +235,7 @@ describe('TextField', () => {
   describe('show remove button only when it is filled and focused/hovered', () => {
     /**
      * FIXME: This test is not working properly.
-     * @see: https://github.com/testing-library/jest-dom/issues/444
+     * @see https://github.com/testing-library/jest-dom/issues/444
      */
     // it('disappear when empty & focused/hovered', async () => {
     //   const { getByTestId } = renderComponent({ value: '', allowClear: true })

--- a/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.tsx
+++ b/packages/bezier-react/src/components/Forms/RadioGroup/RadioGroup.tsx
@@ -50,7 +50,6 @@ function RadioGroupImpl<Value extends string>({
  *
  * `RadioGroup` is a context of the `Radio` components. also, it renders an element which has the 'radiogroup' role.
  * It controls all the parts of a radio group.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
+++ b/packages/bezier-react/src/components/Forms/SegmentedControl/SegmentedControl.tsx
@@ -223,7 +223,6 @@ function SegmentedControlImpl<
  * If you have more than five items, use a different element, such as a dropdown.
  *
  * `SegmentedControl` can be used as a radio group, tabs element depending on its `type`.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Forms/Slider/Slider.tsx
@@ -71,7 +71,6 @@ const SliderThumb = forwardRef<HTMLDivElement, Pick<SliderProps, 'disableTooltip
 /**
  * An input component where the user selects a value from within a given range.
  * The value of the slider is shown in a tooltip, and in some cases you can add a guide scale.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.tsx
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.tsx
@@ -17,7 +17,6 @@ const SWITCH_HANDLE_TEST_ID = 'bezier-react-switch-handle'
 
 /**
  * `Switch` is an input component where user can toggle checked state of the element.
- *
  * @example
  * ```tsx
  * <Switch

--- a/packages/bezier-react/src/components/Forms/Switch/Switch.types.ts
+++ b/packages/bezier-react/src/components/Forms/Switch/Switch.types.ts
@@ -17,7 +17,6 @@ interface SwitchOwnProps extends Omit<SwitchPrimitiveProps, 'asChild'> {
   /**
    * The state of the switch when it is initially rendered.
    * Use when you do not need to control its state.
-   *
    * @default false
    */
   defaultChecked?: boolean

--- a/packages/bezier-react/src/components/Icon/Icon.types.ts
+++ b/packages/bezier-react/src/components/Icon/Icon.types.ts
@@ -24,7 +24,6 @@ interface IconOwnProps {
   /**
    * Controls which icon should be rendered.
    * Inject the icon component from the @channel.io/bezier-icons package into this prop.
-   *
    * @example
    * ```tsx
    * import { HeartFilledIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.tsx
@@ -22,7 +22,6 @@ import styles from './LegacyStack.module.scss'
  * `Stack` always fills the parent element.
  *
  * Be reminded to list `StackItem`s to be direct child of `Stack`.
- *
  * @example
  *
  * ```tsx
@@ -65,12 +64,12 @@ export const LegacyStack = forwardRef<HTMLElement, LegacyStackProps>(function St
           if (!isValidElement(element)) { return element }
 
           /**
-             * NOTE: this assumes that this element is `StackItem`.
-             *
-             * Even if the child is not a `StackItem` component,
-             * it could forward the prop to `StackItem` deeper in the tree,
-             * or implement a custom behavior compatible with `StackItemProps`.
-             */
+           * NOTE: this assumes that this element is `StackItem`.
+           *
+           * Even if the child is not a `StackItem` component,
+           * it could forward the prop to `StackItem` deeper in the tree,
+           * or implement a custom behavior compatible with `StackItemProps`.
+           */
           if (firstValidElementIdx.current === -1) { firstValidElementIdx.current = index }
           return cloneElement(element, {
             ...element.props,

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.types.ts
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.types.ts
@@ -10,8 +10,6 @@ interface LegacyStackOwnProps {
   /**
    * Direction of this stack.
    *
-   * @remarks
-   *
    * If you are directly using this prop in application code,
    * consider using `HStack` or `VStack` instead.
    */
@@ -22,7 +20,6 @@ interface LegacyStackOwnProps {
    *
    * The `justify` prop given to child `StackItem` component
    * overrides the default alignment.
-   *
    * @default start
    */
   justify?: AxisAlignment
@@ -32,7 +29,6 @@ interface LegacyStackOwnProps {
    *
    * The `align` prop given to child `StackItem` component
    * overrides the default alignment.
-   *
    * @default stretch
    */
   align?: AxisAlignment
@@ -43,10 +39,8 @@ interface LegacyStackOwnProps {
    * `marginBefore` and `marginAfter` prop given to child `StackItem` component
    * overrides the default spacing.
    *
-   * @remarks
    * `spacing` could be enumerated in later design, if bezier design system
    * decides to define a guideline for linear layout.
-   *
    * @default 0
    */
   spacing?: number

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.tsx
@@ -19,7 +19,6 @@ const sanitizeWeight = (weight: number): number => {
 
 /**
  * @deprecated Use layout components(`Box`, `Stack`) that support flex item related properties (`shrink`, `grow`) instead.
- *
  * @example
  *
  * ```

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.types.ts
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.types.ts
@@ -10,8 +10,6 @@ interface LegacyStackItemOwnProps {
   /**
    * Direction of this stack item.
    *
-   * @remarks
-   *
    * If you are directly using this prop in application code, don't.
    * This prop will be provided from parent `Stack` component.
    */
@@ -33,7 +31,6 @@ interface LegacyStackItemOwnProps {
 
   /**
    * Idle size of this component along the main axis, in pixels.
-   *
    * @default auto
    */
   size?: number
@@ -46,7 +43,6 @@ interface LegacyStackItemOwnProps {
    *
    * If the weight is larger, this child will be affected **more** from
    * the parent size update.
-   *
    * @default 0
    */
   weight?: number
@@ -55,7 +51,6 @@ interface LegacyStackItemOwnProps {
    * Allows this component to grow as parent expands.
    *
    * You might want to use this prop together with `weight`.
-   *
    * @default false
    */
   grow?: boolean
@@ -64,7 +59,6 @@ interface LegacyStackItemOwnProps {
    * Allows this component to shrink as parent shrinks.
    *
    * You might want to use htis prop together with `weight`.
-   *
    * @default false
    */
   shrink?: boolean
@@ -74,7 +68,6 @@ interface LegacyStackItemOwnProps {
    *
    * If you do not specify this, the margin will be determined
    * by the default spacing of parent `Stack`.
-   *
    * @default 0
    */
   marginBefore?: number
@@ -84,7 +77,6 @@ interface LegacyStackItemOwnProps {
    *
    * If you do not specify this, the margin will be determined
    * by the default spacing of parent `Stack`.
-   *
    * @default 0
    */
   marginAfter?: number
@@ -92,7 +84,6 @@ interface LegacyStackItemOwnProps {
 
 /**
  * @deprecated Use layout components(`Box`, `Stack`) that support flex item related properties (`shrink`, `grow`) instead.
- *
  * @example
  *
  * ```

--- a/packages/bezier-react/src/components/Modal/Modal.tsx
+++ b/packages/bezier-react/src/components/Modal/Modal.tsx
@@ -67,7 +67,6 @@ const [
  * `Modal` is a context of the Modal-related components. It doesn't render any DOM node.
  * It controls the visibility of the entire component and provides
  * handlers and accessibility properties to Modal-related components.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Navigator/NavItem/NavItem.tsx
+++ b/packages/bezier-react/src/components/Navigator/NavItem/NavItem.tsx
@@ -18,7 +18,6 @@ export const NAV_ITEM_LEFT_ICON_TEST_ID = 'bezier-react-nav-item-left-icon'
 
 /**
  * `NavItem` is a component for an item where you can navigate to another link.
- *
  * @example
  * ```tsx
  * <NavItem

--- a/packages/bezier-react/src/components/Overlay/Overlay.stories.tsx
+++ b/packages/bezier-react/src/components/Overlay/Overlay.stories.tsx
@@ -126,4 +126,3 @@ export const Primary: StoryObj<OverlayProps> = {
 }
 
 export default meta
-

--- a/packages/bezier-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/bezier-react/src/components/Overlay/Overlay.types.ts
@@ -48,7 +48,7 @@ interface OverlayOwnProps {
   show?: boolean
   /**
    * Specify a container element to portal the content into.
-   * @note When placed inside a `Modal`, default value is the container element of `Modal`.
+   * When placed inside a `Modal`, default value is the container element of `Modal`.
    * @default document.body
    */
   container?: HTMLElement | null

--- a/packages/bezier-react/src/components/ProgressBar/ProgressBar.types.ts
+++ b/packages/bezier-react/src/components/ProgressBar/ProgressBar.types.ts
@@ -6,7 +6,6 @@ import type {
 
 /**
  * @deprecated Use string literal instead of enum.
- *
  * @example
  *
  * ```tsx
@@ -20,7 +19,6 @@ export enum ProgressBarSize {
 
 /**
  * @deprecated Use string literal instead of enum.
- *
  * @example
  *
  * ```tsx
@@ -37,14 +35,12 @@ interface ProgressBarOwnProps {
   /**
    * CSS Width of total progress bar.
    * If given value is number, `px` is suffixed to given value.
-   *
    * @default 36
    */
   width?: number | string
 
   /**
    * Progress value in floating point number (between 0 and 1, inclusive).
-   *
    * @default 0
    */
   value?: number

--- a/packages/bezier-react/src/components/Stack/Stack.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack.tsx
@@ -23,7 +23,6 @@ import styles from './Stack.module.scss'
 
 /**
  * `Stack` is a layout component used to group elements together and apply a space between them.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Tabs/Tabs.tsx
+++ b/packages/bezier-react/src/components/Tabs/Tabs.tsx
@@ -41,7 +41,6 @@ import styles from './Tabs.module.scss'
  * `Tabs` is a set of layered section of content.
  *
  * `Tabs` is a context of the Tab-related components and gives accessibility properties to Tab-related components.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/TagBadge/Badge/Badge.tsx
+++ b/packages/bezier-react/src/components/TagBadge/Badge/Badge.tsx
@@ -25,7 +25,6 @@ export const BADGE_TEST_ID = 'bezier-react-badge'
 
 /**
  * `Badge` is a component for representing badge, which consists of text and icon.
- *
  * @example
  * ```tsx
  * <Badge

--- a/packages/bezier-react/src/components/TagBadge/Tag/Tag.tsx
+++ b/packages/bezier-react/src/components/TagBadge/Tag/Tag.tsx
@@ -34,7 +34,6 @@ export const TAG_DELETE_TEST_ID = 'bezier-react-tag-delete-icon'
 
 /**
  * `Tag` is a component for representing tag, which shows close icon when `onDelete` property is specified.
- *
  * @example
  * ```tsx
  * <Tag

--- a/packages/bezier-react/src/components/Text/Text.tsx
+++ b/packages/bezier-react/src/components/Text/Text.tsx
@@ -18,7 +18,6 @@ import styles from './Text.module.scss'
 
 /**
  * `Text` is a component for representing the typography of a design system.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/TokenProvider/TokenProvider.tsx
+++ b/packages/bezier-react/src/components/TokenProvider/TokenProvider.tsx
@@ -27,7 +27,7 @@ const tokenSet: Record<ThemeName, ThemedTokenSet> = Object.freeze({
 })
 
 /**
- * @private For internal use only.
+ * @private
  */
 export function TokenProvider({
   themeName,

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -115,7 +115,6 @@ const [
 
 /**
  * `TooltipProvider` is used to globally provide props to child tooltips.
- *
  * @example
  *
  * ```tsx
@@ -150,7 +149,6 @@ export function TooltipProvider({
 
 /**
  * `Tooltip` is a component that shows additional information when the mouse hovers or the keyboard is focused.
- *
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
@@ -77,7 +77,7 @@ interface TooltipOptions {
   offset?: number
   /**
    * Specify a container element to portal the content into.
-   * @note When placed inside a `Modal`, default value is the container element of `Modal`.
+   * When placed inside a `Modal`, default value is the container element of `Modal`.
    * @default document.body
    */
   container?: HTMLElement | null

--- a/packages/bezier-react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/bezier-react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -7,7 +7,6 @@ import { type VisuallyHiddenProps } from './VisuallyHidden.types'
 /**
  * `VisuallyHidden` is a component that visually hides the content. It doesn't render any DOM node.
  * It is useful when you want to provide additional information to screen readers.
- *
  * @example
  *
  * ```tsx
@@ -15,7 +14,6 @@ import { type VisuallyHiddenProps } from './VisuallyHidden.types'
  *   <span>This is a visually hidden text.</span>
  * </VisuallyHidden>
  * ```
- *
  */
 export function VisuallyHidden({
   children,

--- a/packages/bezier-react/src/components/WindowProvider/WindowProvider.types.ts
+++ b/packages/bezier-react/src/components/WindowProvider/WindowProvider.types.ts
@@ -8,8 +8,7 @@ export interface WindowContextValue {
 
 interface WindowProviderOwnProps {
   /**
-   * injected window
-   * @required
+   * Injected window object.
    */
   window: Window
 }

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -17,7 +17,6 @@ export interface RenderConfigProps {
    * Specifies which HTML tag should be used to render this component.
    *
    * `as` prop directly comes from the polymorphic "as" prop of `styled-components`.
-   *
    * @see https://styled-components.com/docs/api#as-polymorphic-prop
    */
   as?: React.ElementType

--- a/packages/bezier-react/src/utils/react.ts
+++ b/packages/bezier-react/src/utils/react.ts
@@ -14,7 +14,6 @@ type StrictContextValue = NonNullableValue | null
 
 /**
  * A function that makes it easy to use the React `createContext` function.
- *
  * @param defaultValue The default value of the context.
  * @param providerName The name of the provider component.
  * **Required if `defaultValue` is `null`able. (not `undefined`!)** Used to make the error message human-readable if contextValue is `null`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2971,6 +2971,7 @@ __metadata:
     classnames: ^2.3.2
     core-js: ^3.32.2
     eslint-config-bezier: "workspace:*"
+    eslint-plugin-jsdoc: ^48.0.4
     eslint-plugin-storybook: ^0.6.13
     identity-obj-proxy: ^3.0.0
     lightningcss: ^1.22.1
@@ -3807,6 +3808,17 @@ __metadata:
   peerDependencies:
     react: ">=16.8.0"
   checksum: 700b6e5bbb37a9231f203bb3af11295eed01d73b2293abece0bc2a2237015e944d7b5114d4887ad9a79776504aa51ed2a8b0ddbc117c54495dd01a6b22f93786
+  languageName: node
+  linkType: hard
+
+"@es-joy/jsdoccomment@npm:~0.41.0":
+  version: 0.41.0
+  resolution: "@es-joy/jsdoccomment@npm:0.41.0"
+  dependencies:
+    comment-parser: 1.4.1
+    esquery: ^1.5.0
+    jsdoc-type-pratt-parser: ~4.0.0
+  checksum: cfe0714027ff8fa82dad8c84f75af3f6df9d6797d60c289b8d3c259c5375c134bd5ca630beba0daed3adceef01a74f19e05052018f6b66ad6a4f483adf599c39
   languageName: node
   linkType: hard
 
@@ -9058,6 +9070,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"are-docs-informative@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "are-docs-informative@npm:0.0.2"
+  checksum: 7a48ca90d66e29afebc4387d7029d86cfe97bad7e796c8e7de01309e02dcfc027250231c02d4ca208d2984170d09026390b946df5d3d02ac638ab35f74501c74
+  languageName: node
+  linkType: hard
+
 "are-we-there-yet@npm:^2.0.0":
   version: 2.0.0
   resolution: "are-we-there-yet@npm:2.0.0"
@@ -10640,6 +10659,13 @@ __metadata:
   version: 8.3.0
   resolution: "commander@npm:8.3.0"
   checksum: 0f82321821fc27b83bd409510bb9deeebcfa799ff0bf5d102128b500b7af22872c0c92cb6a0ebc5a4cf19c6b550fba9cedfa7329d18c6442a625f851377bacf0
+  languageName: node
+  linkType: hard
+
+"comment-parser@npm:1.4.1":
+  version: 1.4.1
+  resolution: "comment-parser@npm:1.4.1"
+  checksum: e0f6f60c5139689c4b1b208ea63e0730d9195a778e90dd909205f74f00b39eb0ead05374701ec5e5c29d6f28eb778cd7bc41c1366ab1d271907f1def132d6bf1
   languageName: node
   linkType: hard
 
@@ -12784,6 +12810,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-jsdoc@npm:^48.0.4":
+  version: 48.0.4
+  resolution: "eslint-plugin-jsdoc@npm:48.0.4"
+  dependencies:
+    "@es-joy/jsdoccomment": ~0.41.0
+    are-docs-informative: ^0.0.2
+    comment-parser: 1.4.1
+    debug: ^4.3.4
+    escape-string-regexp: ^4.0.0
+    esquery: ^1.5.0
+    is-builtin-module: ^3.2.1
+    semver: ^7.5.4
+    spdx-expression-parse: ^4.0.0
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+  checksum: 9a1e8d74278338276c6a5a1b8fe252cfa7339f5fbe674f3c28dcc8270f190caa58fff3b87c4749bd5f3eb5ac6cc4d7cd6d1459f9827cfca93701b67e098c8626
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-jsx-a11y@npm:^6.7.1":
   version: 6.7.1
   resolution: "eslint-plugin-jsx-a11y@npm:6.7.1"
@@ -13003,6 +13048,15 @@ __metadata:
   dependencies:
     estraverse: ^5.1.0
   checksum: a0807e17abd7fbe5fbd4fab673038d6d8a50675cdae6b04fbaa520c34581be0c5fa24582990e8acd8854f671dd291c78bb2efb9e0ed5b62f33bac4f9cf820210
+  languageName: node
+  linkType: hard
+
+"esquery@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "esquery@npm:1.5.0"
+  dependencies:
+    estraverse: ^5.1.0
+  checksum: aefb0d2596c230118656cd4ec7532d447333a410a48834d80ea648b1e7b5c9bc9ed8b5e33a89cb04e487b60d622f44cf5713bf4abed7c97343edefdc84a35900
   languageName: node
   linkType: hard
 
@@ -16206,6 +16260,13 @@ __metadata:
   bin:
     jscodeshift: bin/jscodeshift.js
   checksum: 54ea6d639455883336f80b38a70648821c88b7942315dc0fbab01bc34a9ad0f0f78e3bd69304b5ab167e4262d6ed7e6284c6d32525ab01c89d9118df89b3e2a0
+  languageName: node
+  linkType: hard
+
+"jsdoc-type-pratt-parser@npm:~4.0.0":
+  version: 4.0.0
+  resolution: "jsdoc-type-pratt-parser@npm:4.0.0"
+  checksum: af0629c9517e484be778d8564440fec8de5b7610e0c9c88a3ba4554321364faf72b46689c8d8845faa12c0718437a9ed97e231977efc0f2d50e8a2dbad807eb3
   languageName: node
   linkType: hard
 
@@ -21352,6 +21413,16 @@ __metadata:
     spdx-exceptions: ^2.1.0
     spdx-license-ids: ^3.0.0
   checksum: a1c6e104a2cbada7a593eaa9f430bd5e148ef5290d4c0409899855ce8b1c39652bcc88a725259491a82601159d6dc790bedefc9016c7472f7de8de7361f8ccde
+  languageName: node
+  linkType: hard
+
+"spdx-expression-parse@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "spdx-expression-parse@npm:4.0.0"
+  dependencies:
+    spdx-exceptions: ^2.1.0
+    spdx-license-ids: ^3.0.0
+  checksum: 936be681fbf5edeec3a79c023136479f70d6edb3fd3875089ac86cd324c6c8c81add47399edead296d1d0af17ae5ce88c7f88885eb150b62c2ff6e535841ca6a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- #1256 

## Summary
<!-- Please brief explanation of the changes made -->

4625149

Add & Apply eslint-plugin-jsdoc

## Details
<!-- Please elaborate description of the changes -->

- `eslint-plugin-jsdoc` 패키지를 추가하고 적용합니다.
- 1. jsdoc 포매팅, 2. jsdoc이 없는 퍼블릭 컴포넌트/타입에 경고를 발생시키기 위해서 추가하였습니다.
- 1. 포매팅에는 문제가 없었으나, 2. export 키워드만 존재하면 퍼블릭 컴포넌트/타입으로 구분해버려서, 불필요하게 내부용 모듈에도 경고를 발생시켰습니다. 우선은 off하는 방향으로 했습니다.
- 적용하는 과정에서 잘못된(존재하지 않는) jsdoc tag를 제거합니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- https://github.com/gajus/eslint-plugin-jsdoc
