### PR TITLE
Add `alpha` token to autocomplete suggestion of `bezier-vscode`

### DIFF
--- a/.changeset/selfish-ladybugs-reply.md
+++ b/.changeset/selfish-ladybugs-reply.md
@@ -1,0 +1,5 @@
+---
+'bezier-vscode': minor
+---
+
+Include `alpha` token for autocomplete suggestion.

--- a/packages/bezier-vscode/src/server.ts
+++ b/packages/bezier-vscode/src/server.ts
@@ -14,20 +14,22 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 
 import { deepMerge, hexToRGBA } from './utils'
 
-type TokenValue = string | number | Record<string, string | number>
-type TokenMap = Record<string, Record<string, TokenValue>>
+type TokenValue = string | number
+type AlphaTokenValue = Record<string, string | number>
+type TokenMap = Record<string, Record<string, TokenValue | AlphaTokenValue>>
 
 const assignToTokenMap = (
   target: TokenMap,
   source: TokenMap,
-  fn: Function = (v: TokenMap) => v
+  transformValue: (v: TokenValue | AlphaTokenValue) => TokenValue = (v) =>
+    v as TokenValue
 ) => {
   Object.entries(source).forEach(([category, tokenObject]) => {
     if (target[category] === undefined) {
       target[category] = {}
     }
     Object.entries(tokenObject).forEach(([name, value]) => {
-      target[category][name] = fn(value)
+      target[category][name] = transformValue(value)
     })
   })
 }
@@ -38,12 +40,12 @@ const tokenMap = {} as TokenMap
 assignToTokenMap(
   alphaTokenMap,
   alphaTokens.lightTheme,
-  (v: Record<string, string>) => v.value
+  (v) => (v as AlphaTokenValue).value
 )
 assignToTokenMap(
   alphaTokenMap,
   alphaTokens.global,
-  (v: Record<string, string>) => v.value
+  (v) => (v as AlphaTokenValue).value
 )
 assignToTokenMap(tokenMap, tokens.lightTheme)
 assignToTokenMap(tokenMap, tokens.global)

--- a/packages/bezier-vscode/src/server.ts
+++ b/packages/bezier-vscode/src/server.ts
@@ -14,45 +14,41 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 
 import { deepMerge, hexToRGBA } from './utils'
 
-const alphaTokenMap = {} as Record<string, Record<string, string>>
+type TokenMap = Record<
+  string,
+  Record<string, string | number | Record<string, string | number>>
+>
 
-Object.entries(alphaTokens.lightTheme).forEach(([key, value]) => {
-  if (alphaTokenMap[key] === undefined) {
-    alphaTokenMap[key] = {}
-  }
-  Object.entries(value).forEach(([token, valueRefObject]) => {
-    alphaTokenMap[key][token] = valueRefObject.value
+const assignToTokenMap = (
+  target: TokenMap,
+  source: TokenMap,
+  fn: Function = (v: Record<string, string> | string) => v
+) => {
+  Object.entries(source).forEach(([key, value]) => {
+    if (target[key] === undefined) {
+      target[key] = {}
+    }
+    Object.entries(value).forEach(([token, tokenValue]) => {
+      target[key][token] = fn(tokenValue)
+    })
   })
-})
+}
 
-Object.entries(alphaTokens.global).forEach(([key, value]) => {
-  if (alphaTokenMap[key] === undefined) {
-    alphaTokenMap[key] = {}
-  }
-  Object.entries(value).forEach(([token, valueRefObject]) => {
-    alphaTokenMap[key][token] = valueRefObject.value
-  })
-})
+const alphaTokenMap = {} as TokenMap
+const tokenMap = {} as TokenMap
 
-const tokenMap = {} as Record<string, Record<string, string>>
-
-Object.entries(tokens.lightTheme).forEach(([key, value]) => {
-  if (tokenMap[key] === undefined) {
-    tokenMap[key] = {}
-  }
-  Object.entries(value).forEach(([token, value]) => {
-    tokenMap[key][token] = value
-  })
-})
-
-Object.entries(tokens.global).forEach(([key, value]) => {
-  if (tokenMap[key] === undefined) {
-    tokenMap[key] = {}
-  }
-  Object.entries(value).forEach(([token, value]) => {
-    tokenMap[key][token] = value
-  })
-})
+assignToTokenMap(
+  alphaTokenMap,
+  alphaTokens.lightTheme,
+  (v: Record<string, string>) => v.value
+)
+assignToTokenMap(
+  alphaTokenMap,
+  alphaTokens.global,
+  (v: Record<string, string>) => v.value
+)
+assignToTokenMap(tokenMap, tokens.lightTheme)
+assignToTokenMap(tokenMap, tokens.global)
 
 const allTokenMap = deepMerge(alphaTokenMap, tokenMap) as Record<
   | keyof typeof alphaTokens.global

--- a/packages/bezier-vscode/src/server.ts
+++ b/packages/bezier-vscode/src/server.ts
@@ -90,7 +90,7 @@ const tokenGroupPatterns = {
   shadow: /box-shadow:/,
   gradient: /background:|background-image:/,
   'z-index': /z-index:/,
-  // FIXME: dimension token should be supported later
+  // FIXME: delete Exclude when dimension token is removed
 } satisfies Record<Exclude<TokenGroup, 'dimension'>, RegExp>
 
 const allCompletionItems = Object.values(completionItemsByTokenGroup).flat()

--- a/packages/bezier-vscode/src/server.ts
+++ b/packages/bezier-vscode/src/server.ts
@@ -88,6 +88,7 @@ const tokenGroupPatterns = {
   shadow: /box-shadow:/,
   gradient: /background:|background-image:/,
   'z-index': /z-index:/,
+  // FIXME: dimension token should be supported later
 } satisfies Record<Exclude<TokenGroup, 'dimension'>, RegExp>
 
 const allCompletionItems = Object.values(completionItemsByTokenGroup).flat()

--- a/packages/bezier-vscode/src/utils.ts
+++ b/packages/bezier-vscode/src/utils.ts
@@ -11,3 +11,26 @@ export const hexToRGBA = (hex: string) => {
   }
   return `rgba(${r}, ${g}, ${b}, 1)`
 }
+
+export const deepMerge = (target: any, source: any) => {
+  if (!source || !isObject(source)) return target
+
+  Object.keys(source).forEach((key) => {
+    const targetValue = target[key]
+    const sourceValue = source[key]
+
+    if (isObject(targetValue) && isObject(sourceValue)) {
+      target[key] = deepMerge(Object.assign({}, targetValue), sourceValue)
+    } else if (Array.isArray(targetValue) && Array.isArray(sourceValue)) {
+      target[key] = Array.from(new Set([...targetValue, ...sourceValue]))
+    } else {
+      target[key] = sourceValue
+    }
+  })
+
+  return target
+}
+
+const isObject = (obj: Object) => {
+  return obj && typeof obj === 'object' && !Array.isArray(obj)
+}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- https://github.com/channel-io/bezier-react/issues/2485

## Summary

<!-- Please brief explanation of the changes made -->

- alpha 토큰도 자동완성 추천에 나오도록 합니다. 

## Details

<!-- Please elaborate description of the changes -->

- legacy token, alpha token 별로 `{ category: { [name]: value }` 객체를  assignToTokenMap 함수를 통해 만든 다음에 딥 머지를 했습니다. 이 때 alpha token의 "dimension" category 는 바뀔 예정이라 제외했습니다. 

https://github.com/user-attachments/assets/6c14d51c-9e44-4de7-92c9-419cf933959e





### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- None