### PR TITLE
Change `source` props type of `Icon` component

### DIFF
--- a/.changeset/nervous-days-push.md
+++ b/.changeset/nervous-days-push.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Change `source` type of IconProps to `BezierIcon`

--- a/packages/bezier-react/src/components/Icon/Icon.types.ts
+++ b/packages/bezier-react/src/components/Icon/Icon.types.ts
@@ -1,4 +1,4 @@
-import type React from 'react'
+import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import {
   type BezierComponentProps,
@@ -21,7 +21,7 @@ interface IconOwnProps {
    * <Icon source={HeartFilledIcon} {...} />
    * ```
    */
-  source: React.ElementType<React.SVGProps<SVGSVGElement>>
+  source: BezierIcon
 }
 
 export interface IconProps


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- #1313 

## Summary

<!-- Please brief explanation of the changes made -->

- bezier-icons 의 type declaration 에서 선언되는 타입을 수정하면서 Icon 컴포넌트가 받는 source 타입을 수정하지 않아 사용처에서 타입 에러가 뜹니다. 베지어에서는 타입 체크가 통과되고 있는 것은 아마 @types/react@18.2.61 버전에서 breaking change가 생긴 것에 의한 영향인 것 같습니다. 

## Details

<!-- Please elaborate description of the changes -->

- Icon 의 인터페이스를 BezierIcon 을 바라보도록 수정합니다. Button types 의 LeftContent에서도 BezierIcon 을 직접 바라보고 있어서 일관성 측면에서도 이렇게 하는 게 나아보입니다. 


### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->


- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720/files#diff-32cfd8cb197872bcba371f5018185d2e75fa540b52cda2dd7d8ac12dcc021299L246