### PR TITLE
fix(legacy-stack): add missing default margin style

### DIFF
--- a/.changeset/eight-hounds-smoke.md
+++ b/.changeset/eight-hounds-smoke.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Add missing default margin styles of `LegacyStackItem`

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.module.scss
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.module.scss
@@ -4,6 +4,10 @@
   /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
   flex-shrink: var(--b-shrink-weight);
 
+  /* NOTE: You may think it's unnecessary, but there are application styles that are leaning on that default style default (incorrectly). */
+  margin-top: var(--b-margin-before);
+  margin-bottom: var(--b-margin-after);
+
   &:where(.direction-horizontal) {
     margin-right: var(--b-margin-after);
     margin-left: var(--b-margin-before);

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.module.scss
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.module.scss
@@ -5,17 +5,14 @@
   flex-shrink: var(--b-shrink-weight);
 
   /* NOTE: You may think it's unnecessary, but there are application styles that are leaning on that default style default (incorrectly). */
-  margin-top: var(--b-margin-before);
-  margin-bottom: var(--b-margin-after);
+  margin: var(--b-margin-before) 0 var(--b-margin-after) 0;
 
   &:where(.direction-horizontal) {
-    margin-right: var(--b-margin-after);
-    margin-left: var(--b-margin-before);
+    margin: 0 var(--b-margin-after) 0 var(--b-margin-before);
   }
 
   &:where(.direction-vertical) {
-    margin-top: var(--b-margin-before);
-    margin-bottom: var(--b-margin-after);
+    margin: var(--b-margin-before) 0 var(--b-margin-after) 0;
   }
 
   &:where(.justify-start) {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

Add missing default margin styles of LegacyStackItem

## Details
<!-- Please elaborate description of the changes -->

정상적인 경우라면, `Stack` 이 자식 `StackItem` 에 direction 속성을 주입하는 형태가 되어야 합니다. `StackItem` 의 direction은 undefined가 되면 안됩니다. 하지만 어플리케이션에서 `StackItem` 에 direction 속성을 제대로 주입하지 않은 채로 margin 속성에만 기대어 스타일링 하는 케이스들이 있었습니다(고객 연락처). 이를 수정하기 위해 이전 코드를 참고하여 기본 margin 스타일을 추가하였습니다.

https://github.com/channel-io/bezier-react/blob/898f221836c9c7ec8ea1ec7894d2c9b00b4e2f96/packages/bezier-react/src/components/Stack/StackItem/StackItem.styled.ts#L33-L43

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
