### PR TITLE
fix(modal): fix styling issues when subcomponents are used alone

### DIFF
--- a/.changeset/empty-jars-shop.md
+++ b/.changeset/empty-jars-shop.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fixes issue with `ModalBody`, `ModalFooter` not applying styling correctly when wrapped in other elements.

--- a/packages/bezier-react/src/components/Modal/Modal.module.scss
+++ b/packages/bezier-react/src/components/Modal/Modal.module.scss
@@ -44,6 +44,23 @@ $close-icon-button-margin-y: -6;
   }
 }
 
+.ModalHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: #{$modal-padding}px #{$modal-padding}px 0 #{$modal-padding}px;
+}
+
+.ModalBody {
+  flex: 1;
+  padding: #{$modal-padding}px;
+}
+
+.ModalFooter {
+  display: flex;
+  padding: #{$footer-top-gap}px #{$modal-padding}px #{$modal-padding}px;
+}
+
 .ModalContent {
   position: relative;
 
@@ -67,6 +84,19 @@ $close-icon-button-margin-y: -6;
     animation: content-show var(--transition-m);
   }
 
+  /* NOTE(@ed): Support when ModalFooter is used without ModalBody */
+  /* stylelint-disable-next-line selector-max-specificity */
+  &:has(.ModalBody) .ModalFooter {
+    margin-top: #{$footer-top-gap - $modal-padding}px;
+    padding-top: 0;
+  }
+
+  /* NOTE(@ed): Support when ModalBody is used without ModalHeader */
+  /* stylelint-disable-next-line selector-max-specificity */
+  &:has(.ModalHeader:not(.hidden)) .ModalBody {
+    padding-top: #{$header-body-gap}px;
+  }
+
   &:focus {
     outline: none;
   }
@@ -82,34 +112,6 @@ $close-icon-button-margin-y: -6;
   flex-direction: column;
   width: 100%;
   height: 100%;
-}
-
-.ModalBody {
-  flex: 1;
-  padding: #{$modal-padding}px;
-}
-
-.ModalHeader {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: #{$modal-padding}px #{$modal-padding}px 0 #{$modal-padding}px;
-
-  /* NOTE(@ed): Support when ModalBody is used as stand-alone */
-  &:where(:not(.hidden)) + :is(.ModalBody, * .ModalBody) {
-    padding-top: #{$header-body-gap}px;
-  }
-}
-
-.ModalFooter {
-  display: flex;
-  padding: #{$footer-top-gap}px #{$modal-padding}px #{$modal-padding}px;
-
-  /* NOTE(@ed): Support when ModalFooter is used without ModalBody */
-  :is(.ModalBody + &, .ModalBody + * &) {
-    margin-top: #{$footer-top-gap - $modal-padding}px;
-    padding-top: 0;
-  }
 }
 
 .TitleContainer {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

`Modal` 내부의 `ModalBody`가 `ModalHeader` 없이 사용될 때 혹은 `ModalFooter`가 `ModalBody` 없이 사용될 때 간격이 조절되지 않던 문제를 수정합니다.

## Details
<!-- Please elaborate description of the changes -->

일반적인 케이스에선 문제가 없었으나, 내부 컴포넌트들이 서로 인접해있지 않고 사이에 다른 요소를 두고 있는 경우. 예를 들어,

```html
<ModalHeader />
<div>
  <ModalBody />
</div>
<ModalFooter />
```

위와 같은 경우에 스타일이 제대로 적용되지 않던 문제를 수정했습니다.

`ModalContent` 에서 `:has()` 를 사용하는 방식으로 선택자를 단순화했습니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
