### PR TITLE
feat(theme-provider): spread props

### DIFF
--- a/.changeset/tame-news-yawn.md
+++ b/.changeset/tame-news-yawn.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Add missing spreading props to `ThemeProvider` and related components.

--- a/packages/bezier-react/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/bezier-react/src/components/ThemeProvider/ThemeProvider.tsx
@@ -28,10 +28,13 @@ export function useToken() {
 
 /**
  * `ThemeProvider` is a wrapper component that provides theme context.
+ *
+ * Components that pass to children **must spread props and forward ref.**
  */
 export const ThemeProvider = forwardRef<HTMLElement, ThemeProviderProps>(function ThemeProvider({
   themeName,
   children,
+  ...rest
 }, forwardedRef) {
   return (
     <TokenProvider themeName={themeName}>
@@ -39,6 +42,7 @@ export const ThemeProvider = forwardRef<HTMLElement, ThemeProviderProps>(functio
         ref={forwardedRef}
         // TODO: Change data attribute constant to import from bezier-tokens
         data-bezier-theme={themeName}
+        {...rest}
       >
         { children }
       </Slot>
@@ -48,14 +52,18 @@ export const ThemeProvider = forwardRef<HTMLElement, ThemeProviderProps>(functio
 
 /**
  * `LightThemeProvider` is a wrapper component that provides light theme context.
+ *
+ * Components that pass to children **must spread props and forward ref.**
  */
 export const LightThemeProvider = forwardRef<HTMLElement, FixedThemeProviderProps>(function LightTheme({
   children,
+  ...rest
 }, forwardedRef) {
   return (
     <ThemeProvider
       ref={forwardedRef}
       themeName="light"
+      {...rest}
     >
       { children }
     </ThemeProvider>
@@ -64,14 +72,18 @@ export const LightThemeProvider = forwardRef<HTMLElement, FixedThemeProviderProp
 
 /**
  * `DarkThemeProvider` is a wrapper component that provides dark theme context.
+ *
+ * Components that pass to children **must spread props and forward ref.**
  */
 export const DarkThemeProvider = forwardRef<HTMLElement, FixedThemeProviderProps>(function DarkTheme({
   children,
+  ...rest
 }, forwardedRef) {
   return (
     <ThemeProvider
       ref={forwardedRef}
       themeName="dark"
+      {...rest}
     >
       { children }
     </ThemeProvider>
@@ -83,11 +95,13 @@ export const DarkThemeProvider = forwardRef<HTMLElement, FixedThemeProviderProps
  */
 export const InvertedThemeProvider = forwardRef<HTMLElement, FixedThemeProviderProps>(function InvertedTheme({
   children,
+  ...rest
 }, forwardedRef) {
   return (
     <ThemeProvider
       ref={forwardedRef}
       themeName={useThemeName() === 'light' ? 'dark' : 'light'}
+      {...rest}
     >
       { children }
     </ThemeProvider>

--- a/packages/bezier-react/src/components/ThemeProvider/ThemeProvider.types.ts
+++ b/packages/bezier-react/src/components/ThemeProvider/ThemeProvider.types.ts
@@ -1,11 +1,15 @@
 import type React from 'react'
 
-import { type ChildrenProps } from '~/src/types/props'
+import {
+  type BezierComponentProps,
+  type ChildrenProps,
+} from '~/src/types/props'
 
 import { type TokenProviderProps } from '~/src/components/TokenProvider'
 
 export interface ThemeProviderProps extends
   Pick<TokenProviderProps, 'themeName'>,
+  Omit<BezierComponentProps, 'children'>,
   ChildrenProps<React.ReactElement> {}
 
 export type FixedThemeProviderProps = Omit<ThemeProviderProps, 'themeName'>

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -102,7 +102,8 @@ function getSideAndAlign(
 
 /**
  * `Tooltip` is a component that shows additional information when the mouse hovers or the keyboard is focused.
- * If you want to compose another component with `Tooltip`, **it must spread props and forward ref.**
+ *
+ * Components that pass to children **must spread props and forward ref.**
  * @example
  * ```tsx
  * // Your component must spread props and forward ref.


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

feat(theme-provider): spread props

## Details
<!-- Please elaborate description of the changes -->

- 누락된 ThemeProvider의 prop을 spread합니다. 
- 예를 들어, Tooltip -> ThemeProvider -> Button 식으로 감쌌을 때 이 변경사항 이후로 Button이 Tooltip의 트리거 역할을 잘 수행하게 됩니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
