### PR TITLE
refactor(bezier-figma-plugin): migrate to use bezier-react v2 alpha

### DIFF
--- a/.changeset/early-deers-attend.md
+++ b/.changeset/early-deers-attend.md
@@ -1,0 +1,5 @@
+---
+"bezier-figma-plugin": minor
+---
+
+Upgrade to use @channel.io/bezier-react@2.0.0

--- a/packages/bezier-figma-plugin/package.json
+++ b/packages/bezier-figma-plugin/package.json
@@ -39,11 +39,10 @@
   },
   "dependencies": {
     "@channel.io/bezier-icons": "^0.18.0",
-    "@channel.io/bezier-react": "^1.19.0",
+    "@channel.io/bezier-react": "^2.0.0-alpha.12",
     "octokit": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.15.0",
-    "styled-components": "^5.3.11"
+    "react-router-dom": "^6.15.0"
   }
 }

--- a/packages/bezier-figma-plugin/src/ui/components/ExtractSuccess.tsx
+++ b/packages/bezier-figma-plugin/src/ui/components/ExtractSuccess.tsx
@@ -9,9 +9,7 @@ import {
   Button,
   ButtonColorVariant,
   ButtonStyleVariant,
-  StackItem,
   Text,
-  Typography,
   VStack,
 } from '@channel.io/bezier-react'
 
@@ -26,21 +24,15 @@ function ExtractSuccess() {
 
   return (
     <VStack align="center" justify="center" spacing={2}>
-      <StackItem>
-        <Text typo={Typography.Size18}>아이콘 추출 성공!</Text>
-      </StackItem>
-      <StackItem>
-        { /* @ts-ignore */ }
-        <Text color="bgtxt-blue-normal" as="a" href={url} target="_blank">PR 링크</Text>
-      </StackItem>
-      <StackItem marginBefore={40}>
-        <Button
-          styleVariant={ButtonStyleVariant.Secondary}
-          colorVariant={ButtonColorVariant.MonochromeDark}
-          text="선택 단계로"
-          onClick={handleClickGoHome}
-        />
-      </StackItem>
+      <Text typo="18">아이콘 추출 성공!</Text>
+      { /* @ts-ignore */ }
+      <Text color="bgtxt-blue-normal" as="a" href={url} target="_blank">PR 링크</Text>
+      <Button
+        styleVariant={ButtonStyleVariant.Secondary}
+        colorVariant={ButtonColorVariant.MonochromeDark}
+        text="선택 단계로"
+        onClick={handleClickGoHome}
+      />
     </VStack>
   )
 }

--- a/packages/bezier-figma-plugin/src/ui/components/Home.tsx
+++ b/packages/bezier-figma-plugin/src/ui/components/Home.tsx
@@ -6,7 +6,6 @@ import { HexahedronIcon } from '@channel.io/bezier-icons'
 import {
   ListItem,
   ListItemSize,
-  StackItem,
   VStack,
 } from '@channel.io/bezier-react'
 
@@ -19,14 +18,12 @@ function Home() {
 
   return (
     <VStack align="stretch">
-      <StackItem>
-        <ListItem
-          size={ListItemSize.XL}
-          leftIcon={HexahedronIcon}
-          content="아이콘 추출"
-          onClick={handleClickExtract}
-        />
-      </StackItem>
+      <ListItem
+        size={ListItemSize.L}
+        leftContent={HexahedronIcon}
+        content="아이콘 추출"
+        onClick={handleClickExtract}
+      />
     </VStack>
   )
 }

--- a/packages/bezier-figma-plugin/src/ui/components/IconExtract.tsx
+++ b/packages/bezier-figma-plugin/src/ui/components/IconExtract.tsx
@@ -16,8 +16,6 @@ import {
   FormLabel,
   HStack,
   ProgressBar,
-  Spacer,
-  StackItem,
   Text,
   TextField,
   TextFieldType,
@@ -112,16 +110,12 @@ function Progress({
   }, [])
 
   return (
-    <VStack align="stretch" spacing={6}>
-      <StackItem>
-        <ProgressBar
-          width="100%"
-          value={progressValue}
-        />
-      </StackItem>
-      <StackItem>
-        <Text>{ progressTitle }</Text>
-      </StackItem>
+    <VStack spacing={6}>
+      <ProgressBar
+        width="100%"
+        value={progressValue}
+      />
+      <Text>{ progressTitle }</Text>
     </VStack>
   )
 }
