### PR TITLE
Fix renovate schedule to cron syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":labels(chore:deps)"],
   "timezone": "Asia/Seoul",
-  "schedule": "on Monday after 10am before 7pm every month",
+  "schedule": "0 10-19 1-7 * MON",
   "packageRules": [
     {
       "groupName": "style",


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- resolves https://github.com/channel-io/bezier-react/issues/1217

## Summary

<!-- Please brief explanation of the changes made -->
- 파싱 에러가 나서 cron 문법으로 다시 시도합니다. 



## Details

<!-- Please elaborate description of the changes -->

- `0 10-19 1-7 * MON`-> 매 달 1일에서 7일까지 월요일에 10시에서 19시까지 0분에 실행입니다. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://docs.renovatebot.com/configuration-options/#schedule
- https://stackoverflow.com/questions/51669973/how-to-fire-the-job-on-first-monday-of-month-using-cron-expresssion-in-spring-s
- https://crontab.guru/#0_10-19_1-7_*_MON
