### PR TITLE
Add overflow: hidden to `ListItem` component 

### DIFF
--- a/.changeset/five-plants-rescue.md
+++ b/.changeset/five-plants-rescue.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Add `overflow: hidden` to `ListItem` component

--- a/packages/bezier-react/src/components/ListItem/ListItem.module.scss
+++ b/packages/bezier-react/src/components/ListItem/ListItem.module.scss
@@ -5,6 +5,7 @@
 .ListItem {
   cursor: pointer;
 
+  overflow: hidden;
   display: flex;
   align-items: center;
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- resolves https://github.com/channel-io/bezier-react/issues/2008

## Summary
<!-- Please brief explanation of the changes made -->

- 기존의 ListItem 컴포넌트에는 overflow: hidden 속성이 있었는데 scss 마이그레이션 과정에서 이게 없어지면서 생긴 스타일 차이입니다. 

## Details
<!-- Please elaborate description of the changes -->
- overflow: hidden 을 추가합니다. 

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->
- None

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- https://github.com/channel-io/bezier-react/pull/1925/files#diff-0c1f9928eb5f00ee455ed0cacd8ed51386570711f0502c324ea1fc6d97189970
