### PR TITLE
Use `AlphaSpinner` in `AlphaButton` component set

### DIFF
--- a/.changeset/fluffy-donuts-matter.md
+++ b/.changeset/fluffy-donuts-matter.md
@@ -1,0 +1,8 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Changes in `Button` component set
+
+- use `AlphaSpinner` instead of `Spinner` component for loading state.
+- set size of `AlphaSpinner` to be `Icon` size.

--- a/packages/bezier-react/src/components/AlphaAvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/AlphaAvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
@@ -180,13 +180,13 @@ exports[`AvatarGroup Ellipsis type - Icon Snapshot 1`] = `
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bgtxt-absolute-black-lightest);"
     >
       <svg
-        class="Icon margin"
+        class="Icon size-xs margin"
         data-testid="bezier-icon"
         fill="none"
-        height="16"
+        height="1em"
         style="--b-icon-color: var(--bgtxt-absolute-white-dark);"
         viewBox="0 0 24 24"
-        width="16"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/packages/bezier-react/src/components/AlphaButton/Button.module.scss
+++ b/packages/bezier-react/src/components/AlphaButton/Button.module.scss
@@ -1,3 +1,7 @@
+@use '../../styles/mixins/dimension';
+
+@import '../Icon/Icon.module.scss';
+
 $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
 
 .Button {
@@ -258,12 +262,20 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     }
   }
 
-  .ButtonLoader {
+  & :where(.ButtonLoader) {
     position: absolute;
     inset: 0;
 
     display: flex;
     align-items: center;
     justify-content: center;
+
+    @each $size, $value in $size-map {
+      &:where(.size-#{$size}) {
+        & :is(.Spinner) {
+          @include dimension.square(#{$value}px);
+        }
+      }
+    }
   }
 }

--- a/packages/bezier-react/src/components/AlphaButton/Button.module.scss
+++ b/packages/bezier-react/src/components/AlphaButton/Button.module.scss
@@ -1,6 +1,6 @@
 @use '../../styles/mixins/dimension';
 
-@import '../Icon/Icon.module.scss';
+@import '../Icon/Icon.module';
 
 $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
 

--- a/packages/bezier-react/src/components/AlphaButton/Button.tsx
+++ b/packages/bezier-react/src/components/AlphaButton/Button.tsx
@@ -7,9 +7,9 @@ import {
   type ButtonProps,
   type ButtonSize,
 } from '~/src/components/AlphaButton/Button.types'
+import { AlphaSpinner } from '~/src/components/AlphaSpinner'
 import { BaseButton } from '~/src/components/BaseButton'
 import { Icon, type IconSize } from '~/src/components/Icon'
-import { Spinner } from '~/src/components/Spinner'
 import { Text } from '~/src/components/Text'
 
 import styles from './Button.module.scss'
@@ -40,18 +40,6 @@ function getIconSize(size: ButtonSize) {
       m: 's',
       l: 's',
       xl: 'm',
-    } as const
-  )[size]
-}
-
-function getSpinnerSize(size: ButtonSize) {
-  return (
-    {
-      xs: 'xs',
-      s: 'xs',
-      m: 's',
-      l: 's',
-      xl: 's',
     } as const
   )[size]
 }
@@ -126,10 +114,19 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           />
         </div>
 
-        {/* TODO: use AlphaSpinner */}
         {loading && (
-          <div className={styles.ButtonLoader}>
-            <Spinner size={getSpinnerSize(size)} />
+          <div
+            className={classNames(
+              styles.ButtonLoader,
+              styles[`size-${getIconSize(size)}`]
+            )}
+          >
+            <AlphaSpinner
+              className={styles.Spinner}
+              variant="on-overlay"
+              // NOTE: Spinner size will be overridden by Icon size
+              size="s"
+            />
           </div>
         )}
       </Comp>

--- a/packages/bezier-react/src/components/AlphaButton/Button.tsx
+++ b/packages/bezier-react/src/components/AlphaButton/Button.tsx
@@ -124,8 +124,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             <AlphaSpinner
               className={styles.Spinner}
               variant="on-overlay"
-              // NOTE: Spinner size will be overridden by Icon size
-              size="s"
             />
           </div>
         )}

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.module.scss
@@ -187,7 +187,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
   }
 
   /* internal components */
-  .ButtonContent {
+  & :where(.ButtonContent) {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -197,7 +197,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     }
   }
 
-  .ButtonLoader {
+  & :where(.ButtonLoader) {
     position: absolute;
     inset: 0;
 

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.module.scss
@@ -1,3 +1,7 @@
+@use '../../styles/mixins/dimension';
+
+@import '../Icon/Icon.module.scss';
+
 $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
 
 .FloatingButton {
@@ -200,5 +204,13 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     display: flex;
     align-items: center;
     justify-content: center;
+
+    @each $size, $value in $size-map {
+      &:where(.size-#{$size}) {
+        & :is(.Spinner) {
+          @include dimension.square(#{$value}px);
+        }
+      }
+    }
   }
 }

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.module.scss
@@ -1,6 +1,6 @@
 @use '../../styles/mixins/dimension';
 
-@import '../Icon/Icon.module.scss';
+@import '../Icon/Icon.module';
 
 $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
 

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
@@ -7,9 +7,9 @@ import {
   type FloatingButtonProps,
   type FloatingButtonSize,
 } from '~/src/components/AlphaFloatingButton/FloatingButton.types'
+import { AlphaSpinner } from '~/src/components/AlphaSpinner'
 import { BaseButton } from '~/src/components/BaseButton'
 import { Icon, type IconSize } from '~/src/components/Icon'
-import { Spinner } from '~/src/components/Spinner'
 import { Text } from '~/src/components/Text'
 
 import styles from './FloatingButton.module.scss'
@@ -40,18 +40,6 @@ function getIconSize(size: FloatingButtonSize) {
       m: 's',
       l: 's',
       xl: 'm',
-    } as const
-  )[size]
-}
-
-function getSpinnerSize(size: FloatingButtonSize) {
-  return (
-    {
-      xs: 'xs',
-      s: 'xs',
-      m: 's',
-      l: 's',
-      xl: 's',
     } as const
   )[size]
 }
@@ -125,10 +113,18 @@ export const FloatingButton = forwardRef<
         />
       </div>
 
-      {/* TODO: use AlphaSpinner */}
       {loading && (
-        <div className={styles.ButtonLoader}>
-          <Spinner size={getSpinnerSize(size)} />
+        <div
+          className={classNames(
+            styles.ButtonLoader,
+            styles[`size-${getIconSize(size)}`]
+          )}
+        >
+          <AlphaSpinner
+            size="s"
+            variant="on-overlay"
+            className={styles.Spinner}
+          />
         </div>
       )}
     </Comp>

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
@@ -122,7 +122,6 @@ export const FloatingButton = forwardRef<
         >
           <AlphaSpinner
             className={styles.Spinner}
-            size="s"
             variant="on-overlay"
           />
         </div>

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
@@ -121,9 +121,9 @@ export const FloatingButton = forwardRef<
           )}
         >
           <AlphaSpinner
+            className={styles.Spinner}
             size="s"
             variant="on-overlay"
-            className={styles.Spinner}
           />
         </div>
       )}

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.module.scss
@@ -1,5 +1,7 @@
 @use '../../styles/mixins/dimension';
 
+@import '../Icon/Icon.module.scss';
+
 $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
 
 .FloatingIconButton {
@@ -171,5 +173,13 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     display: flex;
     align-items: center;
     justify-content: center;
+
+    @each $size, $value in $size-map {
+      &:where(.size-#{$size}) {
+        & :is(.Spinner) {
+          @include dimension.square(#{$value}px);
+        }
+      }
+    }
   }
 }

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.module.scss
@@ -1,6 +1,6 @@
 @use '../../styles/mixins/dimension';
 
-@import '../Icon/Icon.module.scss';
+@import '../Icon/Icon.module';
 
 $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
 

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
@@ -76,9 +76,9 @@ export const FloatingIconButton = forwardRef<
           )}
         >
           <AlphaSpinner
+            className={styles.Spinner}
             size="s"
             variant="on-overlay"
-            className={styles.Spinner}
           />
         </div>
       )}

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
@@ -77,7 +77,6 @@ export const FloatingIconButton = forwardRef<
         >
           <AlphaSpinner
             className={styles.Spinner}
-            size="s"
             variant="on-overlay"
           />
         </div>

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
@@ -4,10 +4,10 @@ import { isBezierIcon } from '@channel.io/bezier-icons'
 import classNames from 'classnames'
 
 import { type AlphaFloatingIconButtonProps } from '~/src/components/AlphaFloatingIconButton'
+import { AlphaSpinner } from '~/src/components/AlphaSpinner'
 import { BaseButton } from '~/src/components/BaseButton'
 import { type ButtonSize } from '~/src/components/Button'
 import { Icon } from '~/src/components/Icon'
-import { Spinner } from '~/src/components/Spinner'
 
 import styles from './FloatingIconButton.module.scss'
 
@@ -19,18 +19,6 @@ function getIconSize(size: ButtonSize) {
       m: 's',
       l: 's',
       xl: 'm',
-    } as const
-  )[size]
-}
-
-function getSpinnerSize(size: ButtonSize) {
-  return (
-    {
-      xs: 'xs',
-      s: 'xs',
-      m: 's',
-      l: 's',
-      xl: 's',
     } as const
   )[size]
 }
@@ -80,10 +68,18 @@ export const FloatingIconButton = forwardRef<
         )}
       </div>
 
-      {/* TODO: use AlphaSpinner */}
       {loading && (
-        <div className={styles.ButtonLoader}>
-          <Spinner size={getSpinnerSize(size)} />
+        <div
+          className={classNames(
+            styles.ButtonLoader,
+            styles[`size-${getIconSize(size)}`]
+          )}
+        >
+          <AlphaSpinner
+            size="s"
+            variant="on-overlay"
+            className={styles.Spinner}
+          />
         </div>
       )}
     </Comp>

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
@@ -1,5 +1,7 @@
 @use '../../styles/mixins/dimension';
 
+@import '../Icon/Icon.module.scss';
+
 $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
 
 .IconButton {
@@ -248,5 +250,13 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     display: flex;
     align-items: center;
     justify-content: center;
+
+    @each $size, $value in $size-map {
+      &:where(.size-#{$size}) {
+        & :is(.Spinner) {
+          @include dimension.square(#{$value}px);
+        }
+      }
+    }
   }
 }

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
@@ -1,6 +1,6 @@
 @use '../../styles/mixins/dimension';
 
-@import '../Icon/Icon.module.scss';
+@import '../Icon/Icon.module';
 
 $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
 

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
@@ -233,7 +233,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
   }
 
   /* internal components */
-  .ButtonContent {
+  & :where(.ButtonContent) {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -243,7 +243,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     }
   }
 
-  .ButtonLoader {
+  & :where(.ButtonLoader) {
     position: absolute;
     inset: 0;
 

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
@@ -80,9 +80,9 @@ export const IconButton = forwardRef<HTMLButtonElement, AlphaIconButtonProps>(
             )}
           >
             <AlphaSpinner
+              className={styles.Spinner}
               size="s"
               variant="on-overlay"
-              className={styles.Spinner}
             />
           </div>
         )}

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
@@ -81,7 +81,6 @@ export const IconButton = forwardRef<HTMLButtonElement, AlphaIconButtonProps>(
           >
             <AlphaSpinner
               className={styles.Spinner}
-              size="s"
               variant="on-overlay"
             />
           </div>

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
@@ -4,10 +4,10 @@ import { isBezierIcon } from '@channel.io/bezier-icons'
 import classNames from 'classnames'
 
 import { type AlphaIconButtonProps } from '~/src/components/AlphaIconButton'
+import { AlphaSpinner } from '~/src/components/AlphaSpinner'
 import { BaseButton } from '~/src/components/BaseButton'
 import { type ButtonSize } from '~/src/components/Button'
 import { Icon } from '~/src/components/Icon'
-import { Spinner } from '~/src/components/Spinner'
 
 import styles from './IconButton.module.scss'
 
@@ -19,18 +19,6 @@ function getIconSize(size: ButtonSize) {
       m: 's',
       l: 's',
       xl: 'm',
-    } as const
-  )[size]
-}
-
-function getSpinnerSize(size: ButtonSize) {
-  return (
-    {
-      xs: 'xs',
-      s: 'xs',
-      m: 's',
-      l: 's',
-      xl: 's',
     } as const
   )[size]
 }
@@ -84,10 +72,18 @@ export const IconButton = forwardRef<HTMLButtonElement, AlphaIconButtonProps>(
           )}
         </div>
 
-        {/* TODO: use AlphaSpinner */}
         {loading && (
-          <div className={styles.ButtonLoader}>
-            <Spinner size={getSpinnerSize(size)} />
+          <div
+            className={classNames(
+              styles.ButtonLoader,
+              styles[`size-${getIconSize(size)}`]
+            )}
+          >
+            <AlphaSpinner
+              size="s"
+              variant="on-overlay"
+              className={styles.Spinner}
+            />
           </div>
         )}
       </Comp>

--- a/packages/bezier-react/src/components/AlphaSpinner/Spinner.module.scss
+++ b/packages/bezier-react/src/components/AlphaSpinner/Spinner.module.scss
@@ -14,12 +14,14 @@
   --b-spinner-size: initial;
   --b-spinner-track-color: initial;
   --b-spinner-indicator-color: initial;
+  --b-spinner-stroke-thickness: initial;
 
   /* NOTE: stroke-width is fixed for the exceptional case of use inside buttons */
   --b-spinner-stroke-width: 2px;
+  --b-spinner-view-box-size: 16;
   --b-spinner-stroke-dasharray: 16 9999;
 
-  @include dimension.square(var(--b-spinner-size));
+  @include dimension.square(calc(1px * var(--b-spinner-size)));
 
   display: inline-flex;
   animation: rotate 1s linear infinite;
@@ -39,14 +41,21 @@
     stroke-width: var(--b-spinner-stroke-width);
   }
 
+  &:where(.size-s, .size-m) {
+    --b-spinner-stroke-width: calc(
+      var(--b-spinner-stroke-thickness) * var(--b-spinner-view-box-size) /
+        var(--b-spinner-size)
+    );
+  }
+
   &:where(.size-s) {
-    --b-spinner-size: 28px;
-    --b-spinner-stroke-width: calc(16 * 4px / 28);
+    --b-spinner-size: 28;
+    --b-spinner-stroke-thickness: 4px;
   }
 
   &:where(.size-m) {
-    --b-spinner-size: 50px;
-    --b-spinner-stroke-width: calc(16 * 6px / 50);
+    --b-spinner-size: 50;
+    --b-spinner-stroke-thickness: 6px;
   }
 
   &:where(.variant-primary) {

--- a/packages/bezier-react/src/components/AlphaSpinner/Spinner.module.scss
+++ b/packages/bezier-react/src/components/AlphaSpinner/Spinner.module.scss
@@ -14,8 +14,8 @@
   --b-spinner-size: initial;
   --b-spinner-track-color: initial;
   --b-spinner-indicator-color: initial;
-  --b-spinner-stroke-width: initial;
-  --b-spinner-stroke-dasharray: initial;
+
+  /* NOTE: stroke-width is fixed for the exceptional case of use inside buttons */
   --b-spinner-stroke-width: 2px;
   --b-spinner-stroke-dasharray: 16 9999;
 
@@ -41,10 +41,12 @@
 
   &:where(.size-s) {
     --b-spinner-size: 28px;
+    --b-spinner-stroke-width: calc(16 * 4px / 28);
   }
 
   &:where(.size-m) {
     --b-spinner-size: 50px;
+    --b-spinner-stroke-width: calc(16 * 6px / 50);
   }
 
   &:where(.variant-primary) {

--- a/packages/bezier-react/src/components/AlphaSpinner/Spinner.module.scss
+++ b/packages/bezier-react/src/components/AlphaSpinner/Spinner.module.scss
@@ -16,20 +16,22 @@
   --b-spinner-indicator-color: initial;
   --b-spinner-stroke-width: initial;
   --b-spinner-stroke-dasharray: initial;
+  --b-spinner-stroke-width: 2px;
+  --b-spinner-stroke-dasharray: 16 9999;
 
   @include dimension.square(var(--b-spinner-size));
 
   display: inline-flex;
   animation: rotate 1s linear infinite;
 
-  & .track {
+  & :where(.track) {
     fill: none;
     stroke: var(--b-spinner-track-color);
     stroke-linecap: round;
     stroke-width: var(--b-spinner-stroke-width);
   }
 
-  & .indicator {
+  & :where(.indicator) {
     fill: none;
     stroke: var(--b-spinner-indicator-color);
     stroke-dasharray: var(--b-spinner-stroke-dasharray);
@@ -39,14 +41,10 @@
 
   &:where(.size-s) {
     --b-spinner-size: 28px;
-    --b-spinner-stroke-width: 4px;
-    --b-spinner-stroke-dasharray: 40 9999;
   }
 
   &:where(.size-m) {
     --b-spinner-size: 50px;
-    --b-spinner-stroke-width: 6px;
-    --b-spinner-stroke-dasharray: 60 9999;
   }
 
   &:where(.variant-primary) {

--- a/packages/bezier-react/src/components/AlphaSpinner/Spinner.tsx
+++ b/packages/bezier-react/src/components/AlphaSpinner/Spinner.tsx
@@ -32,14 +32,14 @@ export const Spinner = forwardRef<HTMLSpanElement, SpinnerProps>(
           <circle
             cx="8"
             cy="8"
-            r="7"
+            r="6.5"
             className={styles.track}
           />
 
           <circle
             cx="8"
             cy="8"
-            r="7"
+            r="6.5"
             className={styles.indicator}
           />
         </svg>

--- a/packages/bezier-react/src/components/AlphaSpinner/Spinner.tsx
+++ b/packages/bezier-react/src/components/AlphaSpinner/Spinner.tsx
@@ -18,7 +18,8 @@ export const Spinner = forwardRef<HTMLSpanElement, SpinnerProps>(
         className={classNames(
           styles.Spinner,
           size && styles[`size-${size}`],
-          styles[`variant-${variant}`]
+          styles[`variant-${variant}`],
+          className
         )}
         ref={forwardedRef}
         data-testid={SPINNER_TEST_ID}
@@ -33,7 +34,6 @@ export const Spinner = forwardRef<HTMLSpanElement, SpinnerProps>(
             cy="8"
             r="7"
             className={styles.track}
-            vectorEffect="non-scaling-stroke"
           />
 
           <circle
@@ -41,7 +41,6 @@ export const Spinner = forwardRef<HTMLSpanElement, SpinnerProps>(
             cy="8"
             r="7"
             className={styles.indicator}
-            vectorEffect="non-scaling-stroke"
           />
         </svg>
       </span>

--- a/packages/bezier-react/src/components/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/AvatarGroup/__snapshots__/AvatarGroup.test.tsx.snap
@@ -180,13 +180,13 @@ exports[`AvatarGroup Ellipsis type - Icon Snapshot 1`] = `
       style="--b-smooth-corners-box-border-radius: 42%; --b-smooth-corners-box-shadow-blur-radius: 0px; --b-smooth-corners-box-shadow-spread-radius: 0px; --b-smooth-corners-box-padding: 0px; --b-smooth-corners-box-margin: 0px; --b-smooth-corners-box-background-color: var(--bgtxt-absolute-black-lightest);"
     >
       <svg
