### PR TITLE
Prepare for Sass breaking change

### DIFF
--- a/packages/bezier-react/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/bezier-react/src/components/Checkbox/Checkbox.module.scss
@@ -11,7 +11,7 @@
 
 .Checkbox {
   cursor: inherit;
-  
+
   display: flex;
   align-items: center;
   justify-content: center;
@@ -34,7 +34,6 @@
       visibility: visible;
     }
   }
-
 
   &:where([data-disabled]) {
     background-color: var(--bg-black-dark);

--- a/packages/bezier-react/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/bezier-react/src/components/Checkbox/Checkbox.module.scss
@@ -11,6 +11,16 @@
 
 .Checkbox {
   cursor: inherit;
+  
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  margin: 1px;
+
+  background-color: var(--bg-white-normal);
+  border-radius: 7px;
+  box-shadow: inset 0 0 0 2px var(--bdr-black-dark);
 
   /* stylelint-disable-next-line order/order */
   @include dimension.square(18px);
@@ -25,15 +35,6 @@
     }
   }
 
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  margin: 1px;
-
-  background-color: var(--bg-white-normal);
-  border-radius: 7px;
-  box-shadow: inset 0 0 0 2px var(--bdr-black-dark);
 
   &:where([data-disabled]) {
     background-color: var(--bg-black-dark);

--- a/packages/bezier-react/src/components/RadioGroup/RadioGroup.module.scss
+++ b/packages/bezier-react/src/components/RadioGroup/RadioGroup.module.scss
@@ -19,11 +19,6 @@ $inner-indicator-size: 8px;
 }
 
 .RadioGroupItem {
-  @include interaction.touchable-hover {
-    @include outer-indicator-focus-styles;
-    @include inner-indicator-focus-styles;
-  }
-
   position: relative;
 
   display: flex;
@@ -32,6 +27,12 @@ $inner-indicator-size: 8px;
   width: 100%;
 
   outline: none;
+
+  /* stylelint-disable-next-line order/order */
+  @include interaction.touchable-hover {
+    @include outer-indicator-focus-styles;
+    @include inner-indicator-focus-styles;
+  }
 
   /* Outer Indicator */
   &::before {


### PR DESCRIPTION
#2360

<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
Fixes #2360 
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

## Summary
Prepare for Sass breaking change by migrating deprecated nested-to-unnested rule syntax.
<!-- Please brief explanation of the changes made -->

## Details
Changing the order of the properties in `RadioGroup.module.scss` and `Checkbox.module.scss`
<!-- Please elaborate description of the changes -->

### Breaking change? (Yes/No)

No
