### PR TITLE
Fix `OutlineItem`'s icon size and gap between icon and leftContent

### DIFF
--- a/.changeset/gold-otters-shop.md
+++ b/.changeset/gold-otters-shop.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Fix `OutlineItem` component's icon size and gap between icon and leftContent.

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.module.scss
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.module.scss
@@ -35,9 +35,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-
-  width: 16px;
-  height: 100%;
+  margin-right: 6px;
 }
 
 .LeftContent {

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
@@ -86,7 +86,7 @@ export const OutlineItem = forwardRef<
               <Icon
                 className={styles.Icon}
                 source={open ? ChevronSmallDownIcon : ChevronSmallRightIcon}
-                size="xs"
+                size="s"
                 color="txt-black-dark"
               />
             )}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary

<!-- Please brief explanation of the changes made -->

- OutlineItem 컴포넌트의 아이콘 사이즈와 아이콘의 right margin 을 디자인 스펙에 맞게 변경합니다. 

## Details

<!-- Please elaborate description of the changes -->

- 생략 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- [디자인 스펙(internal)](https://www.figma.com/design/99k33ZxchcPKTz2tzJlZeE/Components?node-id=1164-12605&m=dev)
- [UI Change](https://www.chromatic.com/test?appId=62bead1508281287d3c94d25&id=66ac2aea3a39ce91f17bab5a)
