### PR TITLE
fix(list-item): fix left icon color specificity issue

### DIFF
--- a/.changeset/thin-games-add.md
+++ b/.changeset/thin-games-add.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix `ListItem`'s left icon color specificity issue.

--- a/packages/bezier-react/src/components/ListItem/ListItem.module.scss
+++ b/packages/bezier-react/src/components/ListItem/ListItem.module.scss
@@ -66,6 +66,10 @@
       background-color: var(--bgtxt-blue-lighter);
     }
 
+    & :where(.ListItemLeftIcon) {
+      color: var(--bgtxt-blue-normal);
+    }
+
     /* NOTE: When multiple adjacent elements are active, it naturally stitches the border together. */
     /* stylelint-disable selector-max-specificity */
     &:has(+ .ListItem.active) {
@@ -83,18 +87,33 @@
   &.variant-blue {
     color: var(--bgtxt-blue-normal);
 
+    & :where(.ListItemLeftIcon) {
+      color: var(--bgtxt-blue-normal);
+    }
   }
 
   &.variant-red {
     color: var(--bgtxt-red-normal);
+
+    & :where(.ListItemLeftIcon) {
+      color: var(--bgtxt-red-normal);
+    }
   }
 
   &.variant-green {
     color: var(--bgtxt-green-normal);
+
+    & :where(.ListItemLeftIcon) {
+      color: var(--bgtxt-green-normal);
+    }
   }
 
   &.variant-cobalt {
     color: var(--bgtxt-cobalt-normal);
+
+    & :where(.ListItemLeftIcon) {
+      color: var(--bgtxt-cobalt-normal);
+    }
   }
 }
 

--- a/packages/bezier-react/src/components/ListItem/ListItem.stories.tsx
+++ b/packages/bezier-react/src/components/ListItem/ListItem.stories.tsx
@@ -13,6 +13,7 @@ import { ListItem } from './ListItem'
 import {
   type ListItemProps,
   ListItemSize,
+  ListItemVariant,
 } from './ListItem.types'
 
 const meta: Meta<typeof ListItem> = {
@@ -28,6 +29,7 @@ const Template: StoryFn<ListItemProps> = (props) => (
 export const Primary: StoryObj<ListItemProps> = {
   render: Template,
   args: {
+    variant: ListItemVariant.Monochrome,
     size: ListItemSize.S,
     content: '상담이 열릴 때',
     leftContent: InboxIcon,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
<!-- Please link to issue if one exists -->

- #2009 

## Summary
<!-- Please brief explanation of the changes made -->

Fix `ListItem`'s left icon color specificity issue

## Details
<!-- Please elaborate description of the changes -->

#2009 에서 불필요하다고 판단되어 제거된 LeftIcon을 타겟으로 하는 color 스타일을 원상복구합니다.

```scss
  &:where(.variant-monochrome) {
    color: var(--txt-black-darkest);
    & :where(.ListItemLeftIcon) {
      color: var(--txt-black-dark);
    }
  }
```

- 기존 코드의 LeftIcon을 타겟으로 하는 color 스타일이 active 상태의 아이콘 색상보다 우선하여 적용되는 문제가 발생했고, 이를 수정합니다.
- 스토리북의 args에 variant를 추가합니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No
