### PR TITLE
Let chromatic action run with icon update PR

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   chromatic-deployment:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'ch-builder'
+    #  Skip Chromatic build for version package update PRs or release PRs
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !contains(github.event.pull_request.title, 'ci(changesets)')
     name: Chromatic
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   chromatic-deployment:
     #  Skip Chromatic build for version package update PRs or release PRs
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !contains(github.event.pull_request.title, 'ci(changesets)')
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && !contains(github.event.pull_request.title, 'ci(changesets): version packages')
     name: Chromatic
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- None

## Summary

<!-- Please brief explanation of the changes made -->


- 아이콘 업데이트 PR에서 크로마틱 액션을 실행하도록 변경합니다. 

## Details

<!-- Please elaborate description of the changes -->

- 기존에는 author=ch-builder 로 필터링을 하고 있어서 changesets PR, icon update PR 에서는 크로마틱 액션을 실행하지 않았습니다. icon update PR 같은 경우 files changed 에서 달라진 점을 볼 수 있으니 시각 테스트가 필요하지 않다고 생각했으나, 이번처럼 속성이 변경되서 예상치 못한 사이드 이펙트를 낼 수 있어서 시각 테스트를 넣으면 좋을 것 같습니다. 이번에 달라진 것도 다른 PR에 있는 시각 테스트 결과를 보고 알아차렸기 때문에 효용성이 있을 거라 생각합니다. 
- icon update PR을 changesets PR 과 구별하는 방법을 PR 제목 말고는 떠오르지 않아서 "ci(changesets)" 포함 여부로 판단했습니다. 

### Breaking change? (Yes/No)

<!-- If Yes, please describe the impact and migration path for users -->

- No

## References

<!-- Please list any other resources or points the reviewer should be aware of -->


- No