-        class="Icon margin"
+        class="Icon size-xs margin"
         data-testid="bezier-icon"
         fill="none"
-        height="16"
+        height="1em"
         style="--b-icon-color: var(--bgtxt-absolute-white-dark);"
         viewBox="0 0 24 24"
-        width="16"
+        width="1em"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/packages/bezier-react/src/components/Help/__snapshots__/Help.test.tsx.snap
+++ b/packages/bezier-react/src/components/Help/__snapshots__/Help.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`Help > Snapshot > 1`] = `
 <svg
-  class="Icon margin Icon"
+  class="Icon size-xs margin Icon"
   data-testid="bezier-help"
   fill="none"
-  height="16"
+  height="1em"
   style="--b-icon-color: var(--txt-black-dark);"
   viewBox="0 0 24 24"
-  width="16"
+  width="1em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path

--- a/packages/bezier-react/src/components/Icon/Icon.module.scss
+++ b/packages/bezier-react/src/components/Icon/Icon.module.scss
@@ -1,7 +1,25 @@
+@use '../../styles/mixins/dimension';
+
+$size-map: (
+  xxxs: 10,
+  xxs: 12,
+  xs: 16,
+  s: 20,
+  m: 24,
+  l: 36,
+  xl: 44,
+);
+
 .Icon {
   --b-icon-color: initial;
 
   flex: 0 0 auto;
   color: var(--b-icon-color);
   transition: color var(--transition-s);
+
+  @each $size, $value in $size-map {
+    &:where(.size-#{$size}) {
+      @include dimension.square(#{$value}px);
+    }
+  }
 }

--- a/packages/bezier-react/src/components/Icon/Icon.tsx
+++ b/packages/bezier-react/src/components/Icon/Icon.tsx
@@ -5,24 +5,11 @@ import classNames from 'classnames'
 import { getMarginStyles, splitByMarginProps } from '~/src/types/props-helpers'
 import { tokenCssVar } from '~/src/utils/style'
 
-import { type IconProps, type IconSize } from './Icon.types'
+import { type IconProps } from './Icon.types'
 
 import styles from './Icon.module.scss'
 
 export const ICON_TEST_ID = 'bezier-icon'
-
-const getSizeValue = (size: IconSize) =>
-  (
-    ({
-      xl: 44,
-      l: 36,
-      m: 24,
-      s: 20,
-      xs: 16,
-      xxs: 12,
-      xxxs: 10,
-    }) satisfies Record<IconSize, number>
-  )[size]
 
 export const Icon = memo(
   forwardRef<SVGSVGElement, IconProps>(function Icon(props, forwardedRef) {
@@ -48,9 +35,12 @@ export const Icon = memo(
             ...style,
           } as React.CSSProperties
         }
-        className={classNames(styles.Icon, marginStyles.className, className)}
-        width={getSizeValue(size)}
-        height={getSizeValue(size)}
+        className={classNames(
+          styles.Icon,
+          styles[`size-${size}`],
+          marginStyles.className,
+          className
+        )}
         data-testid={ICON_TEST_ID}
         {...rest}
       />

--- a/packages/bezier-react/src/components/NavGroup/__snapshots__/NavGroup.test.tsx.snap
+++ b/packages/bezier-react/src/components/NavGroup/__snapshots__/NavGroup.test.tsx.snap
@@ -13,13 +13,13 @@ exports[`NavGroup Test > Snapshot > Active 1`] = `
     class="LeftIconWrapper"
   >
     <svg
