### PR TITLE
Fix `variant` props of `AlphaLoader` component used in buttons

### DIFF
--- a/.changeset/cold-adults-thank.md
+++ b/.changeset/cold-adults-thank.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Fix `variant` props of `AlphaLoader` component used in `AlphaButton` component.

--- a/packages/bezier-react/src/components/AlphaButton/Button.tsx
+++ b/packages/bezier-react/src/components/AlphaButton/Button.tsx
@@ -125,7 +125,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             <AlphaLoader
               size="s"
               className={styles.Loader}
-              variant="on-overlay"
+              variant={variant === 'primary' ? 'on-overlay' : 'secondary'}
             />
           </div>
         )}

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
@@ -124,7 +124,7 @@ export const FloatingButton = forwardRef<
           <AlphaLoader
             size="s"
             className={styles.Loader}
-            variant="on-overlay"
+            variant={variant === 'primary' ? 'on-overlay' : 'secondary'}
           />
         </div>
       )}

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
@@ -79,7 +79,7 @@ export const FloatingIconButton = forwardRef<
           <AlphaLoader
             size="s"
             className={styles.Loader}
-            variant="on-overlay"
+            variant={variant === 'primary' ? 'on-overlay' : 'secondary'}
           />
         </div>
       )}

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
@@ -83,7 +83,7 @@ export const IconButton = forwardRef<HTMLButtonElement, AlphaIconButtonProps>(
             <AlphaLoader
               size="s"
               className={styles.Loader}
-              variant="on-overlay"
+              variant={variant === 'primary' ? 'on-overlay' : 'secondary'}
             />
           </div>
         )}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

## Summary

<!-- Please brief explanation of the changes made -->

- 버튼 안에서 사용되는 로더 컴포넌트의 스타일을 버튼 컴포넌트 스펙에 맞게 수정했습니다. primary 버튼일 때는 on-overlay,  아닐 때는 secondary 여야 합니다. 

## Details

<!-- Please elaborate description of the changes -->

- 생략 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- [컴포넌트 스펙(internal)](https://www.notion.so/Button-95e7964c1e174aaa9923abc8ecc193b3?d=12874b55ec7c80dc9732001c0b74a23b&pvs=4#043567a82b2f4b5a9da4abd656d7ce08)
