### PR TITLE
Fix bug in icon generating action when icon is renamed 

### DIFF
--- a/.changeset/long-mugs-count.md
+++ b/.changeset/long-mugs-count.md
@@ -1,5 +1,0 @@
----
-'@channel.io/bezier-icons': patch
----
-
-Fixed bug where `undefined` appears in PR description and changeset when icon is renamed

--- a/.changeset/long-mugs-count.md
+++ b/.changeset/long-mugs-count.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-icons': patch
+---
+
+Fixed bug where `undefined` appears in PR description and changeset when icon is renamed

--- a/packages/bezier-icons/scripts/utils/getChangeLog.js
+++ b/packages/bezier-icons/scripts/utils/getChangeLog.js
@@ -1,4 +1,5 @@
 const { getIconNamesByStatus } = require('./getIconNamesByStatus')
+const { getRenamedIconMap } = require('./getRenamedIconMap')
 
 const yamlFrontMatter = `---
 "@channel.io/bezier-icons": minor
@@ -9,15 +10,22 @@ const statusByKey = {
   M: 'Modified',
   A: 'Added',
   D: 'Deleted',
+  R100: 'Renamed',
 }
 
-const getIconChangeLog = (iconsByStatus) => {
+const getIconChangeLog = (iconsByStatus, iconNameMap) => {
   let changeLog = 'Update icons\n\n'
 
   for (const [key, icons] of Object.entries(iconsByStatus)) {
     changeLog += statusByKey[key]
     changeLog += '\n\n'
-    changeLog += icons.map((icon) => `- ${icon}`).join('\n')
+    if (key !== 'R100') {
+      changeLog += icons.map((icon) => `- ${icon}`).join('\n')
+    } else {
+      changeLog += icons
+        .map((icon) => `- ${icon} -> ${iconNameMap[icon]}`)
+        .join('\n')
+    }
     changeLog += '\n\n'
   }
 
@@ -25,7 +33,8 @@ const getIconChangeLog = (iconsByStatus) => {
 }
 
 const getChangeLog = (gitLog) =>
-  yamlFrontMatter + getIconChangeLog(getIconNamesByStatus(gitLog))
+  yamlFrontMatter +
+  getIconChangeLog(getIconNamesByStatus(gitLog), getRenamedIconMap(gitLog))
 
 module.exports = {
   getChangeLog,

--- a/packages/bezier-icons/scripts/utils/getChangeLog.test.js
+++ b/packages/bezier-icons/scripts/utils/getChangeLog.test.js
@@ -6,7 +6,8 @@ describe('getChangeLog function', () => {
     const gitLog = `M\tpackages/bezier-icons/icons/all.svg
 D\tpackages/bezier-icons/icons/home.svg
 A\tpackages/bezier-icons/icons/people.svg
-A\tpackages/bezier-icons/icons/chevron-right.svg`
+A\tpackages/bezier-icons/icons/chevron-right.svg
+R100\tpackages/bezier-icons/icons/paused.svg\tpackages/bezier-icons/icons/paused-fill.svg`
 
     expect(getChangeLog(gitLog)).toBe(
       `---
@@ -26,7 +27,11 @@ Deleted
 Added
 
 - people.svg
-- chevron-right.svg`
+- chevron-right.svg
+
+Renamed
+
+- paused.svg -> paused-fill.svg`
     )
   })
 })

--- a/packages/bezier-icons/scripts/utils/getPrDescription.js
+++ b/packages/bezier-icons/scripts/utils/getPrDescription.js
@@ -4,12 +4,14 @@ const statusByKey = {
   M: 'modified',
   A: 'added',
   D: 'deleted',
+  R100: 'renamed',
 }
 
 const emojiByKey = {
   M: '✏️',
   A: '🆕',
   D: '🗑️',
+  R100: '✍️',
 }
 
 const getSummary = (iconsByStatus) => {

--- a/packages/bezier-icons/scripts/utils/getPrDescription.test.js
+++ b/packages/bezier-icons/scripts/utils/getPrDescription.test.js
@@ -6,19 +6,22 @@ describe('getDescription function', () => {
     const gitLog = `M\tpackages/bezier-icons/icons/all.svg
 D\tpackages/bezier-icons/icons/home.svg
 A\tpackages/bezier-icons/icons/people.svg
-A\tpackages/bezier-icons/icons/chevron-right.svg`
+A\tpackages/bezier-icons/icons/chevron-right.svg
+R100\tpackages/bezier-icons/icons/paused.svg\tpackages/bezier-icons/icons/paused-fill.svg`
     expect(getDescription(gitLog))
       .toBe(`### Icon update is ready to be merged! 🎉
 
 - 1 icon(s) modified
 - 1 icon(s) deleted
 - 2 icon(s) added
+- 1 icon(s) renamed
 
 | Name | Status |
 |--|--|
 | all.svg | ✏️ |
 | home.svg | 🗑️ |
 | people.svg | 🆕 |
-| chevron-right.svg | 🆕 |`)
+| chevron-right.svg | 🆕 |
+| paused.svg | ✍️ |`)
   })
 })

--- a/packages/bezier-icons/scripts/utils/getRenamedIconMap.js
+++ b/packages/bezier-icons/scripts/utils/getRenamedIconMap.js
@@ -1,0 +1,30 @@
+const getIconName = (path) => path.split('/').at(-1)
+
+const getRenamedIconMap = (gitLog) =>
+  gitLog
+    .trim()
+    .split('\n')
+    .map((line) => line.split('\t'))
+    .filter((line) => line[1].endsWith('.svg'))
+    .reduce((acc, cur) => {
+      const [key, from, to] = cur
+
+      if (key !== 'R100') {
+        return acc
+      }
+
+      const iconName = getIconName(from)
+      const renamedIconName = getIconName(to)
+
+      if (!iconName) {
+        return acc
+      }
+
+      acc[iconName] = renamedIconName
+
+      return acc
+    }, {})
+
+module.exports = {
+  getRenamedIconMap,
+}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

None

## Summary

<!-- Please brief explanation of the changes made -->

- https://github.com/channel-io/bezier-react/pull/2251 에서 PR본문과 changeset에 undefined가 뜨는 버그를 해결합니다. 

## Details

<!-- Please elaborate description of the changes -->

- 아이콘 이름이 변경되었을 때를 `getPrDescription` 함수에서 다루지 않아서 생기는 버그였습니다. 깃 로그를 직접 찍어보니 R100 으로 뜨기 때문에 이 경우를 추가했습니다. 테스트 코드에서 어떤식으로 PR과 changeset에 rename 기록이 추가되는지 확인할 수 있습니다. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- [What does R100 mean?](https://stackoverflow.com/questions/53056942/git-diff-name-status-what-does-r100-mean)
