### PR TITLE
Add "color" prefix to color tokens and fix misnaming of typography tokens

### DIFF
--- a/.changeset/serious-bottles-film.md
+++ b/.changeset/serious-bottles-film.md
@@ -2,4 +2,4 @@
 "@channel.io/bezier-tokens": patch
 ---
 
-Add "color" prefix to alpha color tokens and fix misnaming of alpha typography tokens.
+Add "color" prefix to alpha color tokens and fix misnaming of alpha font/typography tokens.

--- a/.changeset/serious-bottles-film.md
+++ b/.changeset/serious-bottles-film.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-tokens": patch
+---
+
+Add "color" prefix to alpha color tokens and fix misnaming of alpha typography tokens.

--- a/packages/bezier-react/src/components/Modal/Modal.tsx
+++ b/packages/bezier-react/src/components/Modal/Modal.tsx
@@ -407,7 +407,11 @@ export const ModalFooter = forwardRef<HTMLElement, ModalFooterProps>(
  * It **must** be placed outside of the `ModalContent`.
  */
 export function ModalTrigger({ children }: ModalTriggerProps) {
-  return <AlphaDialogPrimitiveTrigger asChild>{children}</AlphaDialogPrimitiveTrigger>
+  return (
+    <AlphaDialogPrimitiveTrigger asChild>
+      {children}
+    </AlphaDialogPrimitiveTrigger>
+  )
 }
 
 /**
@@ -415,5 +419,7 @@ export function ModalTrigger({ children }: ModalTriggerProps) {
  * It passes the handler that closes the modal to the children.
  */
 export function ModalClose({ children }: ModalCloseProps) {
-  return <AlphaDialogPrimitiveClose asChild>{children}</AlphaDialogPrimitiveClose>
+  return (
+    <AlphaDialogPrimitiveClose asChild>{children}</AlphaDialogPrimitiveClose>
+  )
 }

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -215,7 +215,9 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
           disableHoverableContent={!allowHover}
           onOpenChange={onOpenChange}
         >
-          <AlphaTooltipPrimitiveTrigger asChild>{children}</AlphaTooltipPrimitiveTrigger>
+          <AlphaTooltipPrimitiveTrigger asChild>
+            {children}
+          </AlphaTooltipPrimitiveTrigger>
 
           <AlphaTooltipPrimitivePortal container={container}>
             <InvertedThemeProvider>

--- a/packages/bezier-react/src/stories/alpha-color.mdx
+++ b/packages/bezier-react/src/stories/alpha-color.mdx
@@ -23,7 +23,7 @@ export const Color = ({ name, value, reference }) => {
       <VStack
         style={{
           flex: 1,
-          color: 'var(--alpha-fg-black-darkest)',
+          color: 'var(--alpha-color-fg-black-darkest)',
         }}
         spacing={4}
         justify="center"
@@ -36,7 +36,7 @@ export const Color = ({ name, value, reference }) => {
             gap: 3,
             fontSize: 9,
             lineHeight: 1,
-            color: 'var(--alpha-fg-black-dark)',
+            color: 'var(--alpha-color-fg-black-dark)',
           }}
         >
           {reference ? 'var' : ''}
@@ -46,9 +46,9 @@ export const Color = ({ name, value, reference }) => {
               fontSize: 'inherit',
               lineHeight: 'inherit',
               padding: '1px 2px',
-              backgroundColor: 'var(--alpha-bg-grey-lighter)',
+              backgroundColor: 'var(--alpha-color-bg-grey-lighter)',
               borderRadius: 3,
-              border: '1px solid var(--alpha-bg-black-lightest)',
+              border: '1px solid var(--alpha-color-bg-black-lightest)',
             }}
           >
             {reference ? reference : value}
