### PR TITLE
Add transform to style dictionary to get hovered color tokens

### DIFF
--- a/.changeset/dull-falcons-compete.md
+++ b/.changeset/dull-falcons-compete.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-tokens': patch
+---
+
+Add hovered color tokens for alpha functional color.

--- a/packages/bezier-react/src/stories/alpha-color.mdx
+++ b/packages/bezier-react/src/stories/alpha-color.mdx
@@ -1,6 +1,6 @@
 import { Markdown, Meta, DocsStory } from '@storybook/blocks'
 import { tokens } from '@channel.io/bezier-tokens/alpha'
-import { useLayoutEffect } from 'react'
+import { useLayoutEffect, useState } from 'react'
 
 import {
   LightThemeProvider,
@@ -11,66 +11,70 @@ import { HStack, VStack } from '~/src/components/Stack'
 <Meta title="alpha-foundation/Color" />
 
 export const Color = ({ isHoveredColor, name, value, reference }) => {
-  return (
-    <HStack
-      spacing={10}
-      height={80}
-      align="center"
+  const [isHovered, setIsHovered] = useState(false)
+  const color = isHovered ? `var(--${name}-hovered, var(--${name}))` :  `var(--${name})`
+
+return (
+
+<HStack
+  spacing={10}
+  height={80}
+  align="center"
+>
+  <div
+    style={{
+      flex: 1,
+      boxShadow: value,
+      backgroundColor: color,
+      height: '100%',
+    }}
+    onMouseEnter={() => {
+      setIsHovered(true)
+    }}
+    onMouseLeave={() => {
+      setIsHovered(false)
+    }}
+  />
+  <VStack
+    style={{
+      flex: 1,
+      color: 'var(--alpha-color-fg-black-darkest)',
+    }}
+    spacing={4}
+    justify="center"
+  >
+    <span style={{ fontSize: 11 }}>{name}</span>
+    <pre
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 3,
+        fontSize: 9,
+        lineHeight: 1,
+        color: 'var(--alpha-color-fg-black-dark)',
+      }}
     >
-      <div
+      {isHoveredColor ? '' : reference ? 'var' : ''}
+      <pre
         style={{
-          flex: 1,
-          boxShadow: value,
-          backgroundColor: `var(--${name})`,
-          height: '100%',
+          display: 'inline-flex',
+          fontSize: 'inherit',
+          lineHeight: 'inherit',
+          padding: '1px 2px',
+          backgroundColor: 'var(--alpha-color-bg-grey-lighter)',
+          borderRadius: 3,
+          border: '1px solid var(--alpha-color-bg-black-lightest)',
         }}
-      />
-      <VStack
-        style={{
-          flex: 1,
-          color: 'var(--alpha-color-fg-black-darkest)',
-        }}
-        spacing={4}
-        justify="center"
       >
-        <span style={{ fontSize: 11 }}>{name}</span>
-        <pre
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 3,
-            fontSize: 9,
-            lineHeight: 1,
-            color: 'var(--alpha-color-fg-black-dark)',
-          }}
-        >
-          {isHoveredColor ? '' : reference ? 'var' : ''}
-          <pre
-            style={{
-              display: 'inline-flex',
-              fontSize: 'inherit',
-              lineHeight: 'inherit',
-              padding: '1px 2px',
-              backgroundColor: 'var(--alpha-color-bg-grey-lighter)',
-              borderRadius: 3,
-              border: '1px solid var(--alpha-color-bg-black-lightest)',
-            }}
-          >
-            {isHoveredColor ? value : reference ? reference : value}
-          </pre>
-        </pre>
-      </VStack>
-    </HStack>
-  )
-}
+        {isHoveredColor ? value : reference ? reference : value}
+      </pre>
+    </pre>
+  </VStack>
+</HStack>
+)}
 
-export const Primary = () => {
-  useLayoutEffect(() => {
-    document.querySelector('.sbdocs-content').style.maxWidth = '1400px'
-}, [])
-
-return (<HStack>
-
+export const Primary = () => (
+  <HStack>
     <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={0}>
       {Object.entries(tokens.global.color).map(([key, { value, ref }]) => (
         <Color
@@ -95,20 +99,6 @@ return (<HStack>
       </VStack>
     </LightThemeProvider>
 
-    <LightThemeProvider>
-      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={0}>
-        {Object.entries(tokens.lightTheme_hovered.color).map(([key, { value, ref }]) => (
-          <Color
-            key={key}
-            name={key}
-            value={value}
-            reference={ref}
-            isHoveredColor
-          />
-        ))}
-      </VStack>
-    </LightThemeProvider>
-
     <DarkThemeProvider>
       <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={0}>
         {Object.entries(tokens.darkTheme.color).map(([key, { value, ref }]) => (
@@ -122,22 +112,8 @@ return (<HStack>
       </VStack>
     </DarkThemeProvider>
 
-    <DarkThemeProvider>
-      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={0}>
-        {Object.entries(tokens.darkTheme_hovered.color).map(([key, { value, ref }]) => (
-          <Color
-            key={key}
-            name={key}
-            value={value}
-            reference={ref}
-            isHoveredColor
-          />
-        ))}
-      </VStack>
-    </DarkThemeProvider>
-
-  </HStack>)
-}
+  </HStack>
+)
 
 # Color
 

--- a/packages/bezier-react/src/stories/alpha-color.mdx
+++ b/packages/bezier-react/src/stories/alpha-color.mdx
@@ -1,5 +1,6 @@
 import { Markdown, Meta, DocsStory } from '@storybook/blocks'
 import { tokens } from '@channel.io/bezier-tokens/alpha'
+import { useLayoutEffect } from 'react'
 
 import {
   LightThemeProvider,
@@ -63,8 +64,12 @@ export const Color = ({ isHoveredColor, name, value, reference }) => {
   )
 }
 
-export const Primary = () => (
-  <HStack>
+export const Primary = () => {
+  useLayoutEffect(() => {
+    document.querySelector('.sbdocs-content').style.maxWidth = '1400px'
+}, [])
+
+return (<HStack>
 
     <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={0}>
       {Object.entries(tokens.global.color).map(([key, { value, ref }]) => (
@@ -131,8 +136,8 @@ export const Primary = () => (
       </VStack>
     </DarkThemeProvider>
 
-  </HStack>
-)
+  </HStack>)
+}
 
 # Color
 

--- a/packages/bezier-react/src/stories/alpha-color.mdx
+++ b/packages/bezier-react/src/stories/alpha-color.mdx
@@ -1,4 +1,4 @@
-import { Markdown, Meta } from '@storybook/blocks'
+import { Markdown, Meta, DocsStory } from '@storybook/blocks'
 import { tokens } from '@channel.io/bezier-tokens/alpha'
 
 import {
@@ -9,15 +9,19 @@ import { HStack, VStack } from '~/src/components/Stack'
 
 <Meta title="alpha-foundation/Color" />
 
-export const Color = ({ name, value, reference }) => {
+export const Color = ({ isHoveredColor, name, value, reference }) => {
   return (
-    <HStack spacing={20}>
+    <HStack
+      spacing={10}
+      height={80}
+      align="center"
+    >
       <div
         style={{
           flex: 1,
           boxShadow: value,
           backgroundColor: `var(--${name})`,
-          height: 60,
+          height: '100%',
         }}
       />
       <VStack
@@ -39,7 +43,7 @@ export const Color = ({ name, value, reference }) => {
             color: 'var(--alpha-color-fg-black-dark)',
           }}
         >
-          {reference ? 'var' : ''}
+          {isHoveredColor ? '' : reference ? 'var' : ''}
           <pre
             style={{
               display: 'inline-flex',
@@ -51,7 +55,7 @@ export const Color = ({ name, value, reference }) => {
               border: '1px solid var(--alpha-color-bg-black-lightest)',
             }}
           >
-            {reference ? reference : value}
+            {isHoveredColor ? value : reference ? reference : value}
           </pre>
         </pre>
       </VStack>
@@ -62,7 +66,7 @@ export const Color = ({ name, value, reference }) => {
 export const Primary = () => (
   <HStack>
 
-    <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={20}>
+    <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={0}>
       {Object.entries(tokens.global.color).map(([key, { value, ref }]) => (
         <Color
           key={key}
@@ -74,7 +78,7 @@ export const Primary = () => (
     </VStack>
 
     <LightThemeProvider>
-      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={20}>
+      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={0}>
         {Object.entries(tokens.lightTheme.color).map(([key, { value, ref }]) => (
           <Color
             key={key}
@@ -86,14 +90,42 @@ export const Primary = () => (
       </VStack>
     </LightThemeProvider>
 
+    <LightThemeProvider>
+      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={0}>
+        {Object.entries(tokens.lightTheme_hovered.color).map(([key, { value, ref }]) => (
+          <Color
+            key={key}
+            name={key}
+            value={value}
+            reference={ref}
+            isHoveredColor
+          />
+        ))}
+      </VStack>
+    </LightThemeProvider>
+
     <DarkThemeProvider>
-      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={20}>
+      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={0}>
         {Object.entries(tokens.darkTheme.color).map(([key, { value, ref }]) => (
           <Color
             key={key}
             name={key}
             value={value}
             reference={ref}
+          />
+        ))}
+      </VStack>
+    </DarkThemeProvider>
+
+    <DarkThemeProvider>
+      <VStack style={{ flex: 1, backgroundColor: 'var(--alpha-color-surface-normal)' }} padding={0}>
+        {Object.entries(tokens.darkTheme_hovered.color).map(([key, { value, ref }]) => (
+          <Color
+            key={key}
+            name={key}
+            value={value}
+            reference={ref}
+            isHoveredColor
           />
         ))}
       </VStack>

--- a/packages/bezier-tokens/package.json
+++ b/packages/bezier-tokens/package.json
@@ -66,9 +66,11 @@
   "author": "Channel Corp.",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/tinycolor2": "^1",
     "eslint-config-bezier": "workspace:*",
     "minimatch": "^9.0.3",
     "style-dictionary": "^3.9.2",
+    "tinycolor2": "^1.6.0",
     "tsconfig": "workspace:*"
   }
 }

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -224,7 +224,7 @@ async function main() {
         source: ['src/alpha/functional/dark-theme/*.json'],
         reference: ['src/alpha/global/*.json'],
         basePath: BUILD_PATH.BASE_ALPHA,
-        destination: 'darkTheme_hovered',
+        destination: 'darkThemeHovered',
         options: { cssSelector: '[data-bezier-theme="dark"]' },
         isForHovered: true,
       })
@@ -235,7 +235,7 @@ async function main() {
         source: ['src/alpha/functional/light-theme/*.json'],
         reference: ['src/alpha/global/*.json'],
         basePath: BUILD_PATH.BASE_ALPHA,
-        destination: 'lightTheme_hovered',
+        destination: 'lightThemeHovered',
         options: {
           cssSelector: ':where(:root, :host), [data-bezier-theme="light"]',
         },

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -100,7 +100,6 @@ function defineConfig({
   const transforms = isForHovered
     ? HoveredTransforms.map(({ name }) => name)
     : CustomTransforms.map(({ name }) => name)
-  const outputReferences = !isForHovered
 
   return {
     source: [...source, ...reference],
@@ -139,7 +138,7 @@ function defineConfig({
               source.some((src) => minimatch(filePath, src)),
             options: {
               selector: options?.cssSelector,
-              outputReferences,
+              outputReferences: true,
             },
           },
         ],

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -12,11 +12,20 @@ import {
   customJsCjs,
   customJsEsm,
 } from './lib/format'
-import { CSSTransforms, HoveredColorTransforms } from './lib/transform'
+import { CSSTransforms } from './lib/transform'
+import { isHoveredTransformName } from './lib/utils'
 import { mergeCss } from './merge-css'
 
-const CustomTransforms = [...Object.values(CSSTransforms)]
-const HoveredTransforms = [...Object.values(HoveredColorTransforms)]
+const CustomTransforms = [
+  ...Object.values(CSSTransforms).filter(
+    ({ name }) => !isHoveredTransformName(name)
+  ),
+]
+const HoveredTransforms = [
+  ...Object.values(CSSTransforms).filter(({ name }) =>
+    isHoveredTransformName(name)
+  ),
+]
 
 const BUILD_PATH = {
   BASE: 'dist',

--- a/packages/bezier-tokens/scripts/lib/constants.ts
+++ b/packages/bezier-tokens/scripts/lib/constants.ts
@@ -1,0 +1,1 @@
+export const HOVERED = 'hovered'

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -111,10 +111,8 @@ export const CSSTransforms = {
     type: 'name',
     matcher: ({ type, filePath }) =>
       filePath.startsWith('src/alpha') && type === 'color',
-    transformer: ({ name, filePath }) => {
-      return filePath.includes('functional')
-        ? `alpha-${name}-hovered`
-        : `alpha-${name}`
+    transformer: ({ name }) => {
+      return `alpha-${name}-hovered`
     },
   },
   makeHoveredColor: {

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -112,7 +112,7 @@ export const CSSTransforms = {
     matcher: ({ type, filePath }) =>
       filePath.startsWith('src/alpha') && type === 'color',
     transformer: ({ name }) => {
-      return `alpha-${name}-hovered`
+      return `alpha-${name}-${HOVERED}`
     },
   },
   makeHoveredColor: {
@@ -171,6 +171,18 @@ export const CSSTransforms = {
       return filePath.includes('dark-theme')
         ? getHoveredColor(value, 'dark')
         : getHoveredColor(value, 'light')
+    },
+  },
+  removeReference: {
+    name: `custom/css/${HOVERED}/remove-ref`,
+    type: 'attribute',
+    matcher: ({ type, filePath, name }) =>
+      filePath.startsWith('src/alpha') &&
+      type === 'color' &&
+      name.includes(`-${HOVERED}`),
+    transformer: (token) => {
+      token.original.value = null
+      return token
     },
   },
 } satisfies Transforms

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -122,11 +122,9 @@ export const HoveredColorTransforms = {
   makeHoveredColor: {
     name: 'custom/css/hovered-dark',
     type: 'value',
-    /**
-     * NOTE: If transitive is set to true, the global token will be converted and the value referencing it will be converted once more.
-     */
-    transitive: false,
-    matcher: ({ type }) => type === 'color',
+    transitive: true,
+    matcher: ({ type, filePath }) =>
+      type === 'color' && filePath.includes('functional'),
     transformer: ({ value, filePath }) => {
       return filePath.includes('dark-theme')
         ? getHoveredColor(value, 'dark')

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -123,7 +123,7 @@ export const HoveredColorTransforms = {
     name: 'custom/css/hovered-dark',
     type: 'value',
     /**
-     * NOTE: If transitive: true is set, the global token will be converted and the value referencing it will be converted once more
+     * NOTE: If transitive is set to true, the global token will be converted and the value referencing it will be converted once more.
      */
     transitive: false,
     matcher: ({ type }) => type === 'color',

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -1,6 +1,7 @@
 import type { Named, Transform } from 'style-dictionary'
 import tinycolor from 'tinycolor2'
 
+import { HOVERED } from './constants'
 import { clip, extractNumber, toCSSDimension } from './utils'
 
 type CustomTransform = Named<Transform<unknown>>
@@ -105,11 +106,8 @@ export const CSSTransforms = {
         .map(({ color, position }) => `${color} ${position}`)
         .join(', ')})`,
   },
-} satisfies Transforms
-
-export const HoveredColorTransforms = {
   nameTransform: {
-    name: 'custom/css/hovered',
+    name: `custom/css/${HOVERED}/namespace`,
     type: 'name',
     matcher: ({ type, filePath }) =>
       filePath.startsWith('src/alpha') && type === 'color',
@@ -120,7 +118,7 @@ export const HoveredColorTransforms = {
     },
   },
   makeHoveredColor: {
-    name: 'custom/css/hovered-dark',
+    name: `custom/css/${HOVERED}/functional-color`,
     type: 'value',
     transitive: true,
     matcher: ({ type, filePath }) =>

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -106,7 +106,7 @@ export const CSSTransforms = {
         .map(({ color, position }) => `${color} ${position}`)
         .join(', ')})`,
   },
-  nameTransform: {
+  hoveredSuffix: {
     name: `custom/css/${HOVERED}/namespace`,
     type: 'name',
     matcher: ({ type, filePath }) =>

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -1,3 +1,5 @@
+import { HOVERED } from './constants'
+
 export const toCamelCase = (str: string) =>
   str
     .toLowerCase()
@@ -10,3 +12,5 @@ export const toCSSDimension = (value: string) =>
   /^0[a-zA-Z]+$/.test(value) ? 0 : value
 
 export const clip = (value: number) => Math.min(Math.max(value, 0), 1)
+
+export const isHoveredTransformName = (name: string) => name.includes(HOVERED)

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -8,3 +8,5 @@ export const extractNumber = (str: string) =>
 
 export const toCSSDimension = (value: string) =>
   /^0[a-zA-Z]+$/.test(value) ? 0 : value
+
+export const clip = (value: number) => Math.min(Math.max(value, 0), 1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2211,9 +2211,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@channel.io/bezier-tokens@workspace:packages/bezier-tokens"
   dependencies:
+    "@types/tinycolor2": "npm:^1"
     eslint-config-bezier: "workspace:*"
     minimatch: "npm:^9.0.3"
     style-dictionary: "npm:^3.9.2"
+    tinycolor2: "npm:^1.6.0"
     tsconfig: "workspace:*"
   languageName: unknown
   linkType: soft
@@ -6407,6 +6409,13 @@ __metadata:
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
   checksum: 10/72576cc1522090fe497337c2b99d9838e320659ac57fa5560fcbdcbafcf5d0216c6b3a0a8a4ee4fdb3b1f5e3420aa4f6223ab57b82fef3578bec3206425c6cf5
+  languageName: node
+  linkType: hard
+
+"@types/tinycolor2@npm:^1":
+  version: 1.4.6
+  resolution: "@types/tinycolor2@npm:1.4.6"
+  checksum: 10/a662fd177135d27779b7ccba39881a85167f969787c71c7bf51903d288a519ad5b9526e0a4af7bde6444df6b7abe88bae893d569c6d804108c03dfec9509bdf6
   languageName: node
   linkType: hard
 
@@ -18584,7 +18593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinycolor2@npm:^1.4.1":
+"tinycolor2@npm:^1.4.1, tinycolor2@npm:^1.6.0":
   version: 1.6.0
   resolution: "tinycolor2@npm:1.6.0"
   checksum: 10/066c3acf4f82b81c58a0d3ab85f49407efe95ba87afc3c7a16b1d77625193dfbe10dd46c26d0a263c1137361dd5a6a68bff2fb71def5fb9b9aec940fb030bcd4


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- resolves #2413 

## Summary

<!-- Please brief explanation of the changes made -->

- alpha functional 토큰에 대해서 정해진 공식에 따라 hovered color 토큰을 만들기 위해 style dictionary 에 transform 을 추가합니다. 
- 스토리북 > Alpha-foundation > Color 에 hovered color 토큰을 추가합니다. 

## Details

<!-- Please elaborate description of the changes -->

- mergeCSS, mergeJsIndex 함수가 이미 있기 때문에, hovered color 토큰을 만들기 위해 builder를 하나 더 만들기만 하면 merge 함수가 알아서 파일을 합쳐줍니다. 
- 변환 공식은 이슈를 참조해주세요. 추후에 바뀔 여지가 있습니다.

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

-  No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->


- https://styledictionary.com/