### PR TITLE
Fix cache miss during lint, typecheck, test job in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,18 @@ references:
   lint_cache_path: &lint_cache_path
     paths:
       - node_modules/.cache/turbo
-      - packages/*/.eslintcache
+      - packages/bezier-react/.stylelintcache
+      - packages/bezier-react/.eslintcache
+      - packages/bezier-icons/.eslintcache
+      - packages/bezier-figma-plugin/.eslintcache
+      - packages/bezier-codemod/.eslintcache
+      - packages/bezier-vscode/.eslintcache
 
   test_cache_path: &test_cache_path
     paths:
       - node_modules/.cache/turbo
-      - packages/*/.jestcache
+      - packages/bezier-react/.jestcache
+      - packages/bezier-codemod/.jestcache
 
 executors:
   node_executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ references:
 
   test_cache_path: &test_cache_path
     paths:
-      - *turbo_cache_path
+      - node_modules/.cache/turbo
       - packages/bezier-react/.jestcache
       - packages/bezier-codemod/.jestcache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,11 @@ references:
   turbo_cache_path: &turbo_cache_path
     paths:
       - node_modules/.cache/turbo
-  jest_cache_path: &jest_cache_path
+
+  test_cache_path: &test_cache_path
     paths:
+      - *turbo_cache_path
       - packages/bezier-react/.jestcache
-      - packages/bezier-icons/.jestcache
-      - packages/bezier-figma-plugin/.jestcache
       - packages/bezier-codemod/.jestcache
 
 executors:
@@ -61,12 +61,12 @@ jobs:
     executor: node_executor
     steps:
       - *attach_workspace
-      - restore_turbo_cache:
+      - restore_cache:
           keys:
             - lint-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
             - lint-{{ .Environment.CACHE_VERSION }}-
       - run: yarn lint
-      - save_turbo_cache:
+      - save_cache:
           key: lint-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
           <<: *turbo_cache_path
 
@@ -74,12 +74,12 @@ jobs:
     executor: node_executor
     steps:
       - *attach_workspace
-      - restore_turbo_cache:
+      - restore_cache:
           keys:
             - typecheck-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
             - typecheck-{{ .Environment.CACHE_VERSION }}-
       - run: yarn typecheck
-      - save_turbo_cache:
+      - save_cache:
           key: typecheck-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
           <<: *turbo_cache_path
 
@@ -87,23 +87,16 @@ jobs:
     executor: node_executor
     steps:
       - *attach_workspace
-      - restore_turbo_cache:
+      - restore_cache:
           keys:
             - test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
             - test-{{ .Environment.CACHE_VERSION }}-
-      - restore_jest_cache:
-          keys:
-            - jest-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
-            - jest-{{ .Environment.CACHE_VERSION }}-
       - run: yarn test
       - codecov/upload:
           file: './packages/bezier-react/coverage/lcov.info'
-      - save_turbo_cache:
+      - save_cache:
           key: test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *turbo_cache_path
-      - save_jest_cache:
-          key: jest-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *jest_cache_path
+          <<: *test_cache_path
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,7 @@ references:
     attach_workspace:
       at: *workspace_root
 
-  build_cache_paths: &build_cache_paths
-    paths:
-      - node_modules/.cache/turbo
-
-  lint_cache_paths: &lint_cache_paths
-    paths:
-      - node_modules/.cache/turbo
-
-  test_cache_paths: &test_cache_paths
+  cache_paths: &cache_paths
     paths:
       - node_modules/.cache/turbo
 
@@ -53,7 +45,7 @@ jobs:
       - run: yarn build
       - save_cache:
           key: build-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *build_cache_paths
+          <<: *cache_paths
       - persist_to_workspace:
           root: *workspace_root
           paths:
@@ -70,13 +62,20 @@ jobs:
       - run: yarn lint
       - save_cache:
           key: lint-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *lint_cache_paths
+          <<: *cache_paths
 
   typecheck:
     executor: node_executor
     steps:
       - *attach_workspace
+      - restore_cache:
+          keys:
+            - typecheck-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
+            - typecheck-{{ .Environment.CACHE_VERSION }}-
       - run: yarn typecheck
+      - save_cache:
+          key: typecheck-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
+          <<: *cache_paths
 
   test:
     executor: node_executor
@@ -91,7 +90,7 @@ jobs:
           file: './packages/bezier-react/coverage/lcov.info'
       - save_cache:
           key: test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *test_cache_paths
+          <<: *cache_paths
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,18 +17,11 @@ references:
 
   lint_cache_paths: &lint_cache_paths
     paths:
