### PR TITLE
Keep the color of text when hovering over the tertiary `Button` 

### DIFF
--- a/.changeset/strange-spies-provide.md
+++ b/.changeset/strange-spies-provide.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Keep the color of text when hovering over the tertiary `Button` component.

--- a/packages/bezier-react/src/components/Button/Button.module.scss
+++ b/packages/bezier-react/src/components/Button/Button.module.scss
@@ -157,7 +157,6 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled))';
         color: var(--bgtxt-#{$color-variant}-normal);
 
         &#{$active-selector} {
-          color: var(--bgtxt-#{$color-variant}-dark);
           background-color: var(--bgtxt-#{$color-variant}-lightest);
         }
       }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- Fixes #2364 

## Summary

<!-- Please brief explanation of the changes made -->

- 디자인스펙에 따르면 tertiary 버튼은 호버할 때 텍스트의 색깔이 변경되지 않도록 합니다. 지금은 바꾸고 있어서 이를 수정합니다. 
- V2 버튼은 잘 적용되어 있는 상태입니다. 

## Details

<!-- Please elaborate description of the changes -->

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- [스레드 (internal)](https://www.notion.so/channelio/Hover-fg-bezier2-ecf379e359344352bc570255e5b27e96)
