### PR TITLE
Fix typo in `IconProps` jsdoc

### DIFF
--- a/.changeset/quick-seals-sin.md
+++ b/.changeset/quick-seals-sin.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix typo in `IconProps` jsdoc

--- a/packages/bezier-react/src/components/Icon/Icon.types.ts
+++ b/packages/bezier-react/src/components/Icon/Icon.types.ts
@@ -12,7 +12,7 @@ export type IconSize = 'xl' | 'l' | 'm' | 's' | 'xs' | 'xxs' | 'xxxs'
 interface IconOwnProps {
   /**
    * Controls which icon should be rendered.
-   * Inject the icon component from the @channel.io/bezier-icons package into this prop.
+   * Inject the icon component from the `@channel.io/bezier-icons` package into this prop.
    * @example
    * ```tsx
    * import { HeartFilledIcon } from '@channel.io/bezier-icons'


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->
- None

## Summary

<!-- Please brief explanation of the changes made -->

- Icon 컴포넌트의 `source` 속성에 있는 jsdoc의 오타를 수정합니다. 

## Details

<!-- Please elaborate description of the changes -->

| As-is | To-be |
|--------|--------|
| <img width="514" alt="image" src="https://github.com/channel-io/bezier-react/assets/28595102/469db30b-5ce1-44e8-a585-a31948cb4662"> |  <img width="516" alt="image" src="https://github.com/channel-io/bezier-react/assets/28595102/249993c6-3e28-486c-a0a4-56a071fff5b0"> |

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- None
