### PR TITLE
fix(component): make `smoothCornerScript` not throw error when called twice

### DIFF
--- a/.changeset/modern-days-cross.md
+++ b/.changeset/modern-days-cross.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Mute the error of `smoothCornerScript` when called twice.

--- a/packages/bezier-react/src/components/FeatureProvider/SmoothCornersFeature/smoothCornersScript.ts
+++ b/packages/bezier-react/src/components/FeatureProvider/SmoothCornersFeature/smoothCornersScript.ts
@@ -171,5 +171,14 @@ class SmoothCorners {
     ctx.closePath()
   }
 }
-registerPaint('smooth-corners', SmoothCorners)
+
+try {
+  registerPaint('smooth-corners', SmoothCorners)
+} catch (e) {
+  // If the paint already exists, don't make it error.
+  if (e instanceof TypeError) {
+    throw e
+  }
+}
+
 `

--- a/packages/bezier-react/src/components/FeatureProvider/SmoothCornersFeature/smoothCornersScript.ts
+++ b/packages/bezier-react/src/components/FeatureProvider/SmoothCornersFeature/smoothCornersScript.ts
@@ -176,9 +176,5 @@ try {
   registerPaint('smooth-corners', SmoothCorners)
 } catch (e) {
   // If the paint already exists, don't make it error.
-  if (e instanceof TypeError) {
-    throw e
-  }
 }
-
 `


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->
- fixes #2002 
<!-- Fixes #0000 -->

## Summary
<!-- Please brief explanation of the changes made -->
Add `try catch` block to mute the error when `smoothCornerScript` is called twice.

## Details
<!-- Please elaborate description of the changes -->
According to the [MDN documentation on `registerPaint()`](https://developer.mozilla.org/en-US/docs/Web/API/PaintWorkletGlobalScope/registerPaint#exceptions), this function only throws two errors. One when the parameters aren't met, throwing `TypeError` and the other when a worklet already exists with the given name, throwing `DOMException`. I thought that any of those two case won't happen in this particular case, so I just no-oped the `catch` statement. If it is not a good approach, I can narrow the error down to the later one, `DOMException`.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
No.

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

https://developer.mozilla.org/en-US/docs/Web/API/PaintWorkletGlobalScope/registerPaint#exceptions
