### PR TITLE
fix(tokens): restore chart theme 06 color

### DIFF
--- a/.changeset/young-regions-thank.md
+++ b/.changeset/young-regions-thank.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-tokens': patch
+---
+
+Fix duplicated beta chart color token and restore chart theme 06 to #80B6FD.

--- a/packages/bezier-tokens/src/beta/semantic/dark-theme/color.json
+++ b/packages/bezier-tokens/src/beta/semantic/dark-theme/color.json
@@ -751,7 +751,7 @@
             "type": "color"
           },
           "06": {
-            "value": "#9D755E",
+            "value": "#80B6FD",
             "type": "color"
           },
           "07": {

--- a/packages/bezier-tokens/src/beta/semantic/light-theme/color.json
+++ b/packages/bezier-tokens/src/beta/semantic/light-theme/color.json
@@ -751,7 +751,7 @@
             "type": "color"
           },
           "06": {
-            "value": "#9D755E",
+            "value": "#80B6FD",
             "type": "color"
           },
           "07": {


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

- [WEBTECH-6786](https://linear.app/channel/issue/WEBTECH-6786/차트-컬러-재조정-빌트인-베지어-적용)

## Summary

This PR fixes the duplicated beta chart palette entry by restoring chart theme color `06` to `#80B6FD` in both light and dark themes.

## Details

The previous chart color adjustment left `06` and `07` with the same brown token value, which reduced the default palette to nine distinct colors in practice.

This update restores the intended `06` color in both beta semantic theme files and adds a changeset for `@channel.io/bezier-tokens`.

### Breaking change? (Yes/No)

No

## References

- Follow-up fix for the merged WEBTECH-6786 chart palette update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 텍스트 컴포넌트에 폰트 무게 설정 기능 추가

* **버그 수정**
  * 차트 색상 토큰 중복 제거 및 테마 색상값 복구

* **Chores**
  * v4 프리릴리스 채널("next") 시작
  * CI/CD 워크플로우 v4 브랜치 지원 추가
  * 패키지 버전 및 의존성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->