### PR TITLE
fix(deps): move bezier-tokens from dev-deps to deps

### DIFF
--- a/.changeset/friendly-avocados-love.md
+++ b/.changeset/friendly-avocados-love.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Move `@channel.io/bezier-tokens` from dev depdency to dependency

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -70,7 +70,6 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.22.15",
     "@channel.io/bezier-icons": "^0.18.0",
-    "@channel.io/bezier-tokens": "0.1.0-alpha.4",
     "@mdx-js/react": "^1.6.22",
     "@rollup/plugin-alias": "^5.0.0",
     "@rollup/plugin-babel": "^6.0.3",
@@ -135,6 +134,7 @@
     }
   },
   "dependencies": {
+    "@channel.io/bezier-tokens": "0.1.0-alpha.4",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-radio-group": "^1.1.3",


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

fix(deps): move bezier-tokens from dev-deps to deps

## Details
<!-- Please elaborate description of the changes -->

- bezier-tokens가 bezier-react의 dev dependency에 포함되어있어, 사용처에서 bezier-tokens를 install 하지 않습니다.
- bezier-tokens의 타입 정의를 사용하고 있고, 토큰 데이터를 bezier-react 런타임에 사용하고 있으므로 dependency에 명시해야합니다.
- 번외: bezier-icons가 peer dependency인데, 마찬가지로 '만약' bezier-react만 사용하고, bezier-icons를 사용하지 않는 프로젝트가 있다면 BezierIcon 타입을 찾을 수 없어 any로 추론되는 문제가 발생할 수 있겠다는 생각이 듭니다. 큰 문제가 될 거 같진 않지만요..

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
