### PR TITLE
style(bezier-react): adjust tertiary hover colors for redesigned buttons

### DIFF
--- a/.changeset/fifty-turkeys-wish.md
+++ b/.changeset/fifty-turkeys-wish.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Adjust tertiary hover colors for redesigned Button and AlphaButton blue variants.

--- a/packages/bezier-react/src/components/AlphaButton/Button.module.scss
+++ b/packages/bezier-react/src/components/AlphaButton/Button.module.scss
@@ -257,7 +257,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
       }
 
       &:where(.color-blue) {
-        background-color: var(--color-fill-neutral-heaviest-hovered);
+        background-color: var(--color-fill-neutral-transparent-hovered);
       }
     }
 

--- a/packages/bezier-react/src/components/Button/Button.module.scss
+++ b/packages/bezier-react/src/components/Button/Button.module.scss
@@ -228,7 +228,7 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled))';
       }
 
       &#{$active-selector} {
-        background-color: var(--color-fill-neutral-heaviest-hovered);
+        background-color: var(--color-fill-neutral-transparent-hovered);
       }
     }
   }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

## Summary

Adjust the blue `tertiary` hover background for `Button` and `AlphaButton` in the redesigned button override on top of `v4`.

## Details

To prepare for Bezier v3, the existing button components are being temporarily overridden with the redesigned styles and validated within the `v4` prerelease flow.

This PR is a follow-up adjustment for that override. It updates the blue `tertiary` hover background of `Button` and `AlphaButton` to use `--color-fill-neutral-transparent-hovered` so the interaction matches the intended neutral hover treatment.

### Breaking change? (Yes/No)

No

## References

- Added a changeset for `@channel.io/bezier-react`
- Verified with `PATH="/Users/timo/.nvm/versions/node/v22.12.0/bin:$PWD/node_modules/.bin:$PATH" yarn workspace @channel.io/bezier-react lint`
