### PR TITLE
feat(banner): enhance to render link even when content is not a string

### DIFF
--- a/.changeset/strange-colts-beg.md
+++ b/.changeset/strange-colts-beg.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+`Banner` will now render content even if the `content` prop is not a string. The same applies to link-related props.

--- a/packages/bezier-react/src/components/Banner/Banner.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.tsx
@@ -4,10 +4,7 @@ import { isBezierIcon } from '@channel.io/bezier-icons'
 import classNames from 'classnames'
 
 import { warn } from '~/src/utils/assert'
-import {
-  isNil,
-  isString,
-} from '~/src/utils/type'
+import { isNil } from '~/src/utils/type'
 
 import {
   Button,
@@ -122,26 +119,24 @@ export const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner({
       ) }
 
       <div className={styles.Content}>
-        { isString(content) ? (
-          <Text typo="14">
-            { content }
+        <Text typo="14">
+          { content }
 
-            { hasLink && (
-              renderLink({
-                content: (
-                  <Text
-                    className={styles.Link}
-                    typo="14"
-                    bold
-                  >
-                    { linkText }
-                  </Text>
-                ),
-                linkTo,
-              })
-            ) }
-          </Text>
-        ) : content }
+          { hasLink && (
+            renderLink({
+              content: (
+                <Text
+                  className={styles.Link}
+                  typo="14"
+                  bold
+                >
+                  { linkText }
+                </Text>
+              ),
+              linkTo,
+            })
+          ) }
+        </Text>
       </div>
 
       { !isNil(actionIcon) && (


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- Fixes #1486 

## Summary
<!-- Please brief explanation of the changes made -->

feat(banner): enhance to render link even when content is not a string

## Details
<!-- Please elaborate description of the changes -->

- content의 조건부 렌더링 로직을 제거합니다. 이제 content가 무엇이든(ReactNode) 상관없이 content와 하위 링크를 렌더하도록 합니다.
- Banner 컴포넌트 특성 상 대체로 내용이 변하지 않는 텍스트가 들어갈 거로 가정했습니다. content에 빈 문자열을 넣거나 하는 케이스(empty check)를 고려할 필요가 없다고 판단했습니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
