### PR TITLE
chore: enter v4 prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,15 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "eslint-config-bezier": "0.0.1",
+    "tsconfig": "0.0.1",
+    "@channel.io/bezier-codemod": "0.5.0",
+    "bezier-figma-plugin": "0.7.30",
+    "@channel.io/bezier-icons": "0.57.0",
+    "@channel.io/bezier-react": "3.6.6",
+    "@channel.io/bezier-tokens": "0.6.0",
+    "@channel.io/stylelint-bezier": "0.3.3"
+  },
+  "changesets": []
+}

--- a/.changeset/thirty-onions-end.md
+++ b/.changeset/thirty-onions-end.md
@@ -1,0 +1,8 @@
+---
+'@channel.io/bezier-react': major
+'@channel.io/bezier-tokens': major
+---
+
+Start the v4 prerelease channel for upcoming breaking changes in bezier-react and bezier-tokens.
+
+Use the `next` prereleases to validate migrations before the stable v4 release.

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v4
   pull_request:
     paths:
       - packages/bezier-react/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - v4
   pull_request:
 
 jobs:

--- a/.github/workflows/code-connect.yml
+++ b/.github/workflows/code-connect.yml
@@ -6,6 +6,7 @@ on:
       - packages/bezier-react/src/components/**/*.figma.tsx
     branches:
       - main
+      - v4
 
 jobs:
   code-connect:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,10 +16,12 @@ on:
     branches:
       - main
       - alpha
+      - v4
   pull_request:
     branches:
       - main
       - alpha
+      - v4
   schedule:
     #        ┌───────────── minute (0 - 59)
     #        │  ┌───────────── hour (0 - 23)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - alpha
+      - v4
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

- enter Changesets prerelease mode with the `next` tag for the v4 branch
- add an umbrella major changeset for `@channel.io/bezier-react` and `@channel.io/bezier-tokens`
- run release and verification workflows on the `v4` branch

## Why

- create the v4 prerelease lane before follow-up breaking changes land
- allow subsequent changesets merged into `v4` to publish as `4.0.0-next.x` and `1.0.0-next.x`

## Validation

- `yarn changeset status`
