### PR TITLE
Resolve test fail in bezier-icons package

### DIFF
--- a/packages/bezier-icons/utils/utils.test.tsx
+++ b/packages/bezier-icons/utils/utils.test.tsx
@@ -1,14 +1,16 @@
+import { forwardRef } from 'react'
+
 import { createBezierIcon, isBezierIcon } from '.'
 
 describe('Icon utils', () => {
   describe('createBezierIcon', () => {
     it('isBezierIcon returns false for non BezierIcon', () => {
-      const source = () => <svg />
+      const source = forwardRef(() => <svg />)
       expect(isBezierIcon(source)).toBe(false)
     })
 
     it('createBezierIcon returns a BezierIcon', () => {
-      const source = () => <svg />
+      const source = forwardRef(() => <svg />)
       const mockBezierIcon = createBezierIcon(source)
       expect(isBezierIcon(mockBezierIcon)).toBe(true)
     })


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- #1313 

## Summary

<!-- Please brief explanation of the changes made -->

- isBezierIcon 에서 타입 체크하는 것을 바꾸면서 테스트 코드가 실패하는 것을 수정합니다. 

## Details

<!-- Please elaborate description of the changes -->

- https://github.com/channel-io/bezier-react/pull/2329 에서 CI가 통과했던 것은 isBezierIcon 함수가 있는 bezier-icons/utils/index.ts 경로가 turbo.json의 test.inputs 에 없기 때문에 터보 캐시가 힛되서 그런 것 같습니다. 
- https://github.com/channel-io/bezier-react/pull/2328 에서는 이유는 잘 모르겠지만 터보 캐시가 미스되서 테스트를 다시 돌려서 fail 이 뜬 것으로 보입니다. 
- 단순히 bezier-icons에서 코드가 바뀌어도 테스트의 터보 캐시가 힛되는 문제를 수정하려면 turbo.json 에 utils/**/*.ts 경로를 넣으면 되지만, 이렇게 하기보다 bezier-icons나 bezier-tokens같은 패키지도 패키지 디렉토리 바로 밑에 src/ 를 둬서 디렉토리 구조를 통일하는 게 좋아보이긴 합니다. 이거는 논의 후 별도 PR로 작업하는게 좋을 것 같네요. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://turbo.build/repo/docs/reference/configuration#inputs
