### PR TITLE
Fix TabAction typography style for Tab size M

### DIFF
--- a/.changeset/grumpy-flowers-trade.md
+++ b/.changeset/grumpy-flowers-trade.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix `TabAction` typography style for size M.

--- a/packages/bezier-react/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/bezier-react/src/components/Checkbox/Checkbox.module.scss
@@ -1,4 +1,3 @@
-@use "../../styles/mixins/typography";
 @use '../../styles/mixins/dimension';
 @use '../../styles/mixins/interaction';
 
@@ -79,13 +78,7 @@
   }
 }
 
-/**
- * NOTE: When using the `Text` component in combination with the `as` prop,
- * radix-ui lib does not bind the mouse-enter(hover) and click handler.
- */
 .Label {
-  @include typography.size(14);
-
   cursor: inherit;
 
   display: flex;

--- a/packages/bezier-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/bezier-react/src/components/Checkbox/Checkbox.tsx
@@ -16,6 +16,7 @@ import {
   Icon,
   IconSize,
 } from '~/src/components/Icon'
+import { Text } from '~/src/components/Text'
 
 import {
   type CheckboxProps,
@@ -96,12 +97,17 @@ function CheckboxImpl<Checked extends CheckedState>({
         </BaseButton>
       </CheckboxPrimitive.Root>
       { children && (
-        <label
-          className={styles.Label}
+        <Text
+          as="label"
+          // TODO: Apply polymorphic types to `as` prop.
+          // @ts-expect-error
           htmlFor={id}
+          className={styles.Label}
+          typo="14"
+          color="txt-black-darkest"
         >
           { children }
-        </label>
+        </Text>
       ) }
     </div>
   )

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.module.scss
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.module.scss
@@ -1,5 +1,3 @@
-@use "../../styles/mixins/typography";
-
 .OutlineItem {
   cursor: pointer;
 

--- a/packages/bezier-react/src/components/Tabs/Tabs.module.scss
+++ b/packages/bezier-react/src/components/Tabs/Tabs.module.scss
@@ -1,5 +1,4 @@
 @use "sass:math";
-@use "../../styles/mixins/typography";
 
 $tab-item-indicator-height: 3px;
 

--- a/packages/bezier-react/src/components/Tabs/Tabs.tsx
+++ b/packages/bezier-react/src/components/Tabs/Tabs.tsx
@@ -236,7 +236,7 @@ export const TabActions = forwardRef<HTMLDivElement, TabActionsProps>(function T
 function getTypoBy(size: TabSize) {
   return ({
     [TabSize.L]: '14',
-    [TabSize.M]: '14',
+    [TabSize.M]: '13',
     [TabSize.S]: '13',
   } as const)[size]
 }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

TabAction의 타이포그래피가 13이 아닌 14로 지정돼있던 문제를 수정합니다.

## Details
<!-- Please elaborate description of the changes -->

- 리팩토링: 불필요하게 import되던 typography mixin 제거
- 리팩토링: Checkbox의 Label을 Text로 변경 (styled-components 제거 이후 제대로 동작하게 됨)

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- 피그마 Tab 참고
