### PR TITLE
Fix right button of `TextField` component shrinking bug

### DIFF
--- a/.changeset/little-llamas-attend.md
+++ b/.changeset/little-llamas-attend.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Prevent right button of `TextField` from shrinking.

--- a/packages/bezier-react/src/components/TextField/TextField.module.scss
+++ b/packages/bezier-react/src/components/TextField/TextField.module.scss
@@ -104,6 +104,7 @@
 
 .RightContentWrapper {
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   padding-right: 2px;
 }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- resolves https://github.com/channel-io/bezier-react/issues/2280

## Summary

<!-- Please brief explanation of the changes made -->

- `TextField`의 rightContent로 오는 컴포넌트의 width 가 고정되는 버그를 수정합니다. 

## Details

<!-- Please elaborate description of the changes -->

| As-is| To-be |
|--------|--------|
| <img width="356" alt="image" src="https://github.com/user-attachments/assets/7b0ee373-d3bd-4c9e-91bb-afdd148691a2"> | <img width="364" alt="image" src="https://github.com/user-attachments/assets/680339fd-5214-4128-ab00-487582763fce"> |

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

-  No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- None
