### PR TITLE
Fixes `Overlay` not closing in other windows

### DIFF
--- a/.changeset/six-humans-occur.md
+++ b/.changeset/six-humans-occur.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fixes `Overlay` not closing in other windows.

--- a/packages/bezier-react/src/components/Overlay/Overlay.tsx
+++ b/packages/bezier-react/src/components/Overlay/Overlay.tsx
@@ -153,7 +153,10 @@ export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(function Overlay
   }, [])
 
   const handleHideOverlay = useCallback((event: MouseEvent) => {
-    if (!event.target || (event.target instanceof HTMLElement && !event.target.closest(`.${styles.Overlay}`))) {
+    /**
+     * NOTE: Type checking with instanceof makes it difficult to handle cases where the window object is different.
+     */
+    if (!event.target || !(event.target as HTMLElement).closest(`.${styles.Overlay}`)) {
       onHide?.()
 
       if (!enableClickOutside) {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary
<!-- Please brief explanation of the changes made -->

Fixes `Overlay` not closing in other windows

## Details
<!-- Please elaborate description of the changes -->

#1977 에서 타입 강화를 위해 event.target의 인스턴스 체크 로직이 추가되었습니다. `instanceof HTMLElement` 의 `HTMLElement` 는 globalThis(window).HTMLElement와 동일한데, 다른 창에서는 globalThis(window)가 다르므로 HTMLElement의 참조값이 달라 타입 체크가 무조건 실패하는 문제가 있었습니다. 따라서, 오버레이 바깥을 클릭해도 닫히지 않는 문제가 발생했습니다.

타입 단언으로 변경하여 런타임 타입 체크를 제거해 문제를 해결합니다.

### Breaking change? (Yes/No)
<!-- If Yes, please describe the impact and migration path for users -->

No

## References
<!-- Please list any other resources or points the reviewer should be aware of -->

- https://github.com/channel-io/ch-desk-web/pull/15992
