### PR TITLE
Remove `testId` property from the public component API

### DIFF
--- a/.changeset/great-ties-hunt.md
+++ b/.changeset/great-ties-hunt.md
@@ -1,0 +1,9 @@
+---
+"@channel.io/bezier-react": major
+---
+
+**Breaking changes: Remove `testId` and related properties**
+
+No longer supports `testId` and related properties(e.g. `wrapperTestId`). `testId` is a property used internally by the library for testing with testing-library (`getByTestId`). We don't see a need to expose this as a public API, so we remove it.
+
+If you were using it, please replace it with the `data-testid` property. See <https://testing-library.com/docs/queries/bytestid/>.

--- a/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.tsx
+++ b/packages/bezier-react/src/components/AlphaSmoothCornersBox/AlphaSmoothCornersBox.tsx
@@ -30,7 +30,6 @@ export const AlphaSmoothCornersBox = forwardRef<HTMLDivElement, AlphaSmoothCorne
   children,
   style,
   className,
-  testId,
   disabled,
   borderRadius,
   margin,
@@ -72,7 +71,6 @@ export const AlphaSmoothCornersBox = forwardRef<HTMLDivElement, AlphaSmoothCorne
           ? 'enabled'
           : 'disabled'
       }
-      data-testid={testId}
     >
       { children }
     </div>

--- a/packages/bezier-react/src/components/Avatar/Avatar.tsx
+++ b/packages/bezier-react/src/components/Avatar/Avatar.tsx
@@ -33,9 +33,9 @@ export function useAvatarRadiusToken() {
   return useToken().global.radius['radius-42-p']
 }
 
