### PR TITLE
Enable chromatic turbosnap

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,10 +2,6 @@ name: Chromatic
 
 on:
   push:
-    branches:
-      - main
-      - alpha
-  pull_request:
     paths:
       - packages/bezier-react/**
 
@@ -49,6 +45,7 @@ jobs:
           workingDir: packages/bezier-react
           exitZeroOnChanges: true
           autoAcceptChanges: true
+          onlyChanged: true
           skip: dependabot/**
           projectToken: 06157a6fbe6f
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,7 +1,7 @@
 name: Chromatic
 
 on:
-  push:
+  pull_request:
     paths:
       - packages/bezier-react/**
 
@@ -15,6 +15,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # By default checkout action checkouts to merge commit on pull_request event
+          # checkout to the HEAD commit of PR here, because chromatic checkouts to HEAD commit of PR
+          # https://www.chromatic.com/docs/turbosnap#github-pullrequest-triggers
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- Fixes https://github.com/channel-io/bezier-react/issues/2185

## Summary

<!-- Please brief explanation of the changes made -->

- Chromatic의 turbosnap기능을 활성화하고, trigger되는 조건을 push, pull_request에서 push로 변경합니다.

## Details

<!-- Please elaborate description of the changes -->

- turbosnap은 webpack의 디펜던시 그래프를 이용해서 변화가 있는 스토리만 스냅샷을 찍는 기능입니다. 베지어 스토리 갯수가 100개 정도 되서 사용량 제한 5000개를 초과하지 않기 위해 필요한 기능입니다. 자세한 설명은 이슈를 첨고해주세요.
- `Help`컴포넌트를 바꾸는 경우: 디펜던시 그래프에서 Help와 연결된 부분 (Help, FormLabel, FormControl, Modal, Button 등)이 변화가 있다고 판단하고 관련된 스토리 22개만 스냅샷으로 찍습니다([#](https://github.com/yangwooseong/bezier-react/actions/runs/8933306731/job/24538487220)). Modal이나 Button이 연결되어 있다고 판단하는 것은 스토리에서 FormLabel, FormControl을 사용하고 있어서 그렇습니다. 
- `AlphaButton` 컴포넌트를 바꾸는 경우: `AlphaButton`에 의존하는 컴포넌트가 없기 때문에 스냅샷 하나만 찍게 됩니다 ([#](https://github.com/yangwooseong/bezier-react/actions/runs/8933402361/job/24538725045?pr=135)). 
- turbosnap문서에서 pull_request가 아닌 push를 이벤트 트리거로 사용하라고 권장하고 있어서 pull_request를 제거하고 브랜치 필터를 제거했습니다. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://www.chromatic.com/manage?appId=62bead1508281287d3c94d25
- https://www.chromatic.com/docs/turbosnap/
