### PR TITLE
fix(toast): remove the default offset(GNB_OFFSET, 68)

### DIFF
--- a/.changeset/smart-owls-reply.md
+++ b/.changeset/smart-owls-reply.md
@@ -1,0 +1,7 @@
+---
+"@channel.io/bezier-react": major
+---
+
+**Breaking Changes: Remove the default offset(`GNB_WIDTH`) in `Toast`**
+
+Remove the style because it was dependent on a specific application. Use `{ left: 68 }` instead.

--- a/packages/bezier-react/src/components/Toast/Toast.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.tsx
@@ -184,17 +184,11 @@ const [ToastContextProvider, useToastContext] =
     rightToasts: [],
   })
 
-/**
- * @deprecated
- * FIXME: Styling dependent on specific applications.
- */
-const GNB_WIDTH = 68
-
 export function ToastProvider({
   autoDismissTimeout = 3000,
   container: givenContainer,
   offset = {
-    left: GNB_WIDTH,
+    left: 0,
     right: 0,
     bottom: 0,
   },


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

- Fixes #2116 

## Summary

<!-- Please brief explanation of the changes made -->

Remove the default offset value in Toast

## Details

<!-- Please elaborate description of the changes -->

Toast 컴포넌트에서 기본값으로 가지고 있던, 채널 데스크 애플리케이션 종속적인 left offset 상수를 기본값에서 제거합니다.

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

Yes. 필요한 경우 사용처에서 직접 `left: 68` 값을 주어 사용해야합니다.
