### PR TITLE
feat(window-provider): Add `useRootElement` and JSDoc

### DIFF
--- a/.changeset/witty-kids-tie.md
+++ b/.changeset/witty-kids-tie.md
@@ -1,0 +1,11 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Add `useRootElement` hook. It is only available to `WindowProvider` children, and provides easy access to the root element of window context value.
+
+```tsx
+const { window, document, rootElement } = useWindow();
+// Same as useWindow().rootElement
+const rootElement = useRootElement();
+```

--- a/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltipContent.tsx
+++ b/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltipContent.tsx
@@ -20,7 +20,7 @@ import {
 
 import { Text } from '~/src/components/Text'
 import { InvertedThemeProvider } from '~/src/components/ThemeProvider'
-import { useWindow } from '~/src/components/WindowProvider'
+import { useRootElement } from '~/src/components/WindowProvider'
 
 import {
   type LegacyTooltipContentProps,
@@ -90,7 +90,7 @@ export const LegacyTooltipContent: React.FC<LegacyTooltipContentProps> = ({
   forwardedRef,
   ...rest
 }) => {
-  const { rootElement } = useWindow()
+  const rootElement = useRootElement()
 
   const tooltipRef = useRef<HTMLDivElement>(null)
   const tooltipWrapperRef = useRef<HTMLDivElement>(null)

--- a/packages/bezier-react/src/components/Modal/Modal.tsx
+++ b/packages/bezier-react/src/components/Modal/Modal.tsx
@@ -30,7 +30,7 @@ import {
   useThemeName,
 } from '~/src/components/ThemeProvider'
 import { VisuallyHidden } from '~/src/components/VisuallyHidden'
-import { useWindow } from '~/src/components/WindowProvider'
+import { useRootElement } from '~/src/components/WindowProvider'
 
 import {
   type ModalBodyProps,
@@ -124,7 +124,7 @@ export const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(functi
   collisionPadding = { top: 40, bottom: 40 },
   ...rest
 }, forwardedRef) {
-  const { rootElement } = useWindow()
+  const rootElement = useRootElement()
   const container = givenContainer ?? rootElement
   const [contentContainer, setContentContainer] = useState<HTMLElement>()
 

--- a/packages/bezier-react/src/components/Overlay/Overlay.tsx
+++ b/packages/bezier-react/src/components/Overlay/Overlay.tsx
@@ -55,8 +55,7 @@ export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(function Overlay
   onTransitionEnd,
   ...rest
 }, forwardedRef) {
-  const { rootElement } = useWindow()
-  const { window, document } = useWindow()
+  const { window, document, rootElement } = useWindow()
 
   const [shouldRender, setShouldRender] = useState(false)
   const [shouldShow, setShouldShow] = useState(false)
@@ -70,11 +69,9 @@ export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(function Overlay
   const overlayRef = useRef<HTMLDivElement>(null)
   const mergedRef = useMergeRefs<HTMLDivElement>(overlayRef, forwardedRef)
 
-  const defaultContainer = rootElement
   const modalContainer = useModalContainerContext()
-
   const hasContainer = Boolean(givenContainer || modalContainer)
-  const container = givenContainer ?? modalContainer ?? defaultContainer
+  const container = givenContainer ?? modalContainer ?? rootElement
 
   const handleOverlayForceUpdate = useCallback(() => {
     forceUpdate()

--- a/packages/bezier-react/src/components/Toast/Toast.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.tsx
@@ -31,7 +31,10 @@ import {
 } from '~/src/components/Icon'
 import { Text } from '~/src/components/Text'
 import { InvertedThemeProvider } from '~/src/components/ThemeProvider'
-import { useWindow } from '~/src/components/WindowProvider'
+import {
+  useRootElement,
+  useWindow,
+} from '~/src/components/WindowProvider'
 
 import {
   type ToastContextValue,
@@ -214,7 +217,7 @@ export function ToastProvider({
   },
   children = [],
 }: ToastProviderProps) {
-  const { rootElement } = useWindow()
+  const rootElement = useRootElement()
   const isMounted = useIsMounted()
 
   const toastContextValue = useToastProviderValues()

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -18,7 +18,7 @@ import {
 import { HStack } from '~/src/components/Stack'
 import { Text } from '~/src/components/Text'
 import { InvertedThemeProvider } from '~/src/components/ThemeProvider'
-import { useWindow } from '~/src/components/WindowProvider'
+import { useRootElement } from '~/src/components/WindowProvider'
 
 import {
   TooltipPosition,
@@ -135,7 +135,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(function Tooltip
   const [show, setShow] = useState<boolean>(defaultShow ?? false)
   const timeoutRef = useRef<NodeJS.Timeout>()
 
-  const { rootElement } = useWindow()
+  const rootElement = useRootElement()
   const container = containerProp ?? rootElement
 
   const shouldBeHidden = useMemo(() => (

--- a/packages/bezier-react/src/components/WindowProvider/WindowProvider.tsx
+++ b/packages/bezier-react/src/components/WindowProvider/WindowProvider.tsx
@@ -11,8 +11,6 @@ const [WindowContextProvider, useWindowContext] = createContext<WindowContextVal
 
 /**
  * Custom hook to access the window context.
- * Use this hook to get access to the window object and its properties,
- * including the root element, from anywhere in the component tree.
  */
 export function useWindow() {
   return useWindowContext('useWindow')
@@ -20,8 +18,6 @@ export function useWindow() {
 
 /**
  * Custom hook to access the root element from the window context.
- * This is a convenience hook for directly accessing the root element
- * from the window context, without needing to first access the window object.
  */
 export function useRootElement() {
   return useWindowContext('useRootElement').rootElement
@@ -31,7 +27,6 @@ export function useRootElement() {
  * Component provider for the window context.
  * This component wraps its children in the WindowContextProvider, supplying
  * the window object and its root element to the context for consumption
- * by descendant components using the `useWindow` or `useRootElement` hooks.
  */
 export function WindowProvider({
   window,

--- a/packages/bezier-react/src/components/WindowProvider/WindowProvider.tsx
+++ b/packages/bezier-react/src/components/WindowProvider/WindowProvider.tsx
@@ -9,29 +9,42 @@ import {
 
 const [WindowContextProvider, useWindowContext] = createContext<WindowContextValue | null>(null, 'WindowProvider')
 
+/**
+ * Custom hook to access the window context.
+ * Use this hook to get access to the window object and its properties,
+ * including the root element, from anywhere in the component tree.
+ */
 export function useWindow() {
   return useWindowContext('useWindow')
 }
 
 /**
- * A Provider that provides window and document object
- * you can use this provider to inject an external window
+ * Custom hook to access the root element from the window context.
+ * This is a convenience hook for directly accessing the root element
+ * from the window context, without needing to first access the window object.
  */
-export function WindowProvider({ window, children }: WindowProviderProps) {
-  const document = window.document
-  const rootElement = document.body
+export function useRootElement() {
+  return useWindowContext('useRootElement').rootElement
+}
 
-  const value = useMemo(() => ({
-    window,
-    document,
-    rootElement,
-  }), [
-    window,
-    document,
-    rootElement,
-  ])
-
+/**
+ * Component provider for the window context.
+ * This component wraps its children in the WindowContextProvider, supplying
+ * the window object and its root element to the context for consumption
+ * by descendant components using the `useWindow` or `useRootElement` hooks.
+ */
+export function WindowProvider({
+  window,
+  children,
+}: WindowProviderProps) {
   return (
-    <WindowContextProvider value={value}>{ children }</WindowContextProvider>
+    <WindowContextProvider value={useMemo(() => ({
+      window,
+      document: window.document,
+      rootElement: window.document.body,
+    }), [window])}
+    >
+      { children }
+    </WindowContextProvider>
   )
 }

--- a/packages/bezier-react/src/components/WindowProvider/WindowProvider.types.ts
+++ b/packages/bezier-react/src/components/WindowProvider/WindowProvider.types.ts
@@ -1,14 +1,23 @@
 import { type ChildrenProps } from '~/src/types/props'
 
 export interface WindowContextValue {
+  /**
+   * A window containing a DOM document; the `document` property points to the DOM document loaded in that window.
+   */
   window: Window
+  /**
+   * The DOM document loaded in the window.
+   */
   document: Document
+  /**
+   * Same as `document.body`. Specifies the beginning and end of the document body.
+   */
   rootElement: HTMLElement
 }
 
 interface WindowProviderOwnProps {
   /**
-   * Injected window object.
+   * A window containing a DOM document; the document property points to the DOM document loaded in that window.
    */
   window: Window
 }

--- a/packages/bezier-react/src/components/WindowProvider/index.ts
+++ b/packages/bezier-react/src/components/WindowProvider/index.ts
@@ -1,4 +1,5 @@
 export {
+  useRootElement,
   useWindow,
   WindowProvider,
 } from './WindowProvider'


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

## Summary
<!-- Please brief explanation of the changes made -->

feat(window-provider): Add `useRootElement` and JSDoc

## Details
<!-- Please elaborate description of the changes -->

- 사용처에서 useWindow 훅에 대한 학습 없이도 rootElement에 쉽게 접근할 수 있도록 useRootElement 훅을 추가합니다. useWindow().rootElement와 동일합니다.
- JSDoc을 추가합니다.
- 리팩토링: 변수 인라인 등

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
