### PR TITLE
Change repository to `bezier-asset` where figma plugin creates PR 

### DIFF
--- a/.changeset/twelve-crews-visit.md
+++ b/.changeset/twelve-crews-visit.md
@@ -1,0 +1,5 @@
+---
+'bezier-figma-plugin': minor
+---
+
+Change the repository where the figma plugin creates PR from `bezier-react` to `bezier-asset`.

--- a/packages/bezier-figma-plugin/src/config.ts
+++ b/packages/bezier-figma-plugin/src/config.ts
@@ -1,8 +1,8 @@
 const config = {
   repository: {
-    name: 'bezier-react',
-    iconExtractPath: 'packages/bezier-icons/icons',
-    baseBranchName: 'main',
+    name: 'bezier-asset',
+    iconExtractPath: 'directory root',
+    baseBranchName: 'exp',
     owner: 'channel-io',
   },
   commit: {

--- a/packages/bezier-figma-plugin/src/config.ts
+++ b/packages/bezier-figma-plugin/src/config.ts
@@ -1,7 +1,7 @@
 const config = {
   repository: {
     name: 'bezier-asset',
-    iconExtractPath: 'directory root',
+    iconExtractPath: 'asset/icons',
     baseBranchName: 'exp',
     owner: 'channel-io',
   },

--- a/packages/bezier-figma-plugin/src/ui/hooks/useCreatePRWithSvgMap.ts
+++ b/packages/bezier-figma-plugin/src/ui/hooks/useCreatePRWithSvgMap.ts
@@ -32,7 +32,7 @@ export function useCreatePRWithSvgMap({
         tree: [
           {
             sha: blob.sha,
-            path: 'packages/bezier-icons/icons.json',
+            path: 'icons.json',
             type: 'blob',
             mode: '100644',
           },
@@ -84,14 +84,14 @@ export function useCreatePRWithSvgMap({
 
   const createPRWithSvgMap = useCallback(
     async (svgByName: SvgByName) => {
-      const mainBranch = await progress({
-        callback: getMainBranch('main'),
+      const baseBranch = await progress({
+        callback: getMainBranch(config.repository.baseBranchName),
         title: '📦 깃헙에서 정보를 가져오는 중...',
         successValueOffset: 0.3,
       })
 
       const commit = await progress({
-        callback: createCommit(svgByName, mainBranch.sha),
+        callback: createCommit(svgByName, baseBranch.sha),
         title: '🎨 베지어 아이콘 변경사항을 반영하는 중...',
         successValueOffset: 0.3,
       })


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- #2229 

## Summary

<!-- Please brief explanation of the changes made -->

- figma plugin이 PR을 생성하는 레포를 bezier-react에서 bezier-asset으로 변경합니다. 



## Details

<!-- Please elaborate description of the changes -->

- base branch를 main에서 exp로 변경합니다. 
- iconExtractPath를 packages/bezier-icons/icons에서 asset/icons로 변경합니다. 
- 개발 모드로 실행해봤을 때 bezier-asset레포에 [PR](https://github.com/channel-io/bezier-asset/pull/30)이 잘 생성되는 것을 확인했습니다. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

-  No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->
