### PR TITLE
Fix bug in `v2-import-from-bezier-to-styled-components`

### DIFF
--- a/.changeset/giant-terms-impress.md
+++ b/.changeset/giant-terms-impress.md
@@ -1,0 +1,13 @@
+---
+"@channel.io/bezier-codemod": patch
+---
+
+Fix bug in `v2-import-from-bezier-to-styled-components` codemod when there are only named imports as following:
+
+```tsx
+// As-is
+import { css } from "@channel.io/bezier-react";
+
+// To-be
+import { css } from "styled-components";
+```

--- a/packages/bezier-codemod/src/transforms/v2-import-from-bezier-to-styled-components/fixtures/only-named-import.input.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-import-from-bezier-to-styled-components/fixtures/only-named-import.input.tsx
@@ -1,0 +1,3 @@
+import { css } from '@channel.io/bezier-react'
+
+import { type Device } from './device'

--- a/packages/bezier-codemod/src/transforms/v2-import-from-bezier-to-styled-components/fixtures/only-named-import.output.tsx
+++ b/packages/bezier-codemod/src/transforms/v2-import-from-bezier-to-styled-components/fixtures/only-named-import.output.tsx
@@ -1,0 +1,2 @@
+import { css } from 'styled-components';
+import { type Device } from './device'

--- a/packages/bezier-codemod/src/transforms/v2-import-from-bezier-to-styled-components/transform.test.ts
+++ b/packages/bezier-codemod/src/transforms/v2-import-from-bezier-to-styled-components/transform.test.ts
@@ -22,4 +22,8 @@ describe('import transform', () => {
   it('should transform styled import from bezier-react to styled-components, and not remove other import declarations', () => {
     testTransformFunction(__dirname, 'import-without-import-clause', importTransform)
   })
+
+  it('should transform properly when there are only named imports ', () => {
+    testTransformFunction(__dirname, 'only-named-import', importTransform)
+  })
 })

--- a/packages/bezier-codemod/src/transforms/v2-import-from-bezier-to-styled-components/transform.ts
+++ b/packages/bezier-codemod/src/transforms/v2-import-from-bezier-to-styled-components/transform.ts
@@ -23,9 +23,14 @@ const addImportToStyledComponents = (sourceFile: SourceFile, importSpecifier: st
     } else {
       styledComponentsImport.addNamedImport(importSpecifier)
     }
-  } else {
+  } else if (isDefault) {
     sourceFile.insertImportDeclaration(0, {
       defaultImport: STYLED,
+      moduleSpecifier: STYLED_COMPONENTS,
+    })
+  } else {
+    sourceFile.insertImportDeclaration(0, {
+      namedImports: [importSpecifier],
       moduleSpecifier: STYLED_COMPONENTS,
     })
   }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary
<!-- Please brief explanation of the changes made -->

- `v2-import-from-bezier-to-styled-components` 에서 다음과 같이 잘못 변환되는 케이스를 수정합니다.
```tsx
// As-is
import { css } from '@channel.io/bezier-react'

// To-be
import styled from 'styled-components'
```

## Details
<!-- Please elaborate description of the changes -->

- named import 를 추가할 때 default import 여부에 상관 없이 import styled from 'styled-components' 를 추가해서 생긴 버그입니다. named import 일 때 올바른 import 문을 추가하여 바로잡습니다. 

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

- No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->
