### PR TITLE
refactor(form-helper-text): fix invalid object key of get form context props

### DIFF
--- a/packages/bezier-react/src/components/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/FormHelperText/FormHelperText.tsx
@@ -41,7 +41,7 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(function
   } = getProps?.(rest) ?? {
     visible: true,
     ref: noop,
-    classNameFromControl: undefined,
+    className: undefined,
     ...rest,
   }
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

FormHelperText: Fix invalid object key of get form context props

## Details
<!-- Please elaborate description of the changes -->

간단한 변경사항이므로 Summary로 대체합니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
