### PR TITLE
Add token for transparent color

### DIFF
--- a/.changeset/blue-frogs-destroy.md
+++ b/.changeset/blue-frogs-destroy.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-tokens': patch
+---
+
+Add `white-alpha/transparent` token.

--- a/.changeset/sixty-trains-relate.md
+++ b/.changeset/sixty-trains-relate.md
@@ -1,0 +1,7 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Changes with `Button` component
+- Change `white` to `white-absolute` in `color` props.
+- Apply `white-alpha/transparent` token for `tertiary` button.

--- a/packages/bezier-react/src/components/AlphaButton/Button.module.scss
+++ b/packages/bezier-react/src/components/AlphaButton/Button.module.scss
@@ -67,6 +67,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
       purple: var(--alpha-color-bg-purple-normal),
       dark-grey: var(--alpha-color-bg-grey-darkest),
       light-grey: var(--alpha-color-bg-black-dark),
+      white-absolute: var(--alpha-color-bg-absolute-white-dark),
     );
 
     @each $color, $background-color in $background-color-by-color {
@@ -87,6 +88,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
       purple: var(--alpha-color-bg-purple-lightest),
       dark-grey: var(--alpha-color-bg-black-lighter),
       light-grey: var(--alpha-color-bg-black-lighter),
+      white-absolute: var(--alpha-color-bg-absolute-white-lightest),
     );
 
     @each $color, $background-color in $background-color-by-color {
@@ -146,7 +148,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     }
   }
 
-  &:where(.variant-tertiary.color-white) {
+  &:where(.variant-tertiary.color-white-absolute) {
     & :where(.ButtonIcon) {
       color: var(--alpha-color-fg-absolute-white-light);
     }
@@ -212,7 +214,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
         }
       }
 
-      &:where(.color-dark-grey, .color-light-grey, .color-white) {
+      &:where(.color-dark-grey, .color-light-grey, .color-white-absolute) {
         background-color: var(--bg-black-lighter);
       }
     }
@@ -229,7 +231,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
       }
     }
 
-    &:where(.color-white.variant-tertiary) {
+    &:where(.color-white-absolute.variant-tertiary) {
       & :where(.ButtonIcon) {
         color: var(--alpha-color-fg-absolute-white-normal);
       }

--- a/packages/bezier-react/src/components/AlphaButton/Button.module.scss
+++ b/packages/bezier-react/src/components/AlphaButton/Button.module.scss
@@ -97,7 +97,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
   }
 
   &:where(.variant-tertiary) {
-    background-color: initial;
+    background-color: var(--alpha-color-bg-white-white-alpha-transparent);
   }
 
   /* color */

--- a/packages/bezier-react/src/components/AlphaButton/Button.types.ts
+++ b/packages/bezier-react/src/components/AlphaButton/Button.types.ts
@@ -21,7 +21,7 @@ export type ButtonColor =
   | 'purple'
   | 'dark-grey'
   | 'light-grey'
-  | 'white'
+  | 'white-absolute'
 
 export type ButtonSize = 'xs' | 's' | 'm' | 'l' | 'xl'
 

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
@@ -50,6 +50,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
       purple: var(--alpha-color-bg-purple-normal),
       dark-grey: var(--alpha-color-bg-grey-darkest),
       light-grey: var(--alpha-color-bg-black-dark),
+      white-absolute: var(--alpha-color-bg-absolute-white-dark),
     );
 
     @each $color, $background-color in $background-color-by-color {
@@ -70,6 +71,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
       purple: var(--alpha-color-bg-purple-lightest),
       dark-grey: var(--alpha-color-bg-black-lighter),
       light-grey: var(--alpha-color-bg-black-lighter),
+      white-absolute: var(--alpha-color-bg-absolute-white-lightest),
     );
 
     @each $color, $background-color in $background-color-by-color {
@@ -129,7 +131,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     }
   }
 
-  &:where(.variant-tertiary.color-white) {
+  &:where(.variant-tertiary.color-white-absolute) {
     & :where(.ButtonIcon) {
       color: var(--alpha-color-fg-absolute-white-normal);
     }
@@ -195,7 +197,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
         }
       }
 
-      &:where(.color-dark-grey, .color-light-grey, .color-white) {
+      &:where(.color-dark-grey, .color-light-grey, .color-white-absolute) {
         background-color: var(--bg-black-lighter);
       }
     }
@@ -212,7 +214,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
       }
     }
 
-    &:where(.color-white.variant-tertiary) {
+    &:where(.color-white-absolute.variant-tertiary) {
       & :where(.ButtonIcon) {
         color: var(--alpha-color-fg-absolute-white-normal);
       }

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
@@ -80,7 +80,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
   }
 
   &:where(.variant-tertiary) {
-    background-color: initial;
+    background-color: var(--alpha-color-bg-white-white-alpha-transparent);
   }
 
   /* color */

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.types.ts
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.types.ts
@@ -21,7 +21,7 @@ type IconButtonColor =
   | 'purple'
   | 'dark-grey'
   | 'light-grey'
-  | 'white'
+  | 'white-absolute'
 
 type IconButtonSize = 'xs' | 's' | 'm' | 'l' | 'xl'
 

--- a/packages/bezier-tokens/src/alpha/functional/light-theme/color.json
+++ b/packages/bezier-tokens/src/alpha/functional/light-theme/color.json
@@ -366,6 +366,10 @@
           "light": {
             "value": "{color.white.20}",
             "type": "color"
+          },
+          "transparent": {
+            "value": "{color.white.0}",
+            "type": "color"
           }
         }
       },


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary

<!-- Please brief explanation of the changes made -->

- 새롭게 디자인 스펙에 추가된 transparent 토큰을 bezier-tokens에 추가하고, tertiary 버튼에 이를 사용합니다. 

## Details

<!-- Please elaborate description of the changes -->

- 버튼의 color속성 중에서 `white`를 `white-absolute`로 변경합니다. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- [디자인 스펙 변경사항(internal)](https://desk.channel.io/root/groups/v2_BezierRelease-364583/6656c24932354c6650e6)
