### PR TITLE
Add CI pipeline by GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: ci
+on: [pull_request]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    env:
+      TURBO_API: http://127.0.0.1:9080
+      TURBO_TOKEN: ${{ secrets.TURBO_SERVER_TOKEN }}
+      TURBO_TEAM: bezier-react
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'yarn'
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: TurboRepo Local Server
+        uses: felixmosh/turborepo-gh-artifacts@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
+
+      - name: Build
+        run: yarn build
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Typecheck
+        run: yarn typecheck
+
+      - name: Test
+        run: yarn test


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- Fixes https://github.com/channel-io/bezier-react/issues/2159
- Fixes https://github.com/channel-io/bezier-react/issues/1684

## Summary

<!-- Please brief explanation of the changes made -->

- GitHub Action 기반의 CI 워크플로우를 추가합니다.
- 워크플로우에서 secrets.TURBO_SERVER_TOKEN 를 사용하고 있기 때문에 이 pr이 머지되기 전에 레포지토리 시크릿으로 설정해야 합니다. Settings > Secrets and Variables > Actions > Repository Secrets 에서 설정 가능합니다. 값은 아무거나 해도 되기 때문에 적당한 해시값으로 하면 될 것 같습니다. 제가 권한이 없어서 설정 부탁드립니다 @sungik-choi 
- pr 이 머지되고 ci가 잘 도는 것을 확인하면 Circle CI 설정 파일(config.yml)을 제거하면 될 것 같습니다.

## Details

<!-- Please elaborate description of the changes -->

- https://github.com/channel-io/bezier-react/issues/1684 에서 제안한 것처럼 build, lint, typecheck, test 를 하나의 job 안에서 실행합니다. 
- 깃헙 artifact 를 리모트 캐시로 저장하는 action 을 사용하여 리모트 캐시를 활성화합니다. 
- 현재 [4분](https://app.circleci.com/insights/github/channel-io/bezier-react?reporting-window=last-7-days)정도 걸리는 시간이 풀 터보일 때는 [1분](https://github.com/yangwooseong/bezier-react/actions/runs/8732888817/job/23960590103)으로, bezier-react패키지만 변경될 때는 [2분](https://github.com/yangwooseong/bezier-react/actions/runs/8732848886/job/23960494941)으로 줄어들었습니다. 그리고 수정하지 않은 패키지들은 캐시 힛이 되기 때문에, bezier-tokens같은 패키지를 수정하면 [1분 20초](https://github.com/yangwooseong/bezier-react/actions/runs/8732871347/job/23960548359)정도 시간밖에 안걸리게 됩니다.

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://github.com/felixmosh/turborepo-gh-artifacts
