### PR TITLE
Resolve warning message of `KeyValueItem` component during test

### DIFF
--- a/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.tsx
+++ b/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.tsx
@@ -88,7 +88,7 @@ function ActionButton({ children }: { children: KeyValueItemAction }) {
   const Wrapper = !isEmpty(children.tooltip) ? Tooltip : React.Fragment
 
   return (
-    <Wrapper content={children.tooltip}>
+    <Wrapper {...(children.tooltip ? { content: children.tooltip } : {})}>
       <Button
         size="xs"
         leftContent={children.icon}

--- a/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.tsx
+++ b/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.tsx
@@ -85,10 +85,11 @@ function ActionButton({ children }: { children: KeyValueItemAction }) {
     return children
   }
 
-  const Wrapper = !isEmpty(children.tooltip) ? Tooltip : React.Fragment
+  const withTooltip = !isEmpty(children.tooltip)
+  const Wrapper = withTooltip ? Tooltip : React.Fragment
 
   return (
-    <Wrapper {...(children.tooltip ? { content: children.tooltip } : {})}>
+    <Wrapper {...(withTooltip ? { content: children.tooltip } : {})}>
       <Button
         size="xs"
         leftContent={children.icon}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- None

<!-- Fixes #0000 -->

## Summary
<!-- Please brief explanation of the changes made -->

-  test 도중 아래 메시지가 뜨는 것을 막습니다. 
 
<img width="921" alt="image" src="https://github.com/channel-io/bezier-react/assets/28595102/7d7fca82-26ae-468c-acf7-bcad54d15e48">

## Details
<!-- Please elaborate description of the changes -->

- React.Fragment 일 때 content={undefined} 형식으로 props가 들어가서 뜨는 로그입니다. props 주입을 조건부로 변경해서 로그가 안뜨도록 했습니다. 

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

- No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- None
