### PR TITLE
Fix bug of "+1" emoji not rendering

### DIFF
--- a/.changeset/stale-spoons-guess.md
+++ b/.changeset/stale-spoons-guess.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Fix a bug where "+1" emoji does not render.

--- a/packages/bezier-react/src/components/Emoji/Emoji.tsx
+++ b/packages/bezier-react/src/components/Emoji/Emoji.tsx
@@ -12,7 +12,7 @@ import styles from './Emoji.module.scss'
 export const EMOJI_TEST_ID = 'bezier-emoji'
 
 const getEmojiUrl = (name: EmojiProps['name'], size: '160' | '80' | '44') => {
-  return `https://cf${isDev() ? '.exp' : ''}.channel.io/asset/emoji/images/${size}/${name}.png`
+  return `https://cf${isDev() ? '.exp' : ''}.channel.io/asset/emoji/images/${size}/${encodeURIComponent(name)}.png`
 }
 
 /**


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- Fixes #2449 

## Summary

- "+1"(👍) 이모지가 렌더링 되지 않은 버그를 수정합니다. 

<!-- Please brief explanation of the changes made -->

## Details

<!-- Please elaborate description of the changes -->

- emoji 이름으로 부터 url 을 계산할 때 인코딩 처리가 누락되어 있던 것이 원인이었습니다. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- None
