### PR TITLE
Fix runtime error in `isBezierIcon` function

### DIFF
--- a/.changeset/wicked-lies-appear.md
+++ b/.changeset/wicked-lies-appear.md
@@ -2,4 +2,4 @@
 '@channel.io/bezier-icons': patch
 ---
 
-check nullish in isBezierIcon to block NPE error
+Check if value is nullish in `isBezierIcon` function to block runtime error.

--- a/.changeset/wicked-lies-appear.md
+++ b/.changeset/wicked-lies-appear.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-icons': patch
+---
+
+check nullish in isBezierIcon to block NPE error

--- a/packages/bezier-icons/utils/index.ts
+++ b/packages/bezier-icons/utils/index.ts
@@ -6,7 +6,7 @@
 const BEZIER_ICON_ID = '__bezier__icon'
 
 export function isBezierIcon(arg: any) {
-  return typeof arg === 'object' && arg[BEZIER_ICON_ID] === true
+  return !!arg && typeof arg === 'object' && arg[BEZIER_ICON_ID] === true
 }
 
 export function createBezierIcon(source: any) {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary

<!-- Please brief explanation of the changes made -->

아래 함수에서 생길 수 있는 버그를 수정합니다. arg가 null 일 때 typeof arg === 'object' 이기 때문에 런타임 에러가 납니다. 

```tsx
export function isBezierIcon(arg: any) {
  return typeof arg === 'object' && arg[BEZIER_ICON_ID] === true
}
```

## Details

<!-- Please elaborate description of the changes -->

- undefined 일 떄는 typeof arg === 'undefined` 이어서 Button 의 leftContent 속성에 아무것도 넣지 않는 경우에는 에러가 뜨지 않고 있었습니다. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://github.com/channel-io/bezier-react/pull/2329/files#diff-7045a70c57f70692f95240783652cbbeb87e13a5528a8c45c69f530e4d62e130
