### PR TITLE
build(rollup): shorten css module's scope name

### DIFF
--- a/packages/bezier-react/rollup.config.mjs
+++ b/packages/bezier-react/rollup.config.mjs
@@ -72,9 +72,9 @@ const generateConfig = ({
       autoModules: true,
       modules: {
         /**
-         * ex. b-Button-disabled_1w3e4
+         * ex. b-1w3e4
          */
-        generateScopedName: 'b-[folder]-[local]_[hash:base64:5]',
+        generateScopedName: 'b-[hash:base64:5]',
         hashPrefix: 'bezier',
       },
       plugins: [


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

Shorten css module's scope name

## Details
<!-- Please elaborate description of the changes -->

- folder, local명이 모두 클래스명에 포함되면서 디버깅이 용이해졌지만, 생각보다 유의미하게 CSS 사이즈가 증가했습니다. (전체 사이즈 대비)
- 디버깅 용이성보단 용량을 줄이는 것이 프로덕션 환경에선 더 중요하다고 판단하여 `b-` prefix와 해시를 제외한 folder, local명을 클래스명에서 제외합니다.
  - bezier-react의 CSS임을 확인할 수는 있도록 `b-` prefix는 유지하도록 했습니다.
- 해시와 prefix, 그리고 hashPrefix를 사용하므로 해시 충돌이 일어날 일은 거의 없다고 봐도 무방할 거 같습니다.

**용량 차이**

- 모두 작성할 경우: 104KB
- local만 제거할 경우: 89KB (-15KB, -14.42%)
- hash를 제외하고 모두 제거할 경우: 75KB (-29KB, -27.88%)
- hash + `b-` prefix: 78KB (-26KB, -25%)

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- https://github.com/madyankin/postcss-modules
