### PR TITLE
Enhance common types

### DIFF
--- a/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.types.ts
+++ b/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.types.ts
@@ -1,5 +1,5 @@
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
   DisableProps,
 } from '~/src/types/props'
@@ -63,8 +63,7 @@ interface AlphaSmoothCornersBoxOwnProps {
 }
 
 export interface AlphaSmoothCornersBoxProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
   DisableProps,
-  React.HTMLAttributes<HTMLDivElement>,
   AlphaSmoothCornersBoxOwnProps {}

--- a/packages/bezier-react/src/components/Avatar/Avatar.types.ts
+++ b/packages/bezier-react/src/components/Avatar/Avatar.types.ts
@@ -1,5 +1,5 @@
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
   DisableProps,
   SizeProps,
@@ -56,8 +56,7 @@ interface AvatarOwnProps {
 }
 
 export interface AvatarProps extends
-  AlphaBezierComponentProps,
-  React.HTMLAttributes<HTMLDivElement>,
+  BezierComponentProps<'div'>,
   SizeProps<AvatarSize>,
   DisableProps,
   ChildrenProps,

--- a/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.types.ts
@@ -1,5 +1,5 @@
 import type {
-  AdditionalStylableProps,
+  AlphaAdditionalStylableProps,
   AlphaBezierComponentProps,
   ChildrenProps,
   SizeProps,
@@ -50,6 +50,6 @@ export interface AvatarGroupProps extends
   AlphaBezierComponentProps,
   ChildrenProps,
   SizeProps<AvatarSize>,
-  AdditionalStylableProps<'ellipsis'>,
+  AlphaAdditionalStylableProps<'ellipsis'>,
   React.HTMLAttributes<HTMLDivElement>,
   AvatarGroupOwnProps {}

--- a/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.types.ts
@@ -1,5 +1,5 @@
 import type {
-  AlphaAdditionalStylableProps,
+  AdditionalOverridableStyleProps,
   BezierComponentProps,
   ChildrenProps,
   SizeProps,
@@ -50,5 +50,5 @@ export interface AvatarGroupProps extends
   BezierComponentProps<'div'>,
   ChildrenProps,
   SizeProps<AvatarSize>,
-  AlphaAdditionalStylableProps<'ellipsis'>,
+  AdditionalOverridableStyleProps<'ellipsis'>,
   AvatarGroupOwnProps {}

--- a/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.types.ts
@@ -1,6 +1,6 @@
 import type {
   AlphaAdditionalStylableProps,
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
   SizeProps,
 } from '~/src/types/props'
@@ -47,9 +47,8 @@ interface AvatarGroupOwnProps {
 }
 
 export interface AvatarGroupProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
   SizeProps<AvatarSize>,
   AlphaAdditionalStylableProps<'ellipsis'>,
-  React.HTMLAttributes<HTMLDivElement>,
   AvatarGroupOwnProps {}

--- a/packages/bezier-react/src/components/Badge/Badge.types.ts
+++ b/packages/bezier-react/src/components/Badge/Badge.types.ts
@@ -1,7 +1,7 @@
 import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type SizeProps,
   type VariantProps,
@@ -20,9 +20,8 @@ interface BadgeOwnProps {
 }
 
 export interface BadgeProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
-  Omit<React.HTMLAttributes<HTMLDivElement>, 'color'>,
   SizeProps<TagBadgeSize>,
   VariantProps<TagBadgeVariant>,
   BadgeOwnProps {}

--- a/packages/bezier-react/src/components/Banner/Banner.types.ts
+++ b/packages/bezier-react/src/components/Banner/Banner.types.ts
@@ -7,7 +7,7 @@ import {
 
 import type {
   AdditionalColorProps,
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ContentProps,
   VariantProps,
 } from '~/src/types/props'
@@ -81,9 +81,8 @@ interface BannerOwnProps {
 }
 
 export interface BannerProps extends
-  AlphaBezierComponentProps,
-  VariantProps<BannerVariant>,
+  Omit<BezierComponentProps<'div'>, keyof ContentProps>,
   ContentProps,
+  VariantProps<BannerVariant>,
   AdditionalColorProps<'icon'>,
-  Omit<React.HTMLAttributes<HTMLDivElement>, keyof ContentProps>,
   BannerOwnProps {}

--- a/packages/bezier-react/src/components/Box/Box.types.ts
+++ b/packages/bezier-react/src/components/Box/Box.types.ts
@@ -1,5 +1,5 @@
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type LayoutProps,
   type MarginProps,
@@ -16,8 +16,7 @@ interface BoxOwnProps {
 }
 
 export interface BoxProps extends
-  AlphaBezierComponentProps,
-  React.HTMLAttributes<HTMLElement>,
+  BezierComponentProps<'div'>,
   PolymorphicProps,
   ChildrenProps,
   LayoutProps,

--- a/packages/bezier-react/src/components/Button/Button.types.ts
+++ b/packages/bezier-react/src/components/Button/Button.types.ts
@@ -1,7 +1,7 @@
 import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type DisableProps,
   type PolymorphicProps,
   type SideContentProps,
@@ -87,10 +87,9 @@ interface ButtonOwnProps {
 }
 
 export interface ButtonProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'button'>,
   PolymorphicProps,
   SizeProps<ButtonSize>,
   DisableProps,
   SideContentProps<SideContent, SideContent>,
-  React.HTMLAttributes<HTMLButtonElement>,
   ButtonOwnProps {}

--- a/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.types.ts
+++ b/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.types.ts
@@ -1,5 +1,5 @@
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type MarginProps,
 } from '~/src/types/props'
@@ -15,9 +15,8 @@ interface ButtonGroupOwnProps {
 }
 
 export interface ButtonGroupProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'div'>, 'role'>,
   ChildrenProps,
   MarginProps,
   Pick<StackProps, 'justify'>,
-  Omit<React.HTMLAttributes<HTMLDivElement>, 'role'>,
   ButtonGroupOwnProps {}

--- a/packages/bezier-react/src/components/Center/Center.types.ts
+++ b/packages/bezier-react/src/components/Center/Center.types.ts
@@ -1,5 +1,5 @@
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type LayoutProps,
   type MarginProps,
@@ -16,8 +16,7 @@ interface CenterOwnProps {
 }
 
 export interface CenterProps extends
-  AlphaBezierComponentProps,
-  React.HTMLAttributes<HTMLDivElement>,
+  BezierComponentProps<'div'>,
   ChildrenProps,
   LayoutProps,
   MarginProps,

--- a/packages/bezier-react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/bezier-react/src/components/Checkbox/Checkbox.types.ts
@@ -1,5 +1,5 @@
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type FormFieldProps,
 } from '~/src/types/props'
@@ -39,8 +39,7 @@ interface CheckboxOwnProps<Checked extends CheckedState> {
 }
 
 export interface CheckboxProps<Checked extends CheckedState> extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'button'>, keyof CheckboxOwnProps<Checked>>,
   ChildrenProps,
   FormFieldProps,
-  Omit<React.HTMLAttributes<HTMLButtonElement>, keyof CheckboxOwnProps<Checked>>,
   CheckboxOwnProps<Checked> {}

--- a/packages/bezier-react/src/components/Divider/Divider.types.ts
+++ b/packages/bezier-react/src/components/Divider/Divider.types.ts
@@ -1,6 +1,6 @@
 import type { SeparatorProps as SeparatorPrimitiveProps } from '@radix-ui/react-separator'
 
-import type { AlphaBezierComponentProps } from '~/src/types/props'
+import type { BezierComponentProps } from '~/src/types/props'
 
 interface DividerOwnProps {
   /**
@@ -27,6 +27,6 @@ interface DividerOwnProps {
 }
 
 export interface DividerProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   SeparatorPrimitiveProps,
   DividerOwnProps {}

--- a/packages/bezier-react/src/components/Emoji/Emoji.types.ts
+++ b/packages/bezier-react/src/components/Emoji/Emoji.types.ts
@@ -1,5 +1,5 @@
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   SizeProps,
 } from '~/src/types/props'
 
@@ -23,6 +23,6 @@ interface EmojiOwnProps {
 }
 
 export interface EmojiProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   SizeProps<EmojiSize>,
   EmojiOwnProps {}

--- a/packages/bezier-react/src/components/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/FormControl/FormControl.tsx
@@ -14,10 +14,7 @@ import {
   type SizeProps,
 } from '~/src/types/props'
 import { ariaAttr } from '~/src/utils/dom'
-import {
-  getFormFieldSizeClassName,
-  splitByBezierComponentProps,
-} from '~/src/utils/props'
+import { getFormFieldSizeClassName } from '~/src/utils/props'
 import { createContext } from '~/src/utils/react'
 import { isNil } from '~/src/utils/type'
 
@@ -85,12 +82,15 @@ const Container = forwardRef<HTMLElement, ContainerProps>(function Container({
 })
 
 export const FormControl = forwardRef<HTMLElement, FormControlProps>(function FormControl({
+  children,
   id: idProp,
   testId = FORM_CONTROL_TEST_ID,
   labelPosition = 'top',
   size = 'm',
-  style,
-  children,
+  hasError,
+  required,
+  readOnly,
+  disabled,
   ...rest
 }, forwardedRef) {
   const [groupNode, setGroupNode] = useState<HTMLElement | null>(null)
@@ -115,8 +115,6 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     errorMessageId,
     helperTextId,
   ])
-
-  const [bezierProps, formCommonProps] = useMemo(() => splitByBezierComponentProps(rest), [rest])
 
   const getGroupProps = useCallback<GroupPropsGetter>(ownProps => ({
     id: groupId,
@@ -151,38 +149,44 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     id: fieldId,
     size,
     'aria-describedby': groupNode ? undefined : describerId,
-    ...formCommonProps,
+    hasError,
+    required,
+    readOnly,
+    disabled,
     ...ownProps,
   }), [
     fieldId,
     describerId,
     size,
-    formCommonProps,
+    hasError,
+    required,
+    readOnly,
+    disabled,
     groupNode,
   ])
 
   const getHelperTextProps = useCallback<HelperTextPropsGetter>(ownProps => ({
     id: helperTextId,
-    visible: isNil(formCommonProps?.hasError) || !formCommonProps?.hasError,
+    visible: isNil(hasError) || !hasError,
     ref: setHelperTextNode,
     className: classNames(styles.FormHelperTextWrapper, labelPosition === 'left' && styles['position-left']),
     ...ownProps,
   }), [
     helperTextId,
     labelPosition,
-    formCommonProps,
+    hasError,
   ])
 
   const getErrorMessageProps = useCallback<ErrorMessagePropsGetter>(ownProps => ({
     id: errorMessageId,
-    visible: isNil(formCommonProps?.hasError) || formCommonProps?.hasError,
+    visible: isNil(hasError) || hasError,
     ref: setErrorMessageNode,
     className: classNames(styles.FormHelperTextWrapper, labelPosition === 'left' && styles['position-left']),
     ...ownProps,
   }), [
     errorMessageId,
     labelPosition,
-    formCommonProps,
+    hasError,
   ])
 
   const contextValue = useMemo(() => ({
@@ -195,7 +199,10 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     getFieldProps,
     getHelperTextProps,
     getErrorMessageProps,
-    ...formCommonProps,
+    hasError,
+    required,
+    readOnly,
+    disabled,
   }), [
     id,
     labelId,
@@ -206,7 +213,10 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
     getFieldProps,
     getHelperTextProps,
     getErrorMessageProps,
-    formCommonProps,
+    hasError,
+    required,
+    readOnly,
+    disabled,
   ])
 
   if (!children) { return null }
@@ -214,9 +224,8 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
   return (
     <FormControlContextProvider value={contextValue}>
       <Container
-        {...bezierProps}
+        {...rest}
         ref={forwardedRef}
-        style={style}
         testId={testId}
         labelPosition={labelPosition}
       >

--- a/packages/bezier-react/src/components/FormControl/FormControl.types.ts
+++ b/packages/bezier-react/src/components/FormControl/FormControl.types.ts
@@ -1,5 +1,5 @@
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
   FormFieldProps,
   FormFieldSize,
@@ -53,12 +53,12 @@ export interface FormControlContextValue extends FormFieldProps {
 }
 
 export interface ContainerProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
   Pick<FormControlOwnProps, 'labelPosition'> {}
 
 export interface FormControlProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
   FormFieldProps,
   SizeProps<FormFieldSize>,

--- a/packages/bezier-react/src/components/FormGroup/FormGroup.types.ts
+++ b/packages/bezier-react/src/components/FormGroup/FormGroup.types.ts
@@ -1,12 +1,11 @@
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
 } from '~/src/types/props'
 
 import type { StackProps } from '~/src/components/Stack'
 
 export interface FormGroupProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
-  Partial<Pick<StackProps, 'direction' | 'spacing'>>,
-  React.HTMLAttributes<HTMLDivElement> {}
+  Partial<Pick<StackProps, 'direction' | 'spacing'>> {}

--- a/packages/bezier-react/src/components/FormHelperText/FormHelperText.types.ts
+++ b/packages/bezier-react/src/components/FormHelperText/FormHelperText.types.ts
@@ -1,5 +1,4 @@
 import {
-  type AlphaBezierComponentProps,
   type ChildrenProps,
   type IdentifierProps,
   type MarginProps,
@@ -12,10 +11,9 @@ interface BaseHelperTextOwnProps {
 }
 
 export interface BaseHelperTextProps extends
-  AlphaBezierComponentProps,
+  Omit<TextProps, keyof MarginProps>,
   ChildrenProps,
   Partial<IdentifierProps>,
-  Omit<TextProps, keyof MarginProps>,
   BaseHelperTextOwnProps {}
 
 export interface FormHelperTextProps extends Omit<BaseHelperTextProps, 'type'> {}

--- a/packages/bezier-react/src/components/FormLabel/FormLabel.types.ts
+++ b/packages/bezier-react/src/components/FormLabel/FormLabel.types.ts
@@ -1,5 +1,4 @@
 import {
-  type AlphaBezierComponentProps,
   type ChildrenProps,
   type IdentifierProps,
   type MarginProps,
@@ -13,8 +12,7 @@ interface FormLabelOwnProps {
 }
 
 export interface FormLabelProps extends
-  AlphaBezierComponentProps,
-  ChildrenProps,
   Omit<TextProps, keyof MarginProps>,
+  ChildrenProps,
   Partial<IdentifierProps>,
   FormLabelOwnProps {}

--- a/packages/bezier-react/src/components/Help/Help.types.ts
+++ b/packages/bezier-react/src/components/Help/Help.types.ts
@@ -1,11 +1,7 @@
-import {
-  type AlphaBezierComponentProps,
-  type ChildrenProps,
-} from '~/src/types/props'
+import { type ChildrenProps } from '~/src/types/props'
 
 import { type TooltipProps } from '~/src/components/Tooltip'
 
 export interface HelpProps extends
-  AlphaBezierComponentProps,
-  ChildrenProps,
-  Omit<TooltipProps, 'content' | 'children'> {}
+  Omit<TooltipProps, 'content' | 'children'>,
+  ChildrenProps {}

--- a/packages/bezier-react/src/components/Icon/Icon.types.ts
+++ b/packages/bezier-react/src/components/Icon/Icon.types.ts
@@ -1,7 +1,7 @@
 import type React from 'react'
 
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ColorProps,
   type MarginProps,
   type SizeProps,
@@ -36,9 +36,8 @@ interface IconOwnProps {
 }
 
 export interface IconProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'svg'>, keyof ColorProps>,
   MarginProps,
   SizeProps<IconSize>,
   ColorProps,
-  Omit<React.HTMLAttributes<SVGSVGElement>, keyof ColorProps>,
   IconOwnProps {}

--- a/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.types.ts
+++ b/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.types.ts
@@ -3,7 +3,7 @@ import type React from 'react'
 import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
 } from '~/src/types/props'
 
@@ -24,7 +24,6 @@ interface KeyValueItemOwnProps {
 }
 
 export interface KeyValueItemProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
-  React.HTMLAttributes<HTMLDivElement>,
   KeyValueItemOwnProps {}

--- a/packages/bezier-react/src/components/LegacyIcon/LegacyIcon.types.ts
+++ b/packages/bezier-react/src/components/LegacyIcon/LegacyIcon.types.ts
@@ -21,5 +21,5 @@ interface LegacyIconOptions {
  * <LegacyIcon name="all" color="bg-black-dark" />
  */
 export interface LegacyIconProps extends
-  Omit<IconProps, 'source'>,
+  Omit<IconProps, 'source' | keyof LegacyIconOptions>,
   LegacyIconOptions {}

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.types.ts
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.types.ts
@@ -1,5 +1,5 @@
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
   PolymorphicProps,
 } from '~/src/types/props'
@@ -50,8 +50,7 @@ interface LegacyStackOwnProps {
  * @deprecated Use `Stack` instead.s
  */
 export default interface LegacyStackProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   PolymorphicProps,
   ChildrenProps,
-  React.HTMLAttributes<HTMLElement>,
   LegacyStackOwnProps {}

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.types.ts
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.types.ts
@@ -1,5 +1,5 @@
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
   PolymorphicProps,
 } from '~/src/types/props'
@@ -96,7 +96,7 @@ interface LegacyStackItemOwnProps {
  * ```
  */
 export default interface LegacyStackItemProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   PolymorphicProps,
   ChildrenProps,
   LegacyStackItemOwnProps {}

--- a/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltip.types.ts
+++ b/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltip.types.ts
@@ -1,7 +1,7 @@
 import { type Ref } from 'react'
 
 import {
-  type AlphaAdditionalStylableProps,
+  type AdditionalOverridableStyleProps,
   type BezierComponentProps,
   type ChildrenProps,
   type ContentProps,
@@ -26,7 +26,7 @@ export interface LegacyTooltipProps extends
   ChildrenProps,
   ContentProps,
   DisableProps,
-  AlphaAdditionalStylableProps<'content' | 'contentWrapper'>,
+  AdditionalOverridableStyleProps<'content' | 'contentWrapper'>,
   LegacyTooltipOptions {
 }
 
@@ -40,7 +40,7 @@ LegacyTooltipOptions,
   Omit<BezierComponentProps<'div'>, keyof ContentProps>,
   PolymorphicProps,
   ContentProps,
-  AlphaAdditionalStylableProps<'content' | 'contentWrapper'>,
+  AdditionalOverridableStyleProps<'content' | 'contentWrapper'>,
   DisableProps {
   tooltipContainer: HTMLDivElement | null
   forwardedRef: Ref<HTMLDivElement>

--- a/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltip.types.ts
+++ b/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltip.types.ts
@@ -2,7 +2,7 @@ import { type Ref } from 'react'
 
 import {
   type AlphaAdditionalStylableProps,
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type ContentProps,
   type DisableProps,
@@ -21,13 +21,12 @@ interface LegacyTooltipOptions {
 }
 
 export interface LegacyTooltipProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'div'>, keyof ContentProps>,
   PolymorphicProps,
   ChildrenProps,
   ContentProps,
   DisableProps,
   AlphaAdditionalStylableProps<'content' | 'contentWrapper'>,
-  Omit<React.HTMLAttributes<HTMLDivElement>, keyof ContentProps>,
   LegacyTooltipOptions {
 }
 
@@ -38,7 +37,7 @@ LegacyTooltipOptions,
 'offset' |
 'allowHover'
 >,
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'div'>, keyof ContentProps>,
   PolymorphicProps,
   ContentProps,
   AlphaAdditionalStylableProps<'content' | 'contentWrapper'>,

--- a/packages/bezier-react/src/components/ListItem/ListItem.types.ts
+++ b/packages/bezier-react/src/components/ListItem/ListItem.types.ts
@@ -4,7 +4,7 @@ import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
   ActivatableProps,
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ContentProps,
   DisableProps,
   LinkProps,
@@ -36,14 +36,13 @@ interface ListItemOwnProps {
 }
 
 export interface ListItemProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps, keyof ContentProps>,
+  ContentProps,
   PolymorphicProps,
   SizeProps<ListItemSize>,
   VariantProps<ListItemVariant>,
-  ContentProps,
   SideContentProps<React.ReactNode | BezierIcon, React.ReactNode>,
   LinkProps,
   DisableProps,
   ActivatableProps,
-  Omit<React.HTMLAttributes<HTMLElement>, 'content'>,
   ListItemOwnProps {}

--- a/packages/bezier-react/src/components/Modal/Modal.types.ts
+++ b/packages/bezier-react/src/components/Modal/Modal.types.ts
@@ -1,5 +1,5 @@
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type SideContentProps,
 } from '~/src/types/props'
@@ -122,24 +122,20 @@ export interface ModalProps extends
   ModalOwnProps {}
 
 export interface ModalContentProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
-  React.HTMLAttributes<HTMLDivElement>,
   ModalContentOwnProps {}
 
 export interface ModalHeaderProps extends
-  AlphaBezierComponentProps,
-  Omit<React.HTMLAttributes<HTMLElement>, keyof ModalHeaderOwnProps>,
+  Omit<BezierComponentProps<'header'>, keyof ModalHeaderOwnProps>,
   ModalHeaderOwnProps {}
 
 export interface ModalBodyProps extends
-  AlphaBezierComponentProps,
-  ChildrenProps,
-  React.HTMLAttributes<HTMLDivElement> {}
+  BezierComponentProps<'div'>,
+  ChildrenProps {}
 
 export interface ModalFooterProps extends
-  AlphaBezierComponentProps,
-  React.HTMLAttributes<HTMLElement>,
+  BezierComponentProps<'footer'>,
   ModalFooterOwnProps {}
 
 export interface ModalTriggerProps extends

--- a/packages/bezier-react/src/components/NavGroup/NavGroup.types.ts
+++ b/packages/bezier-react/src/components/NavGroup/NavGroup.types.ts
@@ -2,7 +2,7 @@ import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
   ActivatableProps,
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
   ContentProps,
   SideContentProps,
@@ -15,11 +15,10 @@ interface NavGroupOwnProps {
 }
 
 export interface NavGroupProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'button'>, keyof ContentProps | keyof NavGroupOwnProps>,
   ChildrenProps,
   ContentProps,
   Required<Pick<SideContentProps<BezierIcon>, 'leftContent'>>,
   Pick<SideContentProps, 'rightContent'>,
   ActivatableProps,
-  Omit<React.HTMLAttributes<HTMLButtonElement>, 'onClick' | 'content'>,
   NavGroupOwnProps {}

--- a/packages/bezier-react/src/components/NavItem/NavItem.types.ts
+++ b/packages/bezier-react/src/components/NavItem/NavItem.types.ts
@@ -2,7 +2,7 @@ import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
   ActivatableProps,
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ContentProps,
   LinkProps,
   SideContentProps,
@@ -15,10 +15,9 @@ interface NavItemOwnProps {
 }
 
 export interface NavItemProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'a'>, keyof ContentProps | keyof NavItemOwnProps>,
   ContentProps,
   LinkProps,
   SideContentProps<BezierIcon, React.ReactNode>,
   ActivatableProps,
-  Omit<React.HTMLAttributes<HTMLAnchorElement>, 'onClick' | 'content'>,
   NavItemOwnProps {}

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.types.ts
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.types.ts
@@ -2,7 +2,7 @@ import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
   ActivatableProps,
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
   ContentProps,
   LinkProps,
@@ -21,12 +21,11 @@ interface OutlineItemOwnProps {
 }
 
 export interface OutlineItemProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps, keyof ContentProps>,
   PolymorphicProps,
   ChildrenProps,
   ContentProps,
   SideContentProps<BezierIcon | React.ReactNode, React.ReactNode>,
   ActivatableProps,
   LinkProps,
-  Omit<React.HTMLAttributes<HTMLElement>, 'content'>,
   OutlineItemOwnProps {}

--- a/packages/bezier-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/bezier-react/src/components/Overlay/Overlay.types.ts
@@ -1,9 +1,7 @@
-import type React from 'react'
-
 import {
   type AdditionalTestIdProps,
   type AlphaAdditionalStylableProps,
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
 } from '~/src/types/props'
 
@@ -63,9 +61,8 @@ interface OverlayOwnProps {
 }
 
 export interface OverlayProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
   AlphaAdditionalStylableProps<'container'>,
   AdditionalTestIdProps<'container'>,
-  React.HTMLAttributes<HTMLDivElement>,
   OverlayOwnProps {}

--- a/packages/bezier-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/bezier-react/src/components/Overlay/Overlay.types.ts
@@ -1,6 +1,6 @@
 import {
+  type AdditionalOverridableStyleProps,
   type AdditionalTestIdProps,
-  type AlphaAdditionalStylableProps,
   type BezierComponentProps,
   type ChildrenProps,
 } from '~/src/types/props'
@@ -63,6 +63,6 @@ interface OverlayOwnProps {
 export interface OverlayProps extends
   BezierComponentProps<'div'>,
   ChildrenProps,
-  AlphaAdditionalStylableProps<'container'>,
+  AdditionalOverridableStyleProps<'container'>,
   AdditionalTestIdProps<'container'>,
   OverlayOwnProps {}

--- a/packages/bezier-react/src/components/ProgressBar/ProgressBar.types.ts
+++ b/packages/bezier-react/src/components/ProgressBar/ProgressBar.types.ts
@@ -1,5 +1,5 @@
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   SizeProps,
   VariantProps,
 } from '~/src/types/props'
@@ -47,7 +47,7 @@ interface ProgressBarOwnProps {
 }
 
 export interface ProgressBarProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   SizeProps<ProgressBarSize | `${ProgressBarSize}`>,
   VariantProps<ProgressBarVariant | `${ProgressBarVariant}`>,
   ProgressBarOwnProps {}

--- a/packages/bezier-react/src/components/RadioGroup/RadioGroup.types.ts
+++ b/packages/bezier-react/src/components/RadioGroup/RadioGroup.types.ts
@@ -1,7 +1,7 @@
 import type * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type FormFieldProps,
 } from '~/src/types/props'
@@ -55,15 +55,13 @@ interface RadioOwnProps<Value extends string> {
 type RadioFormComponentProps = Pick<FormFieldProps, 'disabled' | 'required'>
 
 export interface RadioGroupProps<Value extends string> extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'div'>, keyof RadioGroupOwnProps<Value> | keyof RadioGroupPrimitive.RadioGroupProps>,
   ChildrenProps,
   RadioFormComponentProps,
-  Omit<React.HTMLAttributes<HTMLDivElement>, keyof RadioGroupOwnProps<Value> | keyof RadioGroupPrimitive.RadioGroupProps>,
   RadioGroupOwnProps<Value> {}
 
 export interface RadioProps<Value extends string> extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'button'>, keyof RadioOwnProps<Value>>,
   ChildrenProps,
   RadioFormComponentProps,
-  Omit<React.HTMLAttributes<HTMLButtonElement>, keyof RadioOwnProps<Value>>,
   RadioOwnProps<Value> {}

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.types.ts
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.types.ts
@@ -6,7 +6,7 @@ import {
 } from '@channel.io/bezier-icons'
 
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
   ContentProps,
   SideContentProps,
@@ -29,9 +29,8 @@ interface SectionLabelOwnProps {
 }
 
 export interface SectionLabelProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps, keyof ContentProps>,
   ContentProps,
   ChildrenProps,
   SideContentProps<SectionLabelLeftContent, SectionLabelRightContent | SectionLabelRightContent[]>,
-  Omit<React.HTMLAttributes<HTMLElement>, 'content'>,
   SectionLabelOwnProps {}

--- a/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.types.ts
+++ b/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.types.ts
@@ -3,7 +3,7 @@ import type React from 'react'
 import type * as TabsPrimitive from '@radix-ui/react-tabs'
 
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type DisableProps,
   type FormFieldProps,
@@ -89,10 +89,9 @@ type SegmentedControlOwnProps<Type extends SegmentedControlType, Value extends s
 type RadixTabsPredefinedPropKeys = 'dir'
 
 export type SegmentedControlProps<Type extends SegmentedControlType, Value extends string> =
-  & AlphaBezierComponentProps
+  & Omit<BezierComponentProps<'div'>, RadixTabsPredefinedPropKeys>
   & ChildrenProps
   & SizeProps<SegmentedControlSize>
-  & Omit<React.HTMLAttributes<HTMLDivElement>, RadixTabsPredefinedPropKeys>
   & SegmentedControlOwnProps<Type, Value>
 
 export interface SegmentedControlRadioGroupProps<Value extends string> extends
@@ -104,8 +103,7 @@ export interface SegmentedControlTabsProps<Value extends string> extends
 type RadixTabListPredefinedPropKeys = 'defaultValue'
 
 export interface SegmentedControlTabListProps extends
-  AlphaBezierComponentProps,
-  Omit<React.HTMLAttributes<HTMLDivElement>, RadixTabListPredefinedPropKeys>,
+  Omit<BezierComponentProps<'div'>, RadixTabListPredefinedPropKeys>,
   ChildrenProps {}
 
 export type SegmentedControlItemListProps<Type extends SegmentedControlType, Value extends string> =
@@ -114,16 +112,14 @@ export type SegmentedControlItemListProps<Type extends SegmentedControlType, Val
     : SegmentedControlTabListProps
 
 export interface SegmentedControlItemProps<Value extends string> extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'button'>, keyof SegmentedControlItemOwnProps<Value>>,
   ChildrenProps,
   DisableProps,
-  React.HTMLAttributes<HTMLButtonElement>,
   SideContentProps,
   SegmentedControlItemOwnProps<Value> {}
 
 export interface SegmentedControlTabContentProps<Value extends string> extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
-  React.HTMLAttributes<HTMLDivElement>,
   Pick<TabsPrimitive.TabsContentProps, 'forceMount'>,
   SegmentedControlTabContentOwnProps<Value> {}

--- a/packages/bezier-react/src/components/Select/Select.types.ts
+++ b/packages/bezier-react/src/components/Select/Select.types.ts
@@ -4,7 +4,7 @@ import type {
   AdditionalColorProps,
   AdditionalTestIdProps,
   AlphaAdditionalStylableProps,
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   ChildrenProps,
   FormFieldProps,
   FormFieldSize,
@@ -36,7 +36,7 @@ interface SelectOwnProps {
 }
 
 export interface SelectProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'button'>,
   ChildrenProps,
   FormFieldProps,
   SizeProps<FormFieldSize>,

--- a/packages/bezier-react/src/components/Select/Select.types.ts
+++ b/packages/bezier-react/src/components/Select/Select.types.ts
@@ -2,8 +2,8 @@ import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
   AdditionalColorProps,
+  AdditionalOverridableStyleProps,
   AdditionalTestIdProps,
-  AlphaAdditionalStylableProps,
   BezierComponentProps,
   ChildrenProps,
   FormFieldProps,
@@ -42,6 +42,6 @@ export interface SelectProps extends
   SizeProps<FormFieldSize>,
   SideContentProps<BezierIcon | React.ReactNode, BezierIcon | React.ReactNode>,
   AdditionalTestIdProps<['trigger', 'triggerText', 'dropdown']>,
-  AlphaAdditionalStylableProps<'dropdown'>,
+  AdditionalOverridableStyleProps<'dropdown'>,
   AdditionalColorProps<['icon', 'text']>,
   SelectOwnProps {}

--- a/packages/bezier-react/src/components/Slider/Slider.types.ts
+++ b/packages/bezier-react/src/components/Slider/Slider.types.ts
@@ -1,5 +1,5 @@
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   DisableProps,
 } from '~/src/types/props'
 
@@ -71,7 +71,6 @@ interface SliderOwnProps {
 }
 
 export interface SliderProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'span'>, keyof SliderOwnProps>,
   DisableProps,
-  Omit<React.HTMLAttributes<HTMLSpanElement>, keyof SliderOwnProps>,
   SliderOwnProps {}

--- a/packages/bezier-react/src/components/Spinner/Spinner.types.ts
+++ b/packages/bezier-react/src/components/Spinner/Spinner.types.ts
@@ -1,5 +1,5 @@
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ColorProps,
   type SizeProps,
 } from '~/src/types/props'
@@ -20,7 +20,6 @@ export enum SpinnerThickness {
 }
 
 export interface SpinnerProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'div'>, keyof ColorProps>,
   SizeProps<SpinnerSize>,
-  ColorProps,
-  Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}
+  ColorProps {}

--- a/packages/bezier-react/src/components/Stack/Stack.types.ts
+++ b/packages/bezier-react/src/components/Stack/Stack.types.ts
@@ -1,5 +1,5 @@
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type LayoutProps,
   type MarginProps,
@@ -47,8 +47,7 @@ interface StackOwnProps {
 }
 
 export interface StackProps extends
-  AlphaBezierComponentProps,
-  React.HTMLAttributes<HTMLElement>,
+  BezierComponentProps,
   PolymorphicProps,
   ChildrenProps,
   LayoutProps,

--- a/packages/bezier-react/src/components/Status/Status.types.ts
+++ b/packages/bezier-react/src/components/Status/Status.types.ts
@@ -1,5 +1,5 @@
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   SizeProps,
 } from '~/src/types/props'
 
@@ -24,7 +24,6 @@ interface StatusOwnProps {
 }
 
 export interface StatusProps extends
-  AlphaBezierComponentProps,
-  React.HTMLAttributes<HTMLDivElement>,
+  BezierComponentProps<'div'>,
   SizeProps<StatusSize>,
   StatusOwnProps {}

--- a/packages/bezier-react/src/components/Switch/Switch.types.ts
+++ b/packages/bezier-react/src/components/Switch/Switch.types.ts
@@ -2,7 +2,7 @@ import type { SwitchProps as SwitchPrimitiveProps } from '@radix-ui/react-switch
 
 import type {
   AdditionalTestIdProps,
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   FormFieldProps,
   SizeProps,
 } from '~/src/types/props'
@@ -54,7 +54,7 @@ interface SwitchOwnProps extends Omit<SwitchPrimitiveProps, 'asChild'> {
 }
 
 export interface SwitchProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'button'>, keyof SwitchOwnProps>,
   SizeProps<SwitchSize>,
   FormFieldProps,
   AdditionalTestIdProps<'handle'>,

--- a/packages/bezier-react/src/components/Tabs/Tabs.types.ts
+++ b/packages/bezier-react/src/components/Tabs/Tabs.types.ts
@@ -1,7 +1,7 @@
 import type React from 'react'
 
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type DisableProps,
   type SizeProps,
@@ -64,44 +64,38 @@ interface TabContentOwnProps {
 }
 
 export interface TabsProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'div'>, keyof TabsOwnProps>,
   ChildrenProps,
-  Omit<React.HTMLAttributes<HTMLDivElement>, keyof TabsOwnProps>,
   TabsOwnProps {}
 
 export interface TabListProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
-  SizeProps<TabSize>,
-  React.HTMLAttributes<HTMLDivElement> {}
+  SizeProps<TabSize> {}
 
 export interface TabItemsProps extends
-  AlphaBezierComponentProps,
-  ChildrenProps,
-  React.HTMLAttributes<HTMLDivElement> {}
+  BezierComponentProps<'div'>,
+  ChildrenProps {}
 
 export interface TabItemProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'button'>, keyof TabItemOwnProps>,
   ChildrenProps,
   DisableProps,
-  React.HTMLAttributes<HTMLButtonElement>,
   TabItemOwnProps {}
 
 export interface TabActionsProps extends
-  AlphaBezierComponentProps,
-  React.HTMLAttributes<HTMLDivElement>,
+  BezierComponentProps<'div'>,
   ChildrenProps {}
 
 export type TabActionElement<Link> = [Link] extends [string] ? HTMLAnchorElement : HTMLButtonElement
 
 export interface TabActionProps<Link extends string | undefined> extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps, keyof React.HTMLAttributes<HTMLElement>>,
   ChildrenProps,
   TabActionOwnProps<Link>,
   Omit<React.HTMLAttributes<TabActionElement<Link>>, 'onClick'> {}
 
 export interface TabContentProps extends
-  AlphaBezierComponentProps,
+  BezierComponentProps<'div'>,
   ChildrenProps,
-  React.HTMLAttributes<HTMLDivElement>,
   TabContentOwnProps {}

--- a/packages/bezier-react/src/components/Tag/Tag.types.ts
+++ b/packages/bezier-react/src/components/Tag/Tag.types.ts
@@ -1,5 +1,5 @@
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type ColorProps,
   type SizeProps,
@@ -21,9 +21,8 @@ interface TagOwnProps {
 }
 
 export interface TagProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'div'>, keyof ColorProps>,
   ChildrenProps,
-  Omit<React.HTMLAttributes<HTMLDivElement>, 'color'>,
   SizeProps<TagBadgeSize>,
   VariantProps<TagBadgeVariant>,
   ColorProps,

--- a/packages/bezier-react/src/components/Text/Text.types.ts
+++ b/packages/bezier-react/src/components/Text/Text.types.ts
@@ -1,5 +1,5 @@
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type MarginProps,
   type PolymorphicProps,
@@ -55,8 +55,7 @@ interface TextOwnProps {
 }
 
 export interface TextProps extends
-  AlphaBezierComponentProps,
-  Omit<React.HTMLAttributes<HTMLElement>, keyof TextOwnProps>,
+  Omit<BezierComponentProps, keyof TextOwnProps>,
   PolymorphicProps,
   ChildrenProps,
   MarginProps,

--- a/packages/bezier-react/src/components/TextArea/TextArea.types.ts
+++ b/packages/bezier-react/src/components/TextArea/TextArea.types.ts
@@ -1,9 +1,7 @@
-import type React from 'react'
-
 import { type TextareaAutosizeProps } from 'react-textarea-autosize'
 
 import type {
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   FormFieldProps,
 } from '~/src/types/props'
 
@@ -24,8 +22,7 @@ interface TextAreaOwnProps {
 }
 
 export interface TextAreaProps extends
-  Omit<AlphaBezierComponentProps, 'style'>,
-  Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'style'>,
+  Omit<BezierComponentProps<'textarea'>, 'style'>,
   Pick<TextareaAutosizeProps, 'style'>,
   FormFieldProps,
   TextAreaOwnProps {}

--- a/packages/bezier-react/src/components/TextField/TextField.types.ts
+++ b/packages/bezier-react/src/components/TextField/TextField.types.ts
@@ -4,7 +4,7 @@ import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
   AdditionalColorProps,
-  AlphaAdditionalStylableProps,
+  AdditionalOverridableStyleProps,
   BezierComponentProps,
   FormFieldProps,
   FormFieldSize,
@@ -67,7 +67,7 @@ type OmittedInputHTMLAttributes = 'type' | 'size' | 'readOnly' | 'disabled' | 'o
 
 export interface TextFieldProps extends
   Omit<BezierComponentProps<'input'>, OmittedInputHTMLAttributes>,
-  AlphaAdditionalStylableProps<['wrapper', 'leftWrapper', 'rightWrapper']>,
+  AdditionalOverridableStyleProps<['wrapper', 'leftWrapper', 'rightWrapper']>,
   FormFieldProps,
   SizeProps<FormFieldSize>,
   VariantProps<TextFieldVariant>,

--- a/packages/bezier-react/src/components/TextField/TextField.types.ts
+++ b/packages/bezier-react/src/components/TextField/TextField.types.ts
@@ -5,7 +5,7 @@ import { type BezierIcon } from '@channel.io/bezier-icons'
 import type {
   AdditionalColorProps,
   AlphaAdditionalStylableProps,
-  AlphaBezierComponentProps,
+  BezierComponentProps,
   FormFieldProps,
   FormFieldSize,
   SideContentProps,
@@ -66,11 +66,10 @@ interface TextFieldOwnProps {
 type OmittedInputHTMLAttributes = 'type' | 'size' | 'readOnly' | 'disabled' | 'onFocus'
 
 export interface TextFieldProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'input'>, OmittedInputHTMLAttributes>,
   AlphaAdditionalStylableProps<['wrapper', 'leftWrapper', 'rightWrapper']>,
   FormFieldProps,
   SizeProps<FormFieldSize>,
   VariantProps<TextFieldVariant>,
   SideContentProps<TextFieldItemProps, TextFieldItemProps | TextFieldItemProps[]>,
-  Omit<React.InputHTMLAttributes<HTMLInputElement>, OmittedInputHTMLAttributes>,
   TextFieldOwnProps {}

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
@@ -1,7 +1,7 @@
 import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import {
-  type AlphaBezierComponentProps,
+  type BezierComponentProps,
   type ChildrenProps,
   type ContentProps,
   type DisableProps,
@@ -130,9 +130,8 @@ export interface TooltipProviderProps extends
   TooltipProviderOptions {}
 
 export interface TooltipProps extends
-  AlphaBezierComponentProps,
+  Omit<BezierComponentProps<'div'>, 'title' | keyof ContentProps | keyof ChildrenProps>,
   ChildrenProps<React.ReactElement>,
   ContentProps,
   DisableProps,
-  Omit<React.HTMLAttributes<HTMLDivElement>, 'title' | keyof ContentProps | keyof ChildrenProps>,
   TooltipOptions {}

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -39,11 +39,6 @@ export interface StylableComponentProps {
   className?: string
 }
 
-/**
- * @deprecated Migration to `AlphaBezierComponentProps` is in progress.
- */
-export type BezierComponentProps = RenderConfigProps & StylableComponentProps
-
 /* Component Additional Props */
 export interface ContentProps<Content = React.ReactNode> {
   content?: Content
@@ -78,18 +73,6 @@ export interface IdentifierProps {
   id: string
 }
 
-/**
- * @deprecated Unnecessary property.
- */
-export interface OptionItemProps {
-  optionKey?: string
-}
-
-export interface OptionItemHostProps<OptionKeyType = string> {
-  selectedOptionIndex?: number
-  onChangeOption?: (optionIndex: number, optionKey?: OptionKeyType) => void
-}
-
 type PropNameType = string | string[]
 
 type AdditionalProps<PropName extends PropNameType, Suffix extends string, PropType> = {
@@ -104,13 +87,6 @@ type AdditionalStyleProps<ElementName extends PropNameType> =
 
 type AdditionalClassNameProps<ElementName extends PropNameType> =
   AdditionalProps<ElementName, 'className', string>
-
-/**
- * @deprecated Migration to `AdditionalStylableProps` is in progress.
- */
-export type AdditionalStylableProps<ElementName extends PropNameType> =
-  AdditionalStyleProps<ElementName> &
-  AdditionalClassNameProps<ElementName>
 
 export type AdditionalTestIdProps<ElementName extends PropNameType> =
   AdditionalProps<ElementName, 'testId', string>

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -53,6 +53,7 @@ type HTMLElementProps<Tag extends keyof JSX.IntrinsicElements> = React.Component
 /**
  * Extends base configuration and overridable style properties with standard HTML attributes.
  * Designed for components requiring both custom and standard HTML properties.
+ * @template Tag The tag name of the HTML element (e.g., 'div', 'a', 'button'). If null, returns contains `React.HTMLAttributes<HTMLElement>`.
  */
 export type BezierComponentProps<Tag extends keyof JSX.IntrinsicElements | null = null> =
   & RenderConfigProps
@@ -167,16 +168,11 @@ type AdditionalProps<PropName extends PropNameType, Suffix extends string, PropT
 }
 
 /**
- * Props for adding custom styles to named elements within a component.
+ * Props for adding additional overridable style properties to named elements within a component.
  */
-type AdditionalStyleProps<ElementName extends PropNameType> =
-  AdditionalProps<ElementName, 'style', React.CSSProperties>
-
-/**
- * Props for adding custom class names to named elements within a component.
- */
-type AdditionalClassNameProps<ElementName extends PropNameType> =
-  AdditionalProps<ElementName, 'className', string>
+export type AdditionalOverridableStyleProps<ElementName extends PropNameType> =
+  & AdditionalProps<ElementName, 'style', React.CSSProperties>
+  & AdditionalProps<ElementName, 'className', string>
 
 /**
  * Props for adding test IDs to named elements within a component, useful for testing purposes.
@@ -189,13 +185,6 @@ export type AdditionalTestIdProps<ElementName extends PropNameType> =
  */
 export type AdditionalColorProps<ElementName extends PropNameType> =
   AdditionalProps<ElementName, 'color', SemanticColor>
-
-/**
- * TODO: Remove Alpha prefix after removing styled-components dependency.
- */
-export type AlphaAdditionalStylableProps<ElementName extends PropNameType> =
-  AdditionalStyleProps<ElementName> &
-  AdditionalClassNameProps<ElementName>
 
 /**
  * Props for components that can be activated or deactivated.

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -1,5 +1,8 @@
-import { type CSSProperties } from 'react'
-import type React from 'react'
+import type {
+  CSSProperties,
+  ElementType,
+  ReactNode,
+} from 'react'
 
 import type {
   BackgroundSemanticColor,
@@ -11,70 +14,125 @@ import type {
   ZIndex,
 } from './tokens'
 
-/* Component Base Props */
+/**
+ * Base configuration properties for components, including the HTML element type and test ID.
+ */
 export interface RenderConfigProps {
   /**
    * Specifies which HTML tag should be used to render this component.
-   *
-   * `as` prop directly comes from the polymorphic "as" prop of `styled-components`.
+   * This prop comes directly from the polymorphic "as" prop of `styled-components`.
    * @see https://styled-components.com/docs/api#as-polymorphic-prop
    */
-  as?: React.ElementType
+  as?: ElementType
 
   /**
-   * The test id attribute compatible with `@testing-library/react`.
+   * A test ID attribute compatible with `@testing-library/react`.
    */
   testId?: string
 }
 
+/**
+ * Properties for styling components, including inline CSS and class names.
+ */
 export interface StylableComponentProps {
   /**
-   * Customized inline CSS style for this component.
+   * Custom inline CSS styles for the component.
    */
   style?: CSSProperties
-
   /**
-   * Customized CSS classname for this component.
+   * Custom CSS class name for the component.
    */
   className?: string
 }
 
-/* Component Additional Props */
-export interface ContentProps<Content = React.ReactNode> {
+/**
+ * Props for components that include content.
+ */
+export interface ContentProps<Content = ReactNode> {
+  /**
+   * Content to be rendered within the component.
+   */
   content?: Content
 }
 
-export interface ChildrenProps<Children = React.ReactNode> {
+/**
+ * Props for components that include children elements.
+ */
+export interface ChildrenProps<Children = ReactNode> {
+  /**
+   * Child elements to be rendered within the component.
+   */
   children?: Children
 }
 
+/**
+ * Props for components with variant styles or behaviors.
+ */
 export interface VariantProps<Variant extends string | number> {
+  /**
+   * Variant of the component to be used.
+   */
   variant?: Variant
 }
 
+/**
+ * Props for components with size variations.
+ */
 export interface SizeProps<Size extends string | number> {
+  /**
+   * Size of the component.
+   */
   size?: Size
 }
 
-export interface SideContentProps<LeftContent = React.ReactNode, RightContent = React.ReactNode> {
+/**
+ * Props for components that have content on their sides (left or right).
+ */
+export interface SideContentProps<LeftContent = ReactNode, RightContent = ReactNode> {
+  /**
+   * Content to be displayed on the left side of the component.
+   */
   leftContent?: LeftContent
+  /**
+   * Content to be displayed on the right side of the component.
+   */
   rightContent?: RightContent
 }
 
+/**
+ * Props for components that can be disabled.
+ */
 export interface DisableProps {
+  /**
+   * Whether the component is disabled.
+   */
   disabled?: boolean
 }
 
+/**
+ * Props for components that use color from the design system's palette.
+ */
 export interface ColorProps {
+  /**
+   * Color from the design system's semantic color palette.
+   */
   color?: SemanticColor
 }
 
+/**
+ * Props for components that require an identifier (ID).
+ */
 export interface IdentifierProps {
+  /**
+   * Unique identifier for the component.
+   */
   id: string
 }
 
 type PropNameType = string | string[]
-
+/**
+ * Generic type for defining additional properties with a specific suffix.
+ */
 type AdditionalProps<PropName extends PropNameType, Suffix extends string, PropType> = {
   [Key in `${PropName extends string
     ? PropName
@@ -82,23 +140,47 @@ type AdditionalProps<PropName extends PropNameType, Suffix extends string, PropT
   }${Capitalize<Suffix>}`]?: PropType
 }
 
+/**
+ * Props for adding custom styles to named elements within a component.
+ */
 type AdditionalStyleProps<ElementName extends PropNameType> =
   AdditionalProps<ElementName, 'style', CSSProperties>
 
+/**
+ * Props for adding custom class names to named elements within a component.
+ */
 type AdditionalClassNameProps<ElementName extends PropNameType> =
   AdditionalProps<ElementName, 'className', string>
 
+/**
+ * Props for adding test IDs to named elements within a component, useful for testing purposes.
+ */
 export type AdditionalTestIdProps<ElementName extends PropNameType> =
   AdditionalProps<ElementName, 'testId', string>
 
+/**
+ * Props for adding color properties to named elements within a component.
+ */
 export type AdditionalColorProps<ElementName extends PropNameType> =
   AdditionalProps<ElementName, 'color', SemanticColor>
 
+/**
+ * Props for components that can be activated or deactivated.
+ */
 export interface ActivatableProps {
+  /**
+   * Whether the component is active.
+   */
   active?: boolean
 }
 
+/**
+ * Props for components that act as a link.
+ */
 export interface LinkProps {
+  /**
+   * URL or a URL fragment that the hyperlink points to.
+   */
   href?: string
 }
 
@@ -116,13 +198,20 @@ export interface AlphaBezierComponentProps extends
   Omit<RenderConfigProps, 'as'>,
   Omit<StylableComponentProps, 'interpolation'> {}
 
+/**
+ * Props for polymorphic components that can render as different element types.
+ * @todo Generic type for `as` prop.
+ */
 export interface PolymorphicProps {
   /**
    * Element type to render.
    */
-  as?: React.ElementType
+  as?: ElementType
 }
 
+/**
+ * Props for specifying margins around a component.
+ */
 export interface MarginProps {
   /**
    * the margin area on all four sides of an element.
@@ -164,6 +253,9 @@ export interface MarginProps {
 type Position = 'absolute' | 'fixed' | 'relative' | 'sticky'
 type Overflow = 'auto' | 'hidden' | 'scroll' | 'visible'
 
+/**
+ * Props for defining layout-related properties of a component, such as padding, size, and position.
+ */
 export interface LayoutProps {
   /**
    * the padding area on all four sides of an element.
@@ -337,8 +429,14 @@ export interface LayoutProps {
   overflowY?: Overflow
 }
 
+/**
+ * Enumeration of form field sizes. (TextField, Select)
+ */
 export type FormFieldSize = 'xl' | 'l' | 'm' | 'xs'
 
+/**
+ * Props for form field components, including states like disabled, error, and required.
+ */
 export interface FormFieldProps extends
   DisableProps,
   Partial<IdentifierProps> {

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -19,13 +19,6 @@ import type {
  */
 export interface RenderConfigProps {
   /**
-   * Specifies which HTML tag should be used to render this component.
-   * This prop comes directly from the polymorphic "as" prop of `styled-components`.
-   * @see https://styled-components.com/docs/api#as-polymorphic-prop
-   */
-  as?: ElementType
-
-  /**
    * A test ID attribute compatible with `@testing-library/react`.
    */
   testId?: string
@@ -43,6 +36,24 @@ export interface StylableComponentProps {
    * Custom CSS class name for the component.
    */
   className?: string
+}
+
+/**
+ * TODO: Remove Alpha prefix after removing styled-components dependency.
+ */
+export interface AlphaBezierComponentProps extends
+  RenderConfigProps,
+  StylableComponentProps {}
+
+/**
+ * Props for polymorphic components that can render as different element types.
+ * @todo Generic type for `as` prop.
+ */
+export interface PolymorphicProps {
+  /**
+   * Element type to render.
+   */
+  as?: ElementType
 }
 
 /**
@@ -165,6 +176,13 @@ export type AdditionalColorProps<ElementName extends PropNameType> =
   AdditionalProps<ElementName, 'color', SemanticColor>
 
 /**
+ * TODO: Remove Alpha prefix after removing styled-components dependency.
+ */
+export type AlphaAdditionalStylableProps<ElementName extends PropNameType> =
+AdditionalStyleProps<ElementName> &
+AdditionalClassNameProps<ElementName>
+
+/**
  * Props for components that can be activated or deactivated.
  */
 export interface ActivatableProps {
@@ -182,31 +200,6 @@ export interface LinkProps {
    * URL or a URL fragment that the hyperlink points to.
    */
   href?: string
-}
-
-/**
- * TODO: Remove Alpha prefix after removing styled-components dependency.
- */
-export type AlphaAdditionalStylableProps<ElementName extends PropNameType> =
-  AdditionalStyleProps<ElementName> &
-  AdditionalClassNameProps<ElementName>
-
-/**
- * TODO: Remove Alpha prefix after removing styled-components dependency.
- */
-export interface AlphaBezierComponentProps extends
-  Omit<RenderConfigProps, 'as'>,
-  Omit<StylableComponentProps, 'interpolation'> {}
-
-/**
- * Props for polymorphic components that can render as different element types.
- * @todo Generic type for `as` prop.
- */
-export interface PolymorphicProps {
-  /**
-   * Element type to render.
-   */
-  as?: ElementType
 }
 
 /**

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -25,15 +25,21 @@ export interface RenderConfigProps {
 }
 
 /**
- * Properties for styling components, including inline CSS and class names.
+ * Props for overriding default styles of components. Intended for exceptional use cases where default styles need customization.
  */
-export interface StylableComponentProps {
+export interface OverridableStyleProps {
   /**
    * Custom inline CSS styles for the component.
+   * Intended for specific styling that overrides the component's default styles.
+   *
+   * **🚨 Caution:** Overuse can break the consistency of the overall design. Use only when absolutely necessary.
    */
   style?: CSSProperties
   /**
    * Custom CSS class name for the component.
+   * Intended to apply external styles or override default styles with higher specificity.
+   *
+   * **🚨 Caution:** Overuse can break the consistency of the overall design. Use only when absolutely necessary.
    */
   className?: string
 }
@@ -43,7 +49,7 @@ export interface StylableComponentProps {
  */
 export interface AlphaBezierComponentProps extends
   RenderConfigProps,
-  StylableComponentProps {}
+  OverridableStyleProps {}
 
 /**
  * Props for polymorphic components that can render as different element types.

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -1,10 +1,4 @@
 import type {
-  CSSProperties,
-  ElementType,
-  ReactNode,
-} from 'react'
-
-import type {
   BackgroundSemanticColor,
   BackgroundTextSemanticColor,
   BorderSemanticColor,
@@ -16,8 +10,9 @@ import type {
 
 /**
  * Base configuration properties for components, including the HTML element type and test ID.
+ * @deprecated Remove
  */
-export interface RenderConfigProps {
+interface RenderConfigProps {
   /**
    * A test ID attribute compatible with `@testing-library/react`.
    */
@@ -27,14 +22,14 @@ export interface RenderConfigProps {
 /**
  * Props for overriding default styles of components. Intended for exceptional use cases where default styles need customization.
  */
-export interface OverridableStyleProps {
+interface OverridableStyleProps {
   /**
    * Custom inline CSS styles for the component.
    * Intended for specific styling that overrides the component's default styles.
    *
    * **🚨 Caution:** Overuse can break the consistency of the overall design. Use only when absolutely necessary.
    */
-  style?: CSSProperties
+  style?: React.CSSProperties
   /**
    * Custom CSS class name for the component.
    * Intended to apply external styles or override default styles with higher specificity.
@@ -45,11 +40,24 @@ export interface OverridableStyleProps {
 }
 
 /**
- * TODO: Remove Alpha prefix after removing styled-components dependency.
+ * Retrieves the prop types for a given HTML element specified by its tag name.
+ * This utility type uses JSX.IntrinsicElements to obtain the props associated with standard HTML elements.
+ * @template Tag The tag name of the HTML element (e.g., 'div', 'a', 'button').
+ * @returns The prop types for the HTML element corresponding to the tag name.
+ * @example
+ * type DivProps = ElementProps<'div'>; // React.HTMLAttributes<HTMLDivElement>
+ * type AnchorProps = ElementProps<'a'>; // React.AnchorHTMLAttributes<HTMLAnchorElement>
  */
-export interface AlphaBezierComponentProps extends
-  RenderConfigProps,
-  OverridableStyleProps {}
+type HTMLElementProps<Tag extends keyof JSX.IntrinsicElements> = React.ComponentPropsWithoutRef<Tag>
+
+/**
+ * Extends base configuration and overridable style properties with standard HTML attributes.
+ * Designed for components requiring both custom and standard HTML properties.
+ */
+export type BezierComponentProps<Tag extends keyof JSX.IntrinsicElements | null = null> =
+  & RenderConfigProps
+  & (Tag extends keyof JSX.IntrinsicElements ? HTMLElementProps<Tag> : React.HTMLAttributes<HTMLElement>)
+  & OverridableStyleProps
 
 /**
  * Props for polymorphic components that can render as different element types.
@@ -59,13 +67,13 @@ export interface PolymorphicProps {
   /**
    * Element type to render.
    */
-  as?: ElementType
+  as?: React.ElementType
 }
 
 /**
  * Props for components that include content.
  */
-export interface ContentProps<Content = ReactNode> {
+export interface ContentProps<Content = React.ReactNode> {
   /**
    * Content to be rendered within the component.
    */
@@ -75,7 +83,7 @@ export interface ContentProps<Content = ReactNode> {
 /**
  * Props for components that include children elements.
  */
-export interface ChildrenProps<Children = ReactNode> {
+export interface ChildrenProps<Children = React.ReactNode> {
   /**
    * Child elements to be rendered within the component.
    */
@@ -105,7 +113,7 @@ export interface SizeProps<Size extends string | number> {
 /**
  * Props for components that have content on their sides (left or right).
  */
-export interface SideContentProps<LeftContent = ReactNode, RightContent = ReactNode> {
+export interface SideContentProps<LeftContent = React.ReactNode, RightContent = React.ReactNode> {
   /**
    * Content to be displayed on the left side of the component.
    */
@@ -127,11 +135,11 @@ export interface DisableProps {
 }
 
 /**
- * Props for components that use color from the design system's palette.
+ * Props for components that use color from the design system.
  */
 export interface ColorProps {
   /**
-   * Color from the design system's semantic color palette.
+   * Color from the design system's semantic color.
    */
   color?: SemanticColor
 }
@@ -147,6 +155,7 @@ export interface IdentifierProps {
 }
 
 type PropNameType = string | string[]
+
 /**
  * Generic type for defining additional properties with a specific suffix.
  */
@@ -161,7 +170,7 @@ type AdditionalProps<PropName extends PropNameType, Suffix extends string, PropT
  * Props for adding custom styles to named elements within a component.
  */
 type AdditionalStyleProps<ElementName extends PropNameType> =
-  AdditionalProps<ElementName, 'style', CSSProperties>
+  AdditionalProps<ElementName, 'style', React.CSSProperties>
 
 /**
  * Props for adding custom class names to named elements within a component.
@@ -185,8 +194,8 @@ export type AdditionalColorProps<ElementName extends PropNameType> =
  * TODO: Remove Alpha prefix after removing styled-components dependency.
  */
 export type AlphaAdditionalStylableProps<ElementName extends PropNameType> =
-AdditionalStyleProps<ElementName> &
-AdditionalClassNameProps<ElementName>
+  AdditionalStyleProps<ElementName> &
+  AdditionalClassNameProps<ElementName>
 
 /**
  * Props for components that can be activated or deactivated.
@@ -216,37 +225,37 @@ export interface MarginProps {
    * the margin area on all four sides of an element.
    * @default 0
    */
-  margin?: CSSProperties['margin']
+  margin?: React.CSSProperties['margin']
   /**
    * the margin area on the left and right sides of an element.
    * @default 0
    */
-  marginHorizontal?: CSSProperties['margin']
+  marginHorizontal?: React.CSSProperties['margin']
   /**
    * the margin area on the top and bottom sides of an element.
    * @default 0
    */
-  marginVertical?: CSSProperties['margin']
+  marginVertical?: React.CSSProperties['margin']
   /**
    * the margin area on the top side of an element.
    * @default 0
    */
-  marginTop?: CSSProperties['marginTop']
+  marginTop?: React.CSSProperties['marginTop']
   /**
    * the margin area on the right side of an element.
    * @default 0
    */
-  marginRight?: CSSProperties['marginRight']
+  marginRight?: React.CSSProperties['marginRight']
   /**
    * the margin area on the bottom side of an element.
    * @default 0
    */
-  marginBottom?: CSSProperties['marginBottom']
+  marginBottom?: React.CSSProperties['marginBottom']
   /**
    * the margin area on the left side of an element.
    * @default 0
    */
-  marginLeft?: CSSProperties['marginLeft']
+  marginLeft?: React.CSSProperties['marginLeft']
 }
 
 type Position = 'absolute' | 'fixed' | 'relative' | 'sticky'
@@ -260,67 +269,67 @@ export interface LayoutProps {
    * the padding area on all four sides of an element.
    * @default 0
    */
-  padding?: CSSProperties['padding']
+  padding?: React.CSSProperties['padding']
   /**
    * the padding area on the left and right sides of an element.
    * @default 0
    */
-  paddingHorizontal?: CSSProperties['padding']
+  paddingHorizontal?: React.CSSProperties['padding']
   /**
    * the padding area on the top and bottom sides of an element.
    * @default 0
    */
-  paddingVertical?: CSSProperties['padding']
+  paddingVertical?: React.CSSProperties['padding']
   /**
    * the padding area on the top side of an element.
    * @default 0
    */
-  paddingTop?: CSSProperties['paddingTop']
+  paddingTop?: React.CSSProperties['paddingTop']
   /**
    * the padding area on the right side of an element.
    * @default 0
    */
-  paddingRight?: CSSProperties['paddingRight']
+  paddingRight?: React.CSSProperties['paddingRight']
   /**
    * the padding area on the bottom side of an element.
    * @default 0
    */
-  paddingBottom?: CSSProperties['paddingBottom']
+  paddingBottom?: React.CSSProperties['paddingBottom']
   /**
    * the padding area on the left side of an element.
    * @default 0
    */
-  paddingLeft?: CSSProperties['paddingLeft']
+  paddingLeft?: React.CSSProperties['paddingLeft']
   /**
    * the width of an element.
    * @default initial
    */
-  width?: CSSProperties['width']
+  width?: React.CSSProperties['width']
   /**
    * the height of an element.
    * @default initial
    */
-  height?: CSSProperties['height']
+  height?: React.CSSProperties['height']
   /**
    * the maximum width of an element.
    * @default initial
    */
-  maxWidth?: CSSProperties['maxWidth']
+  maxWidth?: React.CSSProperties['maxWidth']
   /**
    * the minimum width of an element.
    * @default initial
    */
-  minWidth?: CSSProperties['minWidth']
+  minWidth?: React.CSSProperties['minWidth']
   /**
    * the maximum height of an element.
    * @default initial
    */
-  maxHeight?: CSSProperties['maxHeight']
+  maxHeight?: React.CSSProperties['maxHeight']
   /**
    * the minimum height of an element.
    * @default initial
    */
-  minHeight?: CSSProperties['minHeight']
+  minHeight?: React.CSSProperties['minHeight']
   /**
    * how an element is positioned in a document.
    * @default initial
@@ -330,37 +339,37 @@ export interface LayoutProps {
    * the distance between the edges of an element and its containing element.
    * @default auto
    */
-  inset?: CSSProperties['inset']
+  inset?: React.CSSProperties['inset']
   /**
    * the distance between the top edge of an element and the top edge of its containing element.
    * @default auto
    */
-  top?: CSSProperties['top']
+  top?: React.CSSProperties['top']
   /**
    * the distance between the right edge of an element and the right edge of its containing element.
    * @default auto
    */
-  right?: CSSProperties['right']
+  right?: React.CSSProperties['right']
   /**
    * the distance between the bottom edge of an element and the bottom edge of its containing element.
    * @default auto
    */
-  bottom?: CSSProperties['bottom']
+  bottom?: React.CSSProperties['bottom']
   /**
    * the distance between the left edge of an element and the left edge of its containing element.
    * @default auto
    */
-  left?: CSSProperties['left']
+  left?: React.CSSProperties['left']
   /**
    * the flex-shrink factor of a flex item.
    * @default initial
    */
-  shrink?: CSSProperties['flexShrink']
+  shrink?: React.CSSProperties['flexShrink']
   /**
    * the flex-grow factor of a flex item.
    * @default initial
    */
-  grow?: CSSProperties['flexGrow']
+  grow?: React.CSSProperties['flexGrow']
   /**
    * the background color of an element.
    * @default initial
@@ -380,27 +389,27 @@ export interface LayoutProps {
    * the border width of an element.
    * @default 0
    */
-  borderWidth?: CSSProperties['borderWidth']
+  borderWidth?: React.CSSProperties['borderWidth']
   /**
    * the border width of the top side of an element.
    * @default 0
    */
-  borderTopWidth?: CSSProperties['borderTopWidth']
+  borderTopWidth?: React.CSSProperties['borderTopWidth']
   /**
    * the border width of the right side of an element.
    * @default 0
    */
-  borderRightWidth?: CSSProperties['borderRightWidth']
+  borderRightWidth?: React.CSSProperties['borderRightWidth']
   /**
    * the border width of the bottom side of an element.
    * @default 0
    */
-  borderBottomWidth?: CSSProperties['borderBottomWidth']
+  borderBottomWidth?: React.CSSProperties['borderBottomWidth']
   /**
    * the border width of the left side of an element.
    * @default 0
    */
-  borderLeftWidth?: CSSProperties['borderLeftWidth']
+  borderLeftWidth?: React.CSSProperties['borderLeftWidth']
   /**
    * the elevation of an element. (box-shadow)
    * @default initial

--- a/packages/bezier-react/src/utils/props.ts
+++ b/packages/bezier-react/src/utils/props.ts
@@ -1,7 +1,6 @@
 import classNames from 'classnames'
 
 import {
-  type BezierComponentProps,
   type FormFieldSize,
   type LayoutProps,
   type MarginProps,
@@ -26,24 +25,6 @@ import {
   cssDimension,
   tokenCssVar,
 } from './style'
-
-export const splitByBezierComponentProps = <
-  Props extends BezierComponentProps,
->({
-    as,
-    testId,
-    style,
-    className,
-    ...rest
-  }: Props): [BezierComponentProps, Omit<Props, keyof BezierComponentProps>] => [
-    {
-      as,
-      testId,
-      style,
-      className,
-    },
-    rest,
-  ]
 
 export const splitByMarginProps = <Props extends MarginProps>({
   margin,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- Fixes #1321 

## Summary
<!-- Please brief explanation of the changes made -->

Enhance common types

## Details
<!-- Please elaborate description of the changes -->

AlphaBezierComponentProps 를 BezierComponentProps 로 변경하고, 기존 BezierComponentProps는 사용처가 없어 제거했습니다. Alpha prefix를 제거하면서, 몇 가지 개선사항을 추가했습니다.

```tsx
/**
 * Retrieves the prop types for a given HTML element specified by its tag name.
 * This utility type uses JSX.IntrinsicElements to obtain the props associated with standard HTML elements.
 * @template Tag The tag name of the HTML element (e.g., 'div', 'a', 'button').
 * @returns The prop types for the HTML element corresponding to the tag name.
 * @example
 * type DivProps = ElementProps<'div'>; // React.HTMLAttributes<HTMLDivElement>
 * type AnchorProps = ElementProps<'a'>; // React.AnchorHTMLAttributes<HTMLAnchorElement>
 */
type HTMLElementProps<Tag extends keyof JSX.IntrinsicElements> = React.ComponentPropsWithoutRef<Tag>

/**
 * Extends base configuration and overridable style properties with standard HTML attributes.
 * Designed for components requiring both custom and standard HTML properties.
 * @template Tag The tag name of the HTML element (e.g., 'div', 'a', 'button'). If null, returns contains `React.HTMLAttributes<HTMLElement>`.
 */
export type BezierComponentProps<Tag extends keyof JSX.IntrinsicElements | null = null> =
  & RenderConfigProps
  & (Tag extends keyof JSX.IntrinsicElements ? HTMLElementProps<Tag> : React.HTMLAttributes<HTMLElement>)
  & OverridableStyleProps
```

이제 사용처에서 아래와 같이 사용하게 됩니다. 

```diff
export interface ButtonProps extends
- AlphaBezierComponentProps,
- React.HTMLAttributes<HTMLButtonElement>,
+ BezierComponentProps<'button'>
  PolymorphicProps,
  SizeProps<ButtonSize>,
  DisableProps,
  SideContentProps<SideContent, SideContent>,
  ButtonOwnProps {}
```

- `React.HTMLAttributes<HTMLElement>` 타입을 사용하고자 한다면 `BezierComponentProps` 의 제네릭을 비워두면 됩니다.
- HTMLElementTag에 해당하는 HTMLElement 타입을 찾지 않아도 되도록하고(button -> HTMLButtonElement), 컴포넌트 인터페이스에서 HTMLAttributes 타입이 누락되지 않기를 의도했습니다.
- BezierComponentProps는 본디 HTMLElement를 렌더하는 컴포넌트에서만 사용되었고(as, style, className이 포함되어 있었습니다) + 기본적으로 rest prop을 지원하고 있었기 때문에 HTMLAttributes 인터페이스를 지원하는 것이 자연스럽습니다. 또한 rest prop은 [radix-ui Slot과의 호환성](https://www.radix-ui.com/primitives/docs/guides/composition#composing-with-your-own-react-components)을 보장하는 데에도 꼭 필요합니다.
- 실제 모든 컴포넌트를 살펴봤을 때에도 위 가정을 벗어나는 케이스가 없었습니다.

#### 그 외

- JSDoc을 추가합니다.
- `StylableComponentProps` -> `OverridableStyleProps` 로 이름을 변경했습니다. '오버라이드' 라는 점과 '왠만하면 사용하지 말아라' 라는 점을 네이밍과 JSDoc에 녹여내고자 했습니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
