### PR TITLE
Fix icon size of xs `AlphaButton`

### DIFF
--- a/.changeset/few-jokes-worry.md
+++ b/.changeset/few-jokes-worry.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Decreate icon size of `AlphaButton`, `AlphaIconbutton`, `AlphaFloatingButton`, and `AlphaFloatingIconButton`.

--- a/packages/bezier-react/src/components/AlphaButton/Button.tsx
+++ b/packages/bezier-react/src/components/AlphaButton/Button.tsx
@@ -37,7 +37,7 @@ function SideContent({
 function getIconSize(size: ButtonSize) {
   return (
     {
-      xs: 'xxs',
+      xs: 'xs',
       s: 'xs',
       m: 's',
       l: 's',

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
@@ -37,7 +37,7 @@ function SideContent({
 function getIconSize(size: FloatingButtonSize) {
   return (
     {
-      xs: 'xxs',
+      xs: 'xs',
       s: 'xs',
       m: 's',
       l: 's',

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.module.scss
@@ -52,7 +52,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
   &:where(.size-xs) {
     @include dimension.square(20px);
 
-    padding: 4px;
+    padding: 2px;
   }
 
   &:where(.size-s) {

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
@@ -16,7 +16,7 @@ import styles from './FloatingIconButton.module.scss'
 function getIconSize(size: ButtonSize) {
   return (
     {
-      xs: 'xxs',
+      xs: 'xs',
       s: 'xs',
       m: 's',
       l: 's',

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.module.scss
@@ -13,7 +13,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
   &:where(.size-xs) {
     @include dimension.square(20px);
 
-    padding: 4px;
+    padding: 2px;
   }
 
   &:where(.size-s) {

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
@@ -16,7 +16,7 @@ import styles from './IconButton.module.scss'
 function getIconSize(size: ButtonSize) {
   return (
     {
-      xs: 'xxs',
+      xs: 'xs',
       s: 'xs',
       m: 's',
       l: 's',


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary

<!-- Please brief explanation of the changes made -->

- xs 버튼의 아이콘 사이즈를 xxs에서 xs로 조절합니다. IconButton 에서는 패딩도 같이 조절합니다. 

## Details

<!-- Please elaborate description of the changes -->

- 없음 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->
