### PR TITLE
style(bezier-react): tighten medium button text padding

### DIFF
--- a/.changeset/twenty-books-shout.md
+++ b/.changeset/twenty-books-shout.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Tighten horizontal text padding for medium-sized Button, AlphaButton, and AlphaFloatingButton.

--- a/packages/bezier-react/src/components/AlphaButton/Button.module.scss
+++ b/packages/bezier-react/src/components/AlphaButton/Button.module.scss
@@ -63,7 +63,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     padding: 0 10px;
 
     & .ButtonText {
-      padding: 0 4px;
+      padding: 0 3px;
     }
 
     & :is(.ButtonIcon, .Loader) {

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.module.scss
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.module.scss
@@ -81,7 +81,7 @@ $chromatic-colors: 'blue', 'red', 'green', 'cobalt', 'orange', 'pink', 'purple';
     padding: 0 12px;
 
     & .ButtonText {
-      padding: 0 4px;
+      padding: 0 3px;
     }
 
     & :is(.ButtonIcon, .Loader) {

--- a/packages/bezier-react/src/components/Button/Button.module.scss
+++ b/packages/bezier-react/src/components/Button/Button.module.scss
@@ -44,6 +44,14 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled))';
       padding: 0 14px;
     }
 
+    & :where(.ButtonContent) {
+      gap: 2px;
+    }
+
+    & .ButtonText {
+      padding: 0 3px;
+    }
+
     & :is(.ButtonIcon, .ButtonSpinner) {
       width: 18px;
       height: 18px;
@@ -81,7 +89,7 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled))';
     }
   }
 
-  &:where(.size-m, .size-l, .size-xl) {
+  &:where(.size-l, .size-xl) {
     & :where(.ButtonContent) {
       gap: 2px;
     }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Follow [the Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Please link to issue if one exists -->

<!-- Fixes #0000 -->

## Summary

Tighten the horizontal text padding for medium-sized `Button`, `AlphaButton`, and `AlphaFloatingButton`.

## Details

This PR updates the `m` size text wrapper spacing in the existing button override styles.

The horizontal padding of `ButtonText` is adjusted from `4px` to `3px` for:
- `Button`
- `AlphaButton`
- `AlphaFloatingButton`

A changeset for `@channel.io/bezier-react` is also included.

### Breaking change? (Yes/No)

No

## References

- Verified with `PATH="/Users/timo/.nvm/versions/node/v22.12.0/bin:$PWD/node_modules/.bin:$PATH" yarn workspace @channel.io/bezier-react lint`
