### PR TITLE
Remove 1px gap in `s` size `AlphaButton`

### DIFF
--- a/.changeset/chatty-singers-grab.md
+++ b/.changeset/chatty-singers-grab.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Remove 1px gap between icon and text in `s` size `AlphaButton`, `AlphaFloatingButton`.

--- a/packages/bezier-react/src/components/AlphaButton/Button.module.scss
+++ b/packages/bezier-react/src/components/AlphaButton/Button.module.scss
@@ -26,10 +26,6 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     & :where(.ButtonText) {
       padding: 0 3px;
     }
-
-    & :where(.ButtonContent) {
-      gap: 1px;
-    }
   }
 
   &:where(.size-m) {

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.module.scss
@@ -31,10 +31,6 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     & :where(.ButtonText) {
       padding: 0 4px;
     }
-
-    & :where(.ButtonContent) {
-      gap: 1px;
-    }
   }
 
   &:where(.size-m) {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- 없음 

## Summary

<!-- Please brief explanation of the changes made -->

- `s` 사이즈의 `AlphaButton`, `AlphaFloatingButton`에 있는 1px 갭을 제거합니다. 

## Details

<!-- Please elaborate description of the changes -->

- 생략 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://desk.channel.io/root/groups/v2BezierRelease-364583/67246bd9e9aa76c8de5d
