### PR TITLE
Expand `text` type of `Select` component to ReactNode

### DIFF
--- a/.changeset/chatty-glasses-clean.md
+++ b/.changeset/chatty-glasses-clean.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': minor
+---
+
+Expand type of `text` props to ReactNode

--- a/packages/bezier-react/src/components/Select/Select.types.ts
+++ b/packages/bezier-react/src/components/Select/Select.types.ts
@@ -1,3 +1,5 @@
+import { type ReactNode } from 'react'
+
 import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
@@ -23,7 +25,7 @@ export interface SelectRef {
 interface SelectOwnProps {
   defaultFocus?: boolean
   placeholder?: string
-  text?: string
+  text?: ReactNode
   withoutChevron?: boolean
   dropdownContainer?: HTMLElement | null
   dropdownMarginX?: OverlayProps['marginX']


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

- Fixes #2673 

## Summary

<!-- Please brief explanation of the changes made -->

- text 속성의 타입을 string 에서 ReactNode 로 확장합니다. 

## Details

<!-- Please elaborate description of the changes -->

- None

### Breaking change? (Yes/No)

- No

<!-- If Yes, please describe the impact and migration path for users -->

## References

<!-- Please list any other resources or points the reviewer should be aware of -->

- [스레드 (internal)](https://desk.channel.io/root/threads/groups/WebBezier-124831/67fe14f4337dc20e469a/67fe14f4337dc20e469a)
