### PR TITLE
Fix wrong vertical align with icon in `AlphaFloatingIconButton`

### DIFF
--- a/.changeset/short-ads-ring.md
+++ b/.changeset/short-ads-ring.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Fix vertical align bug with icon in `AlphaFloatingIconButton` component.

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.module.scss
@@ -161,6 +161,10 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
 
   /* internal components */
   & :where(.ButtonContent) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
     &:where(.loading) {
       visibility: hidden;
     }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

- resolves #2382

<!-- Fixes #0000 -->

## Summary

<!-- Please brief explanation of the changes made -->

- `AlphaFloatingIconButton`의 아이콘 수직 정렬이 틀어지는 버그를 수정합니다. 

## Details

<!-- Please elaborate description of the changes -->

- ButtonContent에 display: flex 속성을 넣어서 svg와 높이가 같아지도록 합니다. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->