-      class="Icon margin"
+      class="Icon size-s margin"
       data-testid="bezier-nav-group-left-icon"
       fill="none"
-      height="20"
+      height="1em"
       style="--b-icon-color: var(--bgtxt-blue-normal);"
       viewBox="0 0 24 24"
-      width="20"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -40,13 +40,13 @@ exports[`NavGroup Test > Snapshot > Active 1`] = `
     class="RightContentWrapper"
   >
     <svg
-      class="Icon margin"
+      class="Icon size-xs margin"
       data-testid="bezier-icon"
       fill="none"
-      height="16"
+      height="1em"
       style="--b-icon-color: var(--bgtxt-orange-normal);"
       viewBox="0 0 24 24"
-      width="16"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -73,13 +73,13 @@ exports[`NavGroup Test > Snapshot > Not active 1`] = `
     class="LeftIconWrapper"
   >
     <svg
-      class="Icon margin"
+      class="Icon size-s margin"
       data-testid="bezier-nav-group-left-icon"
       fill="none"
-      height="20"
+      height="1em"
       style="--b-icon-color: var(--txt-black-dark);"
       viewBox="0 0 24 24"
-      width="20"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -100,13 +100,13 @@ exports[`NavGroup Test > Snapshot > Not active 1`] = `
     class="RightContentWrapper"
   >
     <svg
-      class="Icon margin"
+      class="Icon size-xs margin"
       data-testid="bezier-icon"
       fill="none"
-      height="16"
+      height="1em"
       style="--b-icon-color: var(--bgtxt-orange-normal);"
       viewBox="0 0 24 24"
-      width="16"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/bezier-react/src/components/NavItem/__snapshots__/NavItem.test.tsx.snap
+++ b/packages/bezier-react/src/components/NavItem/__snapshots__/NavItem.test.tsx.snap
@@ -11,13 +11,13 @@ exports[`NavItem Test > Snapshot > Active 1`] = `
     class="LeftIconWrapper"
   >
     <svg