@@ -177,83 +171,65 @@ function IconExtract() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <VStack align="stretch">
-        <StackItem>
-          <VStack align="stretch" spacing={12}>
-            <StackItem>
-              <FormControl required readOnly={step !== Step.Pending}>
-                <FormLabel help="좌측 상단 Figma 로고 > Help and account > Account settings 에서 발급 받을 수 있습니다.">
-                  Figma personal access token
-                </FormLabel>
-                <TextField
-                  type={TextFieldType.Password}
-                  name="figmaToken"
-                  placeholder="figd_..."
-                  value={figmaToken}
-                  onChange={handleChangeFigmaToken}
-                />
-              </FormControl>
-            </StackItem>
-            <StackItem>
-              <FormControl required readOnly={step !== Step.Pending}>
-                <FormLabel help="Github Repository 쓰기 권한이 있는 토큰을 사용해주세요.">
-                  Github personal access token
-                </FormLabel>
-                <TextField
-                  type={TextFieldType.Password}
-                  name="githubToken"
-                  placeholder="ghp_..."
-                  value={githubToken}
-                  onChange={handleChangeGithubToken}
-                />
-              </FormControl>
-            </StackItem>
-            <StackItem>
-              <FormControl readOnly>
-                <FormLabel>추출할 경로 (루트 기준)</FormLabel>
-                <TextField value={config.repository.iconExtractPath} />
-              </FormControl>
-            </StackItem>
-            <StackItem marginBefore={4}>
-              { errorMessage
-                ? <FormErrorMessage>{ errorMessage }</FormErrorMessage>
-                : <FormHelperText>토큰은 추출 성공 시 로컬 스토리지에 저장됩니다.</FormHelperText> }
-            </StackItem>
-          </VStack>
-        </StackItem>
-
-        <Spacer />
-
-        <StackItem>
-          { step === Step.Pending && (
-            <HStack justify="end" spacing={6}>
-              <StackItem>
-                <Button
-                  type="submit"
-                  styleVariant={ButtonStyleVariant.Primary}
-                  colorVariant={ButtonColorVariant.Blue}
-                  text="아이콘 추출"
-                />
-              </StackItem>
-              <StackItem>
-                <Button
-                  styleVariant={ButtonStyleVariant.Secondary}
-                  colorVariant={ButtonColorVariant.MonochromeDark}
-                  text="선택 단계로"
-                  onClick={handleClickCancel}
-                />
-              </StackItem>
-            </HStack>
-          ) }
-
-          { step === Step.Processing && (
-            <Progress
-              figmaToken={figmaToken}
-              githubToken={githubToken}
-              onError={handleExtractError}
+      <VStack justify="between">
+        <VStack spacing={12}>
+          <FormControl required readOnly={step !== Step.Pending}>
+            <FormLabel help="좌측 상단 Figma 로고 > Help and account > Account settings 에서 발급 받을 수 있습니다.">
+              Figma personal access token
+            </FormLabel>
+            <TextField
+              type={TextFieldType.Password}
+              name="figmaToken"
+              placeholder="figd_..."
+              value={figmaToken}
+              onChange={handleChangeFigmaToken}
             />
-          ) }
-        </StackItem>
+          </FormControl>
+          <FormControl required readOnly={step !== Step.Pending}>
+            <FormLabel help="Github Repository 쓰기 권한이 있는 토큰을 사용해주세요.">
+              Github personal access token
+            </FormLabel>
+            <TextField
+              type={TextFieldType.Password}
+              name="githubToken"
+              placeholder="ghp_..."
+              value={githubToken}
+              onChange={handleChangeGithubToken}
+            />
+          </FormControl>
+          <FormControl readOnly>
+            <FormLabel>추출할 경로 (루트 기준)</FormLabel>
+            <TextField value={config.repository.iconExtractPath} />
+          </FormControl>
+          { errorMessage
+            ? <FormErrorMessage>{ errorMessage }</FormErrorMessage>
+            : <FormHelperText>토큰은 추출 성공 시 로컬 스토리지에 저장됩니다.</FormHelperText> }
+        </VStack>
+
+        { step === Step.Pending && (
+          <HStack justify="end" spacing={6}>
+            <Button
+              type="submit"
+              styleVariant={ButtonStyleVariant.Primary}
+              colorVariant={ButtonColorVariant.Blue}
+              text="아이콘 추출"
+            />
+            <Button
+              styleVariant={ButtonStyleVariant.Secondary}
+              colorVariant={ButtonColorVariant.MonochromeDark}
+              text="선택 단계로"
+              onClick={handleClickCancel}
+            />
+          </HStack>
+        ) }
+
+        { step === Step.Processing && (
+          <Progress
+            figmaToken={figmaToken}
+            githubToken={githubToken}
+            onError={handleExtractError}
+          />
+        ) }
       </VStack>
     </form>
   )

