### PR TITLE
fix(Overlay): Ensure dropdownZIndex properly overrides Overlay z-index

### DIFF
--- a/.changeset/serious-donuts-hug.md
+++ b/.changeset/serious-donuts-hug.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': minor
+---
+
+Ensure dropdownZIndex properly overrides Overlay z-index

--- a/.changeset/serious-donuts-hug.md
+++ b/.changeset/serious-donuts-hug.md
@@ -1,5 +1,5 @@
 ---
-'@channel.io/bezier-react': minor
+'@channel.io/bezier-react': patch
 ---
 
-Ensure dropdownZIndex properly overrides Overlay z-index
+Ensure `dropdownZIndex` property of `Select` properly overrides `Overlay` z-index

--- a/packages/bezier-react/src/components/Overlay/Overlay.module.scss
+++ b/packages/bezier-react/src/components/Overlay/Overlay.module.scss
@@ -20,7 +20,6 @@
 
 .Overlay {
   position: absolute;
-  z-index: var(--z-index-overlay);
 
   &:where(.hidden) {
     opacity: 0;

--- a/packages/bezier-react/src/components/Overlay/Overlay.tsx
+++ b/packages/bezier-react/src/components/Overlay/Overlay.tsx
@@ -15,6 +15,7 @@ import classNames from 'classnames'
 import useEventHandler from '~/src/hooks/useEventHandler'
 import { useIsomorphicLayoutEffect } from '~/src/hooks/useIsomorphicLayoutEffect'
 import useMergeRefs from '~/src/hooks/useMergeRefs'
+import { getZIndexClassName } from '~/src/types/props-helpers'
 
 import { useModalContainerContext } from '~/src/components/Modal'
 import { ThemeProvider, useThemeName } from '~/src/components/ThemeProvider'
@@ -52,6 +53,7 @@ export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(
       containerClassName,
       onHide,
       onTransitionEnd,
+      zIndex = 'overlay',
       ...rest
     },
     forwardedRef
@@ -230,11 +232,14 @@ export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(
       return null
     }
 
+    const zIndexClassName = getZIndexClassName(zIndex)
+
     const Content = (
       <ThemeProvider themeName={themeName}>
         <div
           className={classNames(
             styles.Overlay,
+            zIndexClassName,
             !shouldShow && styles.hidden,
             withTransition && styles.transition,
             className

--- a/packages/bezier-react/src/components/Overlay/Overlay.tsx
+++ b/packages/bezier-react/src/components/Overlay/Overlay.tsx
@@ -232,14 +232,12 @@ export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(
       return null
     }
 
-    const zIndexClassName = getZIndexClassName(zIndex)
-
     const Content = (
       <ThemeProvider themeName={themeName}>
         <div
           className={classNames(
             styles.Overlay,
-            zIndexClassName,
+            getZIndexClassName(zIndex),
             !shouldShow && styles.hidden,
             withTransition && styles.transition,
             className

--- a/packages/bezier-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/bezier-react/src/components/Overlay/Overlay.types.ts
@@ -57,16 +57,16 @@ interface OverlayOwnProps {
   withTransition?: boolean
   enableClickOutside?: boolean
   onHide?: () => void
-}
 
-export interface OverlayProps
-  extends BezierComponentProps<'div'>,
-    ChildrenProps,
-    AdditionalOverridableStyleProps<'container'>,
-    OverlayOwnProps {
   /**
    * z-index of the overlay.
    * @default 'overlay'
    */
   zIndex?: ZIndex
 }
+
+export interface OverlayProps
+  extends BezierComponentProps<'div'>,
+    ChildrenProps,
+    AdditionalOverridableStyleProps<'container'>,
+    OverlayOwnProps {}

--- a/packages/bezier-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/bezier-react/src/components/Overlay/Overlay.types.ts
@@ -64,5 +64,9 @@ export interface OverlayProps
     ChildrenProps,
     AdditionalOverridableStyleProps<'container'>,
     OverlayOwnProps {
+  /**
+   * z-index of the overlay.
+   * @default 'overlay'
+   */
   zIndex?: ZIndex
 }

--- a/packages/bezier-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/bezier-react/src/components/Overlay/Overlay.types.ts
@@ -3,6 +3,7 @@ import {
   type BezierComponentProps,
   type ChildrenProps,
 } from '~/src/types/props'
+import { type ZIndex } from '~/src/types/tokens'
 
 export interface ContainerRectAttr {
   containerWidth: number
@@ -62,4 +63,6 @@ export interface OverlayProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,
     AdditionalOverridableStyleProps<'container'>,
-    OverlayOwnProps {}
+    OverlayOwnProps {
+  zIndex?: ZIndex
+}

--- a/packages/bezier-react/src/components/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Select/Select.tsx
@@ -18,10 +18,7 @@ import {
 } from '@channel.io/bezier-icons'
 import classNames from 'classnames'
 
-import {
-  getFormFieldSizeClassName,
-  getZIndexClassName,
-} from '~/src/types/props-helpers'
+import { getFormFieldSizeClassName } from '~/src/types/props-helpers'
 import { isEmpty } from '~/src/utils/type'
 
 import { BaseButton } from '~/src/components/BaseButton'
@@ -181,12 +178,9 @@ export const Select = forwardRef<SelectRef, SelectProps>(function Select(
       </BaseButton>
 
       <Overlay
+        zIndex={dropdownZIndex}
         style={dropdownStyle}
-        className={classNames(
-          styles.SelectDropdown,
-          getZIndexClassName(dropdownZIndex),
-          dropdownClassName
-        )}
+        className={classNames(styles.SelectDropdown, dropdownClassName)}
         withTransition
         show={isDropdownOpened && !disabled}
         marginX={dropdownMarginX}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

resolves #2615 

## Summary

<!-- Please brief explanation of the changes made -->

- Applied getZIndexClassName to ensure correct z-index stacking.
- Verified that dropdownZIndex now correctly overrides the default z-index in Overlay.
- Checked for similar issues in related components to prevent future conflicts.

## Details

<!-- Please elaborate description of the changes -->

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/dddc1404-4808-48aa-9350-9944afaa954d" />