-      class="Icon margin"
+      class="Icon size-s margin"
       data-testid="bezier-nav-item-left-icon"
       fill="none"
-      height="20"
+      height="1em"
       style="--b-icon-color: var(--bgtxt-blue-normal);"
       viewBox="0 0 24 24"
-      width="20"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -48,13 +48,13 @@ exports[`NavItem Test > Snapshot > Not active 1`] = `
     class="LeftIconWrapper"
   >
     <svg
-      class="Icon margin"
+      class="Icon size-s margin"
       data-testid="bezier-nav-item-left-icon"
       fill="none"
-      height="20"
+      height="1em"
       style="--b-icon-color: var(--txt-black-dark);"
       viewBox="0 0 24 24"
-      width="20"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary

<!-- Please brief explanation of the changes made -->

- `AlphaButton`안에 있는 로더 컴포넌트를 새로 만든 `AlphaSpinner`로 교체합니다. 

## Details

<!-- Please elaborate description of the changes -->

- 디자인 스펙에 의하면, 버튼안에 있는 `AlphaSpinner`의 사이즈는 아이콘 사이즈와 일치해야합니다. 따라서 버튼의 스타일 코드가 아이콘의 사이즈 맵(e.g. s - 20, m -24, ...) 을 알 필요가 있습니다. 이런 비슷한 경우가 SegmentedControl - Divider 컴포넌트에서 variables classname을 사용한 경우가 있었는데, 이 PR에서는 스타일 코드를 직접 `@include`로 가져와서 그 안에 있는 변수에 접근하는 방향으로 해결해봤습니다. 내보내는 쪽과 사용하는 쪽에서 불필요하게 variables classname을 사용하지 않아도 되는 장점이 있어서 이렇게 시도해봤습니다. 
- 이에 따라 아이콘 사이즈를 js로 결정하던 것에서 scss 안에서 맵을 들고 있는 형태로 변경했습니다. 
- Spinner 쪽에서는 vectorEffect="non-scaling-stroke"를 지웠습니다. vectorEffect="non-scaling-stroke"가 없으면, stroke-width=2px로 고정해도 svg 사이즈에 맞게 바뀌기 때문에 사이즈마다 4px, 6px로 지정했던 의도였습니다. 그런데 버튼아래에서 사용하게 되면, 버튼의 아이콘 사이즈마다 다른 storke-width 를 지정하는 것보다 고정된 storke-width로 해놓는 게 자연스러워서 vectorEffect 속성을 지우고, width 를 s,m 사이즈에 따라 (실제 디자인상 stroke-width) / (svg 사이즈 / viewport 사이즈) 으로 계산했습니다. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/vector-effect#non-scaling-stroke
- [피그마(internal)](https://www.figma.com/design/8J76noM3T1Sp5cNPhnYQiG/Action?node-id=790-9448&t=4OAGD5U39M6XhWNo-4)
