### PR TITLE
Change autocomplete logic of `bezier-vscode` 

### DIFF
--- a/.changeset/sixty-horses-care.md
+++ b/.changeset/sixty-horses-care.md
@@ -1,0 +1,5 @@
+---
+'bezier-vscode': minor
+---
+
+Change autocomplete logic. Now token name can trigger autocomplete even without `var` string.

--- a/packages/bezier-vscode/src/server.ts
+++ b/packages/bezier-vscode/src/server.ts
@@ -43,15 +43,15 @@ const completionItemsByTokenGroup = Object.fromEntries(
 ) as Record<TokenGroup, CompletionItem[]>
 
 const tokenGroupPatterns = {
-  radius: /border-radius/,
-  color: /color|background|border(?!-radius)|outline|background-color/,
-  elevation: /box-shadow/,
-  input: /box-shadow/,
-  typography: /font|letter-spacing|line-height/,
-  font: /font|letter-spacing|line-height/,
-  transition: /transition/,
-  opacity: /opacity/,
-  'z-index': /z-index/,
+  radius: /border-radius:/,
+  color: /color:|background:|border(?!-radius):|outline:|background-color:/,
+  elevation: /box-shadow:/,
+  input: /box-shadow:/,
+  typography: /font:|letter-spacing|line-height:/,
+  font: /font:|letter-spacing:|line-height:/,
+  transition: /transition:/,
+  opacity: /opacity:/,
+  'z-index': /z-index:/,
 } satisfies Record<TokenGroup, RegExp>
 
 const allCompletionItems = Object.values(completionItemsByTokenGroup).flat()

--- a/packages/bezier-vscode/src/server.ts
+++ b/packages/bezier-vscode/src/server.ts
@@ -29,8 +29,8 @@ const completionItemsByTokenGroup = Object.fromEntries(
     const completionItems: CompletionItem[] = Object.entries(
       tokenKeyValues
     ).map(([key, value]) => ({
-      label: `--${key}`,
-      insertText: `--${key}`,
+      label: key,
+      insertText: `var(--${key})`,
       // RGBA conversion to display color preview in suggestion item
       detail: groupName === 'color' ? hexToRGBA(value) : String(value),
       kind:
@@ -69,7 +69,7 @@ connection.onInitialize(() => {
       textDocumentSync: TextDocumentSyncKind.Incremental,
       // Tell the client that this server supports code completion.
       completionProvider: {
-        triggerCharacters: ['--'],
+        resolveProvider: true,
       },
     },
   }
@@ -97,7 +97,11 @@ connection.onCompletion(
       end: { line: _textDocumentPosition.position.line, character: 1000 },
     })
 
-    if (!currentText.includes('var(')) {
+    if (
+      Object.values(tokenGroupPatterns).every(
+        (pattern) => !pattern.test(currentText)
+      )
+    ) {
       return []
     }
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- https://github.com/channel-io/bezier-react/issues/2485

## Summary

<!-- Please brief explanation of the changes made -->

- `bezier-vscode` 익스텐션의 자동완성 로직을 아래와 같이 변경합니다. 

## Details

<!-- Please elaborate description of the changes -->

- 바꾸는 이유는 이슈를 참고해주세요. 

As-is 

https://github.com/user-attachments/assets/617d5872-ef8d-4613-aad4-3f6f5471d480



To-be


https://github.com/user-attachments/assets/fe146de3-2aa5-47b1-88b7-f4b03b23a9e1



### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- None