### PR TITLE
Allow template literal for validate-token stylelint rule

### DIFF
--- a/.changeset/orange-eggs-wait.md
+++ b/.changeset/orange-eggs-wait.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/stylelint-bezier': minor
+---
+
+`validate-token` rule passes when template literal is used.

--- a/packages/stylelint-bezier/src/plugins/validate-token/index.ts
+++ b/packages/stylelint-bezier/src/plugins/validate-token/index.ts
@@ -97,7 +97,9 @@ const pluginRule: Rule<boolean> = (primary, secondaryOptions = {}) => {
 
       const [, tokenName] = matches
 
-      if (tokenName.includes('${')) {
+      const hasTemplateLiteral = tokenName.includes('${')
+
+      if (hasTemplateLiteral) {
         return
       }
 

--- a/packages/stylelint-bezier/src/plugins/validate-token/index.ts
+++ b/packages/stylelint-bezier/src/plugins/validate-token/index.ts
@@ -97,6 +97,10 @@ const pluginRule: Rule<boolean> = (primary, secondaryOptions = {}) => {
 
       const [, tokenName] = matches
 
+      if (tokenName.includes('${')) {
+        return
+      }
+
       if (ignorePrefix.some((prefix: string) => tokenName.startsWith(prefix))) {
         return
       }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->


- None

<!-- Fixes #0000 -->

## Summary

<!-- Please brief explanation of the changes made -->

- styled-componets에서 template literal 을 사용하는 경우가 꽤 많아서, 그럴때는 disable 하지 않아도 되게끔 통과시킵니다. 

## Details

<!-- Please elaborate description of the changes -->

- None

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- None
