### PR TITLE
Set required node version as .nvmrc's version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^5.4.2"
   },
   "engines": {
-    "node": ">= 18.20.3",
+    "node": "18.20.3",
     "yarn": "4.2.2"
   },
   "config": {

--- a/packages/bezier-react/src/components/Help/Help.module.scss
+++ b/packages/bezier-react/src/components/Help/Help.module.scss
@@ -1,4 +1,5 @@
 .Help {
+  background-color: red;
   line-height: 0;
 
   &:where(:not([data-state='closed'])) {

--- a/packages/bezier-react/src/components/Help/Help.module.scss
+++ b/packages/bezier-react/src/components/Help/Help.module.scss
@@ -1,5 +1,4 @@
 .Help {
-  background-color: red;
   line-height: 0;
 
   &:where(:not([data-state='closed'])) {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary

<!-- Please brief explanation of the changes made -->

- https://github.com/channel-io/bezier-react/pull/2260 에서 chromatic에서 사용하는 노드 버전이 engine.node 와 달라져서 에러가 뜬 이슈가 있었습니다 ([#](https://github.com/channel-io/bezier-react/actions/runs/9343590910/job/25713414442)). 그 때는 크로마틱 버그로 인식을 못해서 package.json.engine.node 버전을 18.20.3 에서 >=18.20.3으로 바꿔서 해결했는데, 크로마틱의 최신 버전에서 이 이슈가 해결되어서 .nvmrc 버전과 동일한 버전으로 돌립니다.

## Details

<!-- Please elaborate description of the changes -->

- None

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://github.com/chromaui/chromatic-cli/blob/HEAD/CHANGELOG.md#v1154-wed-jun-12-2024 (PR1006이 수정PR)
