### PR TITLE
Fix possible infinite type recursion during inferencing typeof Checkbox on TS 5.6+

### DIFF
--- a/.changeset/upset-candles-grab.md
+++ b/.changeset/upset-candles-grab.md
@@ -2,4 +2,4 @@
 '@channel.io/bezier-react': patch
 ---
 
-Fix infinite type recursion of Checkbox
+Fix infinite type recursion of Checkbox that occurs in TS 5.6+

--- a/.changeset/upset-candles-grab.md
+++ b/.changeset/upset-candles-grab.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Fix infinite type recursion of Checkbox

--- a/packages/bezier-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/bezier-react/src/components/Checkbox/Checkbox.tsx
@@ -98,6 +98,11 @@ function CheckboxImpl<Checked extends CheckedState>(
   )
 }
 
+/* NOTE: This is a workaround to avoid infinite type recursion when directly using `ReturnType` */
+type ReturnTypeOfCheckboxImpl<Checked extends CheckedState> = ReturnType<
+  typeof CheckboxImpl<Checked>
+>
+
 /**
  * `Checkbox` is a control that allows the user to toggle between checked and not checked.
  * It can be used with labels or standalone.
@@ -131,4 +136,4 @@ export const Checkbox = forwardRef(CheckboxImpl) as <
   props: CheckboxProps<Checked> & {
     ref?: React.ForwardedRef<HTMLButtonElement>
   }
-) => ReturnType<typeof CheckboxImpl<Checked>>
+) => ReturnTypeOfCheckboxImpl<Checked>

--- a/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -36,15 +36,19 @@ export default meta
 const VALUES = [
   {
     value: '1',
-    label: 'First',
+    label: 'Opened',
   },
   {
     value: '2',
-    label: 'Second',
+    label: 'Snoozed',
   },
   {
     value: '3',
-    label: 'Third',
+    label: 'Missed',
+  },
+  {
+    value: '4',
+    label: 'Closed',
   },
 ]
 

--- a/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -36,19 +36,15 @@ export default meta
 const VALUES = [
   {
     value: '1',
-    label: 'Opened',
+    label: 'First',
   },
   {
     value: '2',
-    label: 'Snoozed',
+    label: 'Second',
   },
   {
     value: '3',
-    label: 'Missed',
-  },
-  {
-    value: '4',
-    label: 'Closed',
+    label: 'Third',
   },
 ]
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [v] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [v] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [v] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [v] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [v] I wrote or updated **tests** related to the changes. (or didn't have to)
- [v] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

## Summary

<!-- Please brief explanation of the changes made -->
With TS 5.6+, type inferencing of Checkbox sometimes falls into infinite recursion.
This PR fixes the issue by defining the return type of Checkbox, allowing for a checkpoint during type inference.

## Details

<!-- Please elaborate description of the changes -->

### Breaking change? (Yes/No)
No
<!-- If Yes, please describe the impact and migration path for users -->

## References
Here is a [repro](https://github.com/dohyun-ko/repro) of the issue. 

<!-- Please list any other resources or points the reviewer should be aware of -->
