### PR TITLE
Silence aria-descriedby warning in test

### DIFF
--- a/packages/bezier-react/src/components/Modal/Modal.test.tsx
+++ b/packages/bezier-react/src/components/Modal/Modal.test.tsx
@@ -333,7 +333,11 @@ describe('Modal', () => {
           <ModalTrigger>
             <button type="button">{TRIGGER_TEXT}</button>
           </ModalTrigger>
-          <ModalContent>
+          <ModalContent aria-describedby={undefined}>
+            <ModalHeader
+              hidden
+              title={TITLE_TEXT}
+            />
             <ModalBody>
               <input type="text" />
             </ModalBody>

--- a/packages/bezier-react/src/components/Modal/Modal.test.tsx
+++ b/packages/bezier-react/src/components/Modal/Modal.test.tsx
@@ -157,6 +157,7 @@ describe('Modal', () => {
       it("should have proper 'aria-labelledby' attribute (only title)", () => {
         const { getByRole } = renderOpenedModal({
           modalHeaderProps: { title: TITLE_TEXT, subtitle: null },
+          modalContentProps: { 'aria-describedby': undefined },
         })
         expect(getByRole('dialog', { name: TITLE_TEXT })).toBeInTheDocument()
       })
@@ -164,6 +165,7 @@ describe('Modal', () => {
       it("should have proper 'aria-labelledby' attribute (hidden title)", () => {
         const { getByRole } = renderOpenedModal({
           modalHeaderProps: { title: TITLE_TEXT, subtitle: null, hidden: true },
+          modalContentProps: { 'aria-describedby': undefined },
         })
         expect(getByRole('dialog', { name: TITLE_TEXT })).toBeInTheDocument()
       })
@@ -248,6 +250,7 @@ describe('Modal', () => {
 
       it("should be visually hidden when the 'hidden' prop is true", () => {
         const { queryByRole } = renderOpenedModal({
+          modalContentProps: { 'aria-describedby': undefined },
           modalHeaderProps: { title: TITLE_TEXT, hidden: true },
         })
         /**


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary

<!-- Please brief explanation of the changes made -->

2개의 콘솔 warning과 error 메시지를 제거합니다. 
```Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.```
``` 
`DialogContent` requires a `DialogTitle` for the component to be accessible for screen reader users.        
If you want to hide the `DialogTitle`, you can wrap it with our VisuallyHidden component.
```


## Details

<!-- Please elaborate description of the changes -->

- DialogContent 와 연결된 described-by 가 있기를 기대하는데 ModalHeaderProps에 description 을 주지 않아서 워닝이 뜨고 있었습니다. DialogContent에 described-by={undefined} 를 추가했습니다. 
- ModalHeader 가 필요없더라도 VisuallyHidden 을 써야 접근성을 해치지 않기 때문에 명시적으로 hidden 속성을 줬습니다. 


### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- https://www.radix-ui.com/primitives/docs/components/dialog#description