--- a/packages/bezier-figma-plugin/src/ui/index.tsx
+++ b/packages/bezier-figma-plugin/src/ui/index.tsx
@@ -7,20 +7,19 @@ import {
   Routes,
 } from 'react-router-dom'
 
-import {
-  BezierProvider,
-  LightFoundation,
-} from '@channel.io/bezier-react'
+import { AppProvider } from '@channel.io/bezier-react'
 
 import ExtractSuccess from './components/ExtractSuccess'
 import Home from './components/Home'
 import IconExtract from './components/IconExtract'
 
+import '@channel.io/bezier-react/styles.css'
+
 const container = document.getElementById('root') as HTMLElement
 const root = createRoot(container)
 
 root.render(
-  <BezierProvider foundation={LightFoundation}>
+  <AppProvider>
     <MemoryRouter>
       <Routes>
         <Route index element={(<Home />)} />
@@ -28,5 +27,5 @@ root.render(
         <Route path="extract_success" element={(<ExtractSuccess />)} />
       </Routes>
     </MemoryRouter>
-  </BezierProvider>,
+  </AppProvider>,
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,7 +464,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.18.6, @babel/helper-module-imports@npm:^7.22.5":
+"@babel/helper-module-imports@npm:^7.18.6, @babel/helper-module-imports@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-module-imports@npm:7.22.5"
   dependencies:
@@ -2448,7 +2448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.4.5":
+"@babel/traverse@npm:^7.1.6":
   version: 7.22.11
   resolution: "@babel/traverse@npm:7.22.11"
   dependencies:
@@ -2888,39 +2888,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@channel.io/bezier-react@npm:^1.19.0":
-  version: 1.19.0
-  resolution: "@channel.io/bezier-react@npm:1.19.0"
-  dependencies:
-    "@radix-ui/react-checkbox": ^1.0.4
-    "@radix-ui/react-dialog": ^1.0.4
-    "@radix-ui/react-radio-group": ^1.1.3
-    "@radix-ui/react-separator": ^1.0.3
-    "@radix-ui/react-slider": ^1.1.2
-    "@radix-ui/react-slot": ^1.0.2
-    "@radix-ui/react-switch": ^1.0.3
-    "@radix-ui/react-tabs": ^1.0.4
-    "@radix-ui/react-toolbar": ^1.0.4
-    "@radix-ui/react-tooltip": ^1.0.6
-    "@radix-ui/react-visually-hidden": ^1.0.3
-    classnames: ^2.3.2
-    react-resize-detector: ^9.1.0
-    react-textarea-autosize: 8.3.4
-    ssr-window: ^4.0.2
-    uuid: ^9.0.0
-  peerDependencies:
-    "@channel.io/bezier-icons": ">=0.2.0"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    styled-components: ">=5"
-  peerDependenciesMeta:
-    "@channel.io/bezier-icons":
-      optional: true
-  checksum: a54568d3258c0dd5b53572201fad69702d05eb70dc1e2727be180a478155473728997264de2d36294e3b63d452d330a0aff9d959607d615f0a2fee261e332a6e
-  languageName: node
-  linkType: hard
-
-"@channel.io/bezier-react@workspace:packages/bezier-react":
+"@channel.io/bezier-react@^2.0.0-alpha.12, @channel.io/bezier-react@workspace:packages/bezier-react":
   version: 0.0.0-use.local
   resolution: "@channel.io/bezier-react@workspace:packages/bezier-react"
   dependencies:
@@ -3769,36 +3737,6 @@ __metadata:
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
   checksum: 2176d301cc258ea5c2324402997cf8134ebb212469c0d397591636cea8d3c02f2b3cf9fd58dcb748c7a0dade77ebdc1b10284fa63e608c033a1db52fddc69918
-  languageName: node
-  linkType: hard
-
-"@emotion/is-prop-valid@npm:^1.1.0":
-  version: 1.1.3
-  resolution: "@emotion/is-prop-valid@npm:1.1.3"
-  dependencies:
-    "@emotion/memoize": ^0.7.4
-  checksum: 511997c3bbaab5a967db65b65a111afc46c4aac8b3b87a436fd9e3dc2891829a9ada1405b77326f407d93934ee3b831e62248b498c071089312c5be080af75dd
-  languageName: node
-  linkType: hard
-
-"@emotion/memoize@npm:^0.7.4":
-  version: 0.7.5
-  resolution: "@emotion/memoize@npm:0.7.5"
-  checksum: 83da8d4a7649a92c72f960817692bc6be13cc13e107b9f7e878d63766525ed4402881bfeb3cda61145c050281e7e260f114a0a2870515527346f2ef896b915b3
-  languageName: node
-  linkType: hard
-
-"@emotion/stylis@npm:^0.8.4":
-  version: 0.8.5
-  resolution: "@emotion/stylis@npm:0.8.5"
-  checksum: 67ff5958449b2374b329fb96e83cb9025775ffe1e79153b499537c6c8b2eb64b77f32d7b5d004d646973662356ceb646afd9269001b97c54439fceea3203ce65
-  languageName: node
-  linkType: hard
-
-"@emotion/unitless@npm:^0.7.4":
-  version: 0.7.5
-  resolution: "@emotion/unitless@npm:0.7.5"
-  checksum: f976e5345b53fae9414a7b2e7a949aa6b52f8bdbcc84458b1ddc0729e77ba1d1dfdff9960e0da60183877873d3a631fa24d9695dd714ed94bcd3ba5196586a6b
   languageName: node
   linkType: hard
 
@@ -9609,21 +9547,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-styled-components@npm:>= 1.12.0":
-  version: 2.1.4
-  resolution: "babel-plugin-styled-components@npm:2.1.4"
-  dependencies:
-    "@babel/helper-annotate-as-pure": ^7.22.5
-    "@babel/helper-module-imports": ^7.22.5
-    "@babel/plugin-syntax-jsx": ^7.22.5
-    lodash: ^4.17.21
-    picomatch: ^2.3.1
-  peerDependencies:
-    styled-components: ">= 2"
-  checksum: d791aed68d975dae4f73055f86cd47afa99cb402b8113acdaf5678c8b6fba2cbc15543f2debe8ed09becb198aae8be2adfe268ad41f4bca917288e073a622bf8
-  languageName: node
-  linkType: hard
-
 "babel-plugin-transform-react-remove-prop-types@npm:^0.4.24":
   version: 0.4.24
   resolution: "babel-plugin-transform-react-remove-prop-types@npm:0.4.24"
@@ -9749,7 +9672,7 @@ __metadata:
   resolution: "bezier-figma-plugin@workspace:packages/bezier-figma-plugin"
   dependencies:
     "@channel.io/bezier-icons": ^0.18.0
-    "@channel.io/bezier-react": ^1.19.0
+    "@channel.io/bezier-react": ^2.0.0-alpha.12
     "@figma/plugin-typings": ^1.76.0
     "@types/react": ^18.2.21
     "@types/react-dom": ^18.2.7
@@ -9763,7 +9686,6 @@ __metadata:
     react-dom: ^18.2.0
     react-router-dom: ^6.15.0
     style-loader: ^3.3.3
-    styled-components: ^5.3.11
     ts-loader: ^9.4.4
     tsconfig: "workspace:*"
     url-loader: ^4.1.1
@@ -10153,13 +10075,6 @@ __metadata:
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
-  languageName: node
-  linkType: hard
-
-"camelize@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "camelize@npm:1.0.0"
-  checksum: 769f8d10071f57b974d9a51dc02f589dd7fb07ea6a7ecde1a57b52ae68657ba61fe85c60d50661b76c7dbb76b6474fbfd3356aee33cf5f025cd7fd6fb2811b73
   languageName: node
   linkType: hard
 
@@ -11106,13 +11021,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-color-keywords@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "css-color-keywords@npm:1.0.0"
-  checksum: 8f125e3ad477bd03c77b533044bd9e8a6f7c0da52d49bbc0bbe38327b3829d6ba04d368ca49dd9ff3b667d2fc8f1698d891c198bbf8feade1a5501bf5a296408
-  languageName: node
-  linkType: hard
-
 "css-declaration-sorter@npm:^6.3.1":
   version: 6.4.1
   resolution: "css-declaration-sorter@npm:6.4.1"
@@ -11192,17 +11100,6 @@ __metadata:
     domutils: ^3.0.1
     nth-check: ^2.0.1
   checksum: 2772c049b188d3b8a8159907192e926e11824aea525b8282981f72ba3f349cf9ecd523fdf7734875ee2cb772246c22117fc062da105b6d59afe8dcd5c99c9bda
-  languageName: node
-  linkType: hard
-
-"css-to-react-native@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "css-to-react-native@npm:3.0.0"
-  dependencies:
-    camelize: ^1.0.0
-    css-color-keywords: ^1.0.0
-    postcss-value-parser: ^4.0.2
-  checksum: 98a2e9d4fbe9cabc8b744dfdd5ec108396ce497a7b860912a95b299bd52517461281810fcb707965a021a8be39adca9587184a26fb4e926211391a1557aca3c1
   languageName: node
   linkType: hard
 
@@ -14455,15 +14352,6 @@ __metadata:
     capital-case: ^1.0.4
     tslib: ^2.0.3
   checksum: 571c83eeb25e8130d172218712f807c0b96d62b020981400bccc1503a7cf14b09b8b10498a962d2739eccf231d950e3848ba7d420b58a6acd2f9283439546cd9
-  languageName: node
-  linkType: hard
-
-"hoist-non-react-statics@npm:^3.0.0":
-  version: 3.3.2
-  resolution: "hoist-non-react-statics@npm:3.3.2"
-  dependencies:
-    react-is: ^16.7.0
-  checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
   languageName: node
   linkType: hard
 
@@ -19461,7 +19349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-value-parser@npm:^4.0.2, postcss-value-parser@npm:^4.1.0, postcss-value-parser@npm:^4.2.0":
+"postcss-value-parser@npm:^4.1.0, postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 819ffab0c9d51cf0acbabf8996dffbfafbafa57afc0e4c98db88b67f2094cb44488758f06e5da95d7036f19556a4a732525e84289a425f4f6fd8e412a9d7442f
@@ -19975,7 +19863,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
+"react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -20059,18 +19947,6 @@ __metadata:
     react: ^16.0.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
   checksum: 55f4abad7f7523d16b081b5ab20f75c539a54a08253ce7e9df473d48386f42ceca6c31584ba9fa26e3528b498ef6685ec77fb9a22cffc97df05fb326d0bf1b26
-  languageName: node
-  linkType: hard
-
-"react-resize-detector@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "react-resize-detector@npm:9.1.0"
-  dependencies:
-    lodash: ^4.17.21
-  peerDependencies:
-    react: ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 05b263e141fd428eea433e399f88c3e1a379b4a2293958f59b5a5c75dd86c621ce60583724257cc3dc1f5c120a664666ff3fa53d41e6c283687676dc55afa02b
   languageName: node
   linkType: hard
 
@@ -21115,13 +20991,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shallowequal@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "shallowequal@npm:1.1.0"
-  checksum: f4c1de0837f106d2dbbfd5d0720a5d059d1c66b42b580965c8f06bb1db684be8783538b684092648c981294bf817869f743a066538771dbecb293df78f765e00
-  languageName: node
-  linkType: hard
-
 "shebang-command@npm:^1.2.0":
   version: 1.2.0
   resolution: "shebang-command@npm:1.2.0"
@@ -21801,28 +21670,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"styled-components@npm:^5.3.11":
-  version: 5.3.11
-  resolution: "styled-components@npm:5.3.11"
-  dependencies:
-    "@babel/helper-module-imports": ^7.0.0
-    "@babel/traverse": ^7.4.5
-    "@emotion/is-prop-valid": ^1.1.0
-    "@emotion/stylis": ^0.8.4
-    "@emotion/unitless": ^0.7.4
-    babel-plugin-styled-components: ">= 1.12.0"
-    css-to-react-native: ^3.0.0
-    hoist-non-react-statics: ^3.0.0
-    shallowequal: ^1.1.0
-    supports-color: ^5.5.0
-  peerDependencies:
-    react: ">= 16.8.0"
-    react-dom: ">= 16.8.0"
-    react-is: ">= 16.8.0"
-  checksum: 10edd4dae3b0231ec02d86bdd09c88e894eedfa7e9d4f8e562b09fb69c67a27d586cbcf35c785002d59b3bf11e6c0940b0efce40d13ae9ed148b26b1dc8f3284
-  languageName: node
-  linkType: hard
-
 "stylehacks@npm:^5.1.1":
   version: 5.1.1
   resolution: "stylehacks@npm:5.1.1"
@@ -21989,7 +21836,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.3.0, supports-color@npm:^5.5.0":
+"supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

bezier-figma-plugin에 최신 버전의 bezier-react를 적용합니다.

## Details
<!-- Please elaborate description of the changes -->

styled-components를 제거합니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