@@ -62,7 +62,7 @@ export const Color = ({ name, value, reference }) => {
 export const Primary = () => (
   <HStack>
 
-    <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-surface-normal)' }} padding={20}>
+    <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={20}>
       {Object.entries(tokens.global.color).map(([key, { value, ref }]) => (
         <Color
           key={key}
@@ -74,7 +74,7 @@ export const Primary = () => (
     </VStack>
 
     <LightThemeProvider>
-      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-surface-normal)' }} padding={20}>
+      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={20}>
         {Object.entries(tokens.lightTheme.color).map(([key, { value, ref }]) => (
           <Color
             key={key}
@@ -87,7 +87,7 @@ export const Primary = () => (
     </LightThemeProvider>
 
     <DarkThemeProvider>
-      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-surface-normal)' }} padding={20}>
+      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={20}>
         {Object.entries(tokens.darkTheme.color).map(([key, { value, ref }]) => (
           <Color
             key={key}

--- a/packages/bezier-react/src/stories/alpha-shadow.mdx
+++ b/packages/bezier-react/src/stories/alpha-shadow.mdx
@@ -16,14 +16,14 @@ export const Shadow = ({ name, value, reference }) => {
         style={{
           flex: 1,
           boxShadow: value,
-          backgroundColor: 'var(--alpha-surface-normal)',
+          backgroundColor: 'var(--alpha-color-surface-normal)',
           height: 60,
         }}
       />
       <VStack
         style={{
           flex: 1,
-          color: 'var(--alpha-fg-black-darkest)',
+          color: 'var(--alpha-color-fg-black-darkest)',
         }}
         spacing={4}
         justify="center"
@@ -36,7 +36,7 @@ export const Shadow = ({ name, value, reference }) => {
             gap: 3,
             fontSize: 9,
             lineHeight: 1,
-            color: 'var(--alpha-fg-black-dark)',
+            color: 'var(--alpha-color-fg-black-dark)',
           }}
         >
           {reference ? 'var' : ''}
@@ -46,9 +46,9 @@ export const Shadow = ({ name, value, reference }) => {
               fontSize: 'inherit',
               lineHeight: 'inherit',
               padding: '1px 2px',
-              backgroundColor: 'var(--alpha-bg-grey-lighter)',
+              backgroundColor: 'var(--alpha-color-bg-grey-lighter)',
               borderRadius: 3,
-              border: '1px solid var(--alpha-bg-black-lightest)',
+              border: '1px solid var(--alpha-color-bg-black-lightest)',
             }}
           >
             {reference ? reference : value}
@@ -63,7 +63,7 @@ export const Primary = () => (
   <HStack>
 
     <LightThemeProvider>
-      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-surface-normal)' }} padding={40}>
+      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={40}>
         <VStack spacing={40}>
           {Object.entries(tokens.lightTheme.shadow).map(([key, { value, ref }]) => (
             <Shadow
@@ -78,7 +78,7 @@ export const Primary = () => (
     </LightThemeProvider>
 
     <DarkThemeProvider>
-      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-surface-normal)' }} padding={40}>
+      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={40}>
         <VStack spacing={40}>
           {Object.entries(tokens.darkTheme.shadow).map(([key, { value, ref }]) => (
             <Shadow

--- a/packages/bezier-tokens/src/alpha/functional/dark-theme/color.json
+++ b/packages/bezier-tokens/src/alpha/functional/dark-theme/color.json
@@ -2,16 +2,20 @@
   "color": {
     "fg": {
       "black": {
+        "pure": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
+        "darkest": {
+          "value": "{color.white.80}",
+          "type": "color"
+        },
         "darker": {
           "value": "{color.white.60}",
           "type": "color"
         },
         "dark": {
           "value": "{color.white.40}",
-          "type": "color"
-        },
-        "pure": {
-          "value": "{color.white.100}",
           "type": "color"
         },
         "light": {
@@ -244,6 +248,10 @@
     },
     "bg": {
       "black": {
+        "darkest": {
+          "value": "{color.black.60}",
+          "type": "color"
+        },
         "darker": {
           "value": "{color.white.40}",
           "type": "color"
@@ -266,6 +274,10 @@
         }
       },
       "grey": {
+        "darkest": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
         "dark": {
           "value": "{color.grey.500}",
           "type": "color"
@@ -283,12 +295,16 @@
           "type": "color"
         },
         "grey-alpha": {
-          "dark": {
-            "value": "{color.grey-alpha.800-80}",
+          "darkest": {
+            "value": "{color.grey-alpha.700-80}",
             "type": "color"
           },
           "darker": {
             "value": "{color.grey-alpha.800-90}",
+            "type": "color"
+          },
+          "dark": {
+            "value": "{color.grey-alpha.800-80}",
             "type": "color"
           },
           "light": {

--- a/packages/bezier-tokens/src/alpha/functional/dark-theme/color.json
+++ b/packages/bezier-tokens/src/alpha/functional/dark-theme/color.json
@@ -1,759 +1,761 @@
 {
-  "fg": {
-    "black": {
-      "darker": {
-        "value": "{white.60}",
-        "type": "color"
+  "color": {
+    "fg": {
+      "black": {
+        "darker": {
+          "value": "{white.60}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{white.40}",
+          "type": "color"
+        },
+        "pure": {
+          "value": "{white.100}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{white.20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{white.12}",
+          "type": "color"
+        }
       },
-      "dark": {
-        "value": "{white.40}",
-        "type": "color"
+      "white": {
+        "normal": {
+          "value": "{grey.900}",
+          "type": "color"
+        }
       },
-      "pure": {
-        "value": "{white.100}",
-        "type": "color"
+      "blue": {
+        "normal": {
+          "value": "{blue.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{blue.300-45}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{blue.300}",
+          "type": "color"
+        }
       },
-      "light": {
-        "value": "{white.20}",
-        "type": "color"
+      "cobalt": {
+        "normal": {
+          "value": "{cobalt.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{cobalt.300-45}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{cobalt.200}",
+          "type": "color"
+        }
       },
-      "lightest": {
-        "value": "{white.12}",
-        "type": "color"
+      "red": {
+        "normal": {
+          "value": "{red.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{red.300-45}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{red.200}",
+          "type": "color"
+        }
+      },
+      "orange": {
+        "normal": {
+          "value": "{orange.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{orange.300-45}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{orange.200}",
+          "type": "color"
+        }
+      },
+      "green": {
+        "normal": {
+          "value": "{green.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{green.300-45}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{green.200}",
+          "type": "color"
+        }
+      },
+      "teal": {
+        "normal": {
+          "value": "{teal.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{teal.300-45}",
+          "type": "color"
+        }
+      },
+      "olive": {
+        "normal": {
+          "value": "{olive.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{olive.300-45}",
+          "type": "color"
+        }
+      },
+      "yellow": {
+        "normal": {
+          "value": "{yellow.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{yellow.300-45}",
+          "type": "color"
+        }
+      },
+      "pink": {
+        "normal": {
+          "value": "{pink.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{pink.300-45}",
+          "type": "color"
+        }
+      },
+      "purple": {
+        "normal": {
+          "value": "{purple.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{purple.300-45}",
+          "type": "color"
+        }
+      },
+      "navy": {
+        "normal": {
+          "value": "{navy.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{navy.300-45}",
+          "type": "color"
+        }
+      },
+      "absolute": {
+        "black": {
+          "dark": {
+            "value": "{black.100}",
+            "type": "color"
+          },
+          "normal": {
+            "value": "{black.85}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{black.60}",
+            "type": "color"
+          },
+          "lighter": {
+            "value": "{black.40}",
+            "type": "color"
+          },
+          "lightest": {
+            "value": "{black.20}",
+            "type": "color"
+          }
+        },
+        "white": {
+          "dark": {
+            "value": "{white.100}",
+            "type": "color"
+          },
+          "normal": {
+            "value": "{white.90}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{white.60}",
+            "type": "color"
+          },
+          "lighter": {
+            "value": "{white.40}",
+            "type": "color"
+          },
+          "lightest": {
+            "value": "{white.20}",
+            "type": "color"
+          }
+        }
+      },
+      "grey": {
+        "dark": {
+          "value": "{grey.500}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{grey.600}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{grey.700}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{grey.800}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{grey.850}",
+          "type": "color"
+        },
+        "grey-alpha": {
+          "darker": {
+            "value": "{grey-alpha.800-90}",
+            "type": "color"
+          },
+          "dark": {
+            "value": "{grey-alpha.800-80}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{grey-alpha.850-80}",
+            "type": "color"
+          }
+        }
       }
     },
-    "white": {
+    "bg": {
+      "black": {
+        "darker": {
+          "value": "{white.40}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{white.20}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{white.12}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{white.8}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{white.5}",
+          "type": "color"
+        }
+      },
+      "grey": {
+        "dark": {
+          "value": "{grey.500}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{grey.700}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{grey.800}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{grey.850}",
+          "type": "color"
+        },
+        "grey-alpha": {
+          "dark": {
+            "value": "{grey-alpha.800-80}",
+            "type": "color"
+          },
+          "darker": {
+            "value": "{grey-alpha.800-90}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{grey-alpha.850-80}",
+            "type": "color"
+          }
+        },
+        "normal": {
+          "value": "{grey.600}",
+          "type": "color"
+        }
+      },
+      "white": {
+        "highest": {
+          "value": "{grey.700}",
+          "type": "color"
+        },
+        "higher": {
+          "value": "{grey.800}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{grey.900}",
+          "type": "color"
+        },
+        "white-alpha": {
+          "lightest": {
+            "value": "{grey-alpha.800-80}",
+            "type": "color"
+          },
+          "lighter": {
+            "value": "{black.60}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{black.20}",
+            "type": "color"
+          }
+        }
+      },
+      "blue": {
+        "normal": {
+          "value": "{blue.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{blue.300-45}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{blue.300-30}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{blue.300-15}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{blue.400}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-blue.600-40}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-blue.600}",
+          "type": "color"
+        }
+      },
+      "cobalt": {
+        "normal": {
+          "value": "{cobalt.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{cobalt.300-45}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{cobalt.300-30}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{cobalt.300-15}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{cobalt.400}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-cobalt.600-40}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-cobalt.600}",
+          "type": "color"
+        }
+      },
+      "red": {
+        "normal": {
+          "value": "{red.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{red.300-45}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{red.300-30}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{red.300-15}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{red.400}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-red.600-40}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-red.600}",
+          "type": "color"
+        }
+      },
+      "orange": {
+        "normal": {
+          "value": "{orange.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{orange.300-45}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{orange.300-30}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{orange.300-15}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{orange.400}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-orange.600-40}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-orange.600}",
+          "type": "color"
+        }
+      },
+      "green": {
+        "normal": {
+          "value": "{green.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{green.300-45}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{green.300-30}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{green.300-15}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{green.400}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-green.600-40}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-green.600}",
+          "type": "color"
+        }
+      },
+      "teal": {
+        "normal": {
+          "value": "{teal.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{teal.300-45}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{teal.300-30}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{teal.300-15}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{teal.400}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-teal.600-40}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-teal.600}",
+          "type": "color"
+        }
+      },
+      "olive": {
+        "normal": {
+          "value": "{olive.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{olive.300-45}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{olive.300-30}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{olive.300-15}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{olive.400}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-olive.600-40}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-olive.600}",
+          "type": "color"
+        }
+      },
+      "yellow": {
+        "normal": {
+          "value": "{yellow.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{yellow.300-45}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{yellow.300-30}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{yellow.300-15}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{yellow.400}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-yellow.600-40}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-yellow.600}",
+          "type": "color"
+        }
+      },
+      "pink": {
+        "normal": {
+          "value": "{pink.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{pink.300-45}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{pink.300-30}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{pink.300-15}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{pink.400}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-pink.600-40}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-pink.600}",
+          "type": "color"
+        }
+      },
+      "purple": {
+        "normal": {
+          "value": "{purple.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{purple.300-45}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{purple.300-30}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{purple.300-15}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{purple.400}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-purple.600-40}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-purple.600}",
+          "type": "color"
+        }
+      },
+      "navy": {
+        "normal": {
+          "value": "{navy.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{navy.300-45}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{navy.300-30}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{navy.300-15}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{navy.400}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-navy.600-40}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-navy.600}",
+          "type": "color"
+        }
+      },
+      "absolute": {
+        "black": {
+          "dark": {
+            "value": "{black.100}",
+            "type": "color"
+          },
+          "normal": {
+            "value": "{black.85}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{black.60}",
+            "type": "color"
+          },
+          "lighter": {
+            "value": "{black.40}",
+            "type": "color"
+          },
+          "lightest": {
+            "value": "{black.20}",
+            "type": "color"
+          }
+        },
+        "white": {
+          "dark": {
+            "value": "{white.100}",
+            "type": "color"
+          },
+          "normal": {
+            "value": "{white.90}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{white.60}",
+            "type": "color"
+          },
+          "lighter": {
+            "value": "{white.40}",
+            "type": "color"
+          },
+          "lightest": {
+            "value": "{white.20}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "surface": {
+      "lowest": {
+        "value": "{grey.800}",
+        "type": "color"
+      },
+      "lower": {
+        "value": "{grey.850}",
+        "type": "color"
+      },
       "normal": {
         "value": "{grey.900}",
         "type": "color"
       }
     },
-    "blue": {
-      "normal": {
-        "value": "{blue.300}",
+    "shadow": {
+      "xlarge": {
+        "value": "{black.60}",
         "type": "color"
       },
-      "light": {
-        "value": "{blue.300-45}",
+      "large": {
+        "value": "{black.40}",
         "type": "color"
       },
-      "dark": {
-        "value": "{blue.300}",
-        "type": "color"
-      }
-    },
-    "cobalt": {
-      "normal": {
-        "value": "{cobalt.300}",
+      "medium": {
+        "value": "{black.20}",
         "type": "color"
       },
-      "light": {
-        "value": "{cobalt.300-45}",
+      "small": {
+        "value": "{black.15}",
         "type": "color"
       },
-      "dark": {
-        "value": "{cobalt.200}",
-        "type": "color"
-      }
-    },
-    "red": {
-      "normal": {
-        "value": "{red.300}",
+      "base": {
+        "value": "{black.8}",
         "type": "color"
       },
-      "light": {
-        "value": "{red.300-45}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{red.200}",
-        "type": "color"
-      }
-    },
-    "orange": {
-      "normal": {
-        "value": "{orange.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{orange.300-45}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{orange.200}",
-        "type": "color"
-      }
-    },
-    "green": {
-      "normal": {
-        "value": "{green.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{green.300-45}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{green.200}",
-        "type": "color"
-      }
-    },
-    "teal": {
-      "normal": {
-        "value": "{teal.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{teal.300-45}",
-        "type": "color"
-      }
-    },
-    "olive": {
-      "normal": {
-        "value": "{olive.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{olive.300-45}",
-        "type": "color"
-      }
-    },
-    "yellow": {
-      "normal": {
-        "value": "{yellow.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{yellow.300-45}",
-        "type": "color"
-      }
-    },
-    "pink": {
-      "normal": {
-        "value": "{pink.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{pink.300-45}",
-        "type": "color"
-      }
-    },
-    "purple": {
-      "normal": {
-        "value": "{purple.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{purple.300-45}",
-        "type": "color"
-      }
-    },
-    "navy": {
-      "normal": {
-        "value": "{navy.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{navy.300-45}",
-        "type": "color"
-      }
-    },
-    "absolute": {
-      "black": {
-        "dark": {
-          "value": "{black.100}",
-          "type": "color"
-        },
-        "normal": {
-          "value": "{black.85}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{black.60}",
-          "type": "color"
-        },
-        "lighter": {
-          "value": "{black.40}",
-          "type": "color"
-        },
-        "lightest": {
-          "value": "{black.20}",
-          "type": "color"
-        }
-      },
-      "white": {
-        "dark": {
-          "value": "{white.100}",
-          "type": "color"
-        },
-        "normal": {
-          "value": "{white.90}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{white.60}",
-          "type": "color"
-        },
-        "lighter": {
-          "value": "{white.40}",
-          "type": "color"
-        },
-        "lightest": {
-          "value": "{white.20}",
-          "type": "color"
-        }
-      }
-    },
-    "grey": {
-      "dark": {
-        "value": "{grey.500}",
-        "type": "color"
-      },
-      "normal": {
-        "value": "{grey.600}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{grey.700}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{grey.800}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{grey.850}",
-        "type": "color"
-      },
-      "grey-alpha": {
-        "darker": {
-          "value": "{grey-alpha.800-90}",
-          "type": "color"
-        },
-        "dark": {
-          "value": "{grey-alpha.800-80}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{grey-alpha.850-80}",
-          "type": "color"
-        }
-      }
-    }
-  },
-  "bg": {
-    "black": {
-      "darker": {
-        "value": "{white.40}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{white.20}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{white.12}",
-        "type": "color"
-      },
-      "lighter": {
+      "base-inner": {
         "value": "{white.8}",
         "type": "color"
-      },
-      "lightest": {
-        "value": "{white.5}",
-        "type": "color"
       }
     },
-    "grey": {
-      "dark": {
-        "value": "{grey.500}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{grey.700}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{grey.800}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{grey.850}",
-        "type": "color"
-      },
-      "grey-alpha": {
-        "dark": {
-          "value": "{grey-alpha.800-80}",
-          "type": "color"
-        },
-        "darker": {
-          "value": "{grey-alpha.800-90}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{grey-alpha.850-80}",
-          "type": "color"
-        }
-      },
-      "normal": {
-        "value": "{grey.600}",
-        "type": "color"
-      }
-    },
-    "white": {
-      "highest": {
-        "value": "{grey.700}",
-        "type": "color"
-      },
-      "higher": {
-        "value": "{grey.800}",
-        "type": "color"
-      },
-      "normal": {
-        "value": "{grey.900}",
-        "type": "color"
-      },
-      "white-alpha": {
-        "lightest": {
-          "value": "{grey-alpha.800-80}",
-          "type": "color"
-        },
-        "lighter": {
-          "value": "{black.60}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{black.20}",
-          "type": "color"
-        }
-      }
-    },
-    "blue": {
-      "normal": {
-        "value": "{blue.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{blue.300-45}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{blue.300-30}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{blue.300-15}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{blue.400}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-blue.600-40}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-blue.600}",
-        "type": "color"
-      }
-    },
-    "cobalt": {
-      "normal": {
-        "value": "{cobalt.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{cobalt.300-45}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{cobalt.300-30}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{cobalt.300-15}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{cobalt.400}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-cobalt.600-40}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-cobalt.600}",
-        "type": "color"
-      }
-    },
-    "red": {
-      "normal": {
-        "value": "{red.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{red.300-45}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{red.300-30}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{red.300-15}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{red.400}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-red.600-40}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-red.600}",
-        "type": "color"
-      }
-    },
-    "orange": {
-      "normal": {
-        "value": "{orange.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{orange.300-45}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{orange.300-30}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{orange.300-15}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{orange.400}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-orange.600-40}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-orange.600}",
-        "type": "color"
-      }
-    },
-    "green": {
-      "normal": {
-        "value": "{green.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{green.300-45}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{green.300-30}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{green.300-15}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{green.400}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-green.600-40}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-green.600}",
-        "type": "color"
-      }
-    },
-    "teal": {
-      "normal": {
-        "value": "{teal.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{teal.300-45}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{teal.300-30}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{teal.300-15}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{teal.400}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-teal.600-40}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-teal.600}",
-        "type": "color"
-      }
-    },
-    "olive": {
-      "normal": {
-        "value": "{olive.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{olive.300-45}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{olive.300-30}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{olive.300-15}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{olive.400}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-olive.600-40}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-olive.600}",
-        "type": "color"
-      }
-    },
-    "yellow": {
-      "normal": {
-        "value": "{yellow.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{yellow.300-45}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{yellow.300-30}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{yellow.300-15}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{yellow.400}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-yellow.600-40}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-yellow.600}",
-        "type": "color"
-      }
-    },
-    "pink": {
-      "normal": {
-        "value": "{pink.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{pink.300-45}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{pink.300-30}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{pink.300-15}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{pink.400}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-pink.600-40}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-pink.600}",
-        "type": "color"
-      }
-    },
-    "purple": {
-      "normal": {
-        "value": "{purple.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{purple.300-45}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{purple.300-30}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{purple.300-15}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{purple.400}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-purple.600-40}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-purple.600}",
-        "type": "color"
-      }
-    },
-    "navy": {
-      "normal": {
-        "value": "{navy.300}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{navy.300-45}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{navy.300-30}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{navy.300-15}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{navy.400}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-navy.600-40}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-navy.600}",
-        "type": "color"
-      }
-    },
-    "absolute": {
+    "dim": {
       "black": {
-        "dark": {
-          "value": "{black.100}",
+        "light": {
+          "value": "{bg.absolute.black.lightest}",
           "type": "color"
         },
         "normal": {
-          "value": "{black.85}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{black.60}",
-          "type": "color"
-        },
-        "lighter": {
-          "value": "{black.40}",
-          "type": "color"
-        },
-        "lightest": {
-          "value": "{black.20}",
+          "value": "{bg.absolute.black.lighter}",
           "type": "color"
         }
-      },
-      "white": {
-        "dark": {
-          "value": "{white.100}",
-          "type": "color"
-        },
-        "normal": {
-          "value": "{white.90}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{white.60}",
-          "type": "color"
-        },
-        "lighter": {
-          "value": "{white.40}",
-          "type": "color"
-        },
-        "lightest": {
-          "value": "{white.20}",
-          "type": "color"
-        }
-      }
-    }
-  },
-  "surface": {
-    "lowest": {
-      "value": "{grey.800}",
-      "type": "color"
-    },
-    "lower": {
-      "value": "{grey.850}",
-      "type": "color"
-    },
-    "normal": {
-      "value": "{grey.900}",
-      "type": "color"
-    }
-  },
-  "shadow": {
-    "xlarge": {
-      "value": "{black.60}",
-      "type": "color"
-    },
-    "large": {
-      "value": "{black.40}",
-      "type": "color"
-    },
-    "medium": {
-      "value": "{black.20}",
-      "type": "color"
-    },
-    "small": {
-      "value": "{black.15}",
-      "type": "color"
-    },
-    "base": {
-      "value": "{black.8}",
-      "type": "color"
-    },
-    "base-inner": {
-      "value": "{white.8}",
-      "type": "color"
-    }
-  },
-  "dim": {
-    "black": {
-      "light": {
-        "value": "{bg.absolute.black.lightest}",
-        "type": "color"
-      },
-      "normal": {
-        "value": "{bg.absolute.black.lighter}",
-        "type": "color"
       }
     }
   }

--- a/packages/bezier-tokens/src/alpha/functional/dark-theme/color.json
+++ b/packages/bezier-tokens/src/alpha/functional/dark-theme/color.json
@@ -57,7 +57,7 @@
           "type": "color"
         },
         "dark": {
-          "value": "{color.cobalt.200}",
+          "value": "{color.cobalt.300}",
           "type": "color"
         }
       },
@@ -71,7 +71,7 @@
           "type": "color"
         },
         "dark": {
-          "value": "{color.red.200}",
+          "value": "{color.red.300}",
           "type": "color"
         }
       },
@@ -85,7 +85,7 @@
           "type": "color"
         },
         "dark": {
-          "value": "{color.orange.200}",
+          "value": "{color.orange.300}",
           "type": "color"
         }
       },
@@ -99,7 +99,7 @@
           "type": "color"
         },
         "dark": {
-          "value": "{color.green.200}",
+          "value": "{color.green.300}",
           "type": "color"
         }
       },

--- a/packages/bezier-tokens/src/alpha/functional/dark-theme/color.json
+++ b/packages/bezier-tokens/src/alpha/functional/dark-theme/color.json
@@ -3,240 +3,240 @@
     "fg": {
       "black": {
         "darker": {
-          "value": "{white.60}",
+          "value": "{color.white.60}",
           "type": "color"
         },
         "dark": {
-          "value": "{white.40}",
+          "value": "{color.white.40}",
           "type": "color"
         },
         "pure": {
-          "value": "{white.100}",
+          "value": "{color.white.100}",
           "type": "color"
         },
         "light": {
-          "value": "{white.20}",
+          "value": "{color.white.20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{white.12}",
+          "value": "{color.white.12}",
           "type": "color"
         }
       },
       "white": {
         "normal": {
-          "value": "{grey.900}",
+          "value": "{color.grey.900}",
           "type": "color"
         }
       },
       "blue": {
         "normal": {
-          "value": "{blue.300}",
+          "value": "{color.blue.300}",
           "type": "color"
         },
         "light": {
-          "value": "{blue.300-45}",
+          "value": "{color.blue.300-45}",
           "type": "color"
         },
         "dark": {
-          "value": "{blue.300}",
+          "value": "{color.blue.300}",
           "type": "color"
         }
       },
       "cobalt": {
         "normal": {
-          "value": "{cobalt.300}",
+          "value": "{color.cobalt.300}",
           "type": "color"
         },
         "light": {
-          "value": "{cobalt.300-45}",
+          "value": "{color.cobalt.300-45}",
           "type": "color"
         },
         "dark": {
-          "value": "{cobalt.200}",
+          "value": "{color.cobalt.200}",
           "type": "color"
         }
       },
       "red": {
         "normal": {
-          "value": "{red.300}",
+          "value": "{color.red.300}",
           "type": "color"
         },
         "light": {
-          "value": "{red.300-45}",
+          "value": "{color.red.300-45}",
           "type": "color"
         },
         "dark": {
-          "value": "{red.200}",
+          "value": "{color.red.200}",
           "type": "color"
         }
       },
       "orange": {
         "normal": {
-          "value": "{orange.300}",
+          "value": "{color.orange.300}",
           "type": "color"
         },
         "light": {
-          "value": "{orange.300-45}",
+          "value": "{color.orange.300-45}",
           "type": "color"
         },
         "dark": {
-          "value": "{orange.200}",
+          "value": "{color.orange.200}",
           "type": "color"
         }
       },
       "green": {
         "normal": {
-          "value": "{green.300}",
+          "value": "{color.green.300}",
           "type": "color"
         },
         "light": {
-          "value": "{green.300-45}",
+          "value": "{color.green.300-45}",
           "type": "color"
         },
         "dark": {
-          "value": "{green.200}",
+          "value": "{color.green.200}",
           "type": "color"
         }
       },
       "teal": {
         "normal": {
-          "value": "{teal.300}",
+          "value": "{color.teal.300}",
           "type": "color"
         },
         "light": {
-          "value": "{teal.300-45}",
+          "value": "{color.teal.300-45}",
           "type": "color"
         }
       },
       "olive": {
         "normal": {
-          "value": "{olive.300}",
+          "value": "{color.olive.300}",
           "type": "color"
         },
         "light": {
-          "value": "{olive.300-45}",
+          "value": "{color.olive.300-45}",
           "type": "color"
         }
       },
       "yellow": {
         "normal": {
-          "value": "{yellow.300}",
+          "value": "{color.yellow.300}",
           "type": "color"
         },
         "light": {
-          "value": "{yellow.300-45}",
+          "value": "{color.yellow.300-45}",
           "type": "color"
         }
       },
       "pink": {
         "normal": {
-          "value": "{pink.300}",
+          "value": "{color.pink.300}",
           "type": "color"
         },
         "light": {
-          "value": "{pink.300-45}",
+          "value": "{color.pink.300-45}",
           "type": "color"
         }
       },
       "purple": {
         "normal": {
-          "value": "{purple.300}",
+          "value": "{color.purple.300}",
           "type": "color"
         },
         "light": {
-          "value": "{purple.300-45}",
+          "value": "{color.purple.300-45}",
           "type": "color"
         }
       },
       "navy": {
         "normal": {
-          "value": "{navy.300}",
+          "value": "{color.navy.300}",
           "type": "color"
         },
         "light": {
-          "value": "{navy.300-45}",
+          "value": "{color.navy.300-45}",
           "type": "color"
         }
       },
       "absolute": {
         "black": {
           "dark": {
-            "value": "{black.100}",
+            "value": "{color.black.100}",
             "type": "color"
           },
           "normal": {
-            "value": "{black.85}",
+            "value": "{color.black.85}",
             "type": "color"
           },
           "light": {
-            "value": "{black.60}",
+            "value": "{color.black.60}",
             "type": "color"
           },
           "lighter": {
-            "value": "{black.40}",
+            "value": "{color.black.40}",
             "type": "color"
           },
           "lightest": {
-            "value": "{black.20}",
+            "value": "{color.black.20}",
             "type": "color"
           }
         },
         "white": {
           "dark": {
-            "value": "{white.100}",
+            "value": "{color.white.100}",
             "type": "color"
           },
           "normal": {
-            "value": "{white.90}",
+            "value": "{color.white.90}",
             "type": "color"
           },
           "light": {
-            "value": "{white.60}",
+            "value": "{color.white.60}",
             "type": "color"
           },
           "lighter": {
-            "value": "{white.40}",
+            "value": "{color.white.40}",
             "type": "color"
           },
           "lightest": {
-            "value": "{white.20}",
+            "value": "{color.white.20}",
             "type": "color"
           }
         }
       },
       "grey": {
         "dark": {
-          "value": "{grey.500}",
+          "value": "{color.grey.500}",
           "type": "color"
         },
         "normal": {
-          "value": "{grey.600}",
+          "value": "{color.grey.600}",
           "type": "color"
         },
         "light": {
-          "value": "{grey.700}",
+          "value": "{color.grey.700}",
           "type": "color"
         },
         "lighter": {
-          "value": "{grey.800}",
+          "value": "{color.grey.800}",
           "type": "color"
         },
         "lightest": {
-          "value": "{grey.850}",
+          "value": "{color.grey.850}",
           "type": "color"
         },
         "grey-alpha": {
           "darker": {
-            "value": "{grey-alpha.800-90}",
+            "value": "{color.grey-alpha.800-90}",
             "type": "color"
           },
           "dark": {
-            "value": "{grey-alpha.800-80}",
+            "value": "{color.grey-alpha.800-80}",
             "type": "color"
           },
           "light": {
-            "value": "{grey-alpha.850-80}",
+            "value": "{color.grey-alpha.850-80}",
             "type": "color"
           }
         }
@@ -245,462 +245,462 @@
     "bg": {
       "black": {
         "darker": {
-          "value": "{white.40}",
+          "value": "{color.white.40}",
           "type": "color"
         },
         "dark": {
-          "value": "{white.20}",
+          "value": "{color.white.20}",
           "type": "color"
         },
         "light": {
-          "value": "{white.12}",
+          "value": "{color.white.12}",
           "type": "color"
         },
         "lighter": {
-          "value": "{white.8}",
+          "value": "{color.white.8}",
           "type": "color"
         },
         "lightest": {
-          "value": "{white.5}",
+          "value": "{color.white.5}",
           "type": "color"
         }
       },
       "grey": {
         "dark": {
-          "value": "{grey.500}",
+          "value": "{color.grey.500}",
           "type": "color"
         },
         "light": {
-          "value": "{grey.700}",
+          "value": "{color.grey.700}",
           "type": "color"
         },
         "lighter": {
-          "value": "{grey.800}",
+          "value": "{color.grey.800}",
           "type": "color"
         },
         "lightest": {
-          "value": "{grey.850}",
+          "value": "{color.grey.850}",
           "type": "color"
         },
         "grey-alpha": {
           "dark": {
-            "value": "{grey-alpha.800-80}",
+            "value": "{color.grey-alpha.800-80}",
             "type": "color"
           },
           "darker": {
-            "value": "{grey-alpha.800-90}",
+            "value": "{color.grey-alpha.800-90}",
             "type": "color"
           },
           "light": {
-            "value": "{grey-alpha.850-80}",
+            "value": "{color.grey-alpha.850-80}",
             "type": "color"
           }
         },
         "normal": {
-          "value": "{grey.600}",
+          "value": "{color.grey.600}",
           "type": "color"
         }
       },
       "white": {
         "highest": {
-          "value": "{grey.700}",
+          "value": "{color.grey.700}",
           "type": "color"
         },
         "higher": {
-          "value": "{grey.800}",
+          "value": "{color.grey.800}",
           "type": "color"
         },
         "normal": {
-          "value": "{grey.900}",
+          "value": "{color.grey.900}",
           "type": "color"
         },
         "white-alpha": {
           "lightest": {
-            "value": "{grey-alpha.800-80}",
+            "value": "{color.grey-alpha.800-80}",
             "type": "color"
           },
           "lighter": {
-            "value": "{black.60}",
+            "value": "{color.black.60}",
             "type": "color"
           },
           "light": {
-            "value": "{black.20}",
+            "value": "{color.black.20}",
             "type": "color"
           }
         }
       },
       "blue": {
         "normal": {
-          "value": "{blue.300}",
+          "value": "{color.blue.300}",
           "type": "color"
         },
         "light": {
-          "value": "{blue.300-45}",
+          "value": "{color.blue.300-45}",
           "type": "color"
         },
         "lighter": {
-          "value": "{blue.300-30}",
+          "value": "{color.blue.300-30}",
           "type": "color"
         },
         "lightest": {
-          "value": "{blue.300-15}",
+          "value": "{color.blue.300-15}",
           "type": "color"
         },
         "dark": {
-          "value": "{blue.400}",
+          "value": "{color.blue.400}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-blue.600-40}",
+          "value": "{color.shade-blue.600-40}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-blue.600}",
+          "value": "{color.shade-blue.600}",
           "type": "color"
         }
       },
       "cobalt": {
         "normal": {
-          "value": "{cobalt.300}",
+          "value": "{color.cobalt.300}",
           "type": "color"
         },
         "light": {
-          "value": "{cobalt.300-45}",
+          "value": "{color.cobalt.300-45}",
           "type": "color"
         },
         "lighter": {
-          "value": "{cobalt.300-30}",
+          "value": "{color.cobalt.300-30}",
           "type": "color"
         },
         "lightest": {
-          "value": "{cobalt.300-15}",
+          "value": "{color.cobalt.300-15}",
           "type": "color"
         },
         "dark": {
-          "value": "{cobalt.400}",
+          "value": "{color.cobalt.400}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-cobalt.600-40}",
+          "value": "{color.shade-cobalt.600-40}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-cobalt.600}",
+          "value": "{color.shade-cobalt.600}",
           "type": "color"
         }
       },
       "red": {
         "normal": {
-          "value": "{red.300}",
+          "value": "{color.red.300}",
           "type": "color"
         },
         "light": {
-          "value": "{red.300-45}",
+          "value": "{color.red.300-45}",
           "type": "color"
         },
         "lighter": {
-          "value": "{red.300-30}",
+          "value": "{color.red.300-30}",
           "type": "color"
         },
         "lightest": {
-          "value": "{red.300-15}",
+          "value": "{color.red.300-15}",
           "type": "color"
         },
         "dark": {
-          "value": "{red.400}",
+          "value": "{color.red.400}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-red.600-40}",
+          "value": "{color.shade-red.600-40}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-red.600}",
+          "value": "{color.shade-red.600}",
           "type": "color"
         }
       },
       "orange": {
         "normal": {
-          "value": "{orange.300}",
+          "value": "{color.orange.300}",
           "type": "color"
         },
         "light": {
-          "value": "{orange.300-45}",
+          "value": "{color.orange.300-45}",
           "type": "color"
         },
         "lighter": {
-          "value": "{orange.300-30}",
+          "value": "{color.orange.300-30}",
           "type": "color"
         },
         "lightest": {
-          "value": "{orange.300-15}",
+          "value": "{color.orange.300-15}",
           "type": "color"
         },
         "dark": {
-          "value": "{orange.400}",
+          "value": "{color.orange.400}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-orange.600-40}",
+          "value": "{color.shade-orange.600-40}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-orange.600}",
+          "value": "{color.shade-orange.600}",
           "type": "color"
         }
       },
       "green": {
         "normal": {
-          "value": "{green.300}",
+          "value": "{color.green.300}",
           "type": "color"
         },
         "light": {
-          "value": "{green.300-45}",
+          "value": "{color.green.300-45}",
           "type": "color"
         },
         "lighter": {
-          "value": "{green.300-30}",
+          "value": "{color.green.300-30}",
           "type": "color"
         },
         "lightest": {
-          "value": "{green.300-15}",
+          "value": "{color.green.300-15}",
           "type": "color"
         },
         "dark": {
-          "value": "{green.400}",
+          "value": "{color.green.400}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-green.600-40}",
+          "value": "{color.shade-green.600-40}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-green.600}",
+          "value": "{color.shade-green.600}",
           "type": "color"
         }
       },
       "teal": {
         "normal": {
-          "value": "{teal.300}",
+          "value": "{color.teal.300}",
           "type": "color"
         },
         "light": {
-          "value": "{teal.300-45}",
+          "value": "{color.teal.300-45}",
           "type": "color"
         },
         "lighter": {
-          "value": "{teal.300-30}",
+          "value": "{color.teal.300-30}",
           "type": "color"
         },
         "lightest": {
-          "value": "{teal.300-15}",
+          "value": "{color.teal.300-15}",
           "type": "color"
         },
         "dark": {
-          "value": "{teal.400}",
+          "value": "{color.teal.400}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-teal.600-40}",
+          "value": "{color.shade-teal.600-40}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-teal.600}",
+          "value": "{color.shade-teal.600}",
           "type": "color"
         }
       },
       "olive": {
         "normal": {
-          "value": "{olive.300}",
+          "value": "{color.olive.300}",
           "type": "color"
         },
         "light": {
-          "value": "{olive.300-45}",
+          "value": "{color.olive.300-45}",
           "type": "color"
         },
         "lighter": {
-          "value": "{olive.300-30}",
+          "value": "{color.olive.300-30}",
           "type": "color"
         },
         "lightest": {
-          "value": "{olive.300-15}",
+          "value": "{color.olive.300-15}",
           "type": "color"
         },
         "dark": {
-          "value": "{olive.400}",
+          "value": "{color.olive.400}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-olive.600-40}",
+          "value": "{color.shade-olive.600-40}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-olive.600}",
+          "value": "{color.shade-olive.600}",
           "type": "color"
         }
       },
       "yellow": {
         "normal": {
-          "value": "{yellow.300}",
+          "value": "{color.yellow.300}",
           "type": "color"
         },
         "light": {
-          "value": "{yellow.300-45}",
+          "value": "{color.yellow.300-45}",
           "type": "color"
         },
         "lighter": {
-          "value": "{yellow.300-30}",
+          "value": "{color.yellow.300-30}",
           "type": "color"
         },
         "lightest": {
-          "value": "{yellow.300-15}",
+          "value": "{color.yellow.300-15}",
           "type": "color"
         },
         "dark": {
-          "value": "{yellow.400}",
+          "value": "{color.yellow.400}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-yellow.600-40}",
+          "value": "{color.shade-yellow.600-40}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-yellow.600}",
+          "value": "{color.shade-yellow.600}",
           "type": "color"
         }
       },
       "pink": {
         "normal": {
-          "value": "{pink.300}",
+          "value": "{color.pink.300}",
           "type": "color"
         },
         "light": {
-          "value": "{pink.300-45}",
+          "value": "{color.pink.300-45}",
           "type": "color"
         },
         "lighter": {
-          "value": "{pink.300-30}",
+          "value": "{color.pink.300-30}",
           "type": "color"
         },
         "lightest": {
-          "value": "{pink.300-15}",
+          "value": "{color.pink.300-15}",
           "type": "color"
         },
         "dark": {
-          "value": "{pink.400}",
+          "value": "{color.pink.400}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-pink.600-40}",
+          "value": "{color.shade-pink.600-40}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-pink.600}",
+          "value": "{color.shade-pink.600}",
           "type": "color"
         }
       },
       "purple": {
         "normal": {
-          "value": "{purple.300}",
+          "value": "{color.purple.300}",
           "type": "color"
         },
         "light": {
-          "value": "{purple.300-45}",
+          "value": "{color.purple.300-45}",
           "type": "color"
         },
         "lighter": {
-          "value": "{purple.300-30}",
+          "value": "{color.purple.300-30}",
           "type": "color"
         },
         "lightest": {
-          "value": "{purple.300-15}",
+          "value": "{color.purple.300-15}",
           "type": "color"
         },
         "dark": {
-          "value": "{purple.400}",
+          "value": "{color.purple.400}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-purple.600-40}",
+          "value": "{color.shade-purple.600-40}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-purple.600}",
+          "value": "{color.shade-purple.600}",
           "type": "color"
         }
       },
       "navy": {
         "normal": {
-          "value": "{navy.300}",
+          "value": "{color.navy.300}",
           "type": "color"
         },
         "light": {
-          "value": "{navy.300-45}",
+          "value": "{color.navy.300-45}",
           "type": "color"
         },
         "lighter": {
-          "value": "{navy.300-30}",
+          "value": "{color.navy.300-30}",
           "type": "color"
         },
         "lightest": {
-          "value": "{navy.300-15}",
+          "value": "{color.navy.300-15}",
           "type": "color"
         },
         "dark": {
-          "value": "{navy.400}",
+          "value": "{color.navy.400}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-navy.600-40}",
+          "value": "{color.shade-navy.600-40}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-navy.600}",
+          "value": "{color.shade-navy.600}",
           "type": "color"
         }
       },
       "absolute": {
         "black": {
           "dark": {
-            "value": "{black.100}",
+            "value": "{color.black.100}",
             "type": "color"
           },
           "normal": {
-            "value": "{black.85}",
+            "value": "{color.black.85}",
             "type": "color"
           },
           "light": {
-            "value": "{black.60}",
+            "value": "{color.black.60}",
             "type": "color"
           },
           "lighter": {
-            "value": "{black.40}",
+            "value": "{color.black.40}",
             "type": "color"
           },
           "lightest": {
-            "value": "{black.20}",
+            "value": "{color.black.20}",
             "type": "color"
           }
         },
         "white": {
           "dark": {
-            "value": "{white.100}",
+            "value": "{color.white.100}",
             "type": "color"
           },
           "normal": {
-            "value": "{white.90}",
+            "value": "{color.white.90}",
             "type": "color"
           },
           "light": {
-            "value": "{white.60}",
+            "value": "{color.white.60}",
             "type": "color"
           },
           "lighter": {
-            "value": "{white.40}",
+            "value": "{color.white.40}",
             "type": "color"
           },
           "lightest": {
-            "value": "{white.20}",
+            "value": "{color.white.20}",
             "type": "color"
           }
         }
@@ -708,52 +708,52 @@
     },
     "surface": {
       "lowest": {
-        "value": "{grey.800}",
+        "value": "{color.grey.800}",
         "type": "color"
       },
       "lower": {
-        "value": "{grey.850}",
+        "value": "{color.grey.850}",
         "type": "color"
       },
       "normal": {
-        "value": "{grey.900}",
+        "value": "{color.grey.900}",
         "type": "color"
       }
     },
     "shadow": {
       "xlarge": {
-        "value": "{black.60}",
+        "value": "{color.black.60}",
         "type": "color"
       },
       "large": {
-        "value": "{black.40}",
+        "value": "{color.black.40}",
         "type": "color"
       },
       "medium": {
-        "value": "{black.20}",
+        "value": "{color.black.20}",
         "type": "color"
       },
       "small": {
-        "value": "{black.15}",
+        "value": "{color.black.15}",
         "type": "color"
       },
       "base": {
-        "value": "{black.8}",
+        "value": "{color.black.8}",
         "type": "color"
       },
       "base-inner": {
-        "value": "{white.8}",
+        "value": "{color.white.8}",
         "type": "color"
       }
     },
     "dim": {
       "black": {
         "light": {
-          "value": "{bg.absolute.black.lightest}",
+          "value": "{color.bg.absolute.black.lightest}",
           "type": "color"
         },
         "normal": {
-          "value": "{bg.absolute.black.lighter}",
+          "value": "{color.bg.absolute.black.lighter}",
           "type": "color"
         }
       }

--- a/packages/bezier-tokens/src/alpha/functional/gradient.json
+++ b/packages/bezier-tokens/src/alpha/functional/gradient.json
@@ -1,20 +1,6 @@
 {
   "gradient": {
-    "_comment": "WIP, not yet implemented",
     "fg": {
-      "green": {
-        "value": [
-          {
-            "color": "{color.fg.green.normal}",
-            "position": "0%"
-          },
-          {
-            "color": "#7ad890",
-            "position": "100%"
-          }
-        ],
-        "type": "gradient"
-      },
       "black": {
         "value": [
           {

--- a/packages/bezier-tokens/src/alpha/functional/gradient.json
+++ b/packages/bezier-tokens/src/alpha/functional/gradient.json
@@ -5,7 +5,7 @@
       "green": {
         "value": [
           {
-            "color": "{fg.green.normal}",
+            "color": "{color.fg.green.normal}",
             "position": "0%"
           },
           {
@@ -18,11 +18,11 @@
       "black": {
         "value": [
           {
-            "color": "{bg.black.light}",
+            "color": "{color.bg.black.light}",
             "position": "0%"
           },
           {
-            "color": "{bg.black.dark}",
+            "color": "{color.bg.black.dark}",
             "position": "100%"
           }
         ],

--- a/packages/bezier-tokens/src/alpha/functional/light-theme/color.json
+++ b/packages/bezier-tokens/src/alpha/functional/light-theme/color.json
@@ -2,16 +2,20 @@
   "color": {
     "fg": {
       "black": {
+        "pure": {
+          "value": "{color.black.100}",
+          "type": "color"
+        },
+        "darkest": {
+          "value": "{color.black.85}",
+          "type": "color"
+        },
         "darker": {
           "value": "{color.black.60}",
           "type": "color"
         },
         "dark": {
           "value": "{color.black.40}",
-          "type": "color"
-        },
-        "pure": {
-          "value": "{color.black.100}",
           "type": "color"
         },
         "light": {
@@ -291,16 +295,16 @@
           "type": "color"
         },
         "grey-alpha": {
-          "dark": {
-            "value": "{color.grey-alpha.100-80}",
-            "type": "color"
-          },
           "darkest": {
             "value": "{color.grey-alpha.200-80}",
             "type": "color"
           },
           "darker": {
-            "value": "{color.grey-alpha.200-80}",
+            "value": "{color.grey-alpha.100-90}",
+            "type": "color"
+          },
+          "dark": {
+            "value": "{color.grey-alpha.100-80}",
             "type": "color"
           },
           "light": {

--- a/packages/bezier-tokens/src/alpha/functional/light-theme/color.json
+++ b/packages/bezier-tokens/src/alpha/functional/light-theme/color.json
@@ -1,771 +1,773 @@
 {
-  "fg": {
-    "black": {
-      "darker": {
-        "value": "{black.60}",
-        "type": "color"
+  "color": {
+    "fg": {
+      "black": {
+        "darker": {
+          "value": "{black.60}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{black.40}",
+          "type": "color"
+        },
+        "pure": {
+          "value": "{black.100}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{black.15}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{black.8}",
+          "type": "color"
+        }
       },
-      "dark": {
-        "value": "{black.40}",
-        "type": "color"
+      "white": {
+        "normal": {
+          "value": "{white.100}",
+          "type": "color"
+        }
       },
-      "pure": {
-        "value": "{black.100}",
-        "type": "color"
+      "blue": {
+        "normal": {
+          "value": "{blue.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{blue.400-30}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{blue.500}",
+          "type": "color"
+        }
       },
-      "light": {
-        "value": "{black.15}",
-        "type": "color"
+      "cobalt": {
+        "normal": {
+          "value": "{cobalt.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{cobalt.400-30}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{cobalt.500}",
+          "type": "color"
+        }
       },
-      "lightest": {
-        "value": "{black.8}",
-        "type": "color"
+      "red": {
+        "normal": {
+          "value": "{red.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{red.400-30}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{red.500}",
+          "type": "color"
+        }
+      },
+      "orange": {
+        "normal": {
+          "value": "{orange.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{orange.400-30}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{orange.500}",
+          "type": "color"
+        }
+      },
+      "green": {
+        "normal": {
+          "value": "{green.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{green.400-30}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{green.500}",
+          "type": "color"
+        }
+      },
+      "teal": {
+        "normal": {
+          "value": "{teal.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{teal.400-30}",
+          "type": "color"
+        }
+      },
+      "olive": {
+        "normal": {
+          "value": "{olive.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{olive.400-30}",
+          "type": "color"
+        }
+      },
+      "yellow": {
+        "normal": {
+          "value": "{yellow.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{yellow.400-30}",
+          "type": "color"
+        }
+      },
+      "pink": {
+        "normal": {
+          "value": "{pink.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{pink.400-30}",
+          "type": "color"
+        }
+      },
+      "purple": {
+        "normal": {
+          "value": "{purple.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{purple.400-30}",
+          "type": "color"
+        }
+      },
+      "navy": {
+        "normal": {
+          "value": "{navy.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{navy.400-30}",
+          "type": "color"
+        }
+      },
+      "absolute": {
+        "black": {
+          "dark": {
+            "value": "{black.100}",
+            "type": "color"
+          },
+          "normal": {
+            "value": "{black.85}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{black.60}",
+            "type": "color"
+          },
+          "lighter": {
+            "value": "{black.40}",
+            "type": "color"
+          },
+          "lightest": {
+            "value": "{black.20}",
+            "type": "color"
+          }
+        },
+        "white": {
+          "dark": {
+            "value": "{white.100}",
+            "type": "color"
+          },
+          "normal": {
+            "value": "{white.90}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{white.60}",
+            "type": "color"
+          },
+          "lighter": {
+            "value": "{white.40}",
+            "type": "color"
+          },
+          "lightest": {
+            "value": "{white.20}",
+            "type": "color"
+          }
+        }
+      },
+      "grey": {
+        "dark": {
+          "value": "{grey.500}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{grey.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{grey.200}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{grey.100}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{grey.50}",
+          "type": "color"
+        },
+        "grey-alpha": {
+          "darker": {
+            "value": "{grey-alpha.200-80}",
+            "type": "color"
+          },
+          "dark": {
+            "value": "{grey-alpha.100-80}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{grey-alpha.50-80}",
+            "type": "color"
+          }
+        }
       }
     },
-    "white": {
+    "bg": {
+      "black": {
+        "darkest": {
+          "value": "{black.60}",
+          "type": "color"
+        },
+        "darker": {
+          "value": "{black.40}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{black.15}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{black.8}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{black.5}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{black.3}",
+          "type": "color"
+        }
+      },
+      "grey": {
+        "darkest": {
+          "value": "{grey.900}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{grey.500}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{grey.200}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{grey.100}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{grey.50}",
+          "type": "color"
+        },
+        "grey-alpha": {
+          "dark": {
+            "value": "{grey-alpha.100-80}",
+            "type": "color"
+          },
+          "darkest": {
+            "value": "{grey-alpha.200-80}",
+            "type": "color"
+          },
+          "darker": {
+            "value": "{grey-alpha.200-80}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{grey-alpha.50-80}",
+            "type": "color"
+          }
+        },
+        "normal": {
+          "value": "{grey.400}",
+          "type": "color"
+        }
+      },
+      "white": {
+        "highest": {
+          "value": "{white.100}",
+          "type": "color"
+        },
+        "higher": {
+          "value": "{white.100}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{white.100}",
+          "type": "color"
+        },
+        "white-alpha": {
+          "lightest": {
+            "value": "{white.90}",
+            "type": "color"
+          },
+          "lighter": {
+            "value": "{white.60}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{white.20}",
+            "type": "color"
+          }
+        }
+      },
+      "blue": {
+        "normal": {
+          "value": "{blue.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{blue.400-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{blue.400-20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{blue.400-10}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{blue.500}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-blue.400-20}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-blue.400}",
+          "type": "color"
+        }
+      },
+      "cobalt": {
+        "normal": {
+          "value": "{cobalt.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{cobalt.400-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{cobalt.400-20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{cobalt.400-10}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{cobalt.500}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-cobalt.400-20}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-cobalt.400}",
+          "type": "color"
+        }
+      },
+      "red": {
+        "normal": {
+          "value": "{red.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{red.400-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{red.400-20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{red.400-10}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{red.500}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-red.400-20}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-red.400}",
+          "type": "color"
+        }
+      },
+      "orange": {
+        "normal": {
+          "value": "{orange.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{orange.400-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{orange.400-20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{orange.400-10}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{orange.500}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-orange.400-20}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-orange.400}",
+          "type": "color"
+        }
+      },
+      "green": {
+        "normal": {
+          "value": "{green.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{green.400-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{green.400-20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{green.400-10}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{green.500}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-green.400-20}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-green.400}",
+          "type": "color"
+        }
+      },
+      "teal": {
+        "normal": {
+          "value": "{teal.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{teal.400-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{teal.400-20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{teal.400-10}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{teal.500}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-teal.400-20}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-teal.400}",
+          "type": "color"
+        }
+      },
+      "olive": {
+        "normal": {
+          "value": "{olive.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{olive.400-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{olive.400-20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{olive.400-10}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{olive.500}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-olive.400-20}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-olive.400}",
+          "type": "color"
+        }
+      },
+      "yellow": {
+        "normal": {
+          "value": "{yellow.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{yellow.400-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{yellow.400-20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{yellow.400-10}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{yellow.500}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-yellow.400-20}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-yellow.400}",
+          "type": "color"
+        }
+      },
+      "pink": {
+        "normal": {
+          "value": "{pink.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{pink.400-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{pink.400-20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{pink.400-10}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{pink.500}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-pink.400-20}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-pink.400}",
+          "type": "color"
+        }
+      },
+      "purple": {
+        "normal": {
+          "value": "{purple.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{purple.400-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{purple.400-20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{purple.400-10}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{purple.500}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-purple.400-20}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-purple.400}",
+          "type": "color"
+        }
+      },
+      "navy": {
+        "normal": {
+          "value": "{navy.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{navy.400-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{navy.400-20}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{navy.400-10}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{navy.500}",
+          "type": "color"
+        },
+        "shade-light": {
+          "value": "{shade-navy.400-20}",
+          "type": "color"
+        },
+        "shade-normal": {
+          "value": "{shade-navy.400}",
+          "type": "color"
+        }
+      },
+      "absolute": {
+        "black": {
+          "dark": {
+            "value": "{black.100}",
+            "type": "color"
+          },
+          "normal": {
+            "value": "{black.85}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{black.60}",
+            "type": "color"
+          },
+          "lighter": {
+            "value": "{black.40}",
+            "type": "color"
+          },
+          "lightest": {
+            "value": "{black.20}",
+            "type": "color"
+          }
+        },
+        "white": {
+          "dark": {
+            "value": "{white.100}",
+            "type": "color"
+          },
+          "normal": {
+            "value": "{white.90}",
+            "type": "color"
+          },
+          "light": {
+            "value": "{white.60}",
+            "type": "color"
+          },
+          "lighter": {
+            "value": "{white.40}",
+            "type": "color"
+          },
+          "lightest": {
+            "value": "{white.20}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "surface": {
+      "lowest": {
+        "value": "{grey.100}",
+        "type": "color"
+      },
+      "lower": {
+        "value": "{grey.50}",
+        "type": "color"
+      },
       "normal": {
         "value": "{white.100}",
         "type": "color"
       }
     },
-    "blue": {
-      "normal": {
-        "value": "{blue.400}",
+    "shadow": {
+      "xlarge": {
+        "value": "{black.30}",
         "type": "color"
       },
-      "light": {
-        "value": "{blue.400-30}",
+      "large": {
+        "value": "{black.22}",
         "type": "color"
       },
-      "dark": {
-        "value": "{blue.500}",
-        "type": "color"
-      }
-    },
-    "cobalt": {
-      "normal": {
-        "value": "{cobalt.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{cobalt.400-30}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{cobalt.500}",
-        "type": "color"
-      }
-    },
-    "red": {
-      "normal": {
-        "value": "{red.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{red.400-30}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{red.500}",
-        "type": "color"
-      }
-    },
-    "orange": {
-      "normal": {
-        "value": "{orange.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{orange.400-30}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{orange.500}",
-        "type": "color"
-      }
-    },
-    "green": {
-      "normal": {
-        "value": "{green.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{green.400-30}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{green.500}",
-        "type": "color"
-      }
-    },
-    "teal": {
-      "normal": {
-        "value": "{teal.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{teal.400-30}",
-        "type": "color"
-      }
-    },
-    "olive": {
-      "normal": {
-        "value": "{olive.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{olive.400-30}",
-        "type": "color"
-      }
-    },
-    "yellow": {
-      "normal": {
-        "value": "{yellow.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{yellow.400-30}",
-        "type": "color"
-      }
-    },
-    "pink": {
-      "normal": {
-        "value": "{pink.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{pink.400-30}",
-        "type": "color"
-      }
-    },
-    "purple": {
-      "normal": {
-        "value": "{purple.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{purple.400-30}",
-        "type": "color"
-      }
-    },
-    "navy": {
-      "normal": {
-        "value": "{navy.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{navy.400-30}",
-        "type": "color"
-      }
-    },
-    "absolute": {
-      "black": {
-        "dark": {
-          "value": "{black.100}",
-          "type": "color"
-        },
-        "normal": {
-          "value": "{black.85}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{black.60}",
-          "type": "color"
-        },
-        "lighter": {
-          "value": "{black.40}",
-          "type": "color"
-        },
-        "lightest": {
-          "value": "{black.20}",
-          "type": "color"
-        }
-      },
-      "white": {
-        "dark": {
-          "value": "{white.100}",
-          "type": "color"
-        },
-        "normal": {
-          "value": "{white.90}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{white.60}",
-          "type": "color"
-        },
-        "lighter": {
-          "value": "{white.40}",
-          "type": "color"
-        },
-        "lightest": {
-          "value": "{white.20}",
-          "type": "color"
-        }
-      }
-    },
-    "grey": {
-      "dark": {
-        "value": "{grey.500}",
-        "type": "color"
-      },
-      "normal": {
-        "value": "{grey.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{grey.200}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{grey.100}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{grey.50}",
-        "type": "color"
-      },
-      "grey-alpha": {
-        "darker": {
-          "value": "{grey-alpha.200-80}",
-          "type": "color"
-        },
-        "dark": {
-          "value": "{grey-alpha.100-80}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{grey-alpha.50-80}",
-          "type": "color"
-        }
-      }
-    }
-  },
-  "bg": {
-    "black": {
-      "darkest": {
-        "value": "{black.60}",
-        "type": "color"
-      },
-      "darker": {
-        "value": "{black.40}",
-        "type": "color"
-      },
-      "dark": {
+      "medium": {
         "value": "{black.15}",
         "type": "color"
       },
-      "light": {
+      "small": {
         "value": "{black.8}",
         "type": "color"
       },
-      "lighter": {
+      "base": {
         "value": "{black.5}",
         "type": "color"
       },
-      "lightest": {
-        "value": "{black.3}",
+      "base-inner": {
+        "value": "{white.12}",
         "type": "color"
       }
     },
-    "grey": {
-      "darkest": {
-        "value": "{grey.900}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{grey.500}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{grey.200}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{grey.100}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{grey.50}",
-        "type": "color"
-      },
-      "grey-alpha": {
-        "dark": {
-          "value": "{grey-alpha.100-80}",
-          "type": "color"
-        },
-        "darkest": {
-          "value": "{grey-alpha.200-80}",
-          "type": "color"
-        },
-        "darker": {
-          "value": "{grey-alpha.200-80}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{grey-alpha.50-80}",
-          "type": "color"
-        }
-      },
-      "normal": {
-        "value": "{grey.400}",
-        "type": "color"
-      }
-    },
-    "white": {
-      "highest": {
-        "value": "{white.100}",
-        "type": "color"
-      },
-      "higher": {
-        "value": "{white.100}",
-        "type": "color"
-      },
-      "normal": {
-        "value": "{white.100}",
-        "type": "color"
-      },
-      "white-alpha": {
-        "lightest": {
-          "value": "{white.90}",
-          "type": "color"
-        },
-        "lighter": {
-          "value": "{white.60}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{white.20}",
-          "type": "color"
-        }
-      }
-    },
-    "blue": {
-      "normal": {
-        "value": "{blue.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{blue.400-30}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{blue.400-20}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{blue.400-10}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{blue.500}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-blue.400-20}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-blue.400}",
-        "type": "color"
-      }
-    },
-    "cobalt": {
-      "normal": {
-        "value": "{cobalt.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{cobalt.400-30}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{cobalt.400-20}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{cobalt.400-10}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{cobalt.500}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-cobalt.400-20}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-cobalt.400}",
-        "type": "color"
-      }
-    },
-    "red": {
-      "normal": {
-        "value": "{red.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{red.400-30}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{red.400-20}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{red.400-10}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{red.500}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-red.400-20}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-red.400}",
-        "type": "color"
-      }
-    },
-    "orange": {
-      "normal": {
-        "value": "{orange.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{orange.400-30}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{orange.400-20}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{orange.400-10}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{orange.500}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-orange.400-20}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-orange.400}",
-        "type": "color"
-      }
-    },
-    "green": {
-      "normal": {
-        "value": "{green.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{green.400-30}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{green.400-20}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{green.400-10}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{green.500}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-green.400-20}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-green.400}",
-        "type": "color"
-      }
-    },
-    "teal": {
-      "normal": {
-        "value": "{teal.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{teal.400-30}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{teal.400-20}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{teal.400-10}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{teal.500}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-teal.400-20}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-teal.400}",
-        "type": "color"
-      }
-    },
-    "olive": {
-      "normal": {
-        "value": "{olive.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{olive.400-30}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{olive.400-20}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{olive.400-10}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{olive.500}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-olive.400-20}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-olive.400}",
-        "type": "color"
-      }
-    },
-    "yellow": {
-      "normal": {
-        "value": "{yellow.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{yellow.400-30}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{yellow.400-20}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{yellow.400-10}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{yellow.500}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-yellow.400-20}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-yellow.400}",
-        "type": "color"
-      }
-    },
-    "pink": {
-      "normal": {
-        "value": "{pink.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{pink.400-30}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{pink.400-20}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{pink.400-10}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{pink.500}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-pink.400-20}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-pink.400}",
-        "type": "color"
-      }
-    },
-    "purple": {
-      "normal": {
-        "value": "{purple.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{purple.400-30}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{purple.400-20}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{purple.400-10}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{purple.500}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-purple.400-20}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-purple.400}",
-        "type": "color"
-      }
-    },
-    "navy": {
-      "normal": {
-        "value": "{navy.400}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{navy.400-30}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{navy.400-20}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{navy.400-10}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{navy.500}",
-        "type": "color"
-      },
-      "shade-light": {
-        "value": "{shade-navy.400-20}",
-        "type": "color"
-      },
-      "shade-normal": {
-        "value": "{shade-navy.400}",
-        "type": "color"
-      }
-    },
-    "absolute": {
+    "dim": {
       "black": {
-        "dark": {
-          "value": "{black.100}",
+        "light": {
+          "value": "{bg.absolute.black.lightest}",
           "type": "color"
         },
         "normal": {
-          "value": "{black.85}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{black.60}",
-          "type": "color"
-        },
-        "lighter": {
-          "value": "{black.40}",
-          "type": "color"
-        },
-        "lightest": {
-          "value": "{black.20}",
+          "value": "{bg.absolute.black.lighter}",
           "type": "color"
         }
-      },
-      "white": {
-        "dark": {
-          "value": "{white.100}",
-          "type": "color"
-        },
-        "normal": {
-          "value": "{white.90}",
-          "type": "color"
-        },
-        "light": {
-          "value": "{white.60}",
-          "type": "color"
-        },
-        "lighter": {
-          "value": "{white.40}",
-          "type": "color"
-        },
-        "lightest": {
-          "value": "{white.20}",
-          "type": "color"
-        }
-      }
-    }
-  },
-  "surface": {
-    "lowest": {
-      "value": "{grey.100}",
-      "type": "color"
-    },
-    "lower": {
-      "value": "{grey.50}",
-      "type": "color"
-    },
-    "normal": {
-      "value": "{white.100}",
-      "type": "color"
-    }
-  },
-  "shadow": {
-    "xlarge": {
-      "value": "{black.30}",
-      "type": "color"
-    },
-    "large": {
-      "value": "{black.22}",
-      "type": "color"
-    },
-    "medium": {
-      "value": "{black.15}",
-      "type": "color"
-    },
-    "small": {
-      "value": "{black.8}",
-      "type": "color"
-    },
-    "base": {
-      "value": "{black.5}",
-      "type": "color"
-    },
-    "base-inner": {
-      "value": "{white.12}",
-      "type": "color"
-    }
-  },
-  "dim": {
-    "black": {
-      "light": {
-        "value": "{bg.absolute.black.lightest}",
-        "type": "color"
-      },
-      "normal": {
-        "value": "{bg.absolute.black.lighter}",
-        "type": "color"
       }
     }
   }

--- a/packages/bezier-tokens/src/alpha/functional/light-theme/color.json
+++ b/packages/bezier-tokens/src/alpha/functional/light-theme/color.json
@@ -3,240 +3,240 @@
     "fg": {
       "black": {
         "darker": {
-          "value": "{black.60}",
+          "value": "{color.black.60}",
           "type": "color"
         },
         "dark": {
-          "value": "{black.40}",
+          "value": "{color.black.40}",
           "type": "color"
         },
         "pure": {
-          "value": "{black.100}",
+          "value": "{color.black.100}",
           "type": "color"
         },
         "light": {
-          "value": "{black.15}",
+          "value": "{color.black.15}",
           "type": "color"
         },
         "lightest": {
-          "value": "{black.8}",
+          "value": "{color.black.8}",
           "type": "color"
         }
       },
       "white": {
         "normal": {
-          "value": "{white.100}",
+          "value": "{color.white.100}",
           "type": "color"
         }
       },
       "blue": {
         "normal": {
-          "value": "{blue.400}",
+          "value": "{color.blue.400}",
           "type": "color"
         },
         "light": {
-          "value": "{blue.400-30}",
+          "value": "{color.blue.400-30}",
           "type": "color"
         },
         "dark": {
-          "value": "{blue.500}",
+          "value": "{color.blue.500}",
           "type": "color"
         }
       },
       "cobalt": {
         "normal": {
-          "value": "{cobalt.400}",
+          "value": "{color.cobalt.400}",
           "type": "color"
         },
         "light": {
-          "value": "{cobalt.400-30}",
+          "value": "{color.cobalt.400-30}",
           "type": "color"
         },
         "dark": {
-          "value": "{cobalt.500}",
+          "value": "{color.cobalt.500}",
           "type": "color"
         }
       },
       "red": {
         "normal": {
-          "value": "{red.400}",
+          "value": "{color.red.400}",
           "type": "color"
         },
         "light": {
-          "value": "{red.400-30}",
+          "value": "{color.red.400-30}",
           "type": "color"
         },
         "dark": {
-          "value": "{red.500}",
+          "value": "{color.red.500}",
           "type": "color"
         }
       },
       "orange": {
         "normal": {
-          "value": "{orange.400}",
+          "value": "{color.orange.400}",
           "type": "color"
         },
         "light": {
-          "value": "{orange.400-30}",
+          "value": "{color.orange.400-30}",
           "type": "color"
         },
         "dark": {
-          "value": "{orange.500}",
+          "value": "{color.orange.500}",
           "type": "color"
         }
       },
       "green": {
         "normal": {
-          "value": "{green.400}",
+          "value": "{color.green.400}",
           "type": "color"
         },
         "light": {
-          "value": "{green.400-30}",
+          "value": "{color.green.400-30}",
           "type": "color"
         },
         "dark": {
-          "value": "{green.500}",
+          "value": "{color.green.500}",
           "type": "color"
         }
       },
       "teal": {
         "normal": {
-          "value": "{teal.400}",
+          "value": "{color.teal.400}",
           "type": "color"
         },
         "light": {
-          "value": "{teal.400-30}",
+          "value": "{color.teal.400-30}",
           "type": "color"
         }
       },
       "olive": {
         "normal": {
-          "value": "{olive.400}",
+          "value": "{color.olive.400}",
           "type": "color"
         },
         "light": {
-          "value": "{olive.400-30}",
+          "value": "{color.olive.400-30}",
           "type": "color"
         }
       },
       "yellow": {
         "normal": {
-          "value": "{yellow.400}",
+          "value": "{color.yellow.400}",
           "type": "color"
         },
         "light": {
-          "value": "{yellow.400-30}",
+          "value": "{color.yellow.400-30}",
           "type": "color"
         }
       },
       "pink": {
         "normal": {
-          "value": "{pink.400}",
+          "value": "{color.pink.400}",
           "type": "color"
         },
         "light": {
-          "value": "{pink.400-30}",
+          "value": "{color.pink.400-30}",
           "type": "color"
         }
       },
       "purple": {
         "normal": {
-          "value": "{purple.400}",
+          "value": "{color.purple.400}",
           "type": "color"
         },
         "light": {
-          "value": "{purple.400-30}",
+          "value": "{color.purple.400-30}",
           "type": "color"
         }
       },
       "navy": {
         "normal": {
-          "value": "{navy.400}",
+          "value": "{color.navy.400}",
           "type": "color"
         },
         "light": {
-          "value": "{navy.400-30}",
+          "value": "{color.navy.400-30}",
           "type": "color"
         }
       },
       "absolute": {
         "black": {
           "dark": {
-            "value": "{black.100}",
+            "value": "{color.black.100}",
             "type": "color"
           },
           "normal": {
-            "value": "{black.85}",
+            "value": "{color.black.85}",
             "type": "color"
           },
           "light": {
-            "value": "{black.60}",
+            "value": "{color.black.60}",
             "type": "color"
           },
           "lighter": {
-            "value": "{black.40}",
+            "value": "{color.black.40}",
             "type": "color"
           },
           "lightest": {
-            "value": "{black.20}",
+            "value": "{color.black.20}",
             "type": "color"
           }
         },
         "white": {
           "dark": {
-            "value": "{white.100}",
+            "value": "{color.white.100}",
             "type": "color"
           },
           "normal": {
-            "value": "{white.90}",
+            "value": "{color.white.90}",
             "type": "color"
           },
           "light": {
-            "value": "{white.60}",
+            "value": "{color.white.60}",
             "type": "color"
           },
           "lighter": {
-            "value": "{white.40}",
+            "value": "{color.white.40}",
             "type": "color"
           },
           "lightest": {
-            "value": "{white.20}",
+            "value": "{color.white.20}",
             "type": "color"
           }
         }
       },
       "grey": {
         "dark": {
-          "value": "{grey.500}",
+          "value": "{color.grey.500}",
           "type": "color"
         },
         "normal": {
-          "value": "{grey.400}",
+          "value": "{color.grey.400}",
           "type": "color"
         },
         "light": {
-          "value": "{grey.200}",
+          "value": "{color.grey.200}",
           "type": "color"
         },
         "lighter": {
-          "value": "{grey.100}",
+          "value": "{color.grey.100}",
           "type": "color"
         },
         "lightest": {
-          "value": "{grey.50}",
+          "value": "{color.grey.50}",
           "type": "color"
         },
         "grey-alpha": {
           "darker": {
-            "value": "{grey-alpha.200-80}",
+            "value": "{color.grey-alpha.200-80}",
             "type": "color"
           },
           "dark": {
-            "value": "{grey-alpha.100-80}",
+            "value": "{color.grey-alpha.100-80}",
             "type": "color"
           },
           "light": {
-            "value": "{grey-alpha.50-80}",
+            "value": "{color.grey-alpha.50-80}",
             "type": "color"
           }
         }
@@ -245,474 +245,474 @@
     "bg": {
       "black": {
         "darkest": {
-          "value": "{black.60}",
+          "value": "{color.black.60}",
           "type": "color"
         },
         "darker": {
-          "value": "{black.40}",
+          "value": "{color.black.40}",
           "type": "color"
         },
         "dark": {
-          "value": "{black.15}",
+          "value": "{color.black.15}",
           "type": "color"
         },
         "light": {
-          "value": "{black.8}",
+          "value": "{color.black.8}",
           "type": "color"
         },
         "lighter": {
-          "value": "{black.5}",
+          "value": "{color.black.5}",
           "type": "color"
         },
         "lightest": {
-          "value": "{black.3}",
+          "value": "{color.black.3}",
           "type": "color"
         }
       },
       "grey": {
         "darkest": {
-          "value": "{grey.900}",
+          "value": "{color.grey.900}",
           "type": "color"
         },
         "dark": {
-          "value": "{grey.500}",
+          "value": "{color.grey.500}",
           "type": "color"
         },
         "light": {
-          "value": "{grey.200}",
+          "value": "{color.grey.200}",
           "type": "color"
         },
         "lighter": {
-          "value": "{grey.100}",
+          "value": "{color.grey.100}",
           "type": "color"
         },
         "lightest": {
-          "value": "{grey.50}",
+          "value": "{color.grey.50}",
           "type": "color"
         },
         "grey-alpha": {
           "dark": {
-            "value": "{grey-alpha.100-80}",
+            "value": "{color.grey-alpha.100-80}",
             "type": "color"
           },
           "darkest": {
-            "value": "{grey-alpha.200-80}",
+            "value": "{color.grey-alpha.200-80}",
             "type": "color"
           },
           "darker": {
-            "value": "{grey-alpha.200-80}",
+            "value": "{color.grey-alpha.200-80}",
             "type": "color"
           },
           "light": {
-            "value": "{grey-alpha.50-80}",
+            "value": "{color.grey-alpha.50-80}",
             "type": "color"
           }
         },
         "normal": {
-          "value": "{grey.400}",
+          "value": "{color.grey.400}",
           "type": "color"
         }
       },
       "white": {
         "highest": {
-          "value": "{white.100}",
+          "value": "{color.white.100}",
           "type": "color"
         },
         "higher": {
-          "value": "{white.100}",
+          "value": "{color.white.100}",
           "type": "color"
         },
         "normal": {
-          "value": "{white.100}",
+          "value": "{color.white.100}",
           "type": "color"
         },
         "white-alpha": {
           "lightest": {
-            "value": "{white.90}",
+            "value": "{color.white.90}",
             "type": "color"
           },
           "lighter": {
-            "value": "{white.60}",
+            "value": "{color.white.60}",
             "type": "color"
           },
           "light": {
-            "value": "{white.20}",
+            "value": "{color.white.20}",
             "type": "color"
           }
         }
       },
       "blue": {
         "normal": {
-          "value": "{blue.400}",
+          "value": "{color.blue.400}",
           "type": "color"
         },
         "light": {
-          "value": "{blue.400-30}",
+          "value": "{color.blue.400-30}",
           "type": "color"
         },
         "lighter": {
-          "value": "{blue.400-20}",
+          "value": "{color.blue.400-20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{blue.400-10}",
+          "value": "{color.blue.400-10}",
           "type": "color"
         },
         "dark": {
-          "value": "{blue.500}",
+          "value": "{color.blue.500}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-blue.400-20}",
+          "value": "{color.shade-blue.400-20}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-blue.400}",
+          "value": "{color.shade-blue.400}",
           "type": "color"
         }
       },
       "cobalt": {
         "normal": {
-          "value": "{cobalt.400}",
+          "value": "{color.cobalt.400}",
           "type": "color"
         },
         "light": {
-          "value": "{cobalt.400-30}",
+          "value": "{color.cobalt.400-30}",
           "type": "color"
         },
         "lighter": {
-          "value": "{cobalt.400-20}",
+          "value": "{color.cobalt.400-20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{cobalt.400-10}",
+          "value": "{color.cobalt.400-10}",
           "type": "color"
         },
         "dark": {
-          "value": "{cobalt.500}",
+          "value": "{color.cobalt.500}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-cobalt.400-20}",
+          "value": "{color.shade-cobalt.400-20}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-cobalt.400}",
+          "value": "{color.shade-cobalt.400}",
           "type": "color"
         }
       },
       "red": {
         "normal": {
-          "value": "{red.400}",
+          "value": "{color.red.400}",
           "type": "color"
         },
         "light": {
-          "value": "{red.400-30}",
+          "value": "{color.red.400-30}",
           "type": "color"
         },
         "lighter": {
-          "value": "{red.400-20}",
+          "value": "{color.red.400-20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{red.400-10}",
+          "value": "{color.red.400-10}",
           "type": "color"
         },
         "dark": {
-          "value": "{red.500}",
+          "value": "{color.red.500}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-red.400-20}",
+          "value": "{color.shade-red.400-20}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-red.400}",
+          "value": "{color.shade-red.400}",
           "type": "color"
         }
       },
       "orange": {
         "normal": {
-          "value": "{orange.400}",
+          "value": "{color.orange.400}",
           "type": "color"
         },
         "light": {
-          "value": "{orange.400-30}",
+          "value": "{color.orange.400-30}",
           "type": "color"
         },
         "lighter": {
-          "value": "{orange.400-20}",
+          "value": "{color.orange.400-20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{orange.400-10}",
+          "value": "{color.orange.400-10}",
           "type": "color"
         },
         "dark": {
-          "value": "{orange.500}",
+          "value": "{color.orange.500}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-orange.400-20}",
+          "value": "{color.shade-orange.400-20}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-orange.400}",
+          "value": "{color.shade-orange.400}",
           "type": "color"
         }
       },
       "green": {
         "normal": {
-          "value": "{green.400}",
+          "value": "{color.green.400}",
           "type": "color"
         },
         "light": {
-          "value": "{green.400-30}",
+          "value": "{color.green.400-30}",
           "type": "color"
         },
         "lighter": {
-          "value": "{green.400-20}",
+          "value": "{color.green.400-20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{green.400-10}",
+          "value": "{color.green.400-10}",
           "type": "color"
         },
         "dark": {
-          "value": "{green.500}",
+          "value": "{color.green.500}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-green.400-20}",
+          "value": "{color.shade-green.400-20}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-green.400}",
+          "value": "{color.shade-green.400}",
           "type": "color"
         }
       },
       "teal": {
         "normal": {
-          "value": "{teal.400}",
+          "value": "{color.teal.400}",
           "type": "color"
         },
         "light": {
-          "value": "{teal.400-30}",
+          "value": "{color.teal.400-30}",
           "type": "color"
         },
         "lighter": {
-          "value": "{teal.400-20}",
+          "value": "{color.teal.400-20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{teal.400-10}",
+          "value": "{color.teal.400-10}",
           "type": "color"
         },
         "dark": {
-          "value": "{teal.500}",
+          "value": "{color.teal.500}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-teal.400-20}",
+          "value": "{color.shade-teal.400-20}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-teal.400}",
+          "value": "{color.shade-teal.400}",
           "type": "color"
         }
       },
       "olive": {
         "normal": {
-          "value": "{olive.400}",
+          "value": "{color.olive.400}",
           "type": "color"
         },
         "light": {
-          "value": "{olive.400-30}",
+          "value": "{color.olive.400-30}",
           "type": "color"
         },
         "lighter": {
-          "value": "{olive.400-20}",
+          "value": "{color.olive.400-20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{olive.400-10}",
+          "value": "{color.olive.400-10}",
           "type": "color"
         },
         "dark": {
-          "value": "{olive.500}",
+          "value": "{color.olive.500}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-olive.400-20}",
+          "value": "{color.shade-olive.400-20}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-olive.400}",
+          "value": "{color.shade-olive.400}",
           "type": "color"
         }
       },
       "yellow": {
         "normal": {
-          "value": "{yellow.400}",
+          "value": "{color.yellow.400}",
           "type": "color"
         },
         "light": {
-          "value": "{yellow.400-30}",
+          "value": "{color.yellow.400-30}",
           "type": "color"
         },
         "lighter": {
-          "value": "{yellow.400-20}",
+          "value": "{color.yellow.400-20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{yellow.400-10}",
+          "value": "{color.yellow.400-10}",
           "type": "color"
         },
         "dark": {
-          "value": "{yellow.500}",
+          "value": "{color.yellow.500}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-yellow.400-20}",
+          "value": "{color.shade-yellow.400-20}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-yellow.400}",
+          "value": "{color.shade-yellow.400}",
           "type": "color"
         }
       },
       "pink": {
         "normal": {
-          "value": "{pink.400}",
+          "value": "{color.pink.400}",
           "type": "color"
         },
         "light": {
-          "value": "{pink.400-30}",
+          "value": "{color.pink.400-30}",
           "type": "color"
         },
         "lighter": {
-          "value": "{pink.400-20}",
+          "value": "{color.pink.400-20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{pink.400-10}",
+          "value": "{color.pink.400-10}",
           "type": "color"
         },
         "dark": {
-          "value": "{pink.500}",
+          "value": "{color.pink.500}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-pink.400-20}",
+          "value": "{color.shade-pink.400-20}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-pink.400}",
+          "value": "{color.shade-pink.400}",
           "type": "color"
         }
       },
       "purple": {
         "normal": {
-          "value": "{purple.400}",
+          "value": "{color.purple.400}",
           "type": "color"
         },
         "light": {
-          "value": "{purple.400-30}",
+          "value": "{color.purple.400-30}",
           "type": "color"
         },
         "lighter": {
-          "value": "{purple.400-20}",
+          "value": "{color.purple.400-20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{purple.400-10}",
+          "value": "{color.purple.400-10}",
           "type": "color"
         },
         "dark": {
-          "value": "{purple.500}",
+          "value": "{color.purple.500}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-purple.400-20}",
+          "value": "{color.shade-purple.400-20}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-purple.400}",
+          "value": "{color.shade-purple.400}",
           "type": "color"
         }
       },
       "navy": {
         "normal": {
-          "value": "{navy.400}",
+          "value": "{color.navy.400}",
           "type": "color"
         },
         "light": {
-          "value": "{navy.400-30}",
+          "value": "{color.navy.400-30}",
           "type": "color"
         },
         "lighter": {
-          "value": "{navy.400-20}",
+          "value": "{color.navy.400-20}",
           "type": "color"
         },
         "lightest": {
-          "value": "{navy.400-10}",
+          "value": "{color.navy.400-10}",
           "type": "color"
         },
         "dark": {
-          "value": "{navy.500}",
+          "value": "{color.navy.500}",
           "type": "color"
         },
         "shade-light": {
-          "value": "{shade-navy.400-20}",
+          "value": "{color.shade-navy.400-20}",
           "type": "color"
         },
         "shade-normal": {
-          "value": "{shade-navy.400}",
+          "value": "{color.shade-navy.400}",
           "type": "color"
         }
       },
       "absolute": {
         "black": {
           "dark": {
-            "value": "{black.100}",
+            "value": "{color.black.100}",
             "type": "color"
           },
           "normal": {
-            "value": "{black.85}",
+            "value": "{color.black.85}",
             "type": "color"
           },
           "light": {
-            "value": "{black.60}",
+            "value": "{color.black.60}",
             "type": "color"
           },
           "lighter": {
-            "value": "{black.40}",
+            "value": "{color.black.40}",
             "type": "color"
           },
           "lightest": {
-            "value": "{black.20}",
+            "value": "{color.black.20}",
             "type": "color"
           }
         },
         "white": {
           "dark": {
-            "value": "{white.100}",
+            "value": "{color.white.100}",
             "type": "color"
           },
           "normal": {
-            "value": "{white.90}",
+            "value": "{color.white.90}",
             "type": "color"
           },
           "light": {
-            "value": "{white.60}",
+            "value": "{color.white.60}",
             "type": "color"
           },
           "lighter": {
-            "value": "{white.40}",
+            "value": "{color.white.40}",
             "type": "color"
           },
           "lightest": {
-            "value": "{white.20}",
+            "value": "{color.white.20}",
             "type": "color"
           }
         }
@@ -720,52 +720,52 @@
     },
     "surface": {
       "lowest": {
-        "value": "{grey.100}",
+        "value": "{color.grey.100}",
         "type": "color"
       },
       "lower": {
-        "value": "{grey.50}",
+        "value": "{color.grey.50}",
         "type": "color"
       },
       "normal": {
-        "value": "{white.100}",
+        "value": "{color.white.100}",
         "type": "color"
       }
     },
     "shadow": {
       "xlarge": {
-        "value": "{black.30}",
+        "value": "{color.black.30}",
         "type": "color"
       },
       "large": {
-        "value": "{black.22}",
+        "value": "{color.black.22}",
         "type": "color"
       },
       "medium": {
-        "value": "{black.15}",
+        "value": "{color.black.15}",
         "type": "color"
       },
       "small": {
-        "value": "{black.8}",
+        "value": "{color.black.8}",
         "type": "color"
       },
       "base": {
-        "value": "{black.5}",
+        "value": "{color.black.5}",
         "type": "color"
       },
       "base-inner": {
-        "value": "{white.12}",
+        "value": "{color.white.12}",
         "type": "color"
       }
     },
     "dim": {
       "black": {
         "light": {
-          "value": "{bg.absolute.black.lightest}",
+          "value": "{color.bg.absolute.black.lightest}",
           "type": "color"
         },
         "normal": {
-          "value": "{bg.absolute.black.lighter}",
+          "value": "{color.bg.absolute.black.lighter}",
           "type": "color"
         }
       }

--- a/packages/bezier-tokens/src/alpha/functional/shadow.json
+++ b/packages/bezier-tokens/src/alpha/functional/shadow.json
@@ -3,7 +3,7 @@
     "1": {
       "value": [
         {
-          "color": "{shadow.base-inner}",
+          "color": "{color.shadow.base-inner}",
           "type": "innerShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -11,7 +11,7 @@
           "spread": "0px"
         },
         {
-          "color": "{shadow.base}",
+          "color": "{color.shadow.base}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -19,7 +19,7 @@
           "spread": "1px"
         },
         {
-          "color": "{shadow.small}",
+          "color": "{color.shadow.small}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "1px",
@@ -32,7 +32,7 @@
     "2": {
       "value": [
         {
-          "color": "{shadow.base-inner}",
+          "color": "{color.shadow.base-inner}",
           "type": "innerShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -40,7 +40,7 @@
           "spread": "0px"
         },
         {
-          "color": "{shadow.base}",
+          "color": "{color.shadow.base}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -48,7 +48,7 @@
           "spread": "1px"
         },
         {
-          "color": "{shadow.small}",
+          "color": "{color.shadow.small}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "2px",
@@ -61,7 +61,7 @@
     "3": {
       "value": [
         {
-          "color": "{shadow.base-inner}",
+          "color": "{color.shadow.base-inner}",
           "type": "innerShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -69,7 +69,7 @@
           "spread": "0px"
         },
         {
-          "color": "{shadow.base}",
+          "color": "{color.shadow.base}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -77,7 +77,7 @@
           "spread": "1px"
         },
         {
-          "color": "{shadow.medium}",
+          "color": "{color.shadow.medium}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "4px",
@@ -90,7 +90,7 @@
     "4": {
       "value": [
         {
-          "color": "{shadow.base-inner}",
+          "color": "{color.shadow.base-inner}",
           "type": "innerShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -98,7 +98,7 @@
           "spread": "0px"
         },
         {
-          "color": "{shadow.base}",
+          "color": "{color.shadow.base}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -106,7 +106,7 @@
           "spread": "1px"
         },
         {
-          "color": "{shadow.large}",
+          "color": "{color.shadow.large}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "4px",
@@ -119,7 +119,7 @@
     "5": {
       "value": [
         {
-          "color": "{shadow.base-inner}",
+          "color": "{color.shadow.base-inner}",
           "type": "innerShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -127,7 +127,7 @@
           "spread": "0px"
         },
         {
-          "color": "{shadow.base}",
+          "color": "{color.shadow.base}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -135,7 +135,7 @@
           "spread": "1px"
         },
         {
-          "color": "{shadow.xlarge}",
+          "color": "{color.shadow.xlarge}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "6px",
@@ -148,7 +148,7 @@
     "6": {
       "value": [
         {
-          "color": "{shadow.base-inner}",
+          "color": "{color.shadow.base-inner}",
           "type": "innerShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -156,7 +156,7 @@
           "spread": "0px"
         },
         {
-          "color": "{shadow.base}",
+          "color": "{color.shadow.base}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "0px",
@@ -164,7 +164,7 @@
           "spread": "1px"
         },
         {
-          "color": "{shadow.xlarge}",
+          "color": "{color.shadow.xlarge}",
           "type": "dropShadow",
           "offsetX": "0px",
           "offsetY": "12px",

--- a/packages/bezier-tokens/src/alpha/global/color.json
+++ b/packages/bezier-tokens/src/alpha/global/color.json
@@ -1,930 +1,932 @@
 {
-  "blue": {
-    "100": {
-      "value": "#a9c6ff",
-      "type": "color"
-    },
-    "200": {
-      "value": "#96b7ff",
-      "type": "color"
-    },
-    "300": {
-      "value": "#84a5ff",
-      "type": "color"
-    },
-    "400": {
-      "value": "#6d6afc",
-      "type": "color"
-    },
-    "500": {
-      "value": "#5950dc",
-      "type": "color"
-    },
-    "600": {
-      "value": "#4941bc",
-      "type": "color"
-    },
-    "400-30": {
-      "value": "#6d6afc4d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#6d6afc33",
-      "type": "color"
-    },
-    "400-10": {
-      "value": "#6d6afc1a",
-      "type": "color"
-    },
-    "300-45": {
-      "value": "#84a5ff73",
-      "type": "color"
-    },
-    "300-30": {
-      "value": "#84a5ff4d",
-      "type": "color"
-    },
-    "300-15": {
-      "value": "#84a5ff26",
-      "type": "color"
-    }
-  },
-  "cobalt": {
-    "100": {
-      "value": "#afdaff",
-      "type": "color"
-    },
-    "200": {
-      "value": "#9ad1ff",
-      "type": "color"
-    },
-    "300": {
-      "value": "#7dc2fa",
-      "type": "color"
-    },
-    "400": {
-      "value": "#5093e5",
-      "type": "color"
-    },
-    "500": {
-      "value": "#3870d1",
-      "type": "color"
-    },
-    "600": {
-      "value": "#2b59b5",
-      "type": "color"
-    },
-    "400-30": {
-      "value": "#5093e54d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#5093e533",
-      "type": "color"
-    },
-    "400-10": {
-      "value": "#5093e51a",
-      "type": "color"
-    },
-    "300-45": {
-      "value": "#77c0fb73",
-      "type": "color"
-    },
-    "300-30": {
-      "value": "#77c0fb4d",
-      "type": "color"
-    },
-    "300-15": {
-      "value": "#77c0fb26",
-      "type": "color"
-    }
-  },
-  "green": {
-    "100": {
-      "value": "#a4ecb3",
-      "type": "color"
-    },
-    "200": {
-      "value": "#91e5a4",
-      "type": "color"
-    },
-    "300": {
-      "value": "#7ad890",
-      "type": "color"
-    },
-    "400": {
-      "value": "#40ad67",
-      "type": "color"
-    },
-    "500": {
-      "value": "#358761",
-      "type": "color"
-    },
-    "600": {
-      "value": "#327055",
-      "type": "color"
-    },
-    "400-30": {
-      "value": "#40ad674d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#40ad6733",
-      "type": "color"
-    },
-    "400-10": {
-      "value": "#40ad671a",
-      "type": "color"
-    },
-    "300-45": {
-      "value": "#7ad89073",
-      "type": "color"
-    },
-    "300-30": {
-      "value": "#7ad8904d",
-      "type": "color"
-    },
-    "300-15": {
-      "value": "#7ad89026",
-      "type": "color"
-    }
-  },
-  "red": {
-    "100": {
-      "value": "#ffb8b8",
-      "type": "color"
-    },
-    "200": {
-      "value": "#ffa6a6",
-      "type": "color"
-    },
-    "300": {
-      "value": "#ff8c8c",
-      "type": "color"
-    },
-    "400": {
-      "value": "#e55c5c",
-      "type": "color"
-    },
-    "500": {
-      "value": "#bc3a42",
-      "type": "color"
-    },
-    "600": {
-      "value": "#992c34",
-      "type": "color"
-    },
-    "400-30": {
-      "value": "#e55c5c4d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#e55c5c33",
-      "type": "color"
-    },
-    "400-10": {
-      "value": "#e55c5c1a",
-      "type": "color"
-    },
-    "300-45": {
-      "value": "#ff8c8c73",
-      "type": "color"
-    },
-    "300-30": {
-      "value": "#ff8c8c4d",
-      "type": "color"
-    },
-    "300-15": {
-      "value": "#ff8c8c26",
-      "type": "color"
-    }
-  },
-  "black": {
-    "3": {
-      "value": "#00000008",
-      "type": "color"
-    },
-    "5": {
-      "value": "#0000000d",
-      "type": "color"
-    },
-    "8": {
-      "value": "#00000014",
-      "type": "color"
-    },
-    "15": {
-      "value": "#00000026",
-      "type": "color"
-    },
-    "20": {
-      "value": "#00000033",
-      "type": "color"
-    },
-    "22": {
-      "value": "#00000038",
-      "type": "color"
-    },
-    "30": {
-      "value": "#0000004d",
-      "type": "color"
-    },
-    "40": {
-      "value": "#00000066",
-      "type": "color"
-    },
-    "50": {
-      "value": "#00000080",
-      "type": "color"
-    },
-    "60": {
-      "value": "#00000099",
-      "type": "color"
-    },
-    "70": {
-      "value": "#000000b3",
-      "type": "color"
-    },
-    "85": {
-      "value": "#000000d9",
-      "type": "color"
-    },
-    "100": {
-      "value": "#000000",
-      "type": "color"
-    }
-  },
-  "white": {
-    "0": {
-      "value": "#ffffff00",
-      "type": "color"
-    },
-    "5": {
-      "value": "#ffffff0d",
-      "type": "color"
-    },
-    "8": {
-      "value": "#ffffff14",
-      "type": "color"
-    },
-    "12": {
-      "value": "#ffffff1f",
-      "type": "color"
-    },
-    "20": {
-      "value": "#ffffff33",
-      "type": "color"
-    },
-    "40": {
-      "value": "#ffffff66",
-      "type": "color"
-    },
-    "60": {
-      "value": "#ffffff99",
-      "type": "color"
-    },
-    "80": {
-      "value": "#ffffffcc",
-      "type": "color"
-    },
-    "90": {
-      "value": "#ffffffe6",
-      "type": "color"
-    },
-    "100": {
-      "value": "#ffffff",
-      "type": "color"
-    }
-  },
-  "orange": {
-    "100": {
-      "value": "#ffc38f",
-      "type": "color"
-    },
-    "200": {
-      "value": "#ffb77d",
-      "type": "color"
-    },
-    "300": {
-      "value": "#ffa15e",
-      "type": "color"
-    },
-    "400": {
-      "value": "#e67f2b",
-      "type": "color"
-    },
-    "500": {
-      "value": "#c1630d",
-      "type": "color"
-    },
-    "600": {
-      "value": "#a1540c",
-      "type": "color"
-    },
-    "400-30": {
-      "value": "#e67f2b4d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#e67f2b33",
-      "type": "color"
-    },
-    "400-10": {
-      "value": "#e67f2b1a",
-      "type": "color"
-    },
-    "300-45": {
-      "value": "#ffa15e73",
-      "type": "color"
-    },
-    "300-30": {
-      "value": "#ffa15e4d",
-      "type": "color"
-    },
-    "300-15": {
-      "value": "#ffa15e26",
-      "type": "color"
-    }
-  },
-  "yellow": {
-    "100": {
-      "value": "#ffe38f",
-      "type": "color"
-    },
-    "200": {
-      "value": "#fed968",
-      "type": "color"
-    },
-    "300": {
-      "value": "#f9c835",
-      "type": "color"
-    },
-    "400": {
-      "value": "#edae0d",
-      "type": "color"
-    },
-    "500": {
-      "value": "#c38f00",
-      "type": "color"
-    },
-    "600": {
-      "value": "#9e7504",
-      "type": "color"
-    },
-    "400-30": {
-      "value": "#edae0d4d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#edae0d33",
-      "type": "color"
-    },
-    "400-10": {
-      "value": "#edae0d1a",
-      "type": "color"
-    },
-    "300-45": {
-      "value": "#f9c83573",
-      "type": "color"
-    },
-    "300-30": {
-      "value": "#f9c8354d",
-      "type": "color"
-    },
-    "300-15": {
-      "value": "#f9c83526",
-      "type": "color"
-    }
-  },
-  "pink": {
-    "100": {
-      "value": "#ffafef",
-      "type": "color"
-    },
-    "200": {
-      "value": "#f896e5",
-      "type": "color"
-    },
-    "300": {
-      "value": "#ec6fd3",
-      "type": "color"
-    },
-    "400": {
-      "value": "#d64bb5",
-      "type": "color"
-    },
-    "500": {
-      "value": "#b0369e",
-      "type": "color"
-    },
-    "600": {
-      "value": "#962c86",
-      "type": "color"
-    },
-    "400-30": {
-      "value": "#d64bb54d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#d64bb533",
-      "type": "color"
-    },
-    "400-10": {
-      "value": "#d64bb51a",
-      "type": "color"
-    },
-    "300-45": {
-      "value": "#ec6fd373",
-      "type": "color"
-    },
-    "300-30": {
-      "value": "#ec6fd34d",
-      "type": "color"
-    },
-    "300-15": {
-      "value": "#ec6fd326",
-      "type": "color"
-    }
-  },
-  "purple": {
-    "100": {
-      "value": "#d1b5ff",
-      "type": "color"
-    },
-    "200": {
-      "value": "#c19aff",
-      "type": "color"
-    },
-    "300": {
-      "value": "#b184ff",
-      "type": "color"
-    },
-    "400": {
-      "value": "#8e57e7",
-      "type": "color"
-    },
-    "500": {
-      "value": "#6735b6",
-      "type": "color"
-    },
-    "600": {
-      "value": "#54278f",
-      "type": "color"
-    },
-    "400-30": {
-      "value": "#8e57e74d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#8e57e733",
-      "type": "color"
-    },
-    "400-10": {
-      "value": "#8e57e71a",
-      "type": "color"
-    },
-    "300-45": {
-      "value": "#b184ff73",
-      "type": "color"
-    },
-    "300-30": {
-      "value": "#b184ff4d",
-      "type": "color"
-    },
-    "300-15": {
-      "value": "#b184ff26",
-      "type": "color"
-    }
-  },
-  "navy": {
-    "100": {
-      "value": "#a5b2ee",
-      "type": "color"
-    },
-    "200": {
-      "value": "#8b99d9",
-      "type": "color"
-    },
-    "300": {
-      "value": "#7683d3",
-      "type": "color"
-    },
-    "400": {
-      "value": "#424fab",
-      "type": "color"
-    },
-    "500": {
-      "value": "#353888",
-      "type": "color"
-    },
-    "600": {
-      "value": "#22245b",
-      "type": "color"
-    },
-    "400-30": {
-      "value": "#424fab4d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#424fab33",
-      "type": "color"
-    },
-    "400-10": {
-      "value": "#424fab1a",
-      "type": "color"
-    },
-    "300-45": {
-      "value": "#7683d373",
-      "type": "color"
-    },
-    "300-30": {
-      "value": "#7683d34d",
-      "type": "color"
-    },
-    "300-15": {
-      "value": "#7683d326",
-      "type": "color"
-    }
-  },
-  "teal": {
-    "100": {
-      "value": "#9beee6",
-      "type": "color"
-    },
-    "200": {
-      "value": "#72e0d5",
-      "type": "color"
-    },
-    "300": {
-      "value": "#40d3c5",
-      "type": "color"
-    },
-    "400": {
-      "value": "#09b2ac",
-      "type": "color"
-    },
-    "500": {
-      "value": "#068e95",
-      "type": "color"
-    },
-    "600": {
-      "value": "#06687d",
-      "type": "color"
-    },
-    "400-30": {
-      "value": "#09b2ac4d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#09b2ac33",
-      "type": "color"
-    },
-    "400-10": {
-      "value": "#09b2ac1a",
-      "type": "color"
-    },
-    "300-45": {
-      "value": "#40d3c573",
-      "type": "color"
-    },
-    "300-30": {
-      "value": "#40d3c54d",
-      "type": "color"
-    },
-    "300-15": {
-      "value": "#40d3c526",
-      "type": "color"
-    }
-  },
-  "olive": {
-    "100": {
-      "value": "#e7f17c",
-      "type": "color"
-    },
-    "200": {
-      "value": "#dbe56e",
-      "type": "color"
-    },
-    "300": {
-      "value": "#c8d630",
-      "type": "color"
-    },
-    "400": {
-      "value": "#a9b110",
-      "type": "color"
-    },
-    "500": {
-      "value": "#7b801c",
-      "type": "color"
-    },
-    "600": {
-      "value": "#65691c",
-      "type": "color"
-    },
-    "400-30": {
-      "value": "#a9b1104d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#a9b11033",
-      "type": "color"
-    },
-    "400-10": {
-      "value": "#a9b1101a",
-      "type": "color"
-    },
-    "300-45": {
-      "value": "#c8d63073",
-      "type": "color"
-    },
-    "300-30": {
-      "value": "#c8d6304d",
-      "type": "color"
-    },
-    "300-15": {
-      "value": "#c8d63026",
-      "type": "color"
-    }
-  },
-  "grey": {
-    "50": {
-      "value": "#fcfcfc",
-      "type": "color"
-    },
-    "100": {
-      "value": "#f7f7f8",
-      "type": "color"
-    },
-    "200": {
-      "value": "#efeff0",
-      "type": "color"
-    },
-    "300": {
-      "value": "#e2e2e4",
-      "type": "color"
-    },
-    "400": {
-      "value": "#cfcfd1",
-      "type": "color"
-    },
-    "500": {
-      "value": "#a7a7aa",
-      "type": "color"
-    },
-    "600": {
-      "value": "#7b7b7b",
-      "type": "color"
-    },
-    "700": {
-      "value": "#464748",
-      "type": "color"
-    },
-    "800": {
-      "value": "#313234",
-      "type": "color"
-    },
-    "850": {
-      "value": "#2a2b2d",
-      "type": "color"
-    },
-    "900": {
-      "value": "#242428",
-      "type": "color"
-    }
-  },
-  "grey-alpha": {
-    "900-90": {
-      "value": "#242428e6",
-      "type": "color"
-    },
-    "850-80": {
-      "value": "#2a2b2dcc",
-      "type": "color"
-    },
-    "800-80": {
-      "value": "#313234cc",
-      "type": "color"
-    },
-    "700-80": {
-      "value": "#464748cc",
-      "type": "color"
-    },
-    "200-80": {
-      "value": "#efeff0cc",
-      "type": "color"
-    },
-    "100-80": {
-      "value": "#f7f7f8cc",
-      "type": "color"
-    },
-    "50-80": {
-      "value": "#fcfcfccc",
-      "type": "color"
-    },
-    "100-90": {
-      "value": "#f7f7f8e6",
-      "type": "color"
-    },
-    "800-90": {
-      "value": "#313234e6",
-      "type": "color"
-    }
-  },
-  "shade-blue": {
-    "400": {
-      "value": "#7175e0",
-      "type": "color"
-    },
-    "600": {
-      "value": "#4c5289",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#7175e033",
-      "type": "color"
-    },
-    "600-40": {
-      "value": "#4c528966",
-      "type": "color"
-    }
-  },
-  "shade-cobalt": {
-    "400": {
-      "value": "#57ace8",
-      "type": "color"
-    },
-    "600": {
-      "value": "#4a6185",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#57ace833",
-      "type": "color"
-    },
-    "600-40": {
-      "value": "#4a618566",
-      "type": "color"
-    }
-  },
-  "shade-teal": {
-    "400": {
-      "value": "#55aaa7",
-      "type": "color"
-    },
-    "600": {
-      "value": "#47737d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#55aaa733",
-      "type": "color"
-    },
-    "600-40": {
-      "value": "#47737d66",
-      "type": "color"
-    }
-  },
-  "shade-red": {
-    "400": {
-      "value": "#de6870",
-      "type": "color"
-    },
-    "600": {
-      "value": "#904248",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#de687033",
-      "type": "color"
-    },
-    "600-40": {
-      "value": "#90424866",
-      "type": "color"
-    }
-  },
-  "shade-green": {
-    "400": {
-      "value": "#62af7c",
-      "type": "color"
-    },
-    "600": {
-      "value": "#4c7a5e",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#62af7c33",
-      "type": "color"
-    },
-    "600-40": {
-      "value": "#4c7a5e66",
-      "type": "color"
-    }
-  },
-  "shade-olive": {
-    "400": {
-      "value": "#a5a953",
-      "type": "color"
-    },
-    "600": {
-      "value": "#737638",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#a5a95333",
-      "type": "color"
-    },
-    "600-40": {
-      "value": "#73763866",
-      "type": "color"
-    }
-  },
-  "shade-yellow": {
-    "400": {
-      "value": "#e8ae3c",
-      "type": "color"
-    },
-    "600": {
-      "value": "#7d6a26",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#e8ae3c33",
-      "type": "color"
-    },
-    "600-40": {
-      "value": "#7d6a2666",
-      "type": "color"
-    }
-  },
-  "shade-orange": {
-    "400": {
-      "value": "#e08c48",
-      "type": "color"
-    },
-    "600": {
-      "value": "#895a34",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#e08c4833",
-      "type": "color"
-    },
-    "600-40": {
-      "value": "#895a3466",
-      "type": "color"
-    }
-  },
-  "shade-pink": {
-    "400": {
-      "value": "#d369ba",
-      "type": "color"
-    },
-    "600": {
-      "value": "#854075",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#d369ba33",
-      "type": "color"
-    },
-    "600-40": {
-      "value": "#85407566",
-      "type": "color"
-    }
-  },
-  "shade-purple": {
-    "400": {
-      "value": "#9d6fe5",
-      "type": "color"
-    },
-    "600": {
-      "value": "#5b467d",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#9d6fe533",
-      "type": "color"
-    },
-    "600-40": {
-      "value": "#5b467d66",
-      "type": "color"
-    }
-  },
-  "shade-navy": {
-    "400": {
-      "value": "#5f69b0",
-      "type": "color"
-    },
-    "600": {
-      "value": "#373b56",
-      "type": "color"
-    },
-    "400-20": {
-      "value": "#5f69b033",
-      "type": "color"
-    },
-    "600-40": {
-      "value": "#373b5666",
-      "type": "color"
+  "color": {
+    "blue": {
+      "100": {
+        "value": "#a9c6ff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#96b7ff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#84a5ff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#6d6afc",
+        "type": "color"
+      },
+      "500": {
+        "value": "#5950dc",
+        "type": "color"
+      },
+      "600": {
+        "value": "#4941bc",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#6d6afc4d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#6d6afc33",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#6d6afc1a",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#84a5ff73",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#84a5ff4d",
+        "type": "color"
+      },
+      "300-15": {
+        "value": "#84a5ff26",
+        "type": "color"
+      }
+    },
+    "cobalt": {
+      "100": {
+        "value": "#afdaff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#9ad1ff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#7dc2fa",
+        "type": "color"
+      },
+      "400": {
+        "value": "#5093e5",
+        "type": "color"
+      },
+      "500": {
+        "value": "#3870d1",
+        "type": "color"
+      },
+      "600": {
+        "value": "#2b59b5",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#5093e54d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#5093e533",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#5093e51a",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#77c0fb73",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#77c0fb4d",
+        "type": "color"
+      },
+      "300-15": {
+        "value": "#77c0fb26",
+        "type": "color"
+      }
+    },
+    "green": {
+      "100": {
+        "value": "#a4ecb3",
+        "type": "color"
+      },
+      "200": {
+        "value": "#91e5a4",
+        "type": "color"
+      },
+      "300": {
+        "value": "#7ad890",
+        "type": "color"
+      },
+      "400": {
+        "value": "#40ad67",
+        "type": "color"
+      },
+      "500": {
+        "value": "#358761",
+        "type": "color"
+      },
+      "600": {
+        "value": "#327055",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#40ad674d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#40ad6733",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#40ad671a",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#7ad89073",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#7ad8904d",
+        "type": "color"
+      },
+      "300-15": {
+        "value": "#7ad89026",
+        "type": "color"
+      }
+    },
+    "red": {
+      "100": {
+        "value": "#ffb8b8",
+        "type": "color"
+      },
+      "200": {
+        "value": "#ffa6a6",
+        "type": "color"
+      },
+      "300": {
+        "value": "#ff8c8c",
+        "type": "color"
+      },
+      "400": {
+        "value": "#e55c5c",
+        "type": "color"
+      },
+      "500": {
+        "value": "#bc3a42",
+        "type": "color"
+      },
+      "600": {
+        "value": "#992c34",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#e55c5c4d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#e55c5c33",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#e55c5c1a",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#ff8c8c73",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#ff8c8c4d",
+        "type": "color"
+      },
+      "300-15": {
+        "value": "#ff8c8c26",
+        "type": "color"
+      }
+    },
+    "black": {
+      "3": {
+        "value": "#00000008",
+        "type": "color"
+      },
+      "5": {
+        "value": "#0000000d",
+        "type": "color"
+      },
+      "8": {
+        "value": "#00000014",
+        "type": "color"
+      },
+      "15": {
+        "value": "#00000026",
+        "type": "color"
+      },
+      "20": {
+        "value": "#00000033",
+        "type": "color"
+      },
+      "22": {
+        "value": "#00000038",
+        "type": "color"
+      },
+      "30": {
+        "value": "#0000004d",
+        "type": "color"
+      },
+      "40": {
+        "value": "#00000066",
+        "type": "color"
+      },
+      "50": {
+        "value": "#00000080",
+        "type": "color"
+      },
+      "60": {
+        "value": "#00000099",
+        "type": "color"
+      },
+      "70": {
+        "value": "#000000b3",
+        "type": "color"
+      },
+      "85": {
+        "value": "#000000d9",
+        "type": "color"
+      },
+      "100": {
+        "value": "#000000",
+        "type": "color"
+      }
+    },
+    "white": {
+      "0": {
+        "value": "#ffffff00",
+        "type": "color"
+      },
+      "5": {
+        "value": "#ffffff0d",
+        "type": "color"
+      },
+      "8": {
+        "value": "#ffffff14",
+        "type": "color"
+      },
+      "12": {
+        "value": "#ffffff1f",
+        "type": "color"
+      },
+      "20": {
+        "value": "#ffffff33",
+        "type": "color"
+      },
+      "40": {
+        "value": "#ffffff66",
+        "type": "color"
+      },
+      "60": {
+        "value": "#ffffff99",
+        "type": "color"
+      },
+      "80": {
+        "value": "#ffffffcc",
+        "type": "color"
+      },
+      "90": {
+        "value": "#ffffffe6",
+        "type": "color"
+      },
+      "100": {
+        "value": "#ffffff",
+        "type": "color"
+      }
+    },
+    "orange": {
+      "100": {
+        "value": "#ffc38f",
+        "type": "color"
+      },
+      "200": {
+        "value": "#ffb77d",
+        "type": "color"
+      },
+      "300": {
+        "value": "#ffa15e",
+        "type": "color"
+      },
+      "400": {
+        "value": "#e67f2b",
+        "type": "color"
+      },
+      "500": {
+        "value": "#c1630d",
+        "type": "color"
+      },
+      "600": {
+        "value": "#a1540c",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#e67f2b4d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#e67f2b33",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#e67f2b1a",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#ffa15e73",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#ffa15e4d",
+        "type": "color"
+      },
+      "300-15": {
+        "value": "#ffa15e26",
+        "type": "color"
+      }
+    },
+    "yellow": {
+      "100": {
+        "value": "#ffe38f",
+        "type": "color"
+      },
+      "200": {
+        "value": "#fed968",
+        "type": "color"
+      },
+      "300": {
+        "value": "#f9c835",
+        "type": "color"
+      },
+      "400": {
+        "value": "#edae0d",
+        "type": "color"
+      },
+      "500": {
+        "value": "#c38f00",
+        "type": "color"
+      },
+      "600": {
+        "value": "#9e7504",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#edae0d4d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#edae0d33",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#edae0d1a",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#f9c83573",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#f9c8354d",
+        "type": "color"
+      },
+      "300-15": {
+        "value": "#f9c83526",
+        "type": "color"
+      }
+    },
+    "pink": {
+      "100": {
+        "value": "#ffafef",
+        "type": "color"
+      },
+      "200": {
+        "value": "#f896e5",
+        "type": "color"
+      },
+      "300": {
+        "value": "#ec6fd3",
+        "type": "color"
+      },
+      "400": {
+        "value": "#d64bb5",
+        "type": "color"
+      },
+      "500": {
+        "value": "#b0369e",
+        "type": "color"
+      },
+      "600": {
+        "value": "#962c86",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#d64bb54d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#d64bb533",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#d64bb51a",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#ec6fd373",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#ec6fd34d",
+        "type": "color"
+      },
+      "300-15": {
+        "value": "#ec6fd326",
+        "type": "color"
+      }
+    },
+    "purple": {
+      "100": {
+        "value": "#d1b5ff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#c19aff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#b184ff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#8e57e7",
+        "type": "color"
+      },
+      "500": {
+        "value": "#6735b6",
+        "type": "color"
+      },
+      "600": {
+        "value": "#54278f",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#8e57e74d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#8e57e733",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#8e57e71a",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#b184ff73",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#b184ff4d",
+        "type": "color"
+      },
+      "300-15": {
+        "value": "#b184ff26",
+        "type": "color"
+      }
+    },
+    "navy": {
+      "100": {
+        "value": "#a5b2ee",
+        "type": "color"
+      },
+      "200": {
+        "value": "#8b99d9",
+        "type": "color"
+      },
+      "300": {
+        "value": "#7683d3",
+        "type": "color"
+      },
+      "400": {
+        "value": "#424fab",
+        "type": "color"
+      },
+      "500": {
+        "value": "#353888",
+        "type": "color"
+      },
+      "600": {
+        "value": "#22245b",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#424fab4d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#424fab33",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#424fab1a",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#7683d373",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#7683d34d",
+        "type": "color"
+      },
+      "300-15": {
+        "value": "#7683d326",
+        "type": "color"
+      }
+    },
+    "teal": {
+      "100": {
+        "value": "#9beee6",
+        "type": "color"
+      },
+      "200": {
+        "value": "#72e0d5",
+        "type": "color"
+      },
+      "300": {
+        "value": "#40d3c5",
+        "type": "color"
+      },
+      "400": {
+        "value": "#09b2ac",
+        "type": "color"
+      },
+      "500": {
+        "value": "#068e95",
+        "type": "color"
+      },
+      "600": {
+        "value": "#06687d",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#09b2ac4d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#09b2ac33",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#09b2ac1a",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#40d3c573",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#40d3c54d",
+        "type": "color"
+      },
+      "300-15": {
+        "value": "#40d3c526",
+        "type": "color"
+      }
+    },
+    "olive": {
+      "100": {
+        "value": "#e7f17c",
+        "type": "color"
+      },
+      "200": {
+        "value": "#dbe56e",
+        "type": "color"
+      },
+      "300": {
+        "value": "#c8d630",
+        "type": "color"
+      },
+      "400": {
+        "value": "#a9b110",
+        "type": "color"
+      },
+      "500": {
+        "value": "#7b801c",
+        "type": "color"
+      },
+      "600": {
+        "value": "#65691c",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#a9b1104d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#a9b11033",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#a9b1101a",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#c8d63073",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#c8d6304d",
+        "type": "color"
+      },
+      "300-15": {
+        "value": "#c8d63026",
+        "type": "color"
+      }
+    },
+    "grey": {
+      "50": {
+        "value": "#fcfcfc",
+        "type": "color"
+      },
+      "100": {
+        "value": "#f7f7f8",
+        "type": "color"
+      },
+      "200": {
+        "value": "#efeff0",
+        "type": "color"
+      },
+      "300": {
+        "value": "#e2e2e4",
+        "type": "color"
+      },
+      "400": {
+        "value": "#cfcfd1",
+        "type": "color"
+      },
+      "500": {
+        "value": "#a7a7aa",
+        "type": "color"
+      },
+      "600": {
+        "value": "#7b7b7b",
+        "type": "color"
+      },
+      "700": {
+        "value": "#464748",
+        "type": "color"
+      },
+      "800": {
+        "value": "#313234",
+        "type": "color"
+      },
+      "850": {
+        "value": "#2a2b2d",
+        "type": "color"
+      },
+      "900": {
+        "value": "#242428",
+        "type": "color"
+      }
+    },
+    "grey-alpha": {
+      "900-90": {
+        "value": "#242428e6",
+        "type": "color"
+      },
+      "850-80": {
+        "value": "#2a2b2dcc",
+        "type": "color"
+      },
+      "800-80": {
+        "value": "#313234cc",
+        "type": "color"
+      },
+      "700-80": {
+        "value": "#464748cc",
+        "type": "color"
+      },
+      "200-80": {
+        "value": "#efeff0cc",
+        "type": "color"
+      },
+      "100-80": {
+        "value": "#f7f7f8cc",
+        "type": "color"
+      },
+      "50-80": {
+        "value": "#fcfcfccc",
+        "type": "color"
+      },
+      "100-90": {
+        "value": "#f7f7f8e6",
+        "type": "color"
+      },
+      "800-90": {
+        "value": "#313234e6",
+        "type": "color"
+      }
+    },
+    "shade-blue": {
+      "400": {
+        "value": "#7175e0",
+        "type": "color"
+      },
+      "600": {
+        "value": "#4c5289",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#7175e033",
+        "type": "color"
+      },
+      "600-40": {
+        "value": "#4c528966",
+        "type": "color"
+      }
+    },
+    "shade-cobalt": {
+      "400": {
+        "value": "#57ace8",
+        "type": "color"
+      },
+      "600": {
+        "value": "#4a6185",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#57ace833",
+        "type": "color"
+      },
+      "600-40": {
+        "value": "#4a618566",
+        "type": "color"
+      }
+    },
+    "shade-teal": {
+      "400": {
+        "value": "#55aaa7",
+        "type": "color"
+      },
+      "600": {
+        "value": "#47737d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#55aaa733",
+        "type": "color"
+      },
+      "600-40": {
+        "value": "#47737d66",
+        "type": "color"
+      }
+    },
+    "shade-red": {
+      "400": {
+        "value": "#de6870",
+        "type": "color"
+      },
+      "600": {
+        "value": "#904248",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#de687033",
+        "type": "color"
+      },
+      "600-40": {
+        "value": "#90424866",
+        "type": "color"
+      }
+    },
+    "shade-green": {
+      "400": {
+        "value": "#62af7c",
+        "type": "color"
+      },
+      "600": {
+        "value": "#4c7a5e",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#62af7c33",
+        "type": "color"
+      },
+      "600-40": {
+        "value": "#4c7a5e66",
+        "type": "color"
+      }
+    },
+    "shade-olive": {
+      "400": {
+        "value": "#a5a953",
+        "type": "color"
+      },
+      "600": {
+        "value": "#737638",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#a5a95333",
+        "type": "color"
+      },
+      "600-40": {
+        "value": "#73763866",
+        "type": "color"
+      }
+    },
+    "shade-yellow": {
+      "400": {
+        "value": "#e8ae3c",
+        "type": "color"
+      },
+      "600": {
+        "value": "#7d6a26",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#e8ae3c33",
+        "type": "color"
+      },
+      "600-40": {
+        "value": "#7d6a2666",
+        "type": "color"
+      }
+    },
+    "shade-orange": {
+      "400": {
+        "value": "#e08c48",
+        "type": "color"
+      },
+      "600": {
+        "value": "#895a34",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#e08c4833",
+        "type": "color"
+      },
+      "600-40": {
+        "value": "#895a3466",
+        "type": "color"
+      }
+    },
+    "shade-pink": {
+      "400": {
+        "value": "#d369ba",
+        "type": "color"
+      },
+      "600": {
+        "value": "#854075",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#d369ba33",
+        "type": "color"
+      },
+      "600-40": {
+        "value": "#85407566",
+        "type": "color"
+      }
+    },
+    "shade-purple": {
+      "400": {
+        "value": "#9d6fe5",
+        "type": "color"
+      },
+      "600": {
+        "value": "#5b467d",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#9d6fe533",
+        "type": "color"
+      },
+      "600-40": {
+        "value": "#5b467d66",
+        "type": "color"
+      }
+    },
+    "shade-navy": {
+      "400": {
+        "value": "#5f69b0",
+        "type": "color"
+      },
+      "600": {
+        "value": "#373b56",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#5f69b033",
+        "type": "color"
+      },
+      "600-40": {
+        "value": "#373b5666",
+        "type": "color"
+      }
     }
   }
 }

--- a/packages/bezier-tokens/src/alpha/global/font.json
+++ b/packages/bezier-tokens/src/alpha/global/font.json
@@ -86,62 +86,62 @@
         "value": 700,
         "type": "fontWeight"
       }
-    }
-  },
-  "line-height": {
-    "16": {
-      "value": "16px",
-      "type": "dimension"
     },
-    "18": {
-      "value": "18px",
-      "type": "dimension"
+    "line-height": {
+      "16": {
+        "value": "16px",
+        "type": "dimension"
+      },
+      "18": {
+        "value": "18px",
+        "type": "dimension"
+      },
+      "22": {
+        "value": "22px",
+        "type": "dimension"
+      },
+      "23": {
+        "value": "23px",
+        "type": "dimension"
+      },
+      "24": {
+        "value": "24px",
+        "type": "dimension"
+      },
+      "28": {
+        "value": "28px",
+        "type": "dimension"
+      },
+      "32": {
+        "value": "32px",
+        "type": "dimension"
+      },
+      "36": {
+        "value": "36px",
+        "type": "dimension"
+      },
+      "44": {
+        "value": "44px",
+        "type": "dimension"
+      }
     },
-    "22": {
-      "value": "22px",
-      "type": "dimension"
-    },
-    "23": {
-      "value": "23px",
-      "type": "dimension"
-    },
-    "24": {
-      "value": "24px",
-      "type": "dimension"
-    },
-    "28": {
-      "value": "28px",
-      "type": "dimension"
-    },
-    "32": {
-      "value": "32px",
-      "type": "dimension"
-    },
-    "36": {
-      "value": "36px",
-      "type": "dimension"
-    },
-    "44": {
-      "value": "44px",
-      "type": "dimension"
-    }
-  },
-  "letter-spacing": {
-    "0": {
-      "value": "0px",
-      "type": "dimension"
-    },
-    "1": {
-      "value": "0.1px",
-      "type": "dimension"
-    },
-    "2": {
-      "value": "0.2px",
-      "type": "dimension"
-    },
-    "3": {
-      "value": "0.3px",
-      "type": "dimension"
+    "letter-spacing": {
+      "0": {
+        "value": "0px",
+        "type": "dimension"
+      },
+      "1": {
+        "value": "0.1px",
+        "type": "dimension"
+      },
+      "2": {
+        "value": "0.2px",
+        "type": "dimension"
+      },
+      "3": {
+        "value": "0.3px",
+        "type": "dimension"
+      }
     }
   }
 }

--- a/packages/bezier-tokens/src/alpha/global/gradient.json
+++ b/packages/bezier-tokens/src/alpha/global/gradient.json
@@ -4,11 +4,11 @@
       "purple": {
         "value": [
           {
-            "color": "{purple.300}",
+            "color": "{color.purple.300}",
             "position": "50%"
           },
           {
-            "color": "{pink.200}",
+            "color": "{color.pink.200}",
             "position": "100%"
           }
         ],
@@ -17,11 +17,11 @@
       "orange": {
         "value": [
           {
-            "color": "{orange.300}",
+            "color": "{color.orange.300}",
             "position": "50%"
           },
           {
-            "color": "{yellow.200}",
+            "color": "{color.yellow.200}",
             "position": "100%"
           }
         ],
@@ -30,11 +30,11 @@
       "green": {
         "value": [
           {
-            "color": "{green.300}",
+            "color": "{color.green.300}",
             "position": "50%"
           },
           {
-            "color": "{teal.200}",
+            "color": "{color.teal.200}",
             "position": "100%"
           }
         ],
@@ -43,11 +43,11 @@
       "blue": {
         "value": [
           {
-            "color": "{blue.300}",
+            "color": "{color.blue.300}",
             "position": "50%"
           },
           {
-            "color": "{green.200}",
+            "color": "{color.green.200}",
             "position": "100%"
           }
         ],

--- a/packages/bezier-tokens/src/alpha/global/gradient.json
+++ b/packages/bezier-tokens/src/alpha/global/gradient.json
@@ -53,6 +53,21 @@
         ],
         "type": "gradient"
       }
+    },
+    "fg": {
+      "green": {
+        "value": [
+          {
+            "color": "{color.green.400}",
+            "position": "0%"
+          },
+          {
+            "color": "{color.green.300}",
+            "position": "100%"
+          }
+        ],
+        "type": "gradient"
+      }
     }
   }
 }

--- a/packages/bezier-tokens/src/alpha/global/typography.json
+++ b/packages/bezier-tokens/src/alpha/global/typography.json
@@ -89,252 +89,252 @@
           "value": "{letter-spacing.0.value}"
         }
       }
-    }
-  },
-  "title": {
-    "1": {
-      "bold": {
-        "font-weight": {
-          "value": "{font.weight.bold}"
+    },
+    "title": {
+      "1": {
+        "bold": {
+          "font-weight": {
+            "value": "{font.weight.bold}"
+          },
+          "font-size": {
+            "value": "{font.size.22.value}"
+          },
+          "line-height": {
+            "value": "{line-height.28.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.2.value}"
+          }
+        }
+      },
+      "2": {
+        "bold": {
+          "font-weight": {
+            "value": "{font.weight.bold}"
+          },
+          "font-size": {
+            "value": "{font.size.18.value}"
+          },
+          "line-height": {
+            "value": "{line-height.24.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.2.value}"
+          }
         },
-        "font-size": {
-          "value": "{font.size.22.value}"
-        },
-        "line-height": {
-          "value": "{line-height.28.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.2.value}"
+        "semibold": {
+          "font-weight": {
+            "value": "{font.weight.semibold}"
+          },
+          "font-size": {
+            "value": "{font.size.18.value}"
+          },
+          "line-height": {
+            "value": "{line-height.24.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.2.value}"
+          }
+        }
+      },
+      "3": {
+        "semibold": {
+          "font-weight": {
+            "value": "{font.weight.semibold}"
+          },
+          "font-size": {
+            "value": "{font.size.16.value}"
+          },
+          "line-height": {
+            "value": "{line-height.24.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.3.value}"
+          }
         }
       }
     },
-    "2": {
-      "bold": {
-        "font-weight": {
-          "value": "{font.weight.bold}"
+    "body": {
+      "1": {
+        "semibold": {
+          "font-weight": {
+            "value": "{font.weight.semibold}"
+          },
+          "font-size": {
+            "value": "{font.size.16.value}"
+          },
+          "line-height": {
+            "value": "{line-height.24.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.2.value}"
+          }
         },
-        "font-size": {
-          "value": "{font.size.18.value}"
-        },
-        "line-height": {
-          "value": "{line-height.24.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.2.value}"
+        "regular": {
+          "font-weight": {
+            "value": "{font.weight.regular}"
+          },
+          "font-size": {
+            "value": "{font.size.16.value}"
+          },
+          "line-height": {
+            "value": "{line-height.24.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.1.value}"
+          }
         }
       },
-      "semibold": {
-        "font-weight": {
-          "value": "{font.weight.semibold}"
+      "2": {
+        "semibold": {
+          "font-weight": {
+            "value": "{font.weight.semibold}"
+          },
+          "font-size": {
+            "value": "{font.size.15.value}"
+          },
+          "line-height": {
+            "value": "{line-height.22.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.2.value}"
+          }
         },
-        "font-size": {
-          "value": "{font.size.18.value}"
-        },
-        "line-height": {
-          "value": "{line-height.24.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.2.value}"
+        "regular": {
+          "font-weight": {
+            "value": "{font.weight.regular}"
+          },
+          "font-size": {
+            "value": "{font.size.15.value}"
+          },
+          "line-height": {
+            "value": "{line-height.22.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.1.value}"
+          }
         }
       }
     },
-    "3": {
-      "semibold": {
-        "font-weight": {
-          "value": "{font.weight.semibold}"
+    "caption": {
+      "1": {
+        "semibold": {
+          "font-weight": {
+            "value": "{font.weight.semibold}"
+          },
+          "font-size": {
+            "value": "{font.size.14.value}"
+          },
+          "line-height": {
+            "value": "{line-height.18.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.2.value}"
+          }
         },
-        "font-size": {
-          "value": "{font.size.16.value}"
-        },
-        "line-height": {
-          "value": "{line-height.24.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.3.value}"
-        }
-      }
-    }
-  },
-  "body": {
-    "1": {
-      "semibold": {
-        "font-weight": {
-          "value": "{font.weight.semibold}"
-        },
-        "font-size": {
-          "value": "{font.size.16.value}"
-        },
-        "line-height": {
-          "value": "{line-height.24.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.2.value}"
+        "regular": {
+          "font-weight": {
+            "value": "{font.weight.regular}"
+          },
+          "font-size": {
+            "value": "{font.size.14.value}"
+          },
+          "line-height": {
+            "value": "{line-height.18.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.2.value}"
+          }
         }
       },
-      "regular": {
-        "font-weight": {
-          "value": "{font.weight.regular}"
+      "2": {
+        "semibold": {
+          "font-weight": {
+            "value": "{font.weight.semibold}"
+          },
+          "font-size": {
+            "value": "{font.size.13.value}"
+          },
+          "line-height": {
+            "value": "{line-height.18.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.2.value}"
+          }
         },
-        "font-size": {
-          "value": "{font.size.16.value}"
-        },
-        "line-height": {
-          "value": "{line-height.24.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.1.value}"
-        }
-      }
-    },
-    "2": {
-      "semibold": {
-        "font-weight": {
-          "value": "{font.weight.semibold}"
-        },
-        "font-size": {
-          "value": "{font.size.15.value}"
-        },
-        "line-height": {
-          "value": "{line-height.22.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.2.value}"
-        }
-      },
-      "regular": {
-        "font-weight": {
-          "value": "{font.weight.regular}"
-        },
-        "font-size": {
-          "value": "{font.size.15.value}"
-        },
-        "line-height": {
-          "value": "{line-height.22.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.1.value}"
-        }
-      }
-    }
-  },
-  "caption": {
-    "1": {
-      "semibold": {
-        "font-weight": {
-          "value": "{font.weight.semibold}"
-        },
-        "font-size": {
-          "value": "{font.size.14.value}"
-        },
-        "line-height": {
-          "value": "{line-height.18.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.2.value}"
+        "regular": {
+          "font-weight": {
+            "value": "{font.weight.regular}"
+          },
+          "font-size": {
+            "value": "{font.size.13.value}"
+          },
+          "line-height": {
+            "value": "{line-height.18.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.2.value}"
+          }
         }
       },
-      "regular": {
-        "font-weight": {
-          "value": "{font.weight.regular}"
+      "3": {
+        "semibold": {
+          "font-weight": {
+            "value": "{font.weight.semibold}"
+          },
+          "font-size": {
+            "value": "{font.size.12.value}"
+          },
+          "line-height": {
+            "value": "{line-height.16.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.2.value}"
+          }
         },
-        "font-size": {
-          "value": "{font.size.14.value}"
-        },
-        "line-height": {
-          "value": "{line-height.18.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.2.value}"
-        }
-      }
-    },
-    "2": {
-      "semibold": {
-        "font-weight": {
-          "value": "{font.weight.semibold}"
-        },
-        "font-size": {
-          "value": "{font.size.13.value}"
-        },
-        "line-height": {
-          "value": "{line-height.18.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.2.value}"
-        }
-      },
-      "regular": {
-        "font-weight": {
-          "value": "{font.weight.regular}"
-        },
-        "font-size": {
-          "value": "{font.size.13.value}"
-        },
-        "line-height": {
-          "value": "{line-height.18.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.2.value}"
-        }
-      }
-    },
-    "3": {
-      "semibold": {
-        "font-weight": {
-          "value": "{font.weight.semibold}"
-        },
-        "font-size": {
-          "value": "{font.size.12.value}"
-        },
-        "line-height": {
-          "value": "{line-height.16.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.2.value}"
+        "regular": {
+          "font-weight": {
+            "value": "{font.weight.regular}"
+          },
+          "font-size": {
+            "value": "{font.size.12.value}"
+          },
+          "line-height": {
+            "value": "{line-height.16.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.2.value}"
+          }
         }
       },
-      "regular": {
-        "font-weight": {
-          "value": "{font.weight.regular}"
+      "4": {
+        "semibold": {
+          "font-weight": {
+            "value": "{font.weight.semibold}"
+          },
+          "font-size": {
+            "value": "{font.size.11.value}"
+          },
+          "line-height": {
+            "value": "{line-height.16.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.1.value}"
+          }
         },
-        "font-size": {
-          "value": "{font.size.12.value}"
-        },
-        "line-height": {
-          "value": "{line-height.16.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.2.value}"
-        }
-      }
-    },
-    "4": {
-      "semibold": {
-        "font-weight": {
-          "value": "{font.weight.semibold}"
-        },
-        "font-size": {
-          "value": "{font.size.11.value}"
-        },
-        "line-height": {
-          "value": "{line-height.16.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.1.value}"
-        }
-      },
-      "regular": {
-        "font-weight": {
-          "value": "{font.weight.regular}"
-        },
-        "font-size": {
-          "value": "{font.size.11.value}"
-        },
-        "line-height": {
-          "value": "{line-height.16.value}"
-        },
-        "letter-spacing": {
-          "value": "{letter-spacing.1.value}"
+        "regular": {
+          "font-weight": {
+            "value": "{font.weight.regular}"
+          },
+          "font-size": {
+            "value": "{font.size.11.value}"
+          },
+          "line-height": {
+            "value": "{line-height.16.value}"
+          },
+          "letter-spacing": {
+            "value": "{letter-spacing.1.value}"
+          }
         }
       }
     }

--- a/packages/bezier-tokens/src/alpha/global/typography.json
+++ b/packages/bezier-tokens/src/alpha/global/typography.json
@@ -5,13 +5,13 @@
         "value": "{font.weight.regular}"
       },
       "font-size": {
-        "value": "{font.size.15-5.value}"
+        "value": "{font.size.15-5}"
       },
       "line-height": {
-        "value": "{font.line-height.23.value}"
+        "value": "{font.line-height.23}"
       },
       "letter-spacing": {
-        "value": "{font.letter-spacing.2.value}"
+        "value": "{font.letter-spacing.2}"
       }
     },
     "h1": {
@@ -20,13 +20,13 @@
           "value": "{font.weight.bold}"
         },
         "font-size": {
-          "value": "{font.size.36.value}"
+          "value": "{font.size.36}"
         },
         "line-height": {
-          "value": "{font.line-height.44.value}"
+          "value": "{font.line-height.44}"
         },
         "letter-spacing": {
-          "value": "{font.letter-spacing.0.value}"
+          "value": "{font.letter-spacing.0}"
         }
       }
     },
@@ -36,13 +36,13 @@
           "value": "{font.weight.bold}"
         },
         "font-size": {
-          "value": "{font.size.30.value}"
+          "value": "{font.size.30}"
         },
         "line-height": {
-          "value": "{font.line-height.36.value}"
+          "value": "{font.line-height.36}"
         },
         "letter-spacing": {
-          "value": "{font.letter-spacing.0.value}"
+          "value": "{font.letter-spacing.0}"
         }
       },
       "regular": {
@@ -50,13 +50,13 @@
           "value": "{font.weight.regular}"
         },
         "font-size": {
-          "value": "{font.size.30.value}"
+          "value": "{font.size.30}"
         },
         "line-height": {
-          "value": "{font.line-height.36.value}"
+          "value": "{font.line-height.36}"
         },
         "letter-spacing": {
-          "value": "{font.letter-spacing.0.value}"
+          "value": "{font.letter-spacing.0}"
         }
       }
     },
@@ -66,13 +66,13 @@
           "value": "{font.weight.bold}"
         },
         "font-size": {
-          "value": "{font.size.24.value}"
+          "value": "{font.size.24}"
         },
         "line-height": {
-          "value": "{font.line-height.32.value}"
+          "value": "{font.line-height.32}"
         },
         "letter-spacing": {
-          "value": "{font.letter-spacing.0.value}"
+          "value": "{font.letter-spacing.0}"
         }
       },
       "regular": {
@@ -80,13 +80,13 @@
           "value": "{font.weight.regular}"
         },
         "font-size": {
-          "value": "{font.size.24.value}"
+          "value": "{font.size.24}"
         },
         "line-height": {
-          "value": "{font.line-height.32.value}"
+          "value": "{font.line-height.32}"
         },
         "letter-spacing": {
-          "value": "{font.letter-spacing.0.value}"
+          "value": "{font.letter-spacing.0}"
         }
       }
     },
@@ -97,13 +97,13 @@
             "value": "{font.weight.bold}"
           },
           "font-size": {
-            "value": "{font.size.22.value}"
+            "value": "{font.size.22}"
           },
           "line-height": {
-            "value": "{font.line-height.28.value}"
+            "value": "{font.line-height.28}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2}"
           }
         }
       },
@@ -113,13 +113,13 @@
             "value": "{font.weight.bold}"
           },
           "font-size": {
-            "value": "{font.size.18.value}"
+            "value": "{font.size.18}"
           },
           "line-height": {
-            "value": "{font.line-height.24.value}"
+            "value": "{font.line-height.24}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2}"
           }
         },
         "semibold": {
@@ -127,13 +127,13 @@
             "value": "{font.weight.semibold}"
           },
           "font-size": {
-            "value": "{font.size.18.value}"
+            "value": "{font.size.18}"
           },
           "line-height": {
-            "value": "{font.line-height.24.value}"
+            "value": "{font.line-height.24}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2}"
           }
         }
       },
@@ -143,13 +143,13 @@
             "value": "{font.weight.semibold}"
           },
           "font-size": {
-            "value": "{font.size.16.value}"
+            "value": "{font.size.16}"
           },
           "line-height": {
-            "value": "{font.line-height.24.value}"
+            "value": "{font.line-height.24}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.3.value}"
+            "value": "{font.letter-spacing.3}"
           }
         }
       }
@@ -161,13 +161,13 @@
             "value": "{font.weight.semibold}"
           },
           "font-size": {
-            "value": "{font.size.16.value}"
+            "value": "{font.size.16}"
           },
           "line-height": {
-            "value": "{font.line-height.24.value}"
+            "value": "{font.line-height.24}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2}"
           }
         },
         "regular": {
@@ -175,13 +175,13 @@
             "value": "{font.weight.regular}"
           },
           "font-size": {
-            "value": "{font.size.16.value}"
+            "value": "{font.size.16}"
           },
           "line-height": {
-            "value": "{font.line-height.24.value}"
+            "value": "{font.line-height.24}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.1.value}"
+            "value": "{font.letter-spacing.1}"
           }
         }
       },
@@ -191,13 +191,13 @@
             "value": "{font.weight.semibold}"
           },
           "font-size": {
-            "value": "{font.size.15.value}"
+            "value": "{font.size.15}"
           },
           "line-height": {
-            "value": "{font.line-height.22.value}"
+            "value": "{font.line-height.22}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2}"
           }
         },
         "regular": {
@@ -205,13 +205,13 @@
             "value": "{font.weight.regular}"
           },
           "font-size": {
-            "value": "{font.size.15.value}"
+            "value": "{font.size.15}"
           },
           "line-height": {
-            "value": "{font.line-height.22.value}"
+            "value": "{font.line-height.22}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.1.value}"
+            "value": "{font.letter-spacing.1}"
           }
         }
       }
@@ -223,13 +223,13 @@
             "value": "{font.weight.semibold}"
           },
           "font-size": {
-            "value": "{font.size.14.value}"
+            "value": "{font.size.14}"
           },
           "line-height": {
-            "value": "{font.line-height.18.value}"
+            "value": "{font.line-height.18}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2}"
           }
         },
         "regular": {
@@ -237,13 +237,13 @@
             "value": "{font.weight.regular}"
           },
           "font-size": {
-            "value": "{font.size.14.value}"
+            "value": "{font.size.14}"
           },
           "line-height": {
-            "value": "{font.line-height.18.value}"
+            "value": "{font.line-height.18}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2}"
           }
         }
       },
@@ -253,13 +253,13 @@
             "value": "{font.weight.semibold}"
           },
           "font-size": {
-            "value": "{font.size.13.value}"
+            "value": "{font.size.13}"
           },
           "line-height": {
-            "value": "{font.line-height.18.value}"
+            "value": "{font.line-height.18}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2}"
           }
         },
         "regular": {
@@ -267,13 +267,13 @@
             "value": "{font.weight.regular}"
           },
           "font-size": {
-            "value": "{font.size.13.value}"
+            "value": "{font.size.13}"
           },
           "line-height": {
-            "value": "{font.line-height.18.value}"
+            "value": "{font.line-height.18}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2}"
           }
         }
       },
@@ -283,13 +283,13 @@
             "value": "{font.weight.semibold}"
           },
           "font-size": {
-            "value": "{font.size.12.value}"
+            "value": "{font.size.12}"
           },
           "line-height": {
-            "value": "{font.line-height.16.value}"
+            "value": "{font.line-height.16}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2}"
           }
         },
         "regular": {
@@ -297,13 +297,13 @@
             "value": "{font.weight.regular}"
           },
           "font-size": {
-            "value": "{font.size.12.value}"
+            "value": "{font.size.12}"
           },
           "line-height": {
-            "value": "{font.line-height.16.value}"
+            "value": "{font.line-height.16}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2}"
           }
         }
       },
@@ -313,13 +313,13 @@
             "value": "{font.weight.semibold}"
           },
           "font-size": {
-            "value": "{font.size.11.value}"
+            "value": "{font.size.11}"
           },
           "line-height": {
-            "value": "{font.line-height.16.value}"
+            "value": "{font.line-height.16}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.1.value}"
+            "value": "{font.letter-spacing.1}"
           }
         },
         "regular": {
@@ -327,13 +327,13 @@
             "value": "{font.weight.regular}"
           },
           "font-size": {
-            "value": "{font.size.11.value}"
+            "value": "{font.size.11}"
           },
           "line-height": {
-            "value": "{font.line-height.16.value}"
+            "value": "{font.line-height.16}"
           },
           "letter-spacing": {
-            "value": "{font.letter-spacing.1.value}"
+            "value": "{font.letter-spacing.1}"
           }
         }
       }

--- a/packages/bezier-tokens/src/alpha/global/typography.json
+++ b/packages/bezier-tokens/src/alpha/global/typography.json
@@ -8,10 +8,10 @@
         "value": "{font.size.15-5.value}"
       },
       "line-height": {
-        "value": "{line-height.23.value}"
+        "value": "{font.line-height.23.value}"
       },
       "letter-spacing": {
-        "value": "{letter-spacing.2.value}"
+        "value": "{font.letter-spacing.2.value}"
       }
     },
     "h1": {
@@ -23,10 +23,10 @@
           "value": "{font.size.36.value}"
         },
         "line-height": {
-          "value": "{line-height.44.value}"
+          "value": "{font.line-height.44.value}"
         },
         "letter-spacing": {
-          "value": "{letter-spacing.0.value}"
+          "value": "{font.letter-spacing.0.value}"
         }
       }
     },
@@ -39,10 +39,10 @@
           "value": "{font.size.30.value}"
         },
         "line-height": {
-          "value": "{line-height.36.value}"
+          "value": "{font.line-height.36.value}"
         },
         "letter-spacing": {
-          "value": "{letter-spacing.0.value}"
+          "value": "{font.letter-spacing.0.value}"
         }
       },
       "regular": {
@@ -53,10 +53,10 @@
           "value": "{font.size.30.value}"
         },
         "line-height": {
-          "value": "{line-height.36.value}"
+          "value": "{font.line-height.36.value}"
         },
         "letter-spacing": {
-          "value": "{letter-spacing.0.value}"
+          "value": "{font.letter-spacing.0.value}"
         }
       }
     },
@@ -69,10 +69,10 @@
           "value": "{font.size.24.value}"
         },
         "line-height": {
-          "value": "{line-height.32.value}"
+          "value": "{font.line-height.32.value}"
         },
         "letter-spacing": {
-          "value": "{letter-spacing.0.value}"
+          "value": "{font.letter-spacing.0.value}"
         }
       },
       "regular": {
@@ -83,10 +83,10 @@
           "value": "{font.size.24.value}"
         },
         "line-height": {
-          "value": "{line-height.32.value}"
+          "value": "{font.line-height.32.value}"
         },
         "letter-spacing": {
-          "value": "{letter-spacing.0.value}"
+          "value": "{font.letter-spacing.0.value}"
         }
       }
     },
@@ -100,10 +100,10 @@
             "value": "{font.size.22.value}"
           },
           "line-height": {
-            "value": "{line-height.28.value}"
+            "value": "{font.line-height.28.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2.value}"
           }
         }
       },
@@ -116,10 +116,10 @@
             "value": "{font.size.18.value}"
           },
           "line-height": {
-            "value": "{line-height.24.value}"
+            "value": "{font.line-height.24.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2.value}"
           }
         },
         "semibold": {
@@ -130,10 +130,10 @@
             "value": "{font.size.18.value}"
           },
           "line-height": {
-            "value": "{line-height.24.value}"
+            "value": "{font.line-height.24.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2.value}"
           }
         }
       },
@@ -146,10 +146,10 @@
             "value": "{font.size.16.value}"
           },
           "line-height": {
-            "value": "{line-height.24.value}"
+            "value": "{font.line-height.24.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.3.value}"
+            "value": "{font.letter-spacing.3.value}"
           }
         }
       }
@@ -164,10 +164,10 @@
             "value": "{font.size.16.value}"
           },
           "line-height": {
-            "value": "{line-height.24.value}"
+            "value": "{font.line-height.24.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2.value}"
           }
         },
         "regular": {
@@ -178,10 +178,10 @@
             "value": "{font.size.16.value}"
           },
           "line-height": {
-            "value": "{line-height.24.value}"
+            "value": "{font.line-height.24.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.1.value}"
+            "value": "{font.letter-spacing.1.value}"
           }
         }
       },
@@ -194,10 +194,10 @@
             "value": "{font.size.15.value}"
           },
           "line-height": {
-            "value": "{line-height.22.value}"
+            "value": "{font.line-height.22.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2.value}"
           }
         },
         "regular": {
@@ -208,10 +208,10 @@
             "value": "{font.size.15.value}"
           },
           "line-height": {
-            "value": "{line-height.22.value}"
+            "value": "{font.line-height.22.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.1.value}"
+            "value": "{font.letter-spacing.1.value}"
           }
         }
       }
@@ -226,10 +226,10 @@
             "value": "{font.size.14.value}"
           },
           "line-height": {
-            "value": "{line-height.18.value}"
+            "value": "{font.line-height.18.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2.value}"
           }
         },
         "regular": {
@@ -240,10 +240,10 @@
             "value": "{font.size.14.value}"
           },
           "line-height": {
-            "value": "{line-height.18.value}"
+            "value": "{font.line-height.18.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2.value}"
           }
         }
       },
@@ -256,10 +256,10 @@
             "value": "{font.size.13.value}"
           },
           "line-height": {
-            "value": "{line-height.18.value}"
+            "value": "{font.line-height.18.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2.value}"
           }
         },
         "regular": {
@@ -270,10 +270,10 @@
             "value": "{font.size.13.value}"
           },
           "line-height": {
-            "value": "{line-height.18.value}"
+            "value": "{font.line-height.18.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2.value}"
           }
         }
       },
@@ -286,10 +286,10 @@
             "value": "{font.size.12.value}"
           },
           "line-height": {
-            "value": "{line-height.16.value}"
+            "value": "{font.line-height.16.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2.value}"
           }
         },
         "regular": {
@@ -300,10 +300,10 @@
             "value": "{font.size.12.value}"
           },
           "line-height": {
-            "value": "{line-height.16.value}"
+            "value": "{font.line-height.16.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.2.value}"
+            "value": "{font.letter-spacing.2.value}"
           }
         }
       },
@@ -316,10 +316,10 @@
             "value": "{font.size.11.value}"
           },
           "line-height": {
-            "value": "{line-height.16.value}"
+            "value": "{font.line-height.16.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.1.value}"
+            "value": "{font.letter-spacing.1.value}"
           }
         },
         "regular": {
@@ -330,10 +330,10 @@
             "value": "{font.size.11.value}"
           },
           "line-height": {
-            "value": "{line-height.16.value}"
+            "value": "{font.line-height.16.value}"
           },
           "letter-spacing": {
-            "value": "{letter-spacing.1.value}"
+            "value": "{font.letter-spacing.1.value}"
           }
         }
       }

--- a/packages/bezier-tokens/src/alpha/semantic/color.json
+++ b/packages/bezier-tokens/src/alpha/semantic/color.json
@@ -3,37 +3,37 @@
     "primary": {
       "bg": {
         "normal": {
-          "value": "{bg.blue.normal}",
+          "value": "{color.bg.blue.normal}",
           "type": "color"
         },
         "light": {
-          "value": "{bg.blue.light}",
+          "value": "{color.bg.blue.light}",
           "type": "color"
         },
         "lighter": {
-          "value": "{bg.blue.lighter}",
+          "value": "{color.bg.blue.lighter}",
           "type": "color"
         },
         "lightest": {
-          "value": "{bg.blue.lightest}",
+          "value": "{color.bg.blue.lightest}",
           "type": "color"
         },
         "dark": {
-          "value": "{bg.blue.dark}",
+          "value": "{color.bg.blue.dark}",
           "type": "color"
         }
       },
       "fg": {
         "normal": {
-          "value": "{fg.blue.normal}",
+          "value": "{color.fg.blue.normal}",
           "type": "color"
         },
         "light": {
-          "value": "{fg.blue.light}",
+          "value": "{color.fg.blue.light}",
           "type": "color"
         },
         "dark": {
-          "value": "{fg.blue.dark}",
+          "value": "{color.fg.blue.dark}",
           "type": "color"
         }
       }
@@ -41,37 +41,37 @@
     "critical": {
       "bg": {
         "dark": {
-          "value": "{bg.red.dark}",
+          "value": "{color.bg.red.dark}",
           "type": "color"
         },
         "normal": {
-          "value": "{fg.red.normal}",
+          "value": "{color.fg.red.normal}",
           "type": "color"
         },
         "light": {
-          "value": "{bg.red.light}",
+          "value": "{color.bg.red.light}",
           "type": "color"
         },
         "lighter": {
-          "value": "{bg.red.lighter}",
+          "value": "{color.bg.red.lighter}",
           "type": "color"
         },
         "lightest": {
-          "value": "{bg.red.lightest}",
+          "value": "{color.bg.red.lightest}",
           "type": "color"
         }
       },
       "fg": {
         "normal": {
-          "value": "{fg.red.normal}",
+          "value": "{color.fg.red.normal}",
           "type": "color"
         },
         "light": {
-          "value": "{fg.red.light}",
+          "value": "{color.fg.red.light}",
           "type": "color"
         },
         "dark": {
-          "value": "{fg.red.dark}",
+          "value": "{color.fg.red.dark}",
           "type": "color"
         }
       }
@@ -79,37 +79,37 @@
     "warning": {
       "bg": {
         "dark": {
-          "value": "{bg.orange.dark}",
+          "value": "{color.bg.orange.dark}",
           "type": "color"
         },
         "normal": {
-          "value": "{bg.orange.normal}",
+          "value": "{color.bg.orange.normal}",
           "type": "color"
         },
         "light": {
-          "value": "{bg.orange.light}",
+          "value": "{color.bg.orange.light}",
           "type": "color"
         },
         "lighter": {
-          "value": "{bg.orange.lighter}",
+          "value": "{color.bg.orange.lighter}",
           "type": "color"
         },
         "lightest": {
-          "value": "{bg.orange.lightest}",
+          "value": "{color.bg.orange.lightest}",
           "type": "color"
         }
       },
       "fg": {
         "normal": {
-          "value": "{fg.orange.normal}",
+          "value": "{color.fg.orange.normal}",
           "type": "color"
         },
         "light": {
-          "value": "{fg.orange.light}",
+          "value": "{color.fg.orange.light}",
           "type": "color"
         },
         "dark": {
-          "value": "{fg.orange.dark}",
+          "value": "{color.fg.orange.dark}",
           "type": "color"
         }
       }
@@ -117,37 +117,37 @@
     "accent": {
       "bg": {
         "dark": {
-          "value": "{bg.cobalt.dark}",
+          "value": "{color.bg.cobalt.dark}",
           "type": "color"
         },
         "normal": {
-          "value": "{bg.cobalt.normal}",
+          "value": "{color.bg.cobalt.normal}",
           "type": "color"
         },
         "light": {
-          "value": "{bg.cobalt.light}",
+          "value": "{color.bg.cobalt.light}",
           "type": "color"
         },
         "lighter": {
-          "value": "{bg.cobalt.lighter}",
+          "value": "{color.bg.cobalt.lighter}",
           "type": "color"
         },
         "lightest": {
-          "value": "{bg.cobalt.lightest}",
+          "value": "{color.bg.cobalt.lightest}",
           "type": "color"
         }
       },
       "fg": {
         "normal": {
-          "value": "{fg.cobalt.normal}",
+          "value": "{color.fg.cobalt.normal}",
           "type": "color"
         },
         "light": {
-          "value": "{fg.cobalt.light}",
+          "value": "{color.fg.cobalt.light}",
           "type": "color"
         },
         "dark": {
-          "value": "{fg.cobalt.dark}",
+          "value": "{color.fg.cobalt.dark}",
           "type": "color"
         }
       }
@@ -155,37 +155,37 @@
     "success": {
       "bg": {
         "dark": {
-          "value": "{bg.green.dark}",
+          "value": "{color.bg.green.dark}",
           "type": "color"
         },
         "normal": {
-          "value": "{bg.green.normal}",
+          "value": "{color.bg.green.normal}",
           "type": "color"
         },
         "light": {
-          "value": "{bg.green.light}",
+          "value": "{color.bg.green.light}",
           "type": "color"
         },
         "lighter": {
-          "value": "{bg.green.lighter}",
+          "value": "{color.bg.green.lighter}",
           "type": "color"
         },
         "lightest": {
-          "value": "{bg.green.lightest}",
+          "value": "{color.bg.green.lightest}",
           "type": "color"
         }
       },
       "fg": {
         "normal": {
-          "value": "{fg.green.normal}",
+          "value": "{color.fg.green.normal}",
           "type": "color"
         },
         "light": {
-          "value": "{fg.green.light}",
+          "value": "{color.fg.green.light}",
           "type": "color"
         },
         "dark": {
-          "value": "{fg.green.dark}",
+          "value": "{color.fg.green.dark}",
           "type": "color"
         }
       }

--- a/packages/bezier-tokens/src/alpha/semantic/color.json
+++ b/packages/bezier-tokens/src/alpha/semantic/color.json
@@ -1,191 +1,193 @@
 {
-  "primary": {
-    "bg": {
-      "normal": {
-        "value": "{bg.blue.normal}",
-        "type": "color"
+  "color": {
+    "primary": {
+      "bg": {
+        "normal": {
+          "value": "{bg.blue.normal}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{bg.blue.light}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{bg.blue.lighter}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{bg.blue.lightest}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{bg.blue.dark}",
+          "type": "color"
+        }
       },
-      "light": {
-        "value": "{bg.blue.light}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{bg.blue.lighter}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{bg.blue.lightest}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{bg.blue.dark}",
-        "type": "color"
+      "fg": {
+        "normal": {
+          "value": "{fg.blue.normal}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{fg.blue.light}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{fg.blue.dark}",
+          "type": "color"
+        }
       }
     },
-    "fg": {
-      "normal": {
-        "value": "{fg.blue.normal}",
-        "type": "color"
+    "critical": {
+      "bg": {
+        "dark": {
+          "value": "{bg.red.dark}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{fg.red.normal}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{bg.red.light}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{bg.red.lighter}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{bg.red.lightest}",
+          "type": "color"
+        }
       },
-      "light": {
-        "value": "{fg.blue.light}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{fg.blue.dark}",
-        "type": "color"
-      }
-    }
-  },
-  "critical": {
-    "bg": {
-      "dark": {
-        "value": "{bg.red.dark}",
-        "type": "color"
-      },
-      "normal": {
-        "value": "{fg.red.normal}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{bg.red.light}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{bg.red.lighter}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{bg.red.lightest}",
-        "type": "color"
-      }
-    },
-    "fg": {
-      "normal": {
-        "value": "{fg.red.normal}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{fg.red.light}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{fg.red.dark}",
-        "type": "color"
-      }
-    }
-  },
-  "warning": {
-    "bg": {
-      "dark": {
-        "value": "{bg.orange.dark}",
-        "type": "color"
-      },
-      "normal": {
-        "value": "{bg.orange.normal}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{bg.orange.light}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{bg.orange.lighter}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{bg.orange.lightest}",
-        "type": "color"
+      "fg": {
+        "normal": {
+          "value": "{fg.red.normal}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{fg.red.light}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{fg.red.dark}",
+          "type": "color"
+        }
       }
     },
-    "fg": {
-      "normal": {
-        "value": "{fg.orange.normal}",
-        "type": "color"
+    "warning": {
+      "bg": {
+        "dark": {
+          "value": "{bg.orange.dark}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{bg.orange.normal}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{bg.orange.light}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{bg.orange.lighter}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{bg.orange.lightest}",
+          "type": "color"
+        }
       },
-      "light": {
-        "value": "{fg.orange.light}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{fg.orange.dark}",
-        "type": "color"
-      }
-    }
-  },
-  "accent": {
-    "bg": {
-      "dark": {
-        "value": "{bg.cobalt.dark}",
-        "type": "color"
-      },
-      "normal": {
-        "value": "{bg.cobalt.normal}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{bg.cobalt.light}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{bg.cobalt.lighter}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{bg.cobalt.lightest}",
-        "type": "color"
-      }
-    },
-    "fg": {
-      "normal": {
-        "value": "{fg.cobalt.normal}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{fg.cobalt.light}",
-        "type": "color"
-      },
-      "dark": {
-        "value": "{fg.cobalt.dark}",
-        "type": "color"
-      }
-    }
-  },
-  "success": {
-    "bg": {
-      "dark": {
-        "value": "{bg.green.dark}",
-        "type": "color"
-      },
-      "normal": {
-        "value": "{bg.green.normal}",
-        "type": "color"
-      },
-      "light": {
-        "value": "{bg.green.light}",
-        "type": "color"
-      },
-      "lighter": {
-        "value": "{bg.green.lighter}",
-        "type": "color"
-      },
-      "lightest": {
-        "value": "{bg.green.lightest}",
-        "type": "color"
+      "fg": {
+        "normal": {
+          "value": "{fg.orange.normal}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{fg.orange.light}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{fg.orange.dark}",
+          "type": "color"
+        }
       }
     },
-    "fg": {
-      "normal": {
-        "value": "{fg.green.normal}",
-        "type": "color"
+    "accent": {
+      "bg": {
+        "dark": {
+          "value": "{bg.cobalt.dark}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{bg.cobalt.normal}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{bg.cobalt.light}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{bg.cobalt.lighter}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{bg.cobalt.lightest}",
+          "type": "color"
+        }
       },
-      "light": {
-        "value": "{fg.green.light}",
-        "type": "color"
+      "fg": {
+        "normal": {
+          "value": "{fg.cobalt.normal}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{fg.cobalt.light}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{fg.cobalt.dark}",
+          "type": "color"
+        }
+      }
+    },
+    "success": {
+      "bg": {
+        "dark": {
+          "value": "{bg.green.dark}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{bg.green.normal}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{bg.green.light}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{bg.green.lighter}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{bg.green.lightest}",
+          "type": "color"
+        }
       },
-      "dark": {
-        "value": "{fg.green.dark}",
-        "type": "color"
+      "fg": {
+        "normal": {
+          "value": "{fg.green.normal}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{fg.green.light}",
+          "type": "color"
+        },
+        "dark": {
+          "value": "{fg.green.dark}",
+          "type": "color"
+        }
       }
     }
   }

--- a/packages/bezier-tokens/src/alpha/semantic/shadow.json
+++ b/packages/bezier-tokens/src/alpha/semantic/shadow.json
@@ -2,7 +2,7 @@
   "shadow": {
     "error": {
       "value": {
-        "color": "{warning.bg.normal}",
+        "color": "{color.warning.bg.normal}",
         "type": "dropShadow",
         "x": "0px",
         "y": "0px",
@@ -13,7 +13,7 @@
     },
     "active": {
       "value": {
-        "color": "{primary.bg.normal}",
+        "color": "{color.primary.bg.normal}",
         "type": "dropShadow",
         "x": "0px",
         "y": "0px",
@@ -26,7 +26,7 @@
       "default": {
         "value": [
           {
-            "color": "{shadow.base-inner}",
+            "color": "{color.shadow.base-inner}",
             "type": "innerShadow",
             "x": "0px",
             "y": "0px",
@@ -34,7 +34,7 @@
             "spread": "1px"
           },
           {
-            "color": "{shadow.base}",
+            "color": "{color.shadow.base}",
             "type": "dropShadow",
             "x": "0px",
             "y": "1px",
@@ -47,7 +47,7 @@
       "hover": {
         "value": [
           {
-            "color": "{primary.bg.normal}",
+            "color": "{color.primary.bg.normal}",
             "type": "innerShadow",
             "x": "0px",
             "y": "0px",
@@ -55,7 +55,7 @@
             "spread": "1px"
           },
           {
-            "color": "{shadow.base}",
+            "color": "{color.shadow.base}",
             "type": "dropShadow",
             "x": "0px",
             "y": "2px",
@@ -68,7 +68,7 @@
       "active": {
         "value": [
           {
-            "color": "{primary.bg.normal}",
+            "color": "{color.primary.bg.normal}",
             "type": "innerShadow",
             "x": "0px",
             "y": "0px",
@@ -76,7 +76,7 @@
             "spread": "1px"
           },
           {
-            "color": "{primary.bg.light}",
+            "color": "{color.primary.bg.light}",
             "type": "dropShadow",
             "x": "0px",
             "y": "0px",
@@ -84,7 +84,7 @@
             "spread": "3px"
           },
           {
-            "color": "{shadow.base}",
+            "color": "{color.shadow.base}",
             "type": "dropShadow",
             "x": "0px",
             "y": "2px",
@@ -97,7 +97,7 @@
       "error": {
         "value": [
           {
-            "color": "{warning.bg.normal}",
+            "color": "{color.warning.bg.normal}",
             "type": "innerShadow",
             "x": "0px",
             "y": "0px",
@@ -105,7 +105,7 @@
             "spread": "1px"
           },
           {
-            "color": "{warning.bg.light}",
+            "color": "{color.warning.bg.light}",
             "type": "dropShadow",
             "x": "0px",
             "y": "0px",
@@ -113,7 +113,7 @@
             "spread": "3px"
           },
           {
-            "color": "{shadow.base}",
+            "color": "{color.shadow.base}",
             "type": "dropShadow",
             "x": "0px",
             "y": "2px",


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Summary

<!-- Please brief explanation of the changes made -->

Add "color" prefix to color tokens and fix misnaming of typography tokens

## Details

<!-- Please elaborate description of the changes -->

- 논의된 구조에 맞게 색상 토큰 앞에 "color" prefix를 추가합니다.
- font, typography 토큰의 위계가 잘못되어 몇몇 토큰의 이름에 "font", "typography" prefix가 없던 걸 수정합니다.
- style: prettier format

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- [Notion (Internal)](https://www.notion.so/channelio/token-f44d981d3eb04493b1cc527335f89fdd?pvs=4)
