### PR TITLE
Fix wrong pr description in icon update PR

### DIFF
--- a/.github/workflows/generate-icon-changeset.yml
+++ b/.github/workflows/generate-icon-changeset.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -42,3 +43,4 @@ jobs:
           node packages/bezier-icons/scripts/generate-changeset.js
           git add .
           git commit -m "chore(bezier-icons): add changeset"
+          git push origin


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary

<!-- Please brief explanation of the changes made -->

- https://github.com/channel-io/bezier-react/pull/2378 에서 아이콘 변경 내역이 PR 본문에 잘못 나오고 changeset push 가 안되고 있는 것을 수정합니다. 

## Details

<!-- Please elaborate description of the changes -->

- PR본문을 추가하는 워크플로우에서 checkout 액션의 fetch-depth가 default(=1) 이라서 파일이 변경된 것으로 인식하지 않고 추가된것으로 인식해서 모두 Add로 나왔습니다. 0으로 바꿔서 모든 커밋 히스토리를 가져오도록 수정했습니다. 
- 누락된 changeset commit push 를 추가합니다. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- fork한 레포에서 테스트했을 때 잘 나오는 것을 확인했습니다 -> https://github.com/yangwooseong/bezier-react/pull/168
