### PR TITLE
Add use client directive at top of client-component files

### DIFF
--- a/.changeset/gold-nails-crash.md
+++ b/.changeset/gold-nails-crash.md
@@ -1,5 +1,5 @@
 ---
-'@channel.io/bezier-react': patch
+'@channel.io/bezier-react': minor
 ---
 
 The use client directive has been added at the top of all components inside @channel.io/bezier-react.

--- a/.changeset/gold-nails-crash.md
+++ b/.changeset/gold-nails-crash.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+The use client directive has been added at the top of all components inside @channel.io/bezier-react.

--- a/packages/bezier-react/rollup.config.mjs
+++ b/packages/bezier-react/rollup.config.mjs
@@ -113,6 +113,13 @@ const generateConfig = ({ output = [], plugins = [] }) =>
       minifycss(),
       ...plugins,
     ],
+    onwarn(warning, warn) {
+      // Suppress "Module level directives cause errors when bundled" warnings
+      if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
+        return
+      }
+      warn(warning)
+    },
   })
 
 export default defineConfig([

--- a/packages/bezier-react/rollup.config.mjs
+++ b/packages/bezier-react/rollup.config.mjs
@@ -114,8 +114,10 @@ const generateConfig = ({ output = [], plugins = [] }) =>
       ...plugins,
     ],
     onwarn(warning, warn) {
-      // Suppress "Module level directives cause errors when bundled" warnings
-      if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
+      if (
+        warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
+        warning.message.includes('use client')
+      ) {
         return
       }
       warn(warning)

--- a/packages/bezier-react/rollup.config.mjs
+++ b/packages/bezier-react/rollup.config.mjs
@@ -113,13 +113,6 @@ const generateConfig = ({ output = [], plugins = [] }) =>
       minifycss(),
       ...plugins,
     ],
-    onwarn(warning, warn) {
-      // Suppress "Module level directives cause errors when bundled" warnings
-      if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
-        return
-      }
-      warn(warning)
-    },
   })
 
 export default defineConfig([

--- a/packages/bezier-react/src/components/AlphaAvatar/Avatar.tsx
+++ b/packages/bezier-react/src/components/AlphaAvatar/Avatar.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef, useMemo } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/AlphaAvatarGroup/AvatarGroup.tsx
+++ b/packages/bezier-react/src/components/AlphaAvatarGroup/AvatarGroup.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef, useCallback, useMemo } from 'react'
 
 import { MoreIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/AlphaAvatarGroup/AvatarGroup.tsx
+++ b/packages/bezier-react/src/components/AlphaAvatarGroup/AvatarGroup.tsx
@@ -1,4 +1,4 @@
-'use client';
+'use client'
 
 import React, { forwardRef, useCallback, useMemo } from 'react'
 

--- a/packages/bezier-react/src/components/AlphaButton/Button.tsx
+++ b/packages/bezier-react/src/components/AlphaButton/Button.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { isBezierIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/AlphaDialogPrimitive/DialogPrimitive.tsx
+++ b/packages/bezier-react/src/components/AlphaDialogPrimitive/DialogPrimitive.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   Dialog,
   DialogClose,

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { isBezierIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { isBezierIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { isBezierIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/AlphaLoader/Loader.tsx
+++ b/packages/bezier-react/src/components/AlphaLoader/Loader.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/AlphaStatusBadge/StatusBadge.tsx
+++ b/packages/bezier-react/src/components/AlphaStatusBadge/StatusBadge.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { type CSSProperties, forwardRef } from 'react'
 
 import { MoonFilledIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/AlphaToggleButton/ToggleButton.tsx
+++ b/packages/bezier-react/src/components/AlphaToggleButton/ToggleButton.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { isBezierIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/AlphaToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/bezier-react/src/components/AlphaToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef, useMemo } from 'react'
 
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group'

--- a/packages/bezier-react/src/components/AlphaTooltipPrimitive/TooltipPrimitive.tsx
+++ b/packages/bezier-react/src/components/AlphaTooltipPrimitive/TooltipPrimitive.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   Tooltip,
   TooltipArrow,

--- a/packages/bezier-react/src/components/AppProvider/AppProvider.tsx
+++ b/packages/bezier-react/src/components/AppProvider/AppProvider.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useEffect } from 'react'
 
 import { getWindow } from 'ssr-window'

--- a/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
+++ b/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef, useState } from 'react'
 
 import { Slot } from '@radix-ui/react-slot'

--- a/packages/bezier-react/src/components/Avatar/Avatar.tsx
+++ b/packages/bezier-react/src/components/Avatar/Avatar.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef, useMemo } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.tsx
+++ b/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.tsx
@@ -1,3 +1,5 @@
+'use client' 
+
 import React, { forwardRef, useCallback, useMemo } from 'react'
 
 import { MoreIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/Badge/Badge.tsx
+++ b/packages/bezier-react/src/components/Badge/Badge.tsx
@@ -1,3 +1,5 @@
+'use client' 
+
 import React, { forwardRef, memo } from 'react'
 
 import { isEmpty } from '~/src/utils/type'

--- a/packages/bezier-react/src/components/Banner/Banner.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { isBezierIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/BaseButton/BaseButton.tsx
+++ b/packages/bezier-react/src/components/BaseButton/BaseButton.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/BaseTagBadge/BaseTagBadge.tsx
+++ b/packages/bezier-react/src/components/BaseTagBadge/BaseTagBadge.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/Box/Box.tsx
+++ b/packages/bezier-react/src/components/Box/Box.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createElement, forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/Button/Button.tsx
+++ b/packages/bezier-react/src/components/Button/Button.tsx
@@ -1,3 +1,5 @@
+'use client' 
+
 import React, { forwardRef, useCallback } from 'react'
 
 import { isBezierIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { Stack } from '~/src/components/Stack'

--- a/packages/bezier-react/src/components/Center/Center.tsx
+++ b/packages/bezier-react/src/components/Center/Center.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/CheckableAvatar/CheckableAvatar.tsx
+++ b/packages/bezier-react/src/components/CheckableAvatar/CheckableAvatar.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { CheckIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/bezier-react/src/components/Checkbox/Checkbox.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { CheckBoldIcon, HyphenBoldIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/bezier-react/src/components/ConfirmModal/ConfirmModal.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import {

--- a/packages/bezier-react/src/components/Divider/Divider.tsx
+++ b/packages/bezier-react/src/components/Divider/Divider.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import * as SeparatorPrimitive from '@radix-ui/react-separator'

--- a/packages/bezier-react/src/components/Emoji/Emoji.tsx
+++ b/packages/bezier-react/src/components/Emoji/Emoji.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { type CSSProperties, forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/FeatureProvider/FeatureProvider.tsx
+++ b/packages/bezier-react/src/components/FeatureProvider/FeatureProvider.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useMemo, useState } from 'react'
 
 import { useIsomorphicLayoutEffect } from '~/src/hooks/useIsomorphicLayoutEffect'

--- a/packages/bezier-react/src/components/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/FormControl/FormControl.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef, useCallback, useMemo, useState } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/FormGroup/FormGroup.tsx
+++ b/packages/bezier-react/src/components/FormGroup/FormGroup.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import useMergeRefs from '~/src/hooks/useMergeRefs'

--- a/packages/bezier-react/src/components/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/FormHelperText/FormHelperText.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/FormLabel/FormLabel.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/Help/Help.tsx
+++ b/packages/bezier-react/src/components/Help/Help.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { HelpFilledIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/Icon/Icon.tsx
+++ b/packages/bezier-react/src/components/Icon/Icon.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef, memo } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.tsx
+++ b/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { isBezierIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/LegacyIcon/LegacyIcon.tsx
+++ b/packages/bezier-react/src/components/LegacyIcon/LegacyIcon.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { memo } from 'react'
 
 import { icons } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/LegacyStack/LegacyHStack/LegacyHStack.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyHStack/LegacyHStack.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { LegacyStack } from '~/src/components/LegacyStack/LegacyStack'

--- a/packages/bezier-react/src/components/LegacyStack/LegacySpacer/LegacySpacer.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacySpacer/LegacySpacer.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { LegacyStackItem } from '~/src/components/LegacyStack/LegacyStackItem'

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStack/LegacyStack.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, {
   Children,
   cloneElement,

--- a/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyStackItem/LegacyStackItem.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/LegacyStack/LegacyVStack/LegacyVStack.tsx
+++ b/packages/bezier-react/src/components/LegacyStack/LegacyVStack/LegacyVStack.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { LegacyStack } from '~/src/components/LegacyStack/LegacyStack'

--- a/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltip.tsx
+++ b/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltip.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, {
   type Ref,
   forwardRef,

--- a/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltipContent.tsx
+++ b/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltipContent.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactDOM from 'react-dom'
 

--- a/packages/bezier-react/src/components/ListItem/ListItem.tsx
+++ b/packages/bezier-react/src/components/ListItem/ListItem.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { isBezierIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/Modal/Modal.tsx
+++ b/packages/bezier-react/src/components/Modal/Modal.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef, useCallback, useMemo, useState } from 'react'
 
 import { CancelIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/NavGroup/NavGroup.tsx
+++ b/packages/bezier-react/src/components/NavGroup/NavGroup.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import {

--- a/packages/bezier-react/src/components/NavItem/NavItem.tsx
+++ b/packages/bezier-react/src/components/NavItem/NavItem.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef, useMemo } from 'react'
 
 import {

--- a/packages/bezier-react/src/components/Overlay/Overlay.tsx
+++ b/packages/bezier-react/src/components/Overlay/Overlay.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, {
   forwardRef,
   useCallback,

--- a/packages/bezier-react/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/bezier-react/src/components/ProgressBar/ProgressBar.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/bezier-react/src/components/RadioGroup/RadioGroup.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { isBezierIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, {
   type ForwardedRef,
   forwardRef,

--- a/packages/bezier-react/src/components/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Select/Select.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, {
   forwardRef,
   useCallback,

--- a/packages/bezier-react/src/components/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Slider/Slider.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { type CSSProperties, forwardRef, memo } from 'react'
 
 import * as SliderPrimitive from '@radix-ui/react-slider'

--- a/packages/bezier-react/src/components/SmoothCornersBox/SmoothCornersBox.tsx
+++ b/packages/bezier-react/src/components/SmoothCornersBox/SmoothCornersBox.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/Spinner/Spinner.tsx
+++ b/packages/bezier-react/src/components/Spinner/Spinner.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/Stack/Stack.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createElement, forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/Status/Status.tsx
+++ b/packages/bezier-react/src/components/Status/Status.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { type CSSProperties, forwardRef, memo } from 'react'
 
 import { LockIcon, MoonFilledIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/Switch/Switch.tsx
+++ b/packages/bezier-react/src/components/Switch/Switch.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import * as SwitchPrimitive from '@radix-ui/react-switch'

--- a/packages/bezier-react/src/components/Tabs/Tabs.tsx
+++ b/packages/bezier-react/src/components/Tabs/Tabs.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef, useMemo } from 'react'
 
 import { OpenInNewIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/Tag/Tag.tsx
+++ b/packages/bezier-react/src/components/Tag/Tag.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef, memo } from 'react'
 
 import { CancelSmallIcon } from '@channel.io/bezier-icons'

--- a/packages/bezier-react/src/components/Text/Text.tsx
+++ b/packages/bezier-react/src/components/Text/Text.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { createElement, forwardRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/TextArea/TextArea.tsx
+++ b/packages/bezier-react/src/components/TextArea/TextArea.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef, useRef } from 'react'
 
 import classNames from 'classnames'

--- a/packages/bezier-react/src/components/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/TextField/TextField.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, {
   forwardRef,
   useCallback,

--- a/packages/bezier-react/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/bezier-react/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { forwardRef } from 'react'
 
 import { Slot } from '@radix-ui/react-slot'

--- a/packages/bezier-react/src/components/Toast/Toast.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 

--- a/packages/bezier-react/src/components/TokenProvider/TokenProvider.tsx
+++ b/packages/bezier-react/src/components/TokenProvider/TokenProvider.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useMemo } from 'react'
 
 import { tokens } from '@channel.io/bezier-tokens'

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, {
   forwardRef,
   useCallback,

--- a/packages/bezier-react/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/bezier-react/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 
 import * as VisuallyHiddenPrimitive from '@radix-ui/react-visually-hidden'

--- a/packages/bezier-react/src/components/WindowProvider/WindowProvider.tsx
+++ b/packages/bezier-react/src/components/WindowProvider/WindowProvider.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useMemo } from 'react'
 
 import { createContext } from '~/src/utils/react'


### PR DESCRIPTION
components that use react hook or memo...

<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue
#2456 (not close or fixes)
<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

## Summary

<!-- Please brief explanation of the changes made -->
- Add `use client` directives

## Details

<!-- Please elaborate description of the changes -->
- I add `use client` directives to all component filds
- I didn't see any code that used the window API.
- ~~I am not sure about files that `Radix` exports without additional logic.~~
  - As suggested in the comments, I tested it in the code sandbox and found no problems.
  - Currently, directives have been added including this one. When I checked, I saw that hooks, etc. were used in the internal implementation.
```typescript
// page.tsx
import * as Dialog from "@radix-ui/react-dialog";
import * as Tooltip from "@radix-ui/react-tooltip";
import * as Separator from "@radix-ui/react-separator";
import * as Switch from "@radix-ui/react-switch";
import * as VisuallyHidden from "@radix-ui/react-visually-hidden";

export default function Home() {
  return (
    <main className="flex min-h-screen flex-col items-center justify-between p-24">
      {/* code with radix-ui ...*/}
    </main>
  );
}
```
- Add the changeset
- To ignore `Module level directives cause errors when bundled` warnings, I returned onWarn early when the warning appeared.It seemed appropriate to write it inside the `generateConfig`.

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->
No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->
https://github.com/remix-run/remix/issues/8891
https://github.com/rollup/rollup/issues/4699