### PR TITLE
fix(components): change incorrect default value of css variable 'inherit' to 'initial'

### DIFF
--- a/.changeset/chilled-oranges-drum.md
+++ b/.changeset/chilled-oranges-drum.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fixes an issue with color inheritance across components.

--- a/packages/bezier-react/src/components/Icon/Icon.module.scss
+++ b/packages/bezier-react/src/components/Icon/Icon.module.scss
@@ -1,5 +1,5 @@
 .Icon {
-  --b-icon-color: inherit;
+  --b-icon-color: initial;
 
   flex: 0 0 auto;
   color: var(--b-icon-color);

--- a/packages/bezier-react/src/components/ListItem/ListItem.module.scss
+++ b/packages/bezier-react/src/components/ListItem/ListItem.module.scss
@@ -65,10 +65,6 @@
       background-color: var(--bgtxt-blue-lighter);
     }
 
-    & :where(.ListItemLeftIcon) {
-      color: var(--bgtxt-blue-normal);
-    }
-
     /* NOTE: When multiple adjacent elements are active, it naturally stitches the border together. */
     /* stylelint-disable selector-max-specificity */
     &:has(+ .ListItem.active) {
@@ -84,35 +80,20 @@
   }
 
   &.variant-blue {
-    color: var(--bgtxt-blue-normal);
+     color: var(--bgtxt-blue-normal);
 
-    & :where(.ListItemLeftIcon) {
-      color: var(--bgtxt-blue-normal);
-    }
   }
 
   &.variant-red {
     color: var(--bgtxt-red-normal);
-
-    & :where(.ListItemLeftIcon) {
-      color: var(--bgtxt-red-normal);
-    }
   }
 
   &.variant-green {
     color: var(--bgtxt-green-normal);
-
-    & :where(.ListItemLeftIcon) {
-      color: var(--bgtxt-green-normal);
-    }
   }
 
   &.variant-cobalt {
     color: var(--bgtxt-cobalt-normal);
-
-    & :where(.ListItemLeftIcon) {
-      color: var(--bgtxt-cobalt-normal);
-    }
   }
 }
 

--- a/packages/bezier-react/src/components/ListItem/ListItem.module.scss
+++ b/packages/bezier-react/src/components/ListItem/ListItem.module.scss
@@ -80,7 +80,7 @@
   }
 
   &.variant-blue {
-     color: var(--bgtxt-blue-normal);
+    color: var(--bgtxt-blue-normal);
 
   }
 

--- a/packages/bezier-react/src/components/Spinner/Spinner.module.scss
+++ b/packages/bezier-react/src/components/Spinner/Spinner.module.scss
@@ -11,7 +11,7 @@
 }
 
 .Spinner {
-  --b-spinner-color: inherit;
+  --b-spinner-color: initial;
 
   display: inline-block;
 

--- a/packages/bezier-react/src/components/Status/Status.module.scss
+++ b/packages/bezier-react/src/components/Status/Status.module.scss
@@ -3,7 +3,7 @@
 .Status {
   --b-status-size: 0;
   --b-status-border-width: 0;
-  --b-status-bg-color: inherit;
+  --b-status-bg-color: initial;
 
   position: relative;
   z-index: var(--z-index-base);

--- a/packages/bezier-react/src/components/Tabs/Tabs.module.scss
+++ b/packages/bezier-react/src/components/Tabs/Tabs.module.scss
@@ -39,7 +39,6 @@ $tab-item-indicator-height: 3px;
 .TabItem {
   top: 4px;
   overflow: visible;
-  color: inherit;
 
   &::after {
     content: '';

--- a/packages/bezier-react/src/components/Tag/Tag.module.scss
+++ b/packages/bezier-react/src/components/Tag/Tag.module.scss
@@ -4,7 +4,7 @@
   * @see {@link https://github.com/channel-io/bezier-react/issues/1879}
   * share background style logic with `Badge` after removing `color` props
   */
-  --b-tag-badge-background-color: inherit;
+  --b-tag-badge-background-color: initial;
 
   background-color: var(--b-tag-badge-background-color);
 }

--- a/packages/bezier-react/src/components/Text/Text.module.scss
+++ b/packages/bezier-react/src/components/Text/Text.module.scss
@@ -3,7 +3,7 @@
 $typo-sizes: 11, 12, 13, 14, 15, 16, 17, 18, 22, 24, 30, 36;
 
 .Text {
-  --b-text-color: inherit;
+  --b-text-color: initial;
   --b-text-line-clamp: 1;
   --b-text-line-height: initial;
   --b-text-font-size: initial;


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- Fixes #2006

## Summary
<!-- Please brief explanation of the changes made -->

Change incorrect default value of css variable 'inherit' to 'initial'

## Details
<!-- Please elaborate description of the changes -->

잘못된 마이그레이션을 수정합니다. 기존에는 아래와 같은 사고 흐름으로 마이그레이션을 진행했었습니다.

```
// AS-IS
color: colorProp ? colorProp : inherit

// TO-BE
// 스타일 외부에서 --color를 조건부 주입하면 되겠다.
--color: inherit;
color: var(--color)
```

하지만 CSS variable의 초기 키워드로 `inherit` 을 설정하는 것과 해당 속성에 직접적으로 `inherit` 을 설정하는 건 동작이 아예 다릅니다.
위의 예를 들어, `--color: inherit` 은 color 속성에 상위 속성을 적용하는 게 아니라, 접근 가능한 가장 가까운 곳에 위치하는 `--color` 의 값을 상속하게됩니다. 한번 더 자세히 풀어보자면 아래와 같습니다.

```
<div style={{ '--color': 'red' }}>
  <div style={{ 'color': 'blue: }}>
    <Foo />
  </div>
</div>
```

맨 위 예제의 스타일이 적용된 컴포넌트를 `Foo` 라고 했을 때 `Foo` 의 color는 `red` 가 됩니다. **`--color` 는 color가 아니라 상위 `--color` 의 값을 상속받고, color는 `--color` 의 값을 가르키기 때문입니다**. 이를 오버라이드하기 위해선 상위에서 정확하게 `Foo` 요소를 선택하여 color 속성을 지정해줘야 합니다.

이러한 상속 방식은 마이그레이션 이전 컴포넌트의 동작과 다릅니다. [color 속성](https://developer.mozilla.org/ko/docs/Web/CSS/color)은 기본적으로 **[상속을 지원하는 속성](https://developer.mozilla.org/ko/docs/Web/CSS/Inheritance#%EC%83%81%EC%86%8D%EB%90%98%EB%8A%94_%EC%86%8D%EC%84%B1)이기 때문에** inherit 키워드를 지정할 필요가 없습니다. 값을 지정하지 않는다면, 부모의 값을 상속하게 됩니다. CSS variable을 유효하지 않은 값(Invalid Value)으로 만들면 color의 값은 값을 지정하지 않은 것으로 평가됩니다. 그러므로, 기존과 같이 부모의 값을 상속하게 됩니다. CSS variable에는 `initial` 키워드를 사용하여 [명시적으로 유효하지 않은 값](https://drafts.csswg.org/css-variables/#guaranteed-invalid)으로 설정했습니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

> If, for whatever reason, one wants to manually reset a variable to the guaranteed-invalid value, using the keyword [initial](https://drafts.csswg.org/css-cascade-5/#valdef-all-initial) will do this.

- https://drafts.csswg.org/css-variables/#guaranteed-invalid
