### PR TITLE
Exports the tokens object from bezier-tokens

### DIFF
--- a/.changeset/eighty-steaks-play.md
+++ b/.changeset/eighty-steaks-play.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-tokens": minor
+---
+
+Apply deep freeze to the `tokens` object.

--- a/.changeset/plenty-planes-sniff.md
+++ b/.changeset/plenty-planes-sniff.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Now exports the `tokens` object from `@channel.io/bezier-tokens`.

--- a/packages/bezier-react/src/components/Avatar/Avatar.tsx
+++ b/packages/bezier-react/src/components/Avatar/Avatar.tsx
@@ -15,7 +15,7 @@ import {
   Status,
   type StatusSize,
 } from '~/src/components/Status'
-import { useToken } from '~/src/components/ThemeProvider'
+import { useTokens } from '~/src/components/ThemeProvider'
 
 import type { AvatarProps } from './Avatar.types'
 import defaultAvatarUrl from './assets/default-avatar.svg'
@@ -29,7 +29,7 @@ const shadow: AlphaSmoothCornersBoxProps['shadow'] = {
 }
 
 export function useAvatarRadiusToken() {
-  return useToken().global.radius['radius-42-p']
+  return useTokens().global.radius['radius-42-p']
 }
 
 export const AVATAR_WRAPPER_TEST_ID = 'bezier-avatar-wrapper'

--- a/packages/bezier-react/src/components/Icon/Icon.stories.tsx
+++ b/packages/bezier-react/src/components/Icon/Icon.stories.tsx
@@ -39,7 +39,7 @@ import { ListItem } from '~/src/components/ListItem'
 import { Select } from '~/src/components/Select'
 import { Stack } from '~/src/components/Stack'
 import { Text } from '~/src/components/Text'
-import { useToken } from '~/src/components/ThemeProvider'
+import { useTokens } from '~/src/components/ThemeProvider'
 
 import { Icon } from './Icon'
 import mdx from './Icon.mdx'
