### PR TITLE
Implement hovered color with customFormat of SD

### DIFF
--- a/.changeset/tricky-hounds-do.md
+++ b/.changeset/tricky-hounds-do.md
@@ -1,0 +1,8 @@
+---
+'@channel.io/bezier-tokens': patch
+---
+
+Changes to the build result of package.
+
+- `dark(light)ThemeHovered` property of entry object is removed and merged into the `dark(light)Theme` property.
+- duplicate selector issue is resolved in `styles.css` stylesheet.

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -13,14 +13,9 @@ import {
   customJsEsm,
 } from './lib/format'
 import { CSSTransforms } from './lib/transform'
-import { isHoveredTransformName } from './lib/utils'
 import { mergeCss } from './merge-css'
 
-const CustomTransforms = [
-  ...Object.values(CSSTransforms).filter(
-    ({ name }) => !isHoveredTransformName(name)
-  ),
-]
+const CustomTransforms = [...Object.values(CSSTransforms)]
 
 const BUILD_PATH = {
   BASE: 'dist',

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -21,11 +21,6 @@ const CustomTransforms = [
     ({ name }) => !isHoveredTransformName(name)
   ),
 ]
-const HoveredTransforms = [
-  ...Object.values(CSSTransforms).filter(({ name }) =>
-    isHoveredTransformName(name)
-  ),
-]
 
 const BUILD_PATH = {
   BASE: 'dist',
@@ -48,13 +43,6 @@ const AlphaTokenBuilder = CustomTransforms.reduce(
 )
   .registerFormat(alphaCustomJsCjs)
   .registerFormat(alphaCustomJsEsm)
-
-const AlphaHoveredColorTokenBuilder = HoveredTransforms.reduce(
-  (builder, transform) => builder.registerTransform(transform),
-  StyleDictionary
-)
-  .registerFormat(alphaCustomJsCjs)
-  .registerFormat(alphaCustomJsCjs)
 
 function defineWebPlatform({
   options,
@@ -90,16 +78,13 @@ interface DefineConfigOptions {
 
 function defineConfig({
   useAlpha = false,
-  isForHovered = false,
   source,
   reference = [],
   basePath,
   destination,
   options,
 }: DefineConfigOptions): Config {
-  const transforms = isForHovered
-    ? HoveredTransforms.map(({ name }) => name)
-    : CustomTransforms.map(({ name }) => name)
+  const transforms = CustomTransforms.map(({ name }) => name)
 
   return {
     source: [...source, ...reference],
@@ -215,30 +200,6 @@ async function main() {
         basePath: BUILD_PATH.BASE_ALPHA,
         destination: 'darkTheme',
         options: { cssSelector: '[data-bezier-theme="dark"]' },
-      })
-    ),
-    AlphaHoveredColorTokenBuilder.extend(
-      defineConfig({
-        useAlpha: true,
-        source: ['src/alpha/functional/dark-theme/*.json'],
-        reference: ['src/alpha/global/*.json'],
-        basePath: BUILD_PATH.BASE_ALPHA,
-        destination: 'darkThemeHovered',
-        options: { cssSelector: '[data-bezier-theme="dark"]' },
-        isForHovered: true,
-      })
-    ),
-    AlphaHoveredColorTokenBuilder.extend(
-      defineConfig({
-        useAlpha: true,
-        source: ['src/alpha/functional/light-theme/*.json'],
-        reference: ['src/alpha/global/*.json'],
-        basePath: BUILD_PATH.BASE_ALPHA,
-        destination: 'lightThemeHovered',
-        options: {
-          cssSelector: ':where(:root, :host), [data-bezier-theme="light"]',
-        },
-        isForHovered: true,
       })
     ),
   ].forEach((builder) => {

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -7,7 +7,7 @@ import StyleDictionary, {
 
 import { buildJsIndex } from './build-js-index'
 import {
-  alphaCustomCSS,
+  alphaCustomCss,
   alphaCustomJsCjs,
   alphaCustomJsEsm,
   customJsCjs,
@@ -39,7 +39,7 @@ const AlphaTokenBuilder = CustomTransforms.reduce(
 )
   .registerFormat(alphaCustomJsCjs)
   .registerFormat(alphaCustomJsEsm)
-  .registerFormat(alphaCustomCSS)
+  .registerFormat(alphaCustomCss)
 
 function defineWebPlatform({
   options,
@@ -114,7 +114,7 @@ function defineConfig({
         files: [
           {
             destination: `${destination}.css`,
-            format: useAlpha ? alphaCustomCSS.name : 'css/variables',
+            format: useAlpha ? alphaCustomCss.name : 'css/variables',
             filter: ({ filePath }) =>
               source.some((src) => minimatch(filePath, src)),
             options: {

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -67,7 +67,6 @@ interface DefineConfigOptions {
   reference?: string[]
   basePath: string
   destination: string
-  isForHovered?: boolean
   options?: Options & {
     cssSelector: string
   }

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -7,6 +7,7 @@ import StyleDictionary, {
 
 import { buildJsIndex } from './build-js-index'
 import {
+  alphaCustomCSS,
   alphaCustomJsCjs,
   alphaCustomJsEsm,
   customJsCjs,
@@ -38,6 +39,7 @@ const AlphaTokenBuilder = CustomTransforms.reduce(
 )
   .registerFormat(alphaCustomJsCjs)
   .registerFormat(alphaCustomJsEsm)
+  .registerFormat(alphaCustomCSS)
 
 function defineWebPlatform({
   options,
@@ -113,7 +115,7 @@ function defineConfig({
         files: [
           {
             destination: `${destination}.css`,
-            format: 'css/variables',
+            format: useAlpha ? alphaCustomCSS.name : 'css/variables',
             filter: ({ filePath }) =>
               source.some((src) => minimatch(filePath, src)),
             options: {

--- a/packages/bezier-tokens/scripts/lib/constants.ts
+++ b/packages/bezier-tokens/scripts/lib/constants.ts
@@ -1,1 +1,0 @@
-export const HOVERED = 'hovered'

--- a/packages/bezier-tokens/scripts/lib/format.ts
+++ b/packages/bezier-tokens/scripts/lib/format.ts
@@ -4,7 +4,7 @@ import { getHoveredColorToken } from './utils'
 
 type CustomFormat = Named<Format>
 
-const { fileHeader } = formatHelpers
+const { fileHeader, createPropertyFormatter } = formatHelpers
 
 export const customJsCjs: CustomFormat = {
   name: 'custom/js/cjs',
@@ -211,5 +211,30 @@ export const alphaCustomJsEsm: CustomFormat = {
       )}\n` +
       '})\n'
     )
+  },
+}
+
+export const alphaCustomCSS: CustomFormat = {
+  name: 'alpha/custom/css',
+  formatter({ dictionary, options }) {
+    const propertyFormatter = createPropertyFormatter({
+      outputReferences: options.outputReferences,
+      dictionary,
+      format: 'css',
+    })
+
+    const formattedResult = dictionary.allTokens
+      .flatMap((token) => {
+        const shouldMakeHoveredToken =
+          token.type === 'color' && !token.filePath.includes('global')
+
+        return shouldMakeHoveredToken
+          ? [token, getHoveredColorToken(token)]
+          : [token]
+      })
+      .map(propertyFormatter)
+      .join('\n')
+
+    return `${options.selector} {\n` + formattedResult + `\n}\n`
   },
 }

--- a/packages/bezier-tokens/scripts/lib/format.ts
+++ b/packages/bezier-tokens/scripts/lib/format.ts
@@ -210,7 +210,7 @@ export const alphaCustomJsEsm: CustomFormat = {
   },
 }
 
-export const alphaCustomCSS: CustomFormat = {
+export const alphaCustomCss: CustomFormat = {
   name: 'alpha/custom/css',
   formatter({ dictionary, options }) {
     const propertyFormatter = createPropertyFormatter({

--- a/packages/bezier-tokens/scripts/lib/format.ts
+++ b/packages/bezier-tokens/scripts/lib/format.ts
@@ -1,5 +1,7 @@
 import { type Format, type Named, formatHelpers } from 'style-dictionary'
 
+import { getHoveredColorToken } from './utils'
+
 type CustomFormat = Named<Format>
 
 const { fileHeader } = formatHelpers
@@ -97,6 +99,13 @@ export const alphaCustomJsCjs: CustomFormat = {
         (category) =>
           `\n  "${category}": Object.freeze({\n` +
           `${categorizedTokens[category]
+            .flatMap((token) => {
+              if (category !== 'color') {
+                return [token]
+              } else {
+                return [token, getHoveredColorToken(token)]
+              }
+            })
             .map((token) => {
               const ref = (() => {
                 if (!dictionary.usesReference(token.original.value)) {
@@ -154,6 +163,13 @@ export const alphaCustomJsEsm: CustomFormat = {
         (category) =>
           `\n  "${category}": Object.freeze({\n` +
           `${categorizedTokens[category]
+            .flatMap((token) => {
+              if (category !== 'color') {
+                return [token]
+              } else {
+                return [token, getHoveredColorToken(token)]
+              }
+            })
             .map((token) => {
               const ref = (() => {
                 if (!dictionary.usesReference(token.original.value)) {

--- a/packages/bezier-tokens/scripts/lib/format.ts
+++ b/packages/bezier-tokens/scripts/lib/format.ts
@@ -1,6 +1,11 @@
-import { type Format, type Named, formatHelpers } from 'style-dictionary'
+import {
+  type Format,
+  type Named,
+  type TransformedToken,
+  formatHelpers,
+} from 'style-dictionary'
 
-import { getHoveredColorToken, shouldMakeHoveredToken } from './utils'
+import { getHoveredColor, shouldMakeHoveredToken } from './utils'
 
 type CustomFormat = Named<Format>
 
@@ -230,4 +235,17 @@ export const alphaCustomCss: CustomFormat = {
 
     return `${options.selector} {\n` + formattedResult + `\n}\n`
   },
+}
+
+function getHoveredColorToken(token: TransformedToken) {
+  const theme = token.filePath.includes('dark') ? 'dark' : 'light'
+  return {
+    ...token,
+    original: {
+      ...token.original,
+      value: null,
+    },
+    name: `${token.name}-hovered`,
+    value: getHoveredColor(token.value, theme),
+  }
 }

--- a/packages/bezier-tokens/scripts/lib/format.ts
+++ b/packages/bezier-tokens/scripts/lib/format.ts
@@ -127,7 +127,14 @@ export const alphaCustomJsCjs: CustomFormat = {
                 return value
               })()
 
-              return `    "${token.name}": Object.freeze(${JSON.stringify({ value: token.value, ref })}),`
+              const valueObject = ref
+                ? {
+                    value: token.value,
+                    ref,
+                  }
+                : { value: token.value }
+
+              return `    "${token.name}": Object.freeze(${JSON.stringify(valueObject)}),`
             })
             .join('\n')}\n  })`
       )}\n` +
@@ -191,7 +198,14 @@ export const alphaCustomJsEsm: CustomFormat = {
                 return value
               })()
 
-              return `    "${token.name}": Object.freeze(${JSON.stringify({ value: token.value, ref })}),`
+              const valueObject = ref
+                ? {
+                    value: token.value,
+                    ref,
+                  }
+                : { value: token.value }
+
+              return `    "${token.name}": Object.freeze(${JSON.stringify(valueObject)}),`
             })
             .join('\n')}\n  })`
       )}\n` +

--- a/packages/bezier-tokens/scripts/lib/format.ts
+++ b/packages/bezier-tokens/scripts/lib/format.ts
@@ -1,6 +1,6 @@
 import { type Format, type Named, formatHelpers } from 'style-dictionary'
 
-import { getHoveredColorToken } from './utils'
+import { getHoveredColorToken, shouldMakeHoveredToken } from './utils'
 
 type CustomFormat = Named<Format>
 
@@ -99,13 +99,11 @@ export const alphaCustomJsCjs: CustomFormat = {
         (category) =>
           `\n  "${category}": Object.freeze({\n` +
           `${categorizedTokens[category]
-            .flatMap((token) => {
-              if (category !== 'color') {
-                return [token]
-              } else {
-                return [token, getHoveredColorToken(token)]
-              }
-            })
+            .flatMap((token) =>
+              shouldMakeHoveredToken(token)
+                ? [token, getHoveredColorToken(token)]
+                : [token]
+            )
             .map((token) => {
               const ref = (() => {
                 if (!dictionary.usesReference(token.original.value)) {
@@ -170,13 +168,11 @@ export const alphaCustomJsEsm: CustomFormat = {
         (category) =>
           `\n  "${category}": Object.freeze({\n` +
           `${categorizedTokens[category]
-            .flatMap((token) => {
-              if (category !== 'color') {
-                return [token]
-              } else {
-                return [token, getHoveredColorToken(token)]
-              }
-            })
+            .flatMap((token) =>
+              shouldMakeHoveredToken(token)
+                ? [token, getHoveredColorToken(token)]
+                : [token]
+            )
             .map((token) => {
               const ref = (() => {
                 if (!dictionary.usesReference(token.original.value)) {
@@ -224,14 +220,11 @@ export const alphaCustomCSS: CustomFormat = {
     })
 
     const formattedResult = dictionary.allTokens
-      .flatMap((token) => {
-        const shouldMakeHoveredToken =
-          token.type === 'color' && !token.filePath.includes('global')
-
-        return shouldMakeHoveredToken
+      .flatMap((token) =>
+        shouldMakeHoveredToken(token)
           ? [token, getHoveredColorToken(token)]
           : [token]
-      })
+      )
       .map(propertyFormatter)
       .join('\n')
 

--- a/packages/bezier-tokens/scripts/lib/format.ts
+++ b/packages/bezier-tokens/scripts/lib/format.ts
@@ -103,12 +103,7 @@ export const alphaCustomJsCjs: CustomFormat = {
       `${Object.keys(categorizedTokens).map(
         (category) =>
           `\n  "${category}": Object.freeze({\n` +
-          `${categorizedTokens[category]
-            .flatMap((token) =>
-              shouldMakeHoveredToken(token)
-                ? [token, getHoveredColorToken(token)]
-                : [token]
-            )
+          `${processTokensWithHovered(categorizedTokens[category])
             .map((token) => {
               const ref = (() => {
                 if (!dictionary.usesReference(token.original.value)) {
@@ -172,12 +167,7 @@ export const alphaCustomJsEsm: CustomFormat = {
       `${Object.keys(categorizedTokens).map(
         (category) =>
           `\n  "${category}": Object.freeze({\n` +
-          `${categorizedTokens[category]
-            .flatMap((token) =>
-              shouldMakeHoveredToken(token)
-                ? [token, getHoveredColorToken(token)]
-                : [token]
-            )
+          `${processTokensWithHovered(categorizedTokens[category])
             .map((token) => {
               const ref = (() => {
                 if (!dictionary.usesReference(token.original.value)) {
@@ -224,12 +214,7 @@ export const alphaCustomCss: CustomFormat = {
       format: 'css',
     })
 
-    const formattedResult = dictionary.allTokens
-      .flatMap((token) =>
-        shouldMakeHoveredToken(token)
-          ? [token, getHoveredColorToken(token)]
-          : [token]
-      )
+    const formattedResult = processTokensWithHovered(dictionary.allTokens)
       .map(propertyFormatter)
       .join('\n')
 
@@ -237,7 +222,7 @@ export const alphaCustomCss: CustomFormat = {
   },
 }
 
-function getHoveredColorToken(token: TransformedToken) {
+function getHoveredColorToken(token: TransformedToken): TransformedToken {
   const theme = token.filePath.includes('dark') ? 'dark' : 'light'
   return {
     ...token,
@@ -248,4 +233,10 @@ function getHoveredColorToken(token: TransformedToken) {
     name: `${token.name}-hovered`,
     value: getHoveredColor(token.value, theme),
   }
+}
+
+function processTokensWithHovered(tokens: TransformedToken[]) {
+  return tokens.flatMap((token) =>
+    shouldMakeHoveredToken(token) ? [token, getHoveredColorToken(token)] : token
+  )
 }

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -106,15 +106,6 @@ export const CSSTransforms = {
         .map(({ color, position }) => `${color} ${position}`)
         .join(', ')})`,
   },
-  hoveredSuffix: {
-    name: `custom/css/${HOVERED}/namespace`,
-    type: 'name',
-    matcher: ({ type, filePath }) =>
-      filePath.startsWith('src/alpha') && type === 'color',
-    transformer: ({ name }) => {
-      return `alpha-${name}-${HOVERED}`
-    },
-  },
   makeHoveredColor: {
     name: `custom/css/${HOVERED}/functional-color`,
     type: 'value',
@@ -171,18 +162,6 @@ export const CSSTransforms = {
       return filePath.includes('dark-theme')
         ? getHoveredColor(value, 'dark')
         : getHoveredColor(value, 'light')
-    },
-  },
-  removeReference: {
-    name: `custom/css/${HOVERED}/remove-ref`,
-    type: 'attribute',
-    matcher: ({ type, filePath, name }) =>
-      filePath.startsWith('src/alpha') &&
-      type === 'color' &&
-      name.includes(`-${HOVERED}`),
-    transformer: (token) => {
-      token.original.value = null
-      return token
     },
   },
 } satisfies Transforms

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -1,8 +1,6 @@
 import type { Named, Transform } from 'style-dictionary'
-import tinycolor from 'tinycolor2'
 
-import { HOVERED } from './constants'
-import { clip, extractNumber, toCSSDimension } from './utils'
+import { extractNumber, toCSSDimension } from './utils'
 
 type CustomTransform = Named<Transform<unknown>>
 type Transforms = Record<string, CustomTransform>
@@ -105,63 +103,5 @@ export const CSSTransforms = {
       `linear-gradient(90deg, ${value
         .map(({ color, position }) => `${color} ${position}`)
         .join(', ')})`,
-  },
-  makeHoveredColor: {
-    name: `custom/css/${HOVERED}/functional-color`,
-    type: 'value',
-    transitive: true,
-    matcher: ({ type, filePath }) =>
-      type === 'color' && filePath.includes('functional'),
-    transformer: ({ value, filePath }) => {
-      function getHoveredColor(value: string, theme: 'dark' | 'light') {
-        const color = tinycolor(value)
-        const { h, s, l, a } = color.toHsl()
-
-        let alpha = a
-        let lightness = l
-        let saturation = s
-
-        if (a === 0) {
-          alpha = 0.1
-        } else if (a < 0.2) {
-          alpha = alpha * 1.5
-        }
-
-        if (theme === 'light') {
-          if (l <= 0.17) {
-            lightness = (l + 0.07) * 1.1
-            saturation += 0.05
-          } else {
-            lightness *= 0.93
-            saturation -= 0.03
-          }
-        } else {
-          if (l >= 0.83) {
-            lightness = (lightness - 0.2) * 0.98
-            saturation -= 0.03
-          } else {
-            lightness = (lightness + 0.04) * 1.005
-            saturation += 0.05
-          }
-        }
-
-        if (s <= 0.1 || s >= 0.9) {
-          saturation = s
-        }
-
-        const res = tinycolor.fromRatio({
-          h,
-          s: clip(saturation),
-          l: clip(lightness),
-          a: clip(alpha),
-        })
-
-        return res.toHex8String()
-      }
-
-      return filePath.includes('dark-theme')
-        ? getHoveredColor(value, 'dark')
-        : getHoveredColor(value, 'light')
-    },
   },
 } satisfies Transforms

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -1,3 +1,6 @@
+import { type TransformedToken } from 'style-dictionary'
+import tinycolor from 'tinycolor2'
+
 import { HOVERED } from './constants'
 
 export const toCamelCase = (str: string) =>
@@ -11,6 +14,63 @@ export const extractNumber = (str: string) =>
 export const toCSSDimension = (value: string) =>
   /^0[a-zA-Z]+$/.test(value) ? 0 : value
 
-export const clip = (value: number) => Math.min(Math.max(value, 0), 1)
+const clip = (value: number) => Math.min(Math.max(value, 0), 1)
 
 export const isHoveredTransformName = (name: string) => name.includes(HOVERED)
+
+const getHoveredColor = (value: string, theme: 'dark' | 'light') => {
+  const color = tinycolor(value)
+  const { h, s, l, a } = color.toHsl()
+
+  let alpha = a
+  let lightness = l
+  let saturation = s
+
+  if (a === 0) {
+    alpha = 0.1
+  } else if (a < 0.2) {
+    alpha = alpha * 1.5
+  }
+
+  if (theme === 'light') {
+    if (l <= 0.17) {
+      lightness = (l + 0.07) * 1.1
+      saturation += 0.05
+    } else {
+      lightness *= 0.93
+      saturation -= 0.03
+    }
+  } else {
+    if (l >= 0.83) {
+      lightness = (lightness - 0.2) * 0.98
+      saturation -= 0.03
+    } else {
+      lightness = (lightness + 0.04) * 1.005
+      saturation += 0.05
+    }
+  }
+
+  if (s <= 0.1 || s >= 0.9) {
+    saturation = s
+  }
+
+  const res = tinycolor.fromRatio({
+    h,
+    s: clip(saturation),
+    l: clip(lightness),
+    a: clip(alpha),
+  })
+
+  return res.toHex8String()
+}
+
+export const getHoveredColorToken = (
+  token: TransformedToken
+): TransformedToken => {
+  const theme = token.filePath.includes('darkTheme') ? 'dark' : 'light'
+  return {
+    ...token,
+    name: `${token.name}-hovered`,
+    value: getHoveredColor(token.value, theme),
+  }
+}

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -14,7 +14,7 @@ export const toCSSDimension = (value: string) =>
 
 const clip = (value: number) => Math.min(Math.max(value, 0), 1)
 
-const getHoveredColor = (value: string, theme: 'dark' | 'light') => {
+export const getHoveredColor = (value: string, theme: 'dark' | 'light') => {
   const color = tinycolor(value)
   const { h, s, l, a } = color.toHsl()
 
@@ -65,18 +65,3 @@ const getHoveredColor = (value: string, theme: 'dark' | 'light') => {
 export const shouldMakeHoveredToken = ({ type, filePath }: TransformedToken) =>
   type === 'color' &&
   (filePath.includes('functional') || filePath.includes('semantic'))
-
-export const getHoveredColorToken = (
-  token: TransformedToken
-): TransformedToken => {
-  const theme = token.filePath.includes('dark') ? 'dark' : 'light'
-  return {
-    ...token,
-    original: {
-      ...token.original,
-      value: null,
-    },
-    name: `${token.name}-hovered`,
-    value: getHoveredColor(token.value, theme),
-  }
-}

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -66,6 +66,10 @@ export const getHoveredColorToken = (
   const theme = token.filePath.includes('darkTheme') ? 'dark' : 'light'
   return {
     ...token,
+    original: {
+      ...token.original,
+      value: null,
+    },
     name: `${token.name}-hovered`,
     value: getHoveredColor(token.value, theme),
   }

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -60,6 +60,10 @@ const getHoveredColor = (value: string, theme: 'dark' | 'light') => {
   return res.toHex8String()
 }
 
+export const shouldMakeHoveredToken = ({ type, filePath }: TransformedToken) =>
+  type === 'color' &&
+  (filePath.includes('functional') || filePath.includes('semantic'))
+
 export const getHoveredColorToken = (
   token: TransformedToken
 ): TransformedToken => {

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -1,8 +1,6 @@
 import { type TransformedToken } from 'style-dictionary'
 import tinycolor from 'tinycolor2'
 
-import { HOVERED } from './constants'
-
 export const toCamelCase = (str: string) =>
   str
     .toLowerCase()
@@ -15,8 +13,6 @@ export const toCSSDimension = (value: string) =>
   /^0[a-zA-Z]+$/.test(value) ? 0 : value
 
 const clip = (value: number) => Math.min(Math.max(value, 0), 1)
-
-export const isHoveredTransformName = (name: string) => name.includes(HOVERED)
 
 const getHoveredColor = (value: string, theme: 'dark' | 'light') => {
   const color = tinycolor(value)

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -67,7 +67,7 @@ export const shouldMakeHoveredToken = ({ type, filePath }: TransformedToken) =>
 export const getHoveredColorToken = (
   token: TransformedToken
 ): TransformedToken => {
-  const theme = token.filePath.includes('darkTheme') ? 'dark' : 'light'
+  const theme = token.filePath.includes('dark') ? 'dark' : 'light'
   return {
     ...token,
     original: {

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -28,26 +28,28 @@ const getHoveredColor = (value: string, theme: 'dark' | 'light') => {
     alpha = alpha * 1.5
   }
 
-  if (theme === 'light') {
-    if (l <= 0.17) {
-      lightness = (l + 0.07) * 1.1
-      saturation += 0.05
+  if (a !== 0) {
+    if (theme === 'light') {
+      if (l <= 0.17) {
+        lightness = (l + 0.07) * 1.1
+        saturation += 0.05
+      } else {
+        lightness *= 0.93
+        saturation -= 0.03
+      }
     } else {
-      lightness *= 0.93
-      saturation -= 0.03
+      if (l >= 0.83) {
+        lightness = (lightness - 0.2) * 0.98
+        saturation -= 0.03
+      } else {
+        lightness = (lightness + 0.04) * 1.005
+        saturation += 0.05
+      }
     }
-  } else {
-    if (l >= 0.83) {
-      lightness = (lightness - 0.2) * 0.98
-      saturation -= 0.03
-    } else {
-      lightness = (lightness + 0.04) * 1.005
-      saturation += 0.05
-    }
-  }
 
-  if (s <= 0.1 || s >= 0.9) {
-    saturation = s
+    if (s <= 0.1 || s >= 0.9) {
+      saturation = s
+    }
   }
 
   const res = tinycolor.fromRatio({

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -24,7 +24,7 @@ const getHoveredColor = (value: string, theme: 'dark' | 'light') => {
 
   if (a === 0) {
     alpha = 0.1
-  } else if (a < 0.2) {
+  } else if (a <= 0.2) {
     alpha = alpha * 1.5
   }
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- https://github.com/channel-io/bezier-react/pull/2422#discussion_r1772647894

## Summary

<!-- Please brief explanation of the changes made -->

- 기존에 hovered token를 만들기 위해 CustomTransform, HoveredTransform 두 벌로 transform 을 만들고 머지 했던 것을 CustomFormat 에서 hovered token 를 생성하는 것으로 구현을 변경합니다. 이 과정에서 alphaCustomCss 포맷을 추가 구현했습니다. 
- semantic 토큰에도 hovered token을 추가했습니다.
- hovered color 생성 공식을 업데이트 합니다. (alpha = 0.2 포함 여부, alpha = 0일 때 saturation, lightness 유지)

## Details

- 이렇게 구현 방법을 바꾸면 transform 을 여러개 만들어야 할 필요가 없어집니다. 또한 js 로 생성되는 빌드 결과에서 darkThemeHovered 값들이 darkTheme 안으로 들어가게 되서 깔끔해지고 styles.css 안에서 선택자가 중복되고 있던 문제가 해결됩니다. 
- hoveredToken 이 tokens 로 들어가게 되면서 storybook 에도 hovered color 가 추가되었습니다. -> color 토큰이 달라질 때 or hovered color공식이 달라질 때 어떻게 달라지는지 크로마틱 UI test 에서 명시적으로 확인해보면 좋은데 foundation/color가 스토리가 아니라서 테스트에 포함이 안되는 것 같네요. 지금은 빌드 결과를 하나씩 비교해야 해서 의도치 않은 변경을 만들기 쉬운 것 같아요. 스토리로 바꾸는 것은 어떨까요? 

<!-- Please elaborate description of the changes -->
As-is
```typescript
// index.js
exports.tokens = Object.freeze({
  darkTheme: require('./darkTheme'),
  darkThemeHovered: require('./darkThemeHovered'),
  global: require('./global'),
  lightTheme: require('./lightTheme'),
  lightThemeHovered: require('./lightThemeHovered'),
});

// darkThemeHovered.js
module.exports = Object.freeze({
  "color": Object.freeze({
    "alpha-color-dim-black-normal-hovered": Object.freeze({"value":"#14141466","ref":null}),
  })
})

// styles.css
[data-bezier-them="dark"] {
  --alpha-color-dim-black-normal: var(--alpha-color-bg-absolute-black-lighter);
} 
...
[data-bezier-theme="dark"] {
  --alpha-color-dim-black-normal-hovered: #14141466;
}
```
To-be
```typescript
// index.js
exports.tokens = Object.freeze({
  darkTheme: require('./darkTheme'),
  global: require('./global'),
  lightTheme: require('./lightTheme'),
});

// darkTheme.js
module.exports = Object.freeze({
  "color": Object.freeze({
    "alpha-color-dim-black-normal": Object.freeze({"value":"#00000066","ref":"alpha-color-bg-absolute-black-lighter"}),
    "alpha-color-dim-black-normal-hovered": Object.freeze({"value":"#14141466"}),
  })
})

// styles.css
[dark-bezier-theme="dark"] {
  --alpha-color-dim-black-normal: var(--alpha-color-bg-absolute-black-lighter);
  --alpha-color-dim-black-normal-hovered: #14141466;
}
```

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- Yes, js 빌드 결과에서 darkThemeHovered, lightThemeHovered 속성이 없어집니다. 

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://styledictionary.com/reference/utils/format-helpers/#_top
- https://www.notion.so/channelio/Pressed-Hover-Color-11b74b55ec7c8020b6fcfe272da7138b
