### PR TITLE
Add `clickable` property to `ListItem` and `OutlineItem`

### DIFF
--- a/.changeset/chilly-masks-battle.md
+++ b/.changeset/chilly-masks-battle.md
@@ -1,0 +1,6 @@
+---
+'@channel.io/bezier-react': minor
+---
+
+- Add `clickable` property to `ListItem` and `OutlineItem`. This property makes the component appear clickable even when it's not inherently interactive.
+- `OutlineItem` now does not have a clickable style by default.

--- a/packages/bezier-react/src/components/ListItem/ListItem.tsx
+++ b/packages/bezier-react/src/components/ListItem/ListItem.tsx
@@ -43,15 +43,16 @@ export const ListItem = forwardRef<ListItemRef, ListItemProps>(
       active = false,
       focused = false,
       disabled = false,
+      clickable: clickableProp = false,
       href,
       onClick,
       ...rest
     },
     forwardedRef
   ) {
-    const clickable = !isNil(onClick)
     const isLink = !isEmpty(href)
     const Comp = isLink ? 'a' : ((as ?? 'div') as 'div')
+    const clickable = isLink || clickableProp || !isNil(onClick)
 
     return (
       <Comp

--- a/packages/bezier-react/src/components/ListItem/ListItem.types.ts
+++ b/packages/bezier-react/src/components/ListItem/ListItem.types.ts
@@ -7,6 +7,7 @@ import type {
   BezierComponentProps,
   ContentProps,
   DisableProps,
+  InteractiveStyleProps,
   LinkProps,
   PolymorphicProps,
   SideContentProps,
@@ -19,7 +20,6 @@ export type ListItemSize = 'xs' | 's' | 'm' | 'l'
 export type ListItemVariant = 'blue' | 'red' | 'green' | 'cobalt' | 'monochrome'
 
 interface ListItemOwnProps {
-  focused?: boolean
   description?: React.ReactNode
   descriptionMaxLines?: number
 }
@@ -34,4 +34,5 @@ export interface ListItemProps
     LinkProps,
     DisableProps,
     ActivatableProps,
+    InteractiveStyleProps,
     ListItemOwnProps {}

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.module.scss
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.module.scss
@@ -1,6 +1,4 @@
 .OutlineItem {
-  cursor: pointer;
-
   display: flex;
   align-items: center;
 
@@ -17,6 +15,10 @@
     background-color var(--transition-s),
     color var(--transition-s);
 
+  &:where(.clickable) {
+    cursor: pointer;
+  }
+
   &:where(.active) {
     color: var(--bgtxt-blue-normal);
     background-color: var(--bgtxt-blue-lightest);
@@ -26,7 +28,7 @@
     }
   }
 
-  &:where(:not(.active):where(.focused, :hover)) {
+  &:where(.clickable:not(.active):where(.focused, :hover)) {
     background-color: var(--bg-black-lighter);
   }
 }

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
@@ -43,10 +43,12 @@ export const OutlineItem = forwardRef<
     disableChevron = false,
     active = false,
     focused = false,
+    clickable: clickableProp = false,
     leftContent,
     content,
     rightContent,
     href,
+    onClick,
     ...rest
   },
   forwardedRef
@@ -57,6 +59,7 @@ export const OutlineItem = forwardRef<
 
   const isLink = !isEmpty(href)
   const Comp = isLink ? 'a' : ((as ?? 'div') as 'div')
+  const clickable = isLink || clickableProp || !isNil(onClick)
 
   return (
     <>
@@ -76,10 +79,12 @@ export const OutlineItem = forwardRef<
           styles.OutlineItem,
           active && styles.active,
           focused && styles.focused,
+          clickable && styles.clickable,
           className
         )}
         ref={forwardedRef}
         data-testid={OUTLINE_ITEM_TEST_ID}
+        onClick={onClick}
         {...rest}
       >
         {!disableChevron && (

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.types.ts
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.types.ts
@@ -5,6 +5,7 @@ import type {
   BezierComponentProps,
   ChildrenProps,
   ContentProps,
+  InteractiveStyleProps,
   LinkProps,
   PolymorphicProps,
   SideContentProps,
@@ -16,7 +17,6 @@ export interface OutlineItemContextProps {
 
 interface OutlineItemOwnProps {
   open?: boolean
-  focused?: boolean
   disableChevron?: boolean
 }
 
@@ -28,4 +28,5 @@ export interface OutlineItemProps
     SideContentProps<BezierIcon | React.ReactNode, React.ReactNode>,
     ActivatableProps,
     LinkProps,
+    InteractiveStyleProps,
     OutlineItemOwnProps {}

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -199,6 +199,21 @@ export interface LinkProps {
 }
 
 /**
+ * Props for components that are not inherently interactive but can be styled as interactive,
+ * such as when they are children of an anchor element.
+ */
+export interface InteractiveStyleProps {
+  /**
+   * When true, applies styles that make the component appear clickable.
+   */
+  clickable?: boolean
+  /**
+   * When true, applies styles that make the component appear focused.
+   */
+  focused?: boolean
+}
+
+/**
  * Props for specifying margins around a component.
  */
 export interface MarginProps {

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -126,6 +126,7 @@ export interface SideContentProps<
 export interface DisableProps {
   /**
    * Whether the component is disabled.
+   * @default false
    */
   disabled?: boolean
 }
@@ -184,6 +185,7 @@ export type AdditionalColorProps<ElementName extends PropNameType> =
 export interface ActivatableProps {
   /**
    * Whether the component is active.
+   * @default false
    */
   active?: boolean
 }
@@ -205,10 +207,12 @@ export interface LinkProps {
 export interface InteractiveStyleProps {
   /**
    * When true, applies styles that make the component appear clickable.
+   * @default false
    */
   clickable?: boolean
   /**
    * When true, applies styles that make the component appear focused.
+   * @default false
    */
   focused?: boolean
 }
@@ -449,14 +453,17 @@ export type FormFieldSize = 'xl' | 'l' | 'm' | 'xs'
 export interface FormFieldProps extends DisableProps, Partial<IdentifierProps> {
   /**
    * Indicates whether the validation failed.
+   * @default false
    */
   hasError?: boolean
   /**
    * Indicates that the user must specify a value for the input before the owning form can be submitted.
+   * @default false
    */
   required?: boolean
   /**
    * Indicates that the user cannot modify the value of the input.
+   * @default false
    */
   readOnly?: boolean
 }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

## Summary

<!-- Please brief explanation of the changes made -->

Add `clickable` property to `ListItem` and `OutlineItem`

## Details

<!-- Please elaborate description of the changes -->

- `ListItem` 의 경우 실제 사용처에서 링크 역할을 하는 컴포넌트 등 상호작용 가능한 요소의 자식 요소로 사용되는 경우가 많습니다. 이 경우 `onClick` 의 여부만으로 클릭 가능한 스타일을 적용하기가 애매합니다. `clickable` 속성을 추가하여 이런 케이스를 사용처에서 핸들링할 수 있도록 했습니다.
- [Material UI](https://mui.com/material-ui/react-list/)처럼 `ListItemButton` 같은 컴포넌트를 따로 제공하는 방법이 이상적으로 보여지나, 당장 적용하기에는 브레이킹 체인지가 되어야 해서(ListItem은 아예 호버 스타일 등을 지원하지 않는 방향이 되어야겠죠) 적용하기 어렵다고 판단했습니다. 새로운 디자인 시스템 컴포넌트를 구현하고 있는 상황이니 최대한 변경이 적은 방향을 선택했습니다.
- `OutlineItem` 도 `ListItem` 과 비슷한 류로 활용되는 경우가 많아 `clickable` 속성을 추가했습니다.
- 클릭 가능 여부를 판단할 때 각 컴포넌트의 링크 존재 여부를 고려하도록 했습니다.
  - (p.s. 링크로 사용하는 사용처가 데스크에 전혀 없어서, 추후에는 제거하고 링크를 더 잘 사용할 수 있는 방안을 찾아봐야할듯)
- `focused`, `clickable` 속성을 `InteractiveStyleProps` 공용 인터페이스로 분리하고 JSdoc을 추가했습니다.

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://mui.com/material-ui/react-list/
