### PR TITLE
Fix `size` props of `AlphaLoader` component to be required

### DIFF
--- a/.changeset/honest-snakes-hug.md
+++ b/.changeset/honest-snakes-hug.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Fix `size` props of `AlphaLoader` component to be required.

--- a/packages/bezier-react/src/components/AlphaButton/Button.tsx
+++ b/packages/bezier-react/src/components/AlphaButton/Button.tsx
@@ -118,10 +118,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           <div
             className={classNames(
               styles.ButtonLoader,
+              // NOTE: Loader size is the same as icon size
               styles[`size-${getIconSize(size)}`]
             )}
           >
             <AlphaLoader
+              size="s"
               className={styles.Loader}
               variant="on-overlay"
             />

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
@@ -117,10 +117,12 @@ export const FloatingButton = forwardRef<
         <div
           className={classNames(
             styles.ButtonLoader,
+            // NOTE: Loader size is the same as icon size
             styles[`size-${getIconSize(size)}`]
           )}
         >
           <AlphaLoader
+            size="s"
             className={styles.Loader}
             variant="on-overlay"
           />

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
@@ -72,10 +72,12 @@ export const FloatingIconButton = forwardRef<
         <div
           className={classNames(
             styles.ButtonLoader,
+            // NOTE: Loader size is the same as icon size
             styles[`size-${getIconSize(size)}`]
           )}
         >
           <AlphaLoader
+            size="s"
             className={styles.Loader}
             variant="on-overlay"
           />

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
@@ -76,10 +76,12 @@ export const IconButton = forwardRef<HTMLButtonElement, AlphaIconButtonProps>(
           <div
             className={classNames(
               styles.ButtonLoader,
+              // NOTE: Loader size is the same as icon size
               styles[`size-${getIconSize(size)}`]
             )}
           >
             <AlphaLoader
+              size="s"
               className={styles.Loader}
               variant="on-overlay"
             />

--- a/packages/bezier-react/src/components/AlphaLoader/AlphaLoader.stories.tsx
+++ b/packages/bezier-react/src/components/AlphaLoader/AlphaLoader.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 
-import { type Meta, type StoryFn } from '@storybook/react'
+import { type Meta, type StoryFn, type StoryObj } from '@storybook/react'
 
 import { Loader } from './Loader'
 import { type LoaderProps } from './Loader.types'
 
-const meta: Meta<typeof Loader> = {
+const meta = {
   component: Loader,
-}
+} satisfies Meta<typeof Loader>
 
 export default meta
 
@@ -26,4 +26,4 @@ export const Primary = {
       url: 'https://www.figma.com/design/KyhPPZeeC0JBmTclJGe3nn/Status?node-id=6-69&t=aiOXLQegb05Jiqqg-1',
     },
   },
-}
+} satisfies StoryObj<typeof meta>

--- a/packages/bezier-react/src/components/AlphaLoader/Loader.test.tsx
+++ b/packages/bezier-react/src/components/AlphaLoader/Loader.test.tsx
@@ -6,7 +6,12 @@ import { LOADER_TEST_ID, Loader } from './Loader'
 
 describe('Loader >', () => {
   const renderLoader = (props?: React.ComponentProps<typeof Loader>) =>
-    render(<Loader {...props} />)
+    render(
+      <Loader
+        size="s"
+        {...props}
+      />
+    )
 
   it('should render', () => {
     const { getByTestId } = renderLoader()
@@ -22,7 +27,7 @@ describe('Loader >', () => {
 
   it('should forward ref', () => {
     const ref = React.createRef<HTMLDivElement>()
-    renderLoader({ ref })
+    renderLoader({ ref, size: 's' })
     expect(ref.current).toBeInTheDocument()
   })
 

--- a/packages/bezier-react/src/components/AlphaLoader/Loader.types.ts
+++ b/packages/bezier-react/src/components/AlphaLoader/Loader.types.ts
@@ -16,6 +16,6 @@ interface LoaderOwnProps {
 
 export interface LoaderProps
   extends Omit<BezierComponentProps<'span'>, keyof ColorProps>,
-    SizeProps<LoaderSize>,
+    Required<SizeProps<LoaderSize>>,
     ColorProps,
     LoaderOwnProps {}

--- a/packages/bezier-react/src/components/AlphaToggleButton/ToggleButton.tsx
+++ b/packages/bezier-react/src/components/AlphaToggleButton/ToggleButton.tsx
@@ -101,10 +101,12 @@ export const ToggleButton = forwardRef<HTMLButtonElement, ToggleButtonProps>(
             <div
               className={classNames(
                 styles.ButtonLoader,
+                // NOTE: Loader size is the same as icon size
                 styles[`size-${ICON_SIZE}`]
               )}
             >
               <AlphaLoader
+                size="s"
                 className={styles.Loader}
                 variant="secondary"
               />


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary

<!-- Please brief explanation of the changes made -->

- AlphaLoader size 속성의 초기값이 없기 때문에 optional 이 아닌 required로 수정합니다. 

## Details

<!-- Please elaborate description of the changes -->

- 생략 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- [컴포넌트 스펙(internal)](https://www.notion.so/channelio/Loader-e1e30e3fdcb14a3ba94b900d24e0d58e?pvs=4#9141d935a26b4dcea55b108f0bd3e466)
