### PR TITLE
Forward ref to Icon component generated by svgr

### DIFF
--- a/.changeset/nice-ducks-judge.md
+++ b/.changeset/nice-ducks-judge.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-icons': minor
+---
+
+Fix `reactIconTemplate` for ref forwarding.

--- a/packages/bezier-icons/rollup.config.mjs
+++ b/packages/bezier-icons/rollup.config.mjs
@@ -74,7 +74,7 @@ declare module '*.svg' {
   export default content
 }
 
-export declare type IconSource = React.FunctionComponent<React.SVGProps<SVGSVGElement>>
+export declare type IconSource = React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement> & React.RefAttributes<SVGSVGElement>>
 export declare type BezierIcon = IconSource & { __bezier__icon: true }
 
 export declare function isBezierIcon(arg: unknown): arg is BezierIcon
@@ -159,7 +159,7 @@ function svgBuild(options = {}) {
         )
       }
 
-      export default createBezierIcon(${componentName})
+      export default createBezierIcon(forwardRef(${componentName}))
     `
   }
 
@@ -193,6 +193,7 @@ function svgBuild(options = {}) {
           plugins: ['@svgr/plugin-jsx'],
           icon: true,
           jsxRuntime: 'classic',
+          ref: true,
           template: reactIconTemplate,
         },
         {

--- a/packages/bezier-icons/utils/index.ts
+++ b/packages/bezier-icons/utils/index.ts
@@ -6,7 +6,7 @@
 const BEZIER_ICON_ID = '__bezier__icon'
 
 export function isBezierIcon(arg: any) {
-  return typeof arg === 'function' && arg[BEZIER_ICON_ID] === true
+  return typeof arg === 'object' && arg[BEZIER_ICON_ID] === true
 }
 
 export function createBezierIcon(source: any) {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- #1313 

## Summary

<!-- Please brief explanation of the changes made -->

- bezier-icons를 빌드할 때 만들어지는 리액트 컴포넌트에 ref를 forwarding 하도록 svgr template 코드를 수정합니다. 

## Details

<!-- Please elaborate description of the changes -->

- forwardRef로 감싸면 함수가 아닌 객체가 만들어지기 때문에 isBezierIcon가 체크하는 타입도 object로 변경했습니다. 
- 스토리북으로 테스트 했을 때 툴팁의 children 으로 아이콘이 와도 툴팁이 잘 뜨는 것을 확인했습니다. 데스크에서는 bezier-icons의 dist 폴더를 교체해서 테스트 해봤을 때 잘 작동하는 것을 확인했습니다.


### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- 엄밀히 말하면 IconSource 타입이 변경되서 breaking change가 맞으나, IconSource 타입에 의존하는 사용처가 없어 보여서 minor 버전 업으로 진행합니다. 

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://react-svgr.com/docs/options/#ref
