### PR TITLE
feat(toast): assign default value to each property of Toast offset

### DIFF
--- a/packages/bezier-react/src/components/Toast/Toast.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.tsx
@@ -184,14 +184,16 @@ const [ToastContextProvider, useToastContext] =
     rightToasts: [],
   })
 
+const DEFAULT_OFFSET = {
+  left: 0,
+  right: 0,
+  bottom: 0,
+}
+
 export function ToastProvider({
   autoDismissTimeout = 3000,
   container: givenContainer,
-  offset = {
-    left: 0,
-    right: 0,
-    bottom: 0,
-  },
+  offset = DEFAULT_OFFSET,
   children = [],
 }: ToastProviderProps) {
   const rootElement = useRootElement()
@@ -207,10 +209,10 @@ export function ToastProvider({
         <div
           key={placement}
           style={{
-            bottom: px(offset?.bottom),
+            bottom: px(offset?.bottom ?? DEFAULT_OFFSET.bottom),
             ...(placement === 'bottom-right'
-              ? { right: px(offset?.right) }
-              : { left: px(offset?.left) }),
+              ? { right: px(offset?.right ?? DEFAULT_OFFSET.right) }
+              : { left: px(offset?.left ?? DEFAULT_OFFSET.left) }),
           }}
           className={styles.ToastContainer}
         >


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary

<!-- Please brief explanation of the changes made -->

사용성을 위해 Toast에 offset에 특정 값을 하나만 지정해도(예: `{ left: 20 }`) 다른 속성값들에 기본값이 지정되도록 개선합니다.

## Details

<!-- Please elaborate description of the changes -->

생략

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

No