-export const AVATAR_WRAPPER_TEST_ID = 'bezier-react-avatar-wrapper'
-export const AVATAR_TEST_ID = 'bezier-react-avatar'
-export const STATUS_WRAPPER_TEST_ID = 'bezier-react-status-wrapper'
+export const AVATAR_WRAPPER_TEST_ID = 'bezier-avatar-wrapper'
+export const AVATAR_TEST_ID = 'bezier-avatar'
+export const STATUS_WRAPPER_TEST_ID = 'bezier-status-wrapper'
 
 /**
  * `Avatar` is a component for representing some profile image.
@@ -56,7 +56,6 @@ export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(function Avatar({
   fallbackUrl = defaultAvatarUrl,
   size = AvatarSize.Size24,
   name,
-  testId = AVATAR_TEST_ID,
   disabled = false,
   showBorder = false,
   smoothCorners = true,
@@ -93,8 +92,8 @@ export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(function Avatar({
 
     return Contents && (
       <div
-        data-testid={STATUS_WRAPPER_TEST_ID}
         className={styles.StatusWrapper}
+        data-testid={STATUS_WRAPPER_TEST_ID}
       >
         { Contents }
       </div>
@@ -107,19 +106,18 @@ export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(function Avatar({
 
   return (
     <div
-      data-testid={AVATAR_WRAPPER_TEST_ID}
-      data-disabled={disabled}
       className={classNames(
         styles.Avatar,
         styles[`size-${size}`],
         disabled && styles.disabled,
         className,
       )}
+      data-disabled={disabled}
+      data-testid={AVATAR_WRAPPER_TEST_ID}
       {...rest}
     >
       <AlphaSmoothCornersBox
         ref={forwardedRef}
-        testId={testId}
         aria-label={name}
         className={classNames(
           styles.AvatarImage,
@@ -131,6 +129,7 @@ export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(function Avatar({
         shadow={showBorder ? shadow : undefined}
         backgroundColor="bg-white-normal"
         backgroundImage={loadedAvatarUrl}
+        data-testid={AVATAR_TEST_ID}
       >
         { StatusComponent }
       </AlphaSmoothCornersBox>

--- a/packages/bezier-react/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/bezier-react/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Avatar > Snapshot 1`] = `
   aria-label="Name"
   class="SmoothCornersBox AvatarImage"
   data-state="disabled"
-  data-testid="bezier-react-avatar"
+  data-testid="bezier-avatar"
   style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
 />
 `;
@@ -15,7 +15,7 @@ exports[`Avatar > renders border style 1`] = `
   aria-label="Name"
   class="SmoothCornersBox AvatarImage bordered"
   data-state="disabled"
-  data-testid="bezier-react-avatar"
+  data-testid="bezier-avatar"
   style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 2px; --b-smooth-corners-box-shadow-color: var(--bg-white-high); --b-smooth-corners-box-padding: 4px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
 />
 `;
@@ -23,7 +23,7 @@ exports[`Avatar > renders border style 1`] = `
 exports[`Avatar > should have right -2px, bottom -2px style on StatusWrapper 1`] = `
 <div
   class="StatusWrapper"
-  data-testid="bezier-react-status-wrapper"
+  data-testid="bezier-status-wrapper"
 >
   <div
     class="Status size-m"
@@ -35,7 +35,7 @@ exports[`Avatar > should have right -2px, bottom -2px style on StatusWrapper 1`]
 exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when show border 1`] = `
 <div
   class="StatusWrapper"
-  data-testid="bezier-react-status-wrapper"
+  data-testid="bezier-status-wrapper"
 >
   <div
     class="Status size-m"
@@ -47,7 +47,7 @@ exports[`Avatar > should have right 2px, bottom 2px style on StatusWrapper when 
 exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when size grater then 72 1`] = `
 <div
   class="StatusWrapper"
-  data-testid="bezier-react-status-wrapper"
+  data-testid="bezier-status-wrapper"
 >
   <div
     class="Status size-m"
@@ -59,7 +59,7 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
 exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when size grater then 90 1`] = `
 <div
   class="StatusWrapper"
-  data-testid="bezier-react-status-wrapper"
+  data-testid="bezier-status-wrapper"
 >
   <div
     class="Status size-l"
@@ -71,7 +71,7 @@ exports[`Avatar > should have right 4px, bottom 4px style on StatusWrapper when 
 exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when size grater then 72 and show border 1`] = `
 <div
   class="StatusWrapper"
-  data-testid="bezier-react-status-wrapper"
+  data-testid="bezier-status-wrapper"
 >
   <div
     class="Status size-m"
@@ -83,7 +83,7 @@ exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when 
 exports[`Avatar > should have right 8px, bottom 8px style on StatusWrapper when size grater then 90 and show border 1`] = `
 <div
   class="StatusWrapper"
-  data-testid="bezier-react-status-wrapper"
+  data-testid="bezier-status-wrapper"
 >
   <div
     class="Status size-l"

--- a/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.tsx
+++ b/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.tsx
@@ -32,7 +32,7 @@ import styles from './AvatarGroup.module.scss'
 
 const MAX_AVATAR_LIST_COUNT = 99
 const AVATAR_GROUP_DEFAULT_SPACING = 4
-export const AVATAR_GROUP_ELLIPSIS_ICON_TEST_ID = 'bezier-react-avatar-group-ellipsis-icon'
+export const AVATAR_GROUP_ELLIPSIS_ICON_TEST_ID = 'bezier-avatar-group-ellipsis-icon'
 
 function getRestAvatarListCountText(count: number, max: number) {
   const restCount = count - max
@@ -136,11 +136,11 @@ export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(function
       if (ellipsisType === AvatarGroupEllipsisType.Icon) {
         return (
           <div
-            data-testid={AVATAR_GROUP_ELLIPSIS_ICON_TEST_ID}
             key="ellipsis"
             className={styles.AvatarEllipsisIconWrapper}
             onMouseEnter={onMouseEnterEllipsis}
             onMouseLeave={onMouseLeaveEllipsis}
+            data-testid={AVATAR_GROUP_ELLIPSIS_ICON_TEST_ID}
           >
             <AlphaSmoothCornersBox
               borderRadius={AVATAR_BORDER_RADIUS}

--- a/packages/bezier-react/src/components/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
@@ -9,78 +9,78 @@ exports[`AvatarGroup Ellipsis type - Count Snapshot 1`] = `
   <div
     class="Avatar size-24"
     data-disabled="false"
-    data-testid="bezier-react-avatar-wrapper"
+    data-testid="bezier-avatar-wrapper"
   >
     <div
       aria-label="Christian Nwamba"
       class="SmoothCornersBox AvatarImage"
       data-state="disabled"
-      data-testid="bezier-react-avatar"
+      data-testid="bezier-avatar"
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
     />
   </div>
   <div
     class="Avatar size-24"
     data-disabled="false"
-    data-testid="bezier-react-avatar-wrapper"
+    data-testid="bezier-avatar-wrapper"
   >
     <div
       aria-label="Kola Tioluwani"
       class="SmoothCornersBox AvatarImage"
       data-state="disabled"
-      data-testid="bezier-react-avatar"
+      data-testid="bezier-avatar"
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
     />
   </div>
   <div
     class="Avatar size-24"
     data-disabled="false"
-    data-testid="bezier-react-avatar-wrapper"
+    data-testid="bezier-avatar-wrapper"
   >
     <div
       aria-label="Kent Dodds"
       class="SmoothCornersBox AvatarImage"
       data-state="disabled"
-      data-testid="bezier-react-avatar"
+      data-testid="bezier-avatar"
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
     />
   </div>
   <div
     class="Avatar size-24"
     data-disabled="false"
-    data-testid="bezier-react-avatar-wrapper"
+    data-testid="bezier-avatar-wrapper"
   >
     <div
       aria-label="Ryan Florence"
       class="SmoothCornersBox AvatarImage"
       data-state="disabled"
-      data-testid="bezier-react-avatar"
+      data-testid="bezier-avatar"
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
     />
   </div>
   <div
     class="Avatar size-24"
     data-disabled="false"
-    data-testid="bezier-react-avatar-wrapper"
+    data-testid="bezier-avatar-wrapper"
   >
     <div
       aria-label="Dan Abrahmov"
       class="SmoothCornersBox AvatarImage"
       data-state="disabled"
-      data-testid="bezier-react-avatar"
+      data-testid="bezier-avatar"
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
     />
   </div>
   <div
     class="Avatar size-24"
     data-disabled="false"
-    data-testid="bezier-react-avatar-wrapper"
+    data-testid="bezier-avatar-wrapper"
   >
     <div
       aria-label="Prosper Otemuyiwa"
       class="SmoothCornersBox AvatarImage"
       data-state="disabled"
-      data-testid="bezier-react-avatar"
+      data-testid="bezier-avatar"
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
     />
   </div>
@@ -90,7 +90,7 @@ exports[`AvatarGroup Ellipsis type - Count Snapshot 1`] = `
   >
     <span
       class="Text typo-13 margin AvatarEllipsisCount"
-      data-testid="bezier-react-text"
+      data-testid="bezier-text"
       style="--b-text-color: var(--txt-black-dark);"
     >
       +1
@@ -108,71 +108,71 @@ exports[`AvatarGroup Ellipsis type - Icon Snapshot 1`] = `
   <div
     class="Avatar size-24"
     data-disabled="false"
-    data-testid="bezier-react-avatar-wrapper"
+    data-testid="bezier-avatar-wrapper"
   >
     <div
       aria-label="Christian Nwamba"
       class="SmoothCornersBox AvatarImage"
       data-state="disabled"
-      data-testid="bezier-react-avatar"
+      data-testid="bezier-avatar"
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
     />
   </div>
   <div
     class="Avatar size-24"
     data-disabled="false"
-    data-testid="bezier-react-avatar-wrapper"
+    data-testid="bezier-avatar-wrapper"
   >
     <div
       aria-label="Kola Tioluwani"
       class="SmoothCornersBox AvatarImage"
       data-state="disabled"
-      data-testid="bezier-react-avatar"
+      data-testid="bezier-avatar"
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
     />
   </div>
   <div
     class="Avatar size-24"
     data-disabled="false"
-    data-testid="bezier-react-avatar-wrapper"
+    data-testid="bezier-avatar-wrapper"
   >
     <div
       aria-label="Kent Dodds"
       class="SmoothCornersBox AvatarImage"
       data-state="disabled"
-      data-testid="bezier-react-avatar"
+      data-testid="bezier-avatar"
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
     />
   </div>
   <div
     class="Avatar size-24"
     data-disabled="false"
-    data-testid="bezier-react-avatar-wrapper"
+    data-testid="bezier-avatar-wrapper"
   >
     <div
       aria-label="Ryan Florence"
       class="SmoothCornersBox AvatarImage"
       data-state="disabled"
-      data-testid="bezier-react-avatar"
+      data-testid="bezier-avatar"
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
     />
   </div>
   <div
     class="Avatar size-24"
     data-disabled="false"
-    data-testid="bezier-react-avatar-wrapper"
+    data-testid="bezier-avatar-wrapper"
   >
     <div
       aria-label="Dan Abrahmov"
       class="SmoothCornersBox AvatarImage"
       data-state="disabled"
-      data-testid="bezier-react-avatar"
+      data-testid="bezier-avatar"
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
     />
   </div>
   <div
     class="AvatarEllipsisIconWrapper"
-    data-testid="bezier-react-avatar-group-ellipsis-icon"
+    data-testid="bezier-avatar-group-ellipsis-icon"
   >
     <div
       class="SmoothCornersBox AvatarEllipsisIcon"
@@ -181,7 +181,7 @@ exports[`AvatarGroup Ellipsis type - Icon Snapshot 1`] = `
     >
       <svg
         class="Icon margin"
-        data-testid="bezier-react-icon"
+        data-testid="bezier-icon"
         fill="none"
         height="16"
         style="--b-icon-color: var(--bgtxt-absolute-white-dark);"
@@ -200,13 +200,13 @@ exports[`AvatarGroup Ellipsis type - Icon Snapshot 1`] = `
     <div
       class="Avatar size-24"
       data-disabled="false"
-      data-testid="bezier-react-avatar-wrapper"
+      data-testid="bezier-avatar-wrapper"
     >
       <div
         aria-label="Prosper Otemuyiwa"
         class="SmoothCornersBox AvatarImage"
         data-state="disabled"
-        data-testid="bezier-react-avatar"
+        data-testid="bezier-avatar"
         style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bg-white-normal); --b-smooth-corners-box-background-image: url(https://www.google.com);"
       />
     </div>

--- a/packages/bezier-react/src/components/Badge/Badge.tsx
+++ b/packages/bezier-react/src/components/Badge/Badge.tsx
@@ -23,7 +23,7 @@ import { type BadgeProps } from './Badge.types'
 
 import styles from './Badge.module.scss'
 
-export const BADGE_TEST_ID = 'bezier-react-badge'
+export const BADGE_TEST_ID = 'bezier-badge'
 
 /**
  * `Badge` is a component for representing badge, which consists of text and icon.
@@ -44,7 +44,6 @@ export const Badge = memo(forwardRef<HTMLDivElement, BadgeProps>(function Badge(
   icon,
   children,
   className,
-  testId = BADGE_TEST_ID,
   ...rest
 }, forwardedRef) {
   return (
@@ -57,7 +56,7 @@ export const Badge = memo(forwardRef<HTMLDivElement, BadgeProps>(function Badge(
         commonStyles[`size-${size}`],
         className,
       )}
-      data-testid={testId}
+      data-testid={BADGE_TEST_ID}
       {...rest}
     >
       { icon && (

--- a/packages/bezier-react/src/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/packages/bezier-react/src/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -3,6 +3,6 @@
 exports[`Badge test > Snapshot > 1`] = `
 <div
   class="Badge variant-Default TagBadge size-m"
-  data-testid="bezier-react-badge"
+  data-testid="bezier-badge"
 />
 `;

--- a/packages/bezier-react/src/components/Banner/Banner.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.tsx
@@ -30,7 +30,7 @@ import {
 
 import styles from './Banner.module.scss'
 
-const BANNER_TEST_ID = 'bezier-react-banner'
+const BANNER_TEST_ID = 'bezier-banner'
 
 function getActionButtonColorVariant(variant: BannerVariant) {
   return ({
@@ -80,7 +80,6 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner({
   renderLink = externalLinkRenderer,
   actionIcon,
   onClickAction,
-  testId = BANNER_TEST_ID,
   ...rest
 }, forwardedRef) {
   if (isIconName(icon)) {
@@ -95,7 +94,7 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner({
         styles[`variant-${variant}`],
         className,
       )}
-      data-testid={testId}
+      data-testid={BANNER_TEST_ID}
       {...rest}
     >
       { !isNil(icon) && (

--- a/packages/bezier-react/src/components/Box/Box.tsx
+++ b/packages/bezier-react/src/components/Box/Box.tsx
@@ -44,7 +44,6 @@ export const Box = forwardRef<HTMLElement, BoxProps>(function Box(props, forward
     className,
     as = 'div',
     display,
-    testId = 'bezier-react-box',
     ...rest
   } = layoutRest
 
@@ -66,7 +65,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(function Box(props, forward
       layoutStyles.className,
       className,
     ),
-    'data-testid': testId,
+    'data-testid': 'bezier-box',
     ...rest,
   }, children)
 })

--- a/packages/bezier-react/src/components/Button/Button.tsx
+++ b/packages/bezier-react/src/components/Button/Button.tsx
@@ -34,7 +34,7 @@ import {
 
 import styles from './Button.module.scss'
 
-export const BUTTON_TEST_ID = 'bezier-react-button'
+export const BUTTON_TEST_ID = 'bezier-button'
 
 function getTypography(size: ButtonSize) {
   return ({
@@ -100,7 +100,6 @@ function ButtonSideContent({
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button({
   as = 'button',
   className,
-  testId = BUTTON_TEST_ID,
   type = 'button',
   text,
   disabled = false,
@@ -139,9 +138,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
         className,
       )}
       disabled={disabled}
-      data-testid={testId}
-      data-component="BezierButton"
       onClick={handleClick}
+      data-component="BezierButton"
+      data-testid={BUTTON_TEST_ID}
       {...rest}
     >
       <div

--- a/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.test.tsx
@@ -28,7 +28,7 @@ describe('ButtonGroup', () => {
       <ButtonGroup
         {...props}
         withoutSpacing
-        testId="button-group"
+        data-testid="button-group"
       >
         <Button text="button1" />
         <Button text="button2" />

--- a/packages/bezier-react/src/components/Center/Center.tsx
+++ b/packages/bezier-react/src/components/Center/Center.tsx
@@ -34,7 +34,6 @@ export const Center = forwardRef<HTMLDivElement, CenterProps>(function Center(pr
     style,
     className,
     display = 'flex',
-    testId = 'bezier-react-center',
     ...rest
   } = layoutRest
 
@@ -53,7 +52,7 @@ export const Center = forwardRef<HTMLDivElement, CenterProps>(function Center(pr
         layoutStyles.className,
         className,
       )}
-      data-testid={testId}
+      data-testid="bezier-center"
       {...rest}
     >
       { children }

--- a/packages/bezier-react/src/components/Divider/Divider.tsx
+++ b/packages/bezier-react/src/components/Divider/Divider.tsx
@@ -7,7 +7,7 @@ import { type DividerProps } from './Divider.types'
 
 import styles from './Divider.module.scss'
 
-export const DIVIDER_TEST_ID = 'bezier-react-divider'
+export const DIVIDER_TEST_ID = 'bezier-divider'
 
 /**
  * `Divider` is a component to visually or semantically separate content.
@@ -22,7 +22,6 @@ export const DIVIDER_TEST_ID = 'bezier-react-divider'
 export const Divider = forwardRef<HTMLDivElement, DividerProps>(({
   orientation = 'horizontal',
   decorative,
-  testId = DIVIDER_TEST_ID,
   withoutSideIndent = false,
   withoutParallelIndent = false,
   withoutIndent = false,
@@ -38,7 +37,6 @@ export const Divider = forwardRef<HTMLDivElement, DividerProps>(({
   >
     <div
       ref={forwardedRef}
-      data-testid={testId}
       style={style}
       className={classNames(
         styles.Divider,
@@ -49,6 +47,7 @@ export const Divider = forwardRef<HTMLDivElement, DividerProps>(({
         withoutSideIndent && styles['without-side-indent'],
         className,
       )}
+      data-testid={DIVIDER_TEST_ID}
       {...rest}
     />
   </SeparatorPrimitive.Root>

--- a/packages/bezier-react/src/components/Emoji/Emoji.tsx
+++ b/packages/bezier-react/src/components/Emoji/Emoji.tsx
@@ -14,7 +14,7 @@ import {
 
 import styles from './Emoji.module.scss'
 
-export const EMOJI_TEST_ID = 'bezier-react-emoji'
+export const EMOJI_TEST_ID = 'bezier-emoji'
 
 /**
  * `Emoji` is a component for representing emoji with variant size.
@@ -33,13 +33,11 @@ export const Emoji = forwardRef<HTMLDivElement, EmojiProps>(function Emoji({
   className,
   name,
   size = EmojiSize.Size24,
-  testId = EMOJI_TEST_ID,
   ...rest
 }, forwardedRef) {
   return (
     <div
       ref={forwardedRef}
-      data-testid={testId}
       role="img"
       aria-label={name}
       style={{
@@ -51,6 +49,7 @@ export const Emoji = forwardRef<HTMLDivElement, EmojiProps>(function Emoji({
         styles[`size-${size}`],
         className,
       )}
+      data-testid={EMOJI_TEST_ID}
       {...rest}
     />
   )

--- a/packages/bezier-react/src/components/Emoji/__snapshots__/Emoji.test.tsx.snap
+++ b/packages/bezier-react/src/components/Emoji/__snapshots__/Emoji.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Emoji Test > snapshot 1`] = `
 <div
   aria-label="a"
   class="Emoji size-24"
-  data-testid="bezier-react-emoji"
+  data-testid="bezier-emoji"
   role="img"
   style="--b-emoji-background-image: url(https://cf.exp.channel.io/asset/emoji/images/80/a.png);"
 />

--- a/packages/bezier-react/src/components/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/FormControl/FormControl.tsx
@@ -40,12 +40,11 @@ const [
 
 export { useFormControlContext }
 
-export const FORM_CONTROL_TEST_ID = 'bezier-react-form-control'
+export const FORM_CONTROL_TEST_ID = 'bezier-form-control'
 
 const Container = forwardRef<HTMLElement, ContainerProps>(function Container({
   labelPosition,
   children,
-  testId,
   className,
   ...rest
 }, forwardedRef) {
@@ -53,11 +52,10 @@ const Container = forwardRef<HTMLElement, ContainerProps>(function Container({
     case 'top':
       return (
         <Stack
-          {...rest}
           className={className}
           ref={forwardedRef}
           direction="vertical"
-          testId={testId}
+          {...rest}
         >
           { children }
         </Stack>
@@ -67,13 +65,12 @@ const Container = forwardRef<HTMLElement, ContainerProps>(function Container({
     default:
       return (
         <div
-          {...rest}
           ref={forwardedRef as React.ForwardedRef<HTMLDivElement>}
           className={classNames(
             styles.Grid,
             className,
           )}
-          data-testid={testId}
+          {...rest}
         >
           { children }
         </div>
@@ -84,7 +81,6 @@ const Container = forwardRef<HTMLElement, ContainerProps>(function Container({
 export const FormControl = forwardRef<HTMLElement, FormControlProps>(function FormControl({
   children,
   id: idProp,
-  testId = FORM_CONTROL_TEST_ID,
   labelPosition = 'top',
   size = 'm',
   hasError,
@@ -226,8 +222,8 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(function Fo
       <Container
         {...rest}
         ref={forwardedRef}
-        testId={testId}
         labelPosition={labelPosition}
+        data-testid={FORM_CONTROL_TEST_ID}
       >
         { children }
       </Container>

--- a/packages/bezier-react/src/components/FormControl/__snapshots__/FormControl.test.tsx.snap
+++ b/packages/bezier-react/src/components/FormControl/__snapshots__/FormControl.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
 <div>
   <div
     class="Stack display-flex direction-vertical margin layout"
-    data-testid="bezier-react-form-control"
+    data-testid="bezier-form-control"
   >
     <label
       class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
-      data-testid="bezier-react-form-label"
+      data-testid="bezier-form-label"
       id="form-label"
       style="--b-text-color: var(--txt-black-darkest);"
     >
@@ -18,18 +18,18 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       aria-describedby="form-help-text"
       aria-labelledby="form-label"
       class="Stack display-flex direction-vertical justify-start align-stretch wrap margin layout"
-      data-testid="bezier-react-form-group"
+      data-testid="bezier-form-group"
       id="form-group"
       role="group"
       style="--b-stack-spacing: 6px;"
     >
       <div
         class="Stack display-flex direction-vertical margin layout"
-        data-testid="bezier-react-form-control"
+        data-testid="bezier-form-control"
       >
         <label
           class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
-          data-testid="bezier-react-form-label"
+          data-testid="bezier-form-label"
           for="field-:r3:"
           id="field-:r3:-label"
           style="--b-text-color: var(--txt-black-darkest);"
@@ -38,7 +38,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         </label>
         <div
           class="TextFieldWrapper variant-primary size-m size-m"
-          data-testid="bezier-react-text-input"
+          data-testid="bezier-text-input"
         >
           <input
             autocomplete="off"
@@ -51,11 +51,11 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
       </div>
       <div
         class="Stack display-flex direction-vertical margin layout"
-        data-testid="bezier-react-form-control"
+        data-testid="bezier-form-control"
       >
         <label
           class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
-          data-testid="bezier-react-form-label"
+          data-testid="bezier-form-label"
           for="field-:r4:"
           id="field-:r4:-label"
           style="--b-text-color: var(--txt-black-darkest);"
@@ -64,7 +64,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
         </label>
         <div
           class="TextFieldWrapper variant-primary size-m size-m"
-          data-testid="bezier-react-text-input"
+          data-testid="bezier-text-input"
         >
           <input
             aria-invalid="true"
@@ -79,7 +79,7 @@ exports[`FormControl > Snapshot > With multiple field 1`] = `
     </div>
     <p
       class="Text typo-13 align-left margin FormHelperText FormHelperTextWrapper"
-      data-testid="bezier-react-form-helper-text"
+      data-testid="bezier-form-helper-text"
       id="form-help-text"
       style="--b-text-color: var(--txt-black-dark);"
     >
@@ -93,11 +93,11 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 <div>
   <div
     class="Grid"
-    data-testid="bezier-react-form-control"
+    data-testid="bezier-form-control"
   >
     <label
       class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left size-m"
-      data-testid="bezier-react-form-label"
+      data-testid="bezier-form-label"
       id="form-label"
       style="--b-text-color: var(--txt-black-darkest);"
     >
@@ -107,18 +107,18 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       aria-describedby="form-help-text"
       aria-labelledby="form-label"
       class="Stack display-flex direction-vertical justify-start align-stretch wrap margin layout"
-      data-testid="bezier-react-form-group"
+      data-testid="bezier-form-group"
       id="form-group"
       role="group"
       style="--b-stack-spacing: 6px;"
     >
       <div
         class="Stack display-flex direction-vertical margin layout"
-        data-testid="bezier-react-form-control"
+        data-testid="bezier-form-control"
       >
         <label
           class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
-          data-testid="bezier-react-form-label"
+          data-testid="bezier-form-label"
           for="field-:r6:"
           id="field-:r6:-label"
           style="--b-text-color: var(--txt-black-darkest);"
@@ -127,7 +127,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         </label>
         <div
           class="TextFieldWrapper variant-primary size-m size-m"
-          data-testid="bezier-react-text-input"
+          data-testid="bezier-text-input"
         >
           <input
             autocomplete="off"
@@ -140,11 +140,11 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
       </div>
       <div
         class="Stack display-flex direction-vertical margin layout"
-        data-testid="bezier-react-form-control"
+        data-testid="bezier-form-control"
       >
         <label
           class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
-          data-testid="bezier-react-form-label"
+          data-testid="bezier-form-label"
           for="field-:r7:"
           id="field-:r7:-label"
           style="--b-text-color: var(--txt-black-darkest);"
@@ -153,7 +153,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
         </label>
         <div
           class="TextFieldWrapper variant-primary size-m size-m"
-          data-testid="bezier-react-text-input"
+          data-testid="bezier-text-input"
         >
           <input
             aria-invalid="true"
@@ -168,7 +168,7 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
     </div>
     <p
       class="Text typo-13 align-left margin FormHelperText FormHelperTextWrapper position-left"
-      data-testid="bezier-react-form-helper-text"
+      data-testid="bezier-form-helper-text"
       id="form-help-text"
       style="--b-text-color: var(--txt-black-dark);"
     >
@@ -181,11 +181,11 @@ exports[`FormControl > Snapshot > With multiple field and left label position 1`
 exports[`FormControl > Snapshot > With single field 1`] = `
 <div
   class="Stack display-flex direction-vertical margin layout"
-  data-testid="bezier-react-form-control"
+  data-testid="bezier-form-control"
 >
   <label
     class="Text typo-13 bold align-left margin LabelText FormLabelWrapper position-top size-m"
-    data-testid="bezier-react-form-label"
+    data-testid="bezier-form-label"
     for="form"
     id="form-label"
     style="--b-text-color: var(--txt-black-darkest);"
@@ -194,7 +194,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   </label>
   <div
     class="TextFieldWrapper variant-primary size-m size-m"
-    data-testid="bezier-react-text-input"
+    data-testid="bezier-text-input"
   >
     <input
       aria-describedby="form-help-text"
@@ -207,7 +207,7 @@ exports[`FormControl > Snapshot > With single field 1`] = `
   </div>
   <p
     class="Text typo-13 align-left margin FormHelperText FormHelperTextWrapper"
-    data-testid="bezier-react-form-helper-text"
+    data-testid="bezier-form-helper-text"
     id="form-help-text"
     style="--b-text-color: var(--txt-black-dark);"
   >
@@ -219,11 +219,11 @@ exports[`FormControl > Snapshot > With single field 1`] = `
 exports[`FormControl > Snapshot > With single field and left label position 1`] = `
 <div
   class="Grid"
-  data-testid="bezier-react-form-control"
+  data-testid="bezier-form-control"
 >
   <label
     class="Text typo-14 bold align-left margin LabelText FormLabelWrapper position-left size-m"
-    data-testid="bezier-react-form-label"
+    data-testid="bezier-form-label"
     for="form"
     id="form-label"
     style="--b-text-color: var(--txt-black-darkest);"
@@ -232,7 +232,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   </label>
   <div
     class="TextFieldWrapper variant-primary size-m size-m"
-    data-testid="bezier-react-text-input"
+    data-testid="bezier-text-input"
   >
     <input
       aria-describedby="form-help-text"
@@ -245,7 +245,7 @@ exports[`FormControl > Snapshot > With single field and left label position 1`] 
   </div>
   <p
     class="Text typo-13 align-left margin FormHelperText FormHelperTextWrapper position-left"
-    data-testid="bezier-react-form-helper-text"
+    data-testid="bezier-form-helper-text"
     id="form-help-text"
     style="--b-text-color: var(--txt-black-dark);"
   >

--- a/packages/bezier-react/src/components/FormGroup/FormGroup.tsx
+++ b/packages/bezier-react/src/components/FormGroup/FormGroup.tsx
@@ -8,10 +8,9 @@ import { Stack } from '~/src/components/Stack'
 
 import { type FormGroupProps } from './FormGroup.types'
 
-const FORM_GROUP_TEST_ID = 'bezier-react-form-group'
+const FORM_GROUP_TEST_ID = 'bezier-form-group'
 
 export const FormGroup = forwardRef<HTMLDivElement, FormGroupProps>(function FormGroup({
-  testId = FORM_GROUP_TEST_ID,
   spacing = 6,
   direction = 'vertical',
   role = 'group',
@@ -32,8 +31,7 @@ export const FormGroup = forwardRef<HTMLDivElement, FormGroupProps>(function For
 
   return (
     <Stack
-      {...ownProps}
-      data-testid={testId}
+      data-testid={FORM_GROUP_TEST_ID}
       ref={mergedRef}
       wrap
       justify="start"
@@ -41,6 +39,7 @@ export const FormGroup = forwardRef<HTMLDivElement, FormGroupProps>(function For
       spacing={spacing}
       direction={direction}
       role={role}
+      {...ownProps}
     >
       { children }
     </Stack>

--- a/packages/bezier-react/src/components/FormGroup/__snapshots__/FormGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/FormGroup/__snapshots__/FormGroup.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FormGroup > Snapshot > 1`] = `
 <div
   class="Stack display-flex direction-vertical justify-start align-stretch wrap margin layout"
-  data-testid="bezier-react-form-group"
+  data-testid="bezier-form-group"
   role="group"
   style="--b-stack-spacing: 6px;"
 />

--- a/packages/bezier-react/src/components/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/FormHelperText/FormHelperText.tsx
@@ -17,8 +17,8 @@ import type {
 
 import styles from './FormHelperText.module.scss'
 
-export const FORM_HELPER_TEXT_TEST_ID = 'bezier-react-form-helper-text'
-export const FORM_ERROR_MESSAGE_TEST_ID = 'bezier-react-form-error-message'
+export const FORM_HELPER_TEXT_TEST_ID = 'bezier-form-helper-text'
+export const FORM_ERROR_MESSAGE_TEST_ID = 'bezier-form-error-message'
 
 const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function BaseHelperText(props, forwardedRef) {
   const {
@@ -84,7 +84,6 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function
  */
 export const FormHelperText = forwardRef<HTMLSpanElement, FormHelperTextProps>(function FormHelperText(props, forwardedRef) {
   const {
-    testId = FORM_HELPER_TEXT_TEST_ID,
     color = 'txt-black-dark',
     children,
     ...rest
@@ -92,11 +91,11 @@ export const FormHelperText = forwardRef<HTMLSpanElement, FormHelperTextProps>(f
 
   return (
     <BaseHelperText
-      {...rest}
       type="info"
       ref={forwardedRef}
-      testId={testId}
       color={color}
+      data-testid={FORM_HELPER_TEXT_TEST_ID}
+      {...rest}
     >
       { children }
     </BaseHelperText>
@@ -121,7 +120,6 @@ export const FormHelperText = forwardRef<HTMLSpanElement, FormHelperTextProps>(f
  */
 export const FormErrorMessage = forwardRef<HTMLSpanElement, FormErrorMessageProps>(function FormErrorMessage(props, forwardedRef) {
   const {
-    testId = FORM_ERROR_MESSAGE_TEST_ID,
     color = 'bgtxt-orange-normal',
     children,
     ...rest
@@ -129,12 +127,12 @@ export const FormErrorMessage = forwardRef<HTMLSpanElement, FormErrorMessageProp
 
   return (
     <BaseHelperText
-      {...rest}
       aria-live="polite"
       type="error"
       ref={forwardedRef}
-      testId={testId}
       color={color}
+      data-testid={FORM_ERROR_MESSAGE_TEST_ID}
+      {...rest}
     >
       { children }
     </BaseHelperText>

--- a/packages/bezier-react/src/components/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
+++ b/packages/bezier-react/src/components/FormHelperText/__snapshots__/FormHelperText.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`FormErrorMessage > Snapshot > 1`] = `
 <p
   aria-live="polite"
   class="Text typo-13 align-left margin FormHelperText"
-  data-testid="bezier-react-form-error-message"
+  data-testid="bezier-form-error-message"
   id="test"
   style="--b-text-color: var(--bgtxt-orange-normal);"
 >
@@ -15,7 +15,7 @@ exports[`FormErrorMessage > Snapshot > 1`] = `
 exports[`FormHelperText > Snapshot > 1`] = `
 <p
   class="Text typo-13 align-left margin FormHelperText"
-  data-testid="bezier-react-form-helper-text"
+  data-testid="bezier-form-helper-text"
   id="test"
   style="--b-text-color: var(--txt-black-dark);"
 >

--- a/packages/bezier-react/src/components/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/FormLabel/FormLabel.tsx
@@ -17,7 +17,7 @@ import { type FormLabelProps } from './FormLabel.types'
 
 import styles from './FormLabel.module.scss'
 
-export const FORM_LABEL_TEST_ID = 'bezier-react-form-label'
+export const FORM_LABEL_TEST_ID = 'bezier-form-label'
 
 /**
  * `FormLabel` is a component to show label.
@@ -34,7 +34,6 @@ export const FORM_LABEL_TEST_ID = 'bezier-react-form-label'
  */
 export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function FormLabel(props, forwardedRef) {
   const {
-    testId = FORM_LABEL_TEST_ID,
     help,
     bold = true,
     color = 'txt-black-darkest',
@@ -77,11 +76,11 @@ export const FormLabel = forwardRef<HTMLLabelElement, FormLabelProps>(function F
         !HelpComponent && formControlClassName,
       )}
       ref={forwardedRef}
-      testId={testId}
       as="label"
       align="left"
       bold={bold}
       color={color}
+      data-testid={FORM_LABEL_TEST_ID}
       {...ownProps}
     >
       { children }

--- a/packages/bezier-react/src/components/FormLabel/__snapshots__/FormLabel.test.tsx.snap
+++ b/packages/bezier-react/src/components/FormLabel/__snapshots__/FormLabel.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FormLabel > Snapshot > 1`] = `
 <label
   class="Text typo-13 bold align-left margin LabelText"
-  data-testid="bezier-react-form-label"
+  data-testid="bezier-form-label"
   style="--b-text-color: var(--txt-black-darkest);"
 >
   label

--- a/packages/bezier-react/src/components/Help/Help.tsx
+++ b/packages/bezier-react/src/components/Help/Help.tsx
@@ -14,7 +14,7 @@ import { type HelpProps } from './Help.types'
 
 import styles from './Help.module.scss'
 
-export const HELP_TEST_ID = 'bezier-react-help'
+export const HELP_TEST_ID = 'bezier-help'
 export const HELP_DISPLAY_NAME = 'Help'
 
 export const Help = forwardRef<HTMLDivElement, HelpProps>(function Help({
@@ -32,10 +32,10 @@ export const Help = forwardRef<HTMLDivElement, HelpProps>(function Help({
       <div className={styles.Help}>
         <Icon
           className={styles.Icon}
-          testId={HELP_TEST_ID}
           source={HelpFilledIcon}
           size={IconSize.XS}
           color="txt-black-dark"
+          data-testid={HELP_TEST_ID}
         />
       </div>
     </Tooltip>

--- a/packages/bezier-react/src/components/Help/__snapshots__/Help.test.tsx.snap
+++ b/packages/bezier-react/src/components/Help/__snapshots__/Help.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Help > Snapshot > 1`] = `
 <svg
   class="Icon margin Icon"
-  data-testid="bezier-react-help"
+  data-testid="bezier-help"
   fill="none"
   height="16"
   style="--b-icon-color: var(--txt-black-dark);"

--- a/packages/bezier-react/src/components/Icon/Icon.tsx
+++ b/packages/bezier-react/src/components/Icon/Icon.tsx
@@ -18,7 +18,7 @@ import {
 
 import styles from './Icon.module.scss'
 
-export const ICON_TEST_ID = 'bezier-react-icon'
+export const ICON_TEST_ID = 'bezier-icon'
 
 export const Icon = memo(forwardRef<SVGSVGElement, IconProps>(function Icon(
   props,
@@ -28,7 +28,6 @@ export const Icon = memo(forwardRef<SVGSVGElement, IconProps>(function Icon(
   const marginStyles = getMarginStyles(marginProps)
 
   const {
-    testId = ICON_TEST_ID,
     className,
     size = IconSize.Normal,
     color,
@@ -52,7 +51,7 @@ export const Icon = memo(forwardRef<SVGSVGElement, IconProps>(function Icon(
       )}
       width={size}
       height={size}
-      data-testid={testId}
+      data-testid={ICON_TEST_ID}
       {...rest}
     />
   )

--- a/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.tsx
+++ b/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.tsx
@@ -51,7 +51,7 @@ function KeyItem({
             size={IconSize.S}
             source={icon}
             color="txt-black-dark"
-            testId={KEY_VALUE_ITEM_KEY_ICON_TEST_ID}
+            data-testid={KEY_VALUE_ITEM_KEY_ICON_TEST_ID}
           />
         )
         : icon }
@@ -137,21 +137,20 @@ export const KeyValueItem = forwardRef<HTMLDivElement, KeyValueItemProps>(functi
   keyContent,
   actions,
   children,
-  testId = KEY_VALUE_ITEM_TEST_ID,
   onClickKey,
   onClickValue,
-  ...props
+  ...rest
 }, forwardedRef) {
   return (
     <div
-      {...props}
       className={classNames(
         styles.KeyValueItem,
         styles.singleline,
         className,
       )}
       ref={forwardedRef}
-      data-testid={testId}
+      data-testid={KEY_VALUE_ITEM_TEST_ID}
+      {...rest}
     >
       { /* Since it allows for click interaction, it should be interactive content,
         but since it has a button element nested inside it, this is bad HTML markup.
@@ -202,21 +201,20 @@ export const KeyValueMultiLineItem = forwardRef<HTMLDivElement, KeyValueItemProp
   keyIcon,
   keyContent,
   actions,
-  testId = KEY_VALUE_ITEM_TEST_ID,
   onClickKey,
   onClickValue,
-  ...props
+  ...rest
 }, forwardedRef) {
   return (
     <div
-      {...props}
       className={classNames(
         styles.KeyValueItem,
         styles.multiline,
         className,
       )}
       ref={forwardedRef}
-      data-testid={testId}
+      data-testid={KEY_VALUE_ITEM_TEST_ID}
+      {...rest}
     >
       { /* Since it allows for click interaction, it should be interactive content,
         but since it has a button element nested inside it, this is bad HTML markup.

--- a/packages/bezier-react/src/components/LegacyStack/LegacyHStack/LegacyHStack.test.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyHStack/LegacyHStack.test.tsx
@@ -9,7 +9,7 @@ import { LegacyHStack } from './LegacyHStack'
 
 describe('HStack', () => {
   it('creates a horizontal flexbox', () => {
-    const { getByTestId } = render(<LegacyHStack testId="h-stack" />)
+    const { getByTestId } = render(<LegacyHStack data-testid="h-stack" />)
 
     expect(getByTestId('h-stack')).toHaveClass(styles['direction-horizontal'])
   })

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.test.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.test.tsx
@@ -11,19 +11,19 @@ import styles from './LegacyStack.module.scss'
 describe('Stack', () => {
   describe('Flex layout', () => {
     it('creates a flexbox', () => {
-      const { getByTestId } = render(<LegacyStack direction="horizontal" testId="stack" />)
+      const { getByTestId } = render(<LegacyStack direction="horizontal" data-testid="stack" />)
 
       expect(getByTestId('stack')).toHaveClass(styles.LegacyStack)
     })
 
     it('creates a horizontal flexbox when given direction="horizontal"', () => {
-      const { getByTestId } = render(<LegacyStack direction="horizontal" testId="stack" />)
+      const { getByTestId } = render(<LegacyStack direction="horizontal" data-testid="stack" />)
 
       expect(getByTestId('stack')).toHaveClass(styles['direction-horizontal'])
     })
 
     it('creates a vertical flexbox when given direction="vertical"', () => {
-      const { getByTestId } = render(<LegacyStack direction="vertical" testId="stack" />)
+      const { getByTestId } = render(<LegacyStack direction="vertical" data-testid="stack" />)
 
       expect(getByTestId('stack')).toHaveClass(styles['direction-vertical'])
     })
@@ -31,19 +31,19 @@ describe('Stack', () => {
 
   describe('Supports BezierComponentProps interface', () => {
     it('supports as prop', () => {
-      const { getByTestId } = render(<LegacyStack direction="horizontal" testId="stack" as="main" />)
+      const { getByTestId } = render(<LegacyStack direction="horizontal" data-testid="stack" as="main" />)
 
       expect(getByTestId('stack').tagName).toBe('MAIN')
     })
 
     it('supports style prop', () => {
-      const { getByTestId } = render(<LegacyStack direction="horizontal" testId="stack" style={{ backgroundColor: 'red' }} />)
+      const { getByTestId } = render(<LegacyStack direction="horizontal" data-testid="stack" style={{ backgroundColor: 'red' }} />)
 
       expect(getByTestId('stack')).toHaveStyle({ 'background-color': 'red' })
     })
 
     it('supports className prop', () => {
-      const { getByTestId } = render(<LegacyStack direction="horizontal" testId="stack" className="foo" />)
+      const { getByTestId } = render(<LegacyStack direction="horizontal" data-testid="stack" className="foo" />)
 
       expect(getByTestId('stack')).toHaveClass('foo')
     })
@@ -54,9 +54,9 @@ describe('Stack', () => {
 
     const { getByTestId } = render(
       <LegacyStack direction="horizontal" spacing={spacing}>
-        <LegacyStackItem testId="one" />
-        <LegacyStackItem testId="two" />
-        <LegacyStackItem testId="three" />
+        <LegacyStackItem data-testid="one" />
+        <LegacyStackItem data-testid="two" />
+        <LegacyStackItem data-testid="three" />
       </LegacyStack>,
     )
 
@@ -73,9 +73,9 @@ describe('Stack', () => {
         { false }
         { null }
         abc
-        <LegacyStackItem testId="one" />
-        <LegacyStackItem testId="two" />
-        <LegacyStackItem testId="three" />
+        <LegacyStackItem data-testid="one" />
+        <LegacyStackItem data-testid="two" />
+        <LegacyStackItem data-testid="three" />
       </LegacyStack>,
     )
 

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.tsx
@@ -33,7 +33,6 @@ import styles from './LegacyStack.module.scss'
  */
 export const LegacyStack = forwardRef<HTMLElement, LegacyStackProps>(function Stack({
   as = 'div',
-  testId = 'bezier-legacy-stack',
   className,
   children,
   direction,
@@ -55,7 +54,7 @@ export const LegacyStack = forwardRef<HTMLElement, LegacyStackProps>(function St
         className,
       )}
       ref={forwardedRef}
-      data-testid={testId}
+      data-testid="bezier-legacy-stack"
       {...rest}
     >
       { Children.map(

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.test.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.test.tsx
@@ -11,19 +11,19 @@ import styles from './LegacyStackItem.module.scss'
 describe('StackItem', () => {
   describe('Supports BezierComponentProps interface', () => {
     it('supports as prop', () => {
-      const { getByTestId } = render(<LegacyStackItem testId="stack-item" as="main" />)
+      const { getByTestId } = render(<LegacyStackItem data-testid="stack-item" as="main" />)
 
       expect(getByTestId('stack-item').tagName).toBe('MAIN')
     })
 
     it('supports style prop', () => {
-      const { getByTestId } = render(<LegacyStackItem testId="stack-item" style={{ color: 'blue' }} />)
+      const { getByTestId } = render(<LegacyStackItem data-testid="stack-item" style={{ color: 'blue' }} />)
 
       expect(getByTestId('stack-item')).toHaveStyle({ color: 'blue' })
     })
 
     it('supports className prop', () => {
-      const { getByTestId } = render(<LegacyStackItem testId="stack-item" className="foo" />)
+      const { getByTestId } = render(<LegacyStackItem data-testid="stack-item" className="foo" />)
 
       expect(getByTestId('stack-item')).toHaveClass('foo')
     })
@@ -32,7 +32,7 @@ describe('StackItem', () => {
   it('inherits main axis alignment of parent stack-item component', () => {
     const { getByTestId } = render(
       <LegacyStack direction="horizontal" justify="start">
-        <LegacyStackItem testId="item">
+        <LegacyStackItem data-testid="item">
           <div />
         </LegacyStackItem>
       </LegacyStack>,
@@ -44,19 +44,19 @@ describe('StackItem', () => {
   it('can override main axis alignment of parent stack component', () => {
     const { getByTestId } = render(
       <LegacyStack direction="horizontal" justify="start">
-        <LegacyStackItem testId="item-start" justify="start">
+        <LegacyStackItem data-testid="item-start" justify="start">
           <div />
         </LegacyStackItem>
 
-        <LegacyStackItem testId="item-center" justify="center">
+        <LegacyStackItem data-testid="item-center" justify="center">
           <div />
         </LegacyStackItem>
 
-        <LegacyStackItem testId="item-end" justify="end">
+        <LegacyStackItem data-testid="item-end" justify="end">
           <div />
         </LegacyStackItem>
 
-        <LegacyStackItem testId="item-stretch" justify="stretch">
+        <LegacyStackItem data-testid="item-stretch" justify="stretch">
           <div />
         </LegacyStackItem>
       </LegacyStack>,
@@ -71,7 +71,7 @@ describe('StackItem', () => {
   it('inherits cross axis alignment of parent stack component', () => {
     const { getByTestId } = render(
       <LegacyStack direction="horizontal" align="start">
-        <LegacyStackItem testId="item">
+        <LegacyStackItem data-testid="item">
           <div />
         </LegacyStackItem>
       </LegacyStack>,
@@ -83,19 +83,19 @@ describe('StackItem', () => {
   it('can override cross axis alignment of parent stack component', () => {
     const { getByTestId } = render(
       <LegacyStack direction="horizontal" align="center">
-        <LegacyStackItem testId="item-start" align="start">
+        <LegacyStackItem data-testid="item-start" align="start">
           <div />
         </LegacyStackItem>
 
-        <LegacyStackItem testId="item-center" align="center">
+        <LegacyStackItem data-testid="item-center" align="center">
           <div />
         </LegacyStackItem>
 
-        <LegacyStackItem testId="item-end" align="end">
+        <LegacyStackItem data-testid="item-end" align="end">
           <div />
         </LegacyStackItem>
 
-        <LegacyStackItem testId="item-stretch" align="stretch">
+        <LegacyStackItem data-testid="item-stretch" align="stretch">
           <div />
         </LegacyStackItem>
       </LegacyStack>,
@@ -121,10 +121,10 @@ describe('StackItem', () => {
 
       const { getByTestId } = render(
         <LegacyStack direction="horizontal">
-          <LegacyStackItem testId="one" />
-          <LegacyStackItem testId="two" grow shrink weight={1} />
-          <LegacyStackItem testId="three" marginBefore={16} shrink weight={2} />
-          <LegacyStackItem testId="four" style={{ color: 'red' }} marginAfter={20} size={32} />
+          <LegacyStackItem data-testid="one" />
+          <LegacyStackItem data-testid="two" grow shrink weight={1} />
+          <LegacyStackItem data-testid="three" marginBefore={16} shrink weight={2} />
+          <LegacyStackItem data-testid="four" style={{ color: 'red' }} marginAfter={20} size={32} />
         </LegacyStack>,
       )
 

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.tsx
@@ -54,7 +54,7 @@ export const LegacyStackItem = forwardRef<HTMLElement, LegacyStackItemProps>(fun
   shrink = false,
   marginBefore = 0,
   marginAfter = 0,
-  testId = 'bezier-legacy-stack-item',
+  ...rest
 }, forwardedRef) {
   const Comp = as
 
@@ -76,7 +76,8 @@ export const LegacyStackItem = forwardRef<HTMLElement, LegacyStackItemProps>(fun
         styles[`align-${align}`],
         className,
       )}
-      data-testid={testId}
+      data-testid="bezier-legacy-stack-item"
+      {...rest}
     >
       { children }
     </Comp>

--- a/packages/bezier-react/src/components/LegacyStack/LegacyVStack/LegacyVStack.test.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyVStack/LegacyVStack.test.tsx
@@ -9,7 +9,7 @@ import { LegacyVStack } from './LegacyVStack'
 
 describe('VStack', () => {
   it('creates a vertical flexbox', () => {
-    const { getByTestId } = render(<LegacyVStack testId="v-stack" />)
+    const { getByTestId } = render(<LegacyVStack data-testid="v-stack" />)
 
     expect(getByTestId('v-stack')).toHaveClass(styles['direction-vertical'])
   })

--- a/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltip.tsx
+++ b/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltip.tsx
@@ -19,8 +19,8 @@ import { LegacyTooltipContent } from './LegacyTooltipContent'
 
 import styles from './LegacyTooltip.module.scss'
 
-export const TOOLTIP_TEST_ID = 'bezier-react-tooltip'
-export const TOOLTIP_CONTENT_TEST_ID = 'bezier-react-tooltip-content'
+export const TOOLTIP_TEST_ID = 'bezier-tooltip'
+export const TOOLTIP_CONTENT_TEST_ID = 'bezier-tooltip-content'
 
 /**
  * @deprecated Use `Tooltip` instead. It may be removed in the next major version.
@@ -28,7 +28,6 @@ export const TOOLTIP_CONTENT_TEST_ID = 'bezier-react-tooltip-content'
 export const LegacyTooltip = memo(forwardRef(function LegacyTooltip(
   {
     as,
-    testId = TOOLTIP_TEST_ID,
     contentTestId = TOOLTIP_CONTENT_TEST_ID,
     className,
     contentStyle,
@@ -120,7 +119,7 @@ export const LegacyTooltip = memo(forwardRef(function LegacyTooltip(
           keepInContainer={keepInContainer}
           tooltipContainer={tooltipContainerRef.current}
           forwardedRef={forwardedRef}
-          testId={contentTestId}
+          data-testid={contentTestId}
         />
       )
     }
@@ -151,13 +150,13 @@ export const LegacyTooltip = memo(forwardRef(function LegacyTooltip(
   return (
     <div
       ref={tooltipContainerRef}
-      data-testid={testId}
       className={classNames(
         styles.LegacyTooltip,
         className,
       )}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      data-testid={TOOLTIP_TEST_ID}
       {...otherProps}
     >
       { children }

--- a/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltipContent.tsx
+++ b/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltipContent.tsx
@@ -87,8 +87,8 @@ export const LegacyTooltipContent: React.FC<LegacyTooltipContentProps> = ({
   tooltipContainer,
   offset = 4,
   allowHover = false,
-  testId,
   forwardedRef,
+  ...rest
 }) => {
   const { rootElement } = useWindow()
 
@@ -163,7 +163,7 @@ export const LegacyTooltipContent: React.FC<LegacyTooltipContentProps> = ({
               contentClassName,
             )}
             ref={mergedRef}
-            data-testid={testId}
+            {...rest}
           >
             <Text
               color="txt-black-darkest"

--- a/packages/bezier-react/src/components/LegacyTooltip/__snapshots__/LegacyTooltip.test.tsx.snap
+++ b/packages/bezier-react/src/components/LegacyTooltip/__snapshots__/LegacyTooltip.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Tooltip test > Tooltip with default props 1`] = `
   <div>
     <div
       class="LegacyTooltip"
-      data-testid="bezier-react-tooltip"
+      data-testid="bezier-tooltip"
     >
       Text
     </div>
@@ -17,16 +17,16 @@ exports[`Tooltip test > Tooltip with default props 1`] = `
   >
     <div
       class="LegacyTooltipContent"
-      data-testid="bezier-react-tooltip-content"
+      data-testid="bezier-tooltip-content"
     >
       <span
         class="Text typo-13 multi-line-truncated margin"
-        data-testid="bezier-react-text"
+        data-testid="bezier-text"
         style="--b-text-color: var(--txt-black-darkest); --b-text-line-clamp: 20;"
       >
         <span
           class="Text typo-14 margin"
-          data-testid="bezier-react-text"
+          data-testid="bezier-text"
         >
           Hovered
         </span>

--- a/packages/bezier-react/src/components/ListItem/ListItem.tsx
+++ b/packages/bezier-react/src/components/ListItem/ListItem.tsx
@@ -40,7 +40,6 @@ export const LIST_ITEM_TEST_ID = 'bezier-list-item'
 export const ListItem = forwardRef<ListItemRef, ListItemProps>(function ListItem({
   className,
   as,
-  testId = LIST_ITEM_TEST_ID,
   variant = ListItemVariant.Monochrome,
   size = ListItemSize.S,
   content,
@@ -60,7 +59,6 @@ export const ListItem = forwardRef<ListItemRef, ListItemProps>(function ListItem
 
   return (
     <Comp
-      {...rest}
       {...isLink && {
         href,
         draggable: false,
@@ -77,8 +75,9 @@ export const ListItem = forwardRef<ListItemRef, ListItemProps>(function ListItem
         className,
       )}
       ref={forwardedRef}
-      data-testid={testId}
       onClick={!disabled ? onClick : undefined}
+      data-testid={LIST_ITEM_TEST_ID}
+      {...rest}
     >
       <div className={styles.ListItemContent}>
         { !isNil(leftContent) && (

--- a/packages/bezier-react/src/components/NavGroup/NavGroup.tsx
+++ b/packages/bezier-react/src/components/NavGroup/NavGroup.tsx
@@ -22,11 +22,10 @@ import type { NavGroupProps } from './NavGroup.types'
 
 import styles from './NavGroup.module.scss'
 
-export const NAV_GROUP_TEST_ID = 'bezier-react-nav-group'
-export const NAV_GROUP_LEFT_ICON_TEST_ID = 'bezier-react-nav-group-left-icon'
+export const NAV_GROUP_TEST_ID = 'bezier-nav-group'
+export const NAV_GROUP_LEFT_ICON_TEST_ID = 'bezier-nav-group-left-icon'
 
 export const NavGroup = forwardRef<HTMLButtonElement, NavGroupProps>(function NavGroup({
-  testId = NAV_GROUP_TEST_ID,
   name,
   className,
   children,
@@ -59,20 +58,20 @@ export const NavGroup = forwardRef<HTMLButtonElement, NavGroupProps>(function Na
           active && commonStyles.active,
           className,
         )}
-        data-testid={testId}
         role="menuitem"
         aria-haspopup={hasChildren}
         aria-expanded={open}
         aria-controls={ariaName}
         onClick={handleClickItem}
+        data-testid={NAV_GROUP_TEST_ID}
         {...rest}
       >
         <div className={commonStyles.LeftIconWrapper}>
           <Icon
-            testId={NAV_GROUP_LEFT_ICON_TEST_ID}
             source={leftContent}
             size={IconSize.S}
             color={active ? 'bgtxt-blue-normal' : 'txt-black-dark'}
+            data-testid={NAV_GROUP_LEFT_ICON_TEST_ID}
           />
         </div>
 

--- a/packages/bezier-react/src/components/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`NavGroup Test > Snapshot > Active 1`] = `
   aria-controls="generalMenu"
   aria-haspopup="false"
   class="Item active"
-  data-testid="bezier-react-nav-group"
+  data-testid="bezier-nav-group"
   role="menuitem"
   type="button"
 >
@@ -14,7 +14,7 @@ exports[`NavGroup Test > Snapshot > Active 1`] = `
   >
     <svg
       class="Icon margin"
-      data-testid="bezier-react-nav-group-left-icon"
+      data-testid="bezier-nav-group-left-icon"
       fill="none"
       height="20"
       style="--b-icon-color: var(--bgtxt-blue-normal);"
@@ -32,7 +32,7 @@ exports[`NavGroup Test > Snapshot > Active 1`] = `
   </div>
   <span
     class="Text typo-14 truncated margin"
-    data-testid="bezier-react-text"
+    data-testid="bezier-text"
   >
     test-content
   </span>
@@ -41,7 +41,7 @@ exports[`NavGroup Test > Snapshot > Active 1`] = `
   >
     <svg
       class="Icon margin"
-      data-testid="bezier-react-icon"
+      data-testid="bezier-icon"
       fill="none"
       height="16"
       style="--b-icon-color: var(--bgtxt-orange-normal);"
@@ -65,7 +65,7 @@ exports[`NavGroup Test > Snapshot > Not active 1`] = `
   aria-controls="generalMenu"
   aria-haspopup="false"
   class="Item"
-  data-testid="bezier-react-nav-group"
+  data-testid="bezier-nav-group"
   role="menuitem"
   type="button"
 >
@@ -74,7 +74,7 @@ exports[`NavGroup Test > Snapshot > Not active 1`] = `
   >
     <svg
       class="Icon margin"
-      data-testid="bezier-react-nav-group-left-icon"
+      data-testid="bezier-nav-group-left-icon"
       fill="none"
       height="20"
       style="--b-icon-color: var(--txt-black-dark);"
@@ -92,7 +92,7 @@ exports[`NavGroup Test > Snapshot > Not active 1`] = `
   </div>
   <span
     class="Text typo-14 truncated margin"
-    data-testid="bezier-react-text"
+    data-testid="bezier-text"
   >
     test-content
   </span>
@@ -101,7 +101,7 @@ exports[`NavGroup Test > Snapshot > Not active 1`] = `
   >
     <svg
       class="Icon margin"
-      data-testid="bezier-react-icon"
+      data-testid="bezier-icon"
       fill="none"
       height="16"
       style="--b-icon-color: var(--bgtxt-orange-normal);"

--- a/packages/bezier-react/src/components/NavItem/NavItem.tsx
+++ b/packages/bezier-react/src/components/NavItem/NavItem.tsx
@@ -14,8 +14,8 @@ import type { NavItemProps } from './NavItem.types'
 
 import styles from './NavItem.module.scss'
 
-export const NAV_ITEM_TEST_ID = 'bezier-react-nav-item'
-export const NAV_ITEM_LEFT_ICON_TEST_ID = 'bezier-react-nav-item-left-icon'
+export const NAV_ITEM_TEST_ID = 'bezier-nav-item'
+export const NAV_ITEM_LEFT_ICON_TEST_ID = 'bezier-nav-item-left-icon'
 
 /**
  * `NavItem` is a component for an item where you can navigate to another link.
@@ -29,7 +29,6 @@ export const NAV_ITEM_LEFT_ICON_TEST_ID = 'bezier-react-nav-item-left-icon'
  * ```
  */
 export const NavItem = forwardRef<HTMLAnchorElement, NavItemProps>(function NavItem({
-  testId = NAV_ITEM_TEST_ID,
   name,
   style,
   className,
@@ -59,17 +58,17 @@ export const NavItem = forwardRef<HTMLAnchorElement, NavItemProps>(function NavI
           active && styles.active,
           className,
         )}
-        data-testid={testId}
         href={href}
         target={target}
         role="menuitem"
         onClick={handleClickItem}
+        data-testid={NAV_ITEM_TEST_ID}
         {...rest}
       >
         <div className={styles.LeftIconWrapper}>
           { leftContent && (
             <Icon
-              testId={NAV_ITEM_LEFT_ICON_TEST_ID}
+              data-testid={NAV_ITEM_LEFT_ICON_TEST_ID}
               source={leftContent}
               size={IconSize.S}
               color={active ? 'bgtxt-blue-normal' : 'txt-black-dark'}

--- a/packages/bezier-react/src/components/NavItem/__snapshots__/NavItem.test.tsx.snap
+++ b/packages/bezier-react/src/components/NavItem/__snapshots__/NavItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`NavItem Test > Snapshot > Active 1`] = `
 <a
   class="Item active"
-  data-testid="bezier-react-nav-item"
+  data-testid="bezier-nav-item"
   role="menuitem"
   target="_self"
 >
@@ -12,7 +12,7 @@ exports[`NavItem Test > Snapshot > Active 1`] = `
   >
     <svg
       class="Icon margin"
-      data-testid="bezier-react-nav-item-left-icon"
+      data-testid="bezier-nav-item-left-icon"
       fill="none"
       height="20"
       style="--b-icon-color: var(--bgtxt-blue-normal);"
@@ -30,7 +30,7 @@ exports[`NavItem Test > Snapshot > Active 1`] = `
   </div>
   <span
     class="Text typo-14 truncated margin"
-    data-testid="bezier-react-text"
+    data-testid="bezier-text"
   >
     test-content
   </span>
@@ -40,7 +40,7 @@ exports[`NavItem Test > Snapshot > Active 1`] = `
 exports[`NavItem Test > Snapshot > Not active 1`] = `
 <a
   class="Item"
-  data-testid="bezier-react-nav-item"
+  data-testid="bezier-nav-item"
   role="menuitem"
   target="_self"
 >
@@ -49,7 +49,7 @@ exports[`NavItem Test > Snapshot > Not active 1`] = `
   >
     <svg
       class="Icon margin"
-      data-testid="bezier-react-nav-item-left-icon"
+      data-testid="bezier-nav-item-left-icon"
       fill="none"
       height="20"
       style="--b-icon-color: var(--txt-black-dark);"
@@ -67,7 +67,7 @@ exports[`NavItem Test > Snapshot > Not active 1`] = `
   </div>
   <span
     class="Text typo-14 truncated margin"
-    data-testid="bezier-react-text"
+    data-testid="bezier-text"
   >
     test-content
   </span>

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
@@ -36,7 +36,7 @@ const [
 
 const DEFAULT_INDENT = 16
 
-export const OUTLINE_ITEM_TEST_ID = 'bezier-react-outline-item'
+export const OUTLINE_ITEM_TEST_ID = 'bezier-outline-item'
 
 export const OutlineItem = forwardRef<HTMLDivElement & HTMLAnchorElement, OutlineItemProps>(function OutlineItem({
   children,
@@ -51,7 +51,6 @@ export const OutlineItem = forwardRef<HTMLDivElement & HTMLAnchorElement, Outlin
   content,
   rightContent,
   href,
-  testId = OUTLINE_ITEM_TEST_ID,
   ...rest
 }, forwardedRef) {
   const context = useOutlineItemContext()
@@ -64,7 +63,6 @@ export const OutlineItem = forwardRef<HTMLDivElement & HTMLAnchorElement, Outlin
   return (
     <>
       <Comp
-        {...rest}
         {...isLink && {
           href,
           target: '_blank',
@@ -81,7 +79,8 @@ export const OutlineItem = forwardRef<HTMLDivElement & HTMLAnchorElement, Outlin
           className,
         )}
         ref={forwardedRef}
-        data-testid={testId}
+        data-testid={OUTLINE_ITEM_TEST_ID}
+        {...rest}
       >
         { !disableChevron && (
           <div className={styles.Chevron}>

--- a/packages/bezier-react/src/components/Overlay/Overlay.tsx
+++ b/packages/bezier-react/src/components/Overlay/Overlay.tsx
@@ -51,7 +51,6 @@ export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(function Overlay
   enableClickOutside = false,
   containerStyle,
   containerClassName,
-  containerTestId = CONTAINER_TEST_ID,
   onHide,
   onTransitionEnd,
   ...rest
@@ -275,7 +274,7 @@ export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(function Overlay
             containerClassName,
           )}
           ref={containerRef}
-          data-testid={containerTestId}
+          data-testid={CONTAINER_TEST_ID}
         >
           <div className={styles.OverlayWrapper}>
             { Content }

--- a/packages/bezier-react/src/components/Overlay/Overlay.tsx
+++ b/packages/bezier-react/src/components/Overlay/Overlay.tsx
@@ -32,8 +32,8 @@ import { getOverlayStyle } from './utils'
 
 import styles from './Overlay.module.scss'
 
-export const CONTAINER_TEST_ID = 'bezier-react-container'
-export const OVERLAY_TEST_ID = 'bezier-react-overlay'
+export const CONTAINER_TEST_ID = 'bezier-container'
+export const OVERLAY_TEST_ID = 'bezier-overlay'
 export const ESCAPE_KEY = 'Escape'
 
 export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(function Overlay({
@@ -49,7 +49,6 @@ export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(function Overlay
   keepInContainer = false,
   withTransition = false,
   enableClickOutside = false,
-  testId = OVERLAY_TEST_ID,
   containerStyle,
   containerClassName,
   containerTestId = CONTAINER_TEST_ID,
@@ -255,7 +254,7 @@ export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(function Overlay
           }),
         }}
         ref={mergedRef}
-        data-testid={testId}
+        data-testid={OVERLAY_TEST_ID}
         onTransitionEnd={handleTransitionEnd}
         {...rest}
       >

--- a/packages/bezier-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/bezier-react/src/components/Overlay/Overlay.types.ts
@@ -1,6 +1,5 @@
 import {
   type AdditionalOverridableStyleProps,
-  type AdditionalTestIdProps,
   type BezierComponentProps,
   type ChildrenProps,
 } from '~/src/types/props'
@@ -64,5 +63,4 @@ export interface OverlayProps extends
   BezierComponentProps<'div'>,
   ChildrenProps,
   AdditionalOverridableStyleProps<'container'>,
-  AdditionalTestIdProps<'container'>,
   OverlayOwnProps {}

--- a/packages/bezier-react/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/bezier-react/src/components/ProgressBar/ProgressBar.tsx
@@ -18,7 +18,6 @@ export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(function
   variant = 'green',
   width = 36,
   value = 0,
-  testId = 'bezier-progress-bar',
   ...rest
 }, forwardedRef) {
   const clampedValue = clamp(value, 0, 1)
@@ -41,7 +40,7 @@ export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(function
       aria-valuemin={0}
       aria-valuemax={1}
       aria-valuenow={clampedValue}
-      data-testid={testId}
+      data-testid="bezier-progress-bar"
       {...rest}
     >
       <div

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
@@ -110,7 +110,6 @@ export const SectionLabel = forwardRef<HTMLElement, SectionLabelProps>(function 
   leftContent,
   content,
   rightContent,
-  testId = 'bezier-section-label',
   onClick,
   ...props
 }, forwardedRef) {
@@ -120,7 +119,6 @@ export const SectionLabel = forwardRef<HTMLElement, SectionLabelProps>(function 
   return (
     <>
       <Comp
-        {...props}
         // @ts-expect-error
         ref={forwardedRef}
         className={classNames(
@@ -128,8 +126,9 @@ export const SectionLabel = forwardRef<HTMLElement, SectionLabelProps>(function 
           clickable && styles.clickable,
           className,
         )}
-        data-testid={testId}
+        data-testid="bezier-section-label"
         onClick={onClick}
+        {...props}
       >
         { leftContent && (
           <div className={styles.LeftContent}>

--- a/packages/bezier-react/src/components/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Select/Select.tsx
@@ -61,9 +61,6 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
   dropdownMarginY = 6,
   dropdownZIndex = 'overlay',
   dropdownPosition = OverlayPosition.BottomLeft,
-  triggerTestId = 'bezier-select-trigger',
-  triggerTextTestId = 'bezier-select-trigger-text',
-  dropdownTestId = SELECT_DROPDOWN_TEST_ID,
   onClickTrigger,
   onHideDropdown,
   ...rest
@@ -133,7 +130,6 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
         className,
       )}
       ref={containerRef}
-      data-testid="bezier-select-container"
     >
       <button
         className={classNames(
@@ -146,7 +142,6 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
         ref={triggerRef}
         type="button"
         disabled={disabled}
-        data-testid={triggerTestId}
         onClick={handleClickTrigger}
         {...ownProps}
       >
@@ -163,7 +158,7 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
             : leftContent }
 
           <Text
-            data-testid={triggerTextTestId}
+            data-testid="bezier-select-trigger-text"
             typo="14"
             truncated
             color={hasContent ? textColor : 'txt-black-dark'}
@@ -200,7 +195,6 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
           getZIndexClassName(dropdownZIndex),
           dropdownClassName,
         )}
-        data-testid={dropdownTestId}
         withTransition
         show={isDropdownOpened && !disabled}
         marginX={dropdownMarginX}
@@ -208,6 +202,7 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
         target={triggerRef.current}
         container={dropdownContainer || containerRef.current}
         position={dropdownPosition}
+        data-testid={SELECT_DROPDOWN_TEST_ID}
         onHide={handleHideDropdown}
       >
         { children }

--- a/packages/bezier-react/src/components/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Select/Select.tsx
@@ -39,7 +39,7 @@ import {
 
 import styles from './Select.module.scss'
 
-export const SELECT_DROPDOWN_TEST_ID = 'bezier-react-select-dropdown'
+export const SELECT_DROPDOWN_TEST_ID = 'bezier-select-dropdown'
 
 export const Select = forwardRef<SelectRef, SelectProps>(function Select({
   children,
@@ -61,9 +61,8 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
   dropdownMarginY = 6,
   dropdownZIndex = 'overlay',
   dropdownPosition = OverlayPosition.BottomLeft,
-  testId = 'bezier-react-select-container',
-  triggerTestId = 'bezier-react-select-trigger',
-  triggerTextTestId = 'bezier-react-select-trigger-text',
+  triggerTestId = 'bezier-select-trigger',
+  triggerTextTestId = 'bezier-select-trigger-text',
   dropdownTestId = SELECT_DROPDOWN_TEST_ID,
   onClickTrigger,
   onHideDropdown,
@@ -134,7 +133,7 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
         className,
       )}
       ref={containerRef}
-      data-testid={testId}
+      data-testid="bezier-select-container"
     >
       <button
         className={classNames(
@@ -164,7 +163,7 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
             : leftContent }
 
           <Text
-            testId={triggerTextTestId}
+            data-testid={triggerTextTestId}
             typo="14"
             truncated
             color={hasContent ? textColor : 'txt-black-dark'}
@@ -201,7 +200,7 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select({
           getZIndexClassName(dropdownZIndex),
           dropdownClassName,
         )}
-        testId={dropdownTestId}
+        data-testid={dropdownTestId}
         withTransition
         show={isDropdownOpened && !disabled}
         marginX={dropdownMarginX}

--- a/packages/bezier-react/src/components/Select/Select.types.ts
+++ b/packages/bezier-react/src/components/Select/Select.types.ts
@@ -3,7 +3,6 @@ import { type BezierIcon } from '@channel.io/bezier-icons'
 import type {
   AdditionalColorProps,
   AdditionalOverridableStyleProps,
-  AdditionalTestIdProps,
   BezierComponentProps,
   ChildrenProps,
   FormFieldProps,
@@ -41,7 +40,6 @@ export interface SelectProps extends
   FormFieldProps,
   SizeProps<FormFieldSize>,
   SideContentProps<BezierIcon | React.ReactNode, BezierIcon | React.ReactNode>,
-  AdditionalTestIdProps<['trigger', 'triggerText', 'dropdown']>,
   AdditionalOverridableStyleProps<'dropdown'>,
   AdditionalColorProps<['icon', 'text']>,
   SelectOwnProps {}

--- a/packages/bezier-react/src/components/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Slider/Slider.tsx
@@ -18,7 +18,7 @@ import { type SliderProps } from './Slider.types'
 
 import styles from './Slider.module.scss'
 
-export const SLIDER_TEST_ID = 'bezier-react-slider'
+export const SLIDER_TEST_ID = 'bezier-slider'
 
 const SliderGuide = memo<Record<'min' | 'max' | 'value', number>>(function SliderGuide({
   min,
@@ -108,7 +108,10 @@ export const Slider = forwardRef<HTMLSpanElement, SliderProps>(function Slider({
         '--b-slider-width': cssDimension(width),
         ...style,
       } as CSSProperties}
-      data-testid={SLIDER_TEST_ID}
+      className={classNames(
+        styles.Slider,
+        className,
+      )}
       ref={forwardedRef}
       orientation="horizontal"
       defaultValue={defaultValue}
@@ -119,10 +122,7 @@ export const Slider = forwardRef<HTMLSpanElement, SliderProps>(function Slider({
       step={step}
       dir={dir}
       minStepsBetweenThumbs={minStepsBetweenThumbs}
-      className={classNames(
-        styles.Slider,
-        className,
-      )}
+      data-testid={SLIDER_TEST_ID}
       {...rest}
     >
       <SliderPrimitive.Track className={styles.SliderPrimitiveTrack}>

--- a/packages/bezier-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/bezier-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Slider Snapshot should match snapshot 1`] = `
     aria-disabled="false"
     class="Slider"
     data-orientation="horizontal"
-    data-testid="bezier-react-slider"
+    data-testid="bezier-slider"
     dir="ltr"
     style="--b-slider-width: 36px; --radix-slider-thumb-transform: translateX(-50%);"
   >

--- a/packages/bezier-react/src/components/Spinner/Spinner.tsx
+++ b/packages/bezier-react/src/components/Spinner/Spinner.tsx
@@ -11,10 +11,9 @@ import {
 
 import styles from './Spinner.module.scss'
 
-export const SPINNER_TEST_ID = 'bezier-react-spinner'
+export const SPINNER_TEST_ID = 'bezier-spinner'
 
 export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(function Spinner({
-  testId = SPINNER_TEST_ID,
   style,
   className,
   size = SpinnerSize.M,
@@ -35,7 +34,7 @@ export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(function Spinner
         className,
       )}
       key="spinner"
-      data-testid={testId}
+      data-testid={SPINNER_TEST_ID}
     />
   )
 })

--- a/packages/bezier-react/src/components/Stack/Stack.test.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack.test.tsx
@@ -9,19 +9,19 @@ import styles from './Stack.module.scss'
 describe('Stack', () => {
   describe('Flex layout', () => {
     it('creates a flexbox', () => {
-      const { getByTestId } = render(<Stack direction="horizontal" testId="stack" />)
+      const { getByTestId } = render(<Stack direction="horizontal" data-testid="stack" />)
       expect(getByTestId('stack')).toHaveClass(styles.Stack)
       expect(getByTestId('stack')).toHaveClass(styles['display-flex'])
     })
 
     it('creates a horizontal flexbox when given direction="horizontal"', () => {
-      const { getByTestId } = render(<Stack direction="horizontal" testId="stack" spacing={10} />)
+      const { getByTestId } = render(<Stack direction="horizontal" data-testid="stack" spacing={10} />)
       expect(getByTestId('stack')).toHaveClass(styles['direction-horizontal'])
       expect(getByTestId('stack')).toHaveStyle('--b-stack-spacing: 10px')
     })
 
     it('creates a vertical flexbox when given direction="vertical"', () => {
-      const { getByTestId } = render(<Stack direction="vertical" testId="stack" spacing={10} />)
+      const { getByTestId } = render(<Stack direction="vertical" data-testid="stack" spacing={10} />)
       expect(getByTestId('stack')).toHaveClass(styles['direction-vertical'])
       expect(getByTestId('stack')).toHaveStyle('--b-stack-spacing: 10px')
     })
@@ -29,12 +29,12 @@ describe('Stack', () => {
 
   describe('Supports BezierComponentProps interface', () => {
     it('supports style prop', () => {
-      const { getByTestId } = render(<Stack direction="horizontal" testId="stack" style={{ backgroundColor: 'red' }} />)
+      const { getByTestId } = render(<Stack direction="horizontal" data-testid="stack" style={{ backgroundColor: 'red' }} />)
       expect(getByTestId('stack')).toHaveStyle({ 'background-color': 'red' })
     })
 
     it('supports className prop', () => {
-      const { getByTestId } = render(<Stack direction="horizontal" testId="stack" className="foo" />)
+      const { getByTestId } = render(<Stack direction="horizontal" data-testid="stack" className="foo" />)
       expect(getByTestId('stack')).toHaveClass('foo')
     })
   })

--- a/packages/bezier-react/src/components/Stack/Stack.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack.tsx
@@ -53,7 +53,6 @@ export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, f
     spacing,
     reverse,
     wrap,
-    testId = 'bezier-react-stack',
     ...rest
   } = layoutRest
 
@@ -77,7 +76,7 @@ export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, f
       layoutStyles.className,
       className,
     ),
-    'data-testid': testId,
+    'data-testid': 'bezier-stack',
     ...rest,
   }, children)
 })

--- a/packages/bezier-react/src/components/Switch/Switch.tsx
+++ b/packages/bezier-react/src/components/Switch/Switch.tsx
@@ -12,8 +12,8 @@ import {
 
 import styles from './Switch.module.scss'
 
-export const SWITCH_TEST_ID = 'bezier-react-switch'
-const SWITCH_HANDLE_TEST_ID = 'bezier-react-switch-handle'
+export const SWITCH_TEST_ID = 'bezier-switch'
+const SWITCH_HANDLE_TEST_ID = 'bezier-switch-handle'
 
 /**
  * `Switch` is an input component where user can toggle checked state of the element.
@@ -26,7 +26,6 @@ const SWITCH_HANDLE_TEST_ID = 'bezier-react-switch-handle'
  * ```
  */
 export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch({
-  testId = SWITCH_TEST_ID,
   handleTestId = SWITCH_HANDLE_TEST_ID,
   checked,
   defaultChecked = false,
@@ -54,13 +53,13 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch
     >
       <button
         ref={forwardedRef}
-        data-testid={testId}
         className={classNames(
           styles.Switch,
           styles[`size-${size}`],
           className,
         )}
         type="button"
+        data-testid={SWITCH_TEST_ID}
       >
         <SwitchPrimitive.Thumb asChild>
           <span

--- a/packages/bezier-react/src/components/Switch/Switch.tsx
+++ b/packages/bezier-react/src/components/Switch/Switch.tsx
@@ -13,7 +13,6 @@ import {
 import styles from './Switch.module.scss'
 
 export const SWITCH_TEST_ID = 'bezier-switch'
-const SWITCH_HANDLE_TEST_ID = 'bezier-switch-handle'
 
 /**
  * `Switch` is an input component where user can toggle checked state of the element.
@@ -26,7 +25,6 @@ const SWITCH_HANDLE_TEST_ID = 'bezier-switch-handle'
  * ```
  */
 export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch({
-  handleTestId = SWITCH_HANDLE_TEST_ID,
   checked,
   defaultChecked = false,
   onCheckedChange,
@@ -62,10 +60,7 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch
         data-testid={SWITCH_TEST_ID}
       >
         <SwitchPrimitive.Thumb asChild>
-          <span
-            data-testid={handleTestId}
-            className={styles.SwitchThumb}
-          />
+          <span className={styles.SwitchThumb} />
         </SwitchPrimitive.Thumb>
       </button>
     </SwitchPrimitive.Root>

--- a/packages/bezier-react/src/components/Switch/Switch.types.ts
+++ b/packages/bezier-react/src/components/Switch/Switch.types.ts
@@ -1,7 +1,6 @@
 import type { SwitchProps as SwitchPrimitiveProps } from '@radix-ui/react-switch'
 
 import type {
-  AdditionalTestIdProps,
   BezierComponentProps,
   FormFieldProps,
   SizeProps,
@@ -57,5 +56,4 @@ export interface SwitchProps extends
   Omit<BezierComponentProps<'button'>, keyof SwitchOwnProps>,
   SizeProps<SwitchSize>,
   FormFieldProps,
-  AdditionalTestIdProps<'handle'>,
   SwitchOwnProps {}

--- a/packages/bezier-react/src/components/Tag/Tag.tsx
+++ b/packages/bezier-react/src/components/Tag/Tag.tsx
@@ -31,8 +31,8 @@ import { type TagProps } from './Tag.types'
 
 import styles from './Tag.module.scss'
 
-export const TAG_TEST_ID = 'bezier-react-tag'
-export const TAG_DELETE_TEST_ID = 'bezier-react-tag-delete-icon'
+export const TAG_TEST_ID = 'bezier-tag'
+export const TAG_DELETE_TEST_ID = 'bezier-tag-delete-icon'
 
 /**
  * `Tag` is a component for representing tag, which shows close icon when `onDelete` property is specified.
@@ -53,7 +53,6 @@ export const Tag = memo(forwardRef<HTMLDivElement, TagProps>(function Tag({
   color: givenColor,
   children,
   className,
-  testId = TAG_TEST_ID,
   onDelete,
   style,
   ...rest
@@ -62,6 +61,10 @@ export const Tag = memo(forwardRef<HTMLDivElement, TagProps>(function Tag({
 
   return (
     <div
+      style={{
+        '--b-tag-badge-background-color': cssVar(bgColor),
+        ...style,
+      } as CSSProperties}
       className={classNames(
         styles.Tag,
         commonStyles.TagBadge,
@@ -69,11 +72,7 @@ export const Tag = memo(forwardRef<HTMLDivElement, TagProps>(function Tag({
         className,
       )}
       ref={forwardedRef}
-      data-testid={testId}
-      style={{
-        '--b-tag-badge-background-color': cssVar(bgColor),
-        ...style,
-      } as CSSProperties}
+      data-testid={TAG_TEST_ID}
       {...rest}
     >
       { !isEmpty(children) && (
@@ -88,15 +87,15 @@ export const Tag = memo(forwardRef<HTMLDivElement, TagProps>(function Tag({
 
       { !isNil(onDelete) && (
         <Icon
+          className={styles.CloseIcon}
           source={CancelSmallIcon}
           size={IconSize.XS}
-          testId={TAG_DELETE_TEST_ID}
           color="txt-black-darker"
-          className={styles.CloseIcon}
           onClick={(e) => {
             e.stopPropagation()
             onDelete(e)
           }}
+          data-testid={TAG_DELETE_TEST_ID}
         />
       ) }
     </div>

--- a/packages/bezier-react/src/components/Tag/__snapshots__/Tag.test.tsx.snap
+++ b/packages/bezier-react/src/components/Tag/__snapshots__/Tag.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tag test > Snapshot > 1`] = `
 <div
   class="Tag TagBadge size-m"
-  data-testid="bezier-react-tag"
+  data-testid="bezier-tag"
   style="--b-tag-badge-background-color: var(--bg-black-lighter);"
 />
 `;

--- a/packages/bezier-react/src/components/Text/Text.tsx
+++ b/packages/bezier-react/src/components/Text/Text.tsx
@@ -38,7 +38,6 @@ export const Text = forwardRef<HTMLElement, TextProps>(function Text(props, forw
     style,
     className,
     as = 'span',
-    testId = 'bezier-react-text',
     typo = '15',
     color,
     bold,
@@ -68,7 +67,7 @@ export const Text = forwardRef<HTMLElement, TextProps>(function Text(props, forw
       marginStyles.className,
       className,
     ),
-    'data-testid': testId,
+    'data-testid': 'bezier-text',
     ...rest,
   }, children)
 })

--- a/packages/bezier-react/src/components/TextArea/TextArea.tsx
+++ b/packages/bezier-react/src/components/TextArea/TextArea.tsx
@@ -23,7 +23,6 @@ import styles from './TextArea.module.scss'
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(function TextArea({
   style,
   className,
-  testId = 'bezier-react-text-area',
   minRows = TextAreaHeight.Row6,
   maxRows = TextAreaHeight.Row6,
   autoFocus = false,
@@ -77,7 +76,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(function 
       readOnly={readOnly}
       maxRows={maxRows}
       minRows={minRows}
-      data-testid={testId}
+      data-testid="bezier-text-area"
       onKeyDown={handleKeyDown}
       onKeyUp={handleKeyUp}
     />

--- a/packages/bezier-react/src/components/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/TextField/TextField.tsx
@@ -42,8 +42,8 @@ import {
 
 import styles from './TextField.module.scss'
 
-export const TEXT_INPUT_TEST_ID = 'bezier-react-text-input'
-export const TEXT_INPUT_CLEAR_ICON_TEST_ID = 'bezier-react-text-input-clear-icon'
+export const TEXT_INPUT_TEST_ID = 'bezier-text-input'
+export const TEXT_INPUT_CLEAR_ICON_TEST_ID = 'bezier-text-input-clear-icon'
 
 /**
  * FIXME: This mapping constant was defined for UI consistency,
@@ -168,7 +168,6 @@ function TextFieldRightContent({
 export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextField({
   type,
   size: sizeProps,
-  testId = TEXT_INPUT_TEST_ID,
   autoFocus,
   autoComplete = 'off',
   variant = TextFieldVariant.Primary,
@@ -369,7 +368,7 @@ export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextF
         getFormFieldSizeClassName(size),
         wrapperClassName,
       )}
-      data-testid={testId}
+      data-testid={TEXT_INPUT_TEST_ID}
       onMouseDown={focus}
     >
       <TextFieldLeftContent
@@ -416,7 +415,7 @@ export const TextField = forwardRef<TextFieldRef, TextFieldProps>(function TextF
         >
           <Icon
             className={styles.CloseIcon}
-            testId={TEXT_INPUT_CLEAR_ICON_TEST_ID}
+            data-testid={TEXT_INPUT_CLEAR_ICON_TEST_ID}
             source={CancelCircleFilledIcon}
             size={IconSize.XS}
           />

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -163,12 +163,6 @@ export type AdditionalOverridableStyleProps<ElementName extends PropNameType> =
   & AdditionalProps<ElementName, 'className', string>
 
 /**
- * Props for adding test IDs to named elements within a component, useful for testing purposes.
- */
-export type AdditionalTestIdProps<ElementName extends PropNameType> =
-  AdditionalProps<ElementName, 'testId', string>
-
-/**
  * Props for adding color properties to named elements within a component.
  */
 export type AdditionalColorProps<ElementName extends PropNameType> =

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -9,17 +9,6 @@ import type {
 } from './tokens'
 
 /**
- * Base configuration properties for components, including the HTML element type and test ID.
- * @deprecated Remove
- */
-interface RenderConfigProps {
-  /**
-   * A test ID attribute compatible with `@testing-library/react`.
-   */
-  testId?: string
-}
-
-/**
  * Props for overriding default styles of components. Intended for exceptional use cases where default styles need customization.
  */
 interface OverridableStyleProps {
@@ -56,7 +45,6 @@ type HTMLElementProps<Tag extends keyof JSX.IntrinsicElements> = React.Component
  * @template Tag The tag name of the HTML element (e.g., 'div', 'a', 'button'). If null, returns contains `React.HTMLAttributes<HTMLElement>`.
  */
 export type BezierComponentProps<Tag extends keyof JSX.IntrinsicElements | null = null> =
-  & RenderConfigProps
   & (Tag extends keyof JSX.IntrinsicElements ? HTMLElementProps<Tag> : React.HTMLAttributes<HTMLElement>)
   & OverridableStyleProps
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- Fixes #1959

## Summary
<!-- Please brief explanation of the changes made -->

컴포넌트의 공통 속성 중 `testId` 와 그에 연관된 속성(e.g. `wrapperTestId`)을 모두 제거합니다.

## Details
<!-- Please elaborate description of the changes -->

- testId는 라이브러리 내부적으로 testing-library를 사용한 테스트(getByTestId)를 위해 사용하는 속성입니다. 이를 퍼블릭 API로 노출시킬 필요가 없다고 판단하여 제거합니다. data-testid + rest prop(support HTMLAttributes)을 사용한 방식으로 대체했습니다.
- beizer-react-*** 로 시작하는 testId는 bezier-*** 로 변경했습니다 (개인 선호)

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

Yes

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- https://testing-library.com/docs/queries/bytestid/