-      - packages/bezier-react/.stylelintcache
-      - packages/bezier-react/.eslintcache
-      - packages/bezier-icons/.eslintcache
-      - packages/bezier-figma-plugin/.eslintcache
-      - packages/bezier-codemod/.eslintcache
+      - node_modules/.cache/turbo
 
   test_cache_paths: &test_cache_paths
     paths:
-      - packages/bezier-react/.jestcache
-      - packages/bezier-icons/.jestcache
-      - packages/bezier-figma-plugin/.jestcache
-      - packages/bezier-codemod/.jestcache
+      - node_modules/.cache/turbo
 
 executors:
   node_executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,15 @@ references:
     attach_workspace:
       at: *workspace_root
 
-  cache_path: &cache_path
+  turbo_cache_path: &turbo_cache_path
     paths:
       - node_modules/.cache/turbo
+  jest_cache_path: &jest_cache_path
+    paths:
+      - packages/bezier-react/.jestcache
+      - packages/bezier-icons/.jestcache
+      - packages/bezier-figma-plugin/.jestcache
+      - packages/bezier-codemod/.jestcache
 
 executors:
   node_executor:
@@ -45,7 +51,7 @@ jobs:
       - run: yarn build
       - save_cache:
           key: build-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *cache_path
+          <<: *turbo_cache_path
       - persist_to_workspace:
           root: *workspace_root
           paths:
@@ -55,42 +61,49 @@ jobs:
     executor: node_executor
     steps:
       - *attach_workspace
-      - restore_cache:
+      - restore_turbo_cache:
           keys:
             - lint-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
             - lint-{{ .Environment.CACHE_VERSION }}-
       - run: yarn lint
-      - save_cache:
+      - save_turbo_cache:
           key: lint-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *cache_path
+          <<: *turbo_cache_path
 
   typecheck:
     executor: node_executor
     steps:
       - *attach_workspace
-      - restore_cache:
+      - restore_turbo_cache:
           keys:
             - typecheck-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
             - typecheck-{{ .Environment.CACHE_VERSION }}-
       - run: yarn typecheck
-      - save_cache:
+      - save_turbo_cache:
           key: typecheck-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *cache_path
+          <<: *turbo_cache_path
 
   test:
     executor: node_executor
     steps:
       - *attach_workspace
-      - restore_cache:
+      - restore_turbo_cache:
           keys:
             - test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
             - test-{{ .Environment.CACHE_VERSION }}-
+      - restore_jest_cache:
+          keys:
+            - jest-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
+            - jest-{{ .Environment.CACHE_VERSION }}-
       - run: yarn test
       - codecov/upload:
           file: './packages/bezier-react/coverage/lcov.info'
-      - save_cache:
+      - save_turbo_cache:
           key: test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *cache_path
+          <<: *turbo_cache_path
+      - save_jest_cache:
+          key: jest-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
+          <<: *jest_cache_path
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,15 @@ references:
     paths:
       - node_modules/.cache/turbo
 
+  lint_cache_path: &lint_cache_path
+    paths:
+      - node_modules/.cache/turbo
+      - packages/*/*/.eslintcache
+
   test_cache_path: &test_cache_path
     paths:
       - node_modules/.cache/turbo
-      - packages/bezier-react/.jestcache
-      - packages/bezier-codemod/.jestcache
+      - packages/*/*/.jestcache
 
 executors:
   node_executor:
@@ -68,7 +72,7 @@ jobs:
       - run: yarn lint
       - save_cache:
           key: lint-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *turbo_cache_path
+          <<: *lint_cache_path
 
   typecheck:
     executor: node_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
     attach_workspace:
       at: *workspace_root
 
-  cache_paths: &cache_paths
+  cache_path: &cache_path
     paths:
       - node_modules/.cache/turbo
 
@@ -45,7 +45,7 @@ jobs:
       - run: yarn build
       - save_cache:
           key: build-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *cache_paths
+          <<: *cache_path
       - persist_to_workspace:
           root: *workspace_root
           paths:
@@ -62,7 +62,7 @@ jobs:
       - run: yarn lint
       - save_cache:
           key: lint-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *cache_paths
+          <<: *cache_path
 
   typecheck:
     executor: node_executor
@@ -75,7 +75,7 @@ jobs:
       - run: yarn typecheck
       - save_cache:
           key: typecheck-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *cache_paths
+          <<: *cache_path
 
   test:
     executor: node_executor
@@ -90,7 +90,7 @@ jobs:
           file: './packages/bezier-react/coverage/lcov.info'
       - save_cache:
           key: test-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ epoch }}