@@ -200,7 +200,7 @@ function ColorIcon() {
       <LegacyStackItem>
         <Select text={color} style={{ width: 200 }}>
           <div style={{ padding: 6, maxHeight: 200, overflowY: 'auto' }}>
-            { Object.keys(useToken().semantic.color).map((semanticName) => (
+            { Object.keys(useTokens().semantic.color).map((semanticName) => (
               <ListItem
                 key={semanticName}
                 content={semanticName}

--- a/packages/bezier-react/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/bezier-react/src/components/ThemeProvider/ThemeProvider.tsx
@@ -20,10 +20,10 @@ export function useThemeName() {
 }
 
 /**
- * `useToken` is a hook that returns the design token for the current theme.
+ * `useTokens` is a hook that returns the design tokens of the current theme.
  */
-export function useToken() {
-  return useTokenContext('useToken').tokens
+export function useTokens() {
+  return useTokenContext('useTokens').tokens
 }
 
 /**

--- a/packages/bezier-react/src/components/ThemeProvider/index.ts
+++ b/packages/bezier-react/src/components/ThemeProvider/index.ts
@@ -4,7 +4,7 @@ export {
   LightThemeProvider,
   ThemeProvider,
   useThemeName,
-  useToken,
+  useTokens,
 } from './ThemeProvider'
 export {
   type FixedThemeProviderProps,

--- a/packages/bezier-react/src/components/TokenProvider/TokenProvider.tsx
+++ b/packages/bezier-react/src/components/TokenProvider/TokenProvider.tsx
@@ -6,7 +6,7 @@ import { type ThemeName } from '~/src/types/tokens'
 import { createContext } from '~/src/utils/react'
 
 import {
-  type ThemedTokenSet,
+  type ThemeSpecificTokens,
   type TokenContextValue,
   type TokenProviderProps,
 } from './TokenProvider.types'
@@ -15,7 +15,7 @@ const [TokenContextProvider, useTokenContext] = createContext<TokenContextValue 
 
 export { useTokenContext }
 
-const tokenSet: Record<ThemeName, ThemedTokenSet> = Object.freeze({
+const tokenSet: Record<ThemeName, ThemeSpecificTokens> = Object.freeze({
   light: {
     global: tokens.global,
     semantic: tokens.lightTheme,

--- a/packages/bezier-react/src/components/TokenProvider/TokenProvider.types.ts
+++ b/packages/bezier-react/src/components/TokenProvider/TokenProvider.types.ts
@@ -5,14 +5,14 @@ import {
   type ThemeName,
 } from '~/src/types/tokens'
 
-export type ThemedTokenSet = {
+export type ThemeSpecificTokens = {
   global: GlobalToken
   semantic: SemanticToken
 }
 
 export interface TokenContextValue {
   themeName: ThemeName
-  tokens: ThemedTokenSet
+  tokens: ThemeSpecificTokens
 }
 
 interface TokenProviderOwnProps {

--- a/packages/bezier-react/src/index.ts
+++ b/packages/bezier-react/src/index.ts
@@ -1,6 +1,9 @@
 /* --------------------------------- STYLES --------------------------------- */
 import '~/src/styles/index.scss'
 
+/* --------------------------------- TOKENS --------------------------------- */
+export { tokens } from '@channel.io/bezier-tokens'
+
 /* ------------------------------- COMPONENTS ------------------------------- */
 export * from '~/src/components/AlphaSmoothCornersBox'
 export * from '~/src/components/AppProvider'

--- a/packages/bezier-tokens/scripts/lib/format.ts
+++ b/packages/bezier-tokens/scripts/lib/format.ts
@@ -20,16 +20,16 @@ export const customJsCjs: CustomFormat = {
 
     return (
       `${fileHeader({ file })
-      }module.exports = {` +
+      }module.exports = Object.freeze({` +
       `${Object.keys(categorizedTokens).map(category => (
-        `\n  "${category}": {\n` +
+        `\n  "${category}": Object.freeze({\n` +
           `${
             categorizedTokens[category]
               .map((token) => `    "${token.name}": ${JSON.stringify(token.value)},`)
               .join('\n')
-          }\n  }`
+          }\n  })`
       ))}\n` +
-      '}\n'
+      '})\n'
     )
   },
 }
@@ -46,16 +46,16 @@ export const customJsEsm: CustomFormat = {
 
     return (
       `${fileHeader({ file })
-      }export default {` +
+      }export default Object.freeze({` +
       `${Object.keys(categorizedTokens).map(category => (
-        `\n  "${category}": {\n` +
+        `\n  "${category}": Object.freeze({\n` +
           `${
             categorizedTokens[category]
               .map((token) => `    "${token.name}": ${JSON.stringify(token.value)},`)
               .join('\n')
-          }\n  }`
+          }\n  })`
       ))}\n` +
-      '}\n'
+      '})\n'
     )
   },
 }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

Exports the tokens object from bezier-tokens

## Details
<!-- Please elaborate description of the changes -->

bezier-react에서 `tokens` 객체를 export 하도록 변경하고, 몇가지 개선사항들을 적용합니다.

- 변경 이유: `useToken` 훅은 현재 테마에 해당하는 토큰만을 가져올 수 있습니다. 하지만 마이그레이션 하다보니 현재 테마 외에도 다른 테마에 해당하는 토큰 값을 가져오는 유즈 케이스가 꽤 많이 있었습니다. 이 부분은 커버하기 위해, `tokens` 객체를 외부로 내보냅니다.
  - `subTheme` 를 일부만 사용하는 경우, 프론트 다크모드의 경우가 이에 해당합니다.
- `tokens` 객체에 deep freeze를 적용하여 내부 객체의 내용도 불변하도록 개선했습니다.
  - 소소한 개선: 타입스크립트에서 Readonly 타입으로 추론되므로, 타입만으로 해당 토큰의 실제 값을 알 수 있습니다.
- `useToken` 훅의 이름을 `useTokens` 로 변경합니다. `useThemeName` 과 마찬가지로 context value와 훅의 이름을 통일하는 편이 좋다고 생각했습니다(themeName, tokens). 또한 `useToken` 이라는 이름은 개별 토큰을 반환하는 훅일거 같은 뉘앙스를 풍기며, bezier-tokens 패키지의 이름과도 맞지 않는다고 판단했습니다.

<img width="899" alt="image" src="https://github.com/channel-io/bezier-react/assets/58209009/ca9c533c-c939-4f2c-b2fd-dc5c0d4b2edb">

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No (alpha)
