### PR TITLE
feat: add functionality to control arguments based on JSDoc in dev mode

### DIFF
--- a/.changeset/good-cheetahs-study.md
+++ b/.changeset/good-cheetahs-study.md
@@ -1,0 +1,5 @@
+---
+'tsconfig': minor
+---
+
+add functionality to control arguments based on JSDoc in dev mode

--- a/.changeset/good-cheetahs-study.md
+++ b/.changeset/good-cheetahs-study.md
@@ -1,5 +1,0 @@
----
-'tsconfig': minor
----
-
-add functionality to control arguments based on JSDoc in dev mode

--- a/packages/bezier-react/.storybook/main.ts
+++ b/packages/bezier-react/.storybook/main.ts
@@ -65,8 +65,7 @@ export default {
      * `react-docgen-typescript-plugin` introduces significant overhead
      * when HMR is enabled, so we enable it only in production.
      */
-    reactDocgen:
-      process.env.NODE_ENV === 'production' && 'react-docgen-typescript',
+    reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
       shouldRemoveUndefinedFromOptional: true,
       shouldExtractLiteralValuesFromEnum: true,

--- a/packages/bezier-react/.storybook/main.ts
+++ b/packages/bezier-react/.storybook/main.ts
@@ -61,10 +61,6 @@ export default {
   ],
 
   typescript: {
-    /**
-     * `react-docgen-typescript-plugin` introduces significant overhead
-     * when HMR is enabled, so we enable it only in production.
-     */
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
       shouldRemoveUndefinedFromOptional: true,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

close web-7689

## Summary

<!-- Please brief explanation of the changes made -->

Enable JSDoc-based argument controls in development mode

## Details

<!-- Please elaborate description of the changes -->

This PR removes the production-only restriction for the react-docgen-typescript-plugin that generates Storybook documentation from JSDoc comments. As tested, enabling this feature in development mode doesn't seem to cause significant performance issues that were initially concerns. This change will provide a consistent documentation experience across both development and production environments.
Related to PR #931 which originally introduced the JSDoc-based documentation generation but limited it to production builds due to performance concerns.

### Breaking change? (Yes/No)
- No

<!-- If Yes, please describe the impact and migration path for users -->

## References

<!-- Please list any other resources or points the reviewer should be aware of -->