-          <<: *cache_paths
+          <<: *cache_path
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,12 @@ references:
   lint_cache_path: &lint_cache_path
     paths:
       - node_modules/.cache/turbo
-      - packages/*/*/.eslintcache
+      - packages/*/.eslintcache
 
   test_cache_path: &test_cache_path
     paths:
       - node_modules/.cache/turbo
-      - packages/*/*/.jestcache
+      - packages/*/.jestcache
 
 executors:
   node_executor:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "turbo run lint && syncpack lint",
     "format": "prettier . --write",
     "typecheck": "turbo run typecheck",
-    "test": "turbo run test",
+    "test": "turbo run test --force",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "version-packages": "changeset version && yarn --mode=\"update-lockfile\"",
     "release": "turbo run build --filter='@channel.io/*' && changeset publish",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "turbo run lint && syncpack lint",
     "format": "prettier . --write",
     "typecheck": "turbo run typecheck",
-    "test": "turbo run test --force",
+    "test": "turbo run test",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "version-packages": "changeset version && yarn --mode=\"update-lockfile\"",
     "release": "turbo run build --filter='@channel.io/*' && changeset publish",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev --filter=@channel.io/bezier-react",
-    "lint": "turbo run lint && syncpack lint",
+    "lint": "turbo run lint --force && syncpack lint",
     "format": "prettier . --write",
     "typecheck": "turbo run typecheck",
-    "test": "turbo run test",
+    "test": "turbo run test --force",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "version-packages": "changeset version && yarn --mode=\"update-lockfile\"",
     "release": "turbo run build --filter='@channel.io/*' && changeset publish",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev --filter=@channel.io/bezier-react",
-    "lint": "turbo run lint --force && syncpack lint",
+    "lint": "turbo run lint && syncpack lint",
     "format": "prettier . --write",
     "typecheck": "turbo run typecheck",
-    "test": "turbo run test --force",
+    "test": "turbo run test",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "version-packages": "changeset version && yarn --mode=\"update-lockfile\"",
     "release": "turbo run build --filter='@channel.io/*' && changeset publish",

--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,7 @@
       "inputs": ["src/**/*.tsx", "src/**/*.ts"]
     },
     "test": {
-      "outputs": [".jestcache/**"],
+      "outputs": [".jestcache/**", "coverage/*"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "src/**/*.js"]
     },
     "dev": {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- https://github.com/channel-io/bezier-react/issues/1684

## Summary

<!-- Please brief explanation of the changes made -->

- CI에서 lint, typecheck, test job 이 항상 cache miss 인 것을 수정합니다. 

## Details

<!-- Please elaborate description of the changes -->
- job마다 --dry-run=json 옵션을 주고 실행해보니 이전 결과와 hash가 같음에도 불구하고 cache miss가 나고 있었고, 하나의 job 안에서 step(e.g. yarn lint)을 2번 연속으로 실행시키면 cache hit 이 되는 것을 확인했습니다.
- node_modules/.cache/turbo 에 캐시가 저장이 안된다면 2번을 실행시켜도 cache miss가 되어야하기 때문에, 캐시는 잘 저장되는데 워크플로우마다 이것을 공유하지 못하는 상태라고 추측했습니다. 그래서 build 와는 다르게 cache_path가 설정되어 있는 것이 원인으로 추정했고, build와 동일하게 node_modules/.cache/turbo를 cache_path로 설정해서 cache hit 이 되도록 변경했습니다.
- [이전과](https://app.circleci.com/pipelines/github/channel-io/bezier-react/6773/workflows/80dfad03-243e-4060-8951-391d0f1a28c7) 비교해서 FULL TURBO 가 되면 [이제](https://app.circleci.com/pipelines/github/channel-io/bezier-react/6787/workflows/853ede34-f6e7-4d42-8277-ed3e24b02501) 20초 정도가 줄어듭니다.
- 이제 workspace attach하는데 시간을 줄이는 방법을 찾아봐야할 것 같습니다. .cache/turbo 안에 있는 파일(~200MB정도)이 workspace attach, cache save & restore 시간에 영향을 주고 있는 것 같아서, 캐시가 만들어진 시간기준으로 timeout(1주일?)정도를 줘서 주기적으로 제거하는 step을 하나 넣는 것도 좋아보입니다.
- .eslintcache, .jestcache 등은 CI에서 불필요하다고 생각되는데 혹시 의견 있으면 부탁드립니다.

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://turbo.build/repo/docs/core-concepts/caching 
- https://github.com/vercel/turbo/issues/863
