### PR TITLE
feat: add v3 composite components

### DIFF
--- a/.changeset/ripe-donuts-joke.md
+++ b/.changeset/ripe-donuts-joke.md
@@ -1,0 +1,15 @@
+---
+'@channel.io/bezier-react': minor
+---
+
+---
+
+## "@channel.io/bezier-react": minor
+
+Add v3 composite components: `Avatar`, `AvatarGroup`, `Badge`, `Status`, and supporting `BaseTagBadge`.
+
+Notable v3 differences:
+
+- `Avatar` and `AvatarGroup` use v3 primitives internally and beta semantic tokens.
+- `Avatar` status values use `online-dnd` and `offline-dnd`.
+- `Badge` variants use `neutral-light` and `neutral-dark` naming.

--- a/.changeset/ripe-donuts-joke.md
+++ b/.changeset/ripe-donuts-joke.md
@@ -1,10 +1,6 @@
 ---
-'@channel.io/bezier-react': minor
+"@channel.io/bezier-react": minor
 ---
-
----
-
-## "@channel.io/bezier-react": minor
 
 Add v3 composite components: `Avatar`, `AvatarGroup`, `Badge`, `Status`, and supporting `BaseTagBadge`.
 

--- a/packages/bezier-react/src/v3/Avatar/Avatar.module.scss
+++ b/packages/bezier-react/src/v3/Avatar/Avatar.module.scss
@@ -1,0 +1,91 @@
+.Avatar {
+  position: relative;
+  display: block;
+  flex: none;
+
+  &:where(.disabled) {
+    pointer-events: none;
+    opacity: var(--opacity-disabled);
+  }
+
+  &:where(.size-20) {
+    width: 20px;
+    height: 20px;
+  }
+
+  &:where(.size-24) {
+    width: 24px;
+    height: 24px;
+  }
+
+  &:where(.size-30) {
+    width: 30px;
+    height: 30px;
+  }
+
+  &:where(.size-36) {
+    width: 36px;
+    height: 36px;
+  }
+
+  &:where(.size-42) {
+    width: 42px;
+    height: 42px;
+  }
+
+  &:where(.size-48) {
+    width: 48px;
+    height: 48px;
+  }
+
+  &:where(.size-72) {
+    width: 72px;
+    height: 72px;
+  }
+
+  &:where(.size-90) {
+    width: 90px;
+    height: 90px;
+  }
+
+  &:where(.size-120) {
+    width: 120px;
+    height: 120px;
+  }
+}
+
+.AvatarImage {
+  --b-avatar-status-gap: -2px;
+  --b-avatar-computed-status-gap: var(--b-avatar-status-gap);
+
+  position: relative;
+
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+
+  box-sizing: content-box;
+  width: 100%;
+  height: 100%;
+
+  outline: none;
+
+  &:where(.big-size) {
+    --b-avatar-status-gap: 4px;
+  }
+
+  &:where(.bordered[data-state='enabled']) {
+    --b-avatar-computed-status-gap: calc(
+      var(--b-avatar-status-gap) +
+        (2 * var(--b-smooth-corners-box-shadow-spread-radius))
+    );
+  }
+}
+
+.StatusWrapper {
+  position: absolute;
+  right: var(--b-avatar-computed-status-gap);
+  bottom: var(--b-avatar-computed-status-gap);
+  display: flex;
+}

--- a/packages/bezier-react/src/v3/Avatar/Avatar.stories.tsx
+++ b/packages/bezier-react/src/v3/Avatar/Avatar.stories.tsx
@@ -1,0 +1,63 @@
+import { type Meta, type StoryFn, type StoryObj } from '@storybook/react'
+
+import { Avatar } from './Avatar'
+import type { AvatarProps } from './Avatar.types'
+
+const MOCK_AVATAR_URL =
+  'https://cf.channel.io/thumb/200x200/pub-file/1/65fc43ee585607b276f6/tmp-3329819395'
+
+const meta: Meta<typeof Avatar> = {
+  title: 'V3 components/Avatar',
+  component: Avatar,
+  argTypes: {
+    onClick: {
+      action: 'clicked',
+    },
+    onMouseEnter: {
+      action: 'mouseEnter',
+    },
+    onMouseLeave: {
+      action: 'mouseLeave',
+    },
+  },
+}
+
+export default meta
+
+const Template: StoryFn<AvatarProps> = (args) => <Avatar {...args} />
+
+export const Primary: StoryObj<AvatarProps> = {
+  render: Template,
+
+  args: {
+    avatarUrl: MOCK_AVATAR_URL,
+    name: 'Channel',
+    size: '24',
+    showBorder: false,
+    disabled: false,
+    smoothCorners: true,
+  },
+}
+
+const TemplateWithCustomStatus: StoryFn<AvatarProps> = (args) => (
+  <Avatar {...args}>
+    <Avatar
+      avatarUrl="https://bit.ly/kent-c-dodds"
+      name="Kent Dodds"
+      size="20"
+      showBorder
+    />
+  </Avatar>
+)
+
+export const WithCustomStatus: StoryObj<AvatarProps> = {
+  render: TemplateWithCustomStatus,
+
+  args: {
+    avatarUrl: MOCK_AVATAR_URL,
+    name: 'Channel',
+    size: '48',
+    showBorder: false,
+    disabled: false,
+  },
+}

--- a/packages/bezier-react/src/v3/Avatar/Avatar.test.tsx
+++ b/packages/bezier-react/src/v3/Avatar/Avatar.test.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react'
+
+import { render } from '~/src/utils/test'
+import { Status } from '~/src/v3/Status'
+
+import { Avatar } from './Avatar'
+import type { AvatarProps } from './Avatar.types'
+
+import styles from './Avatar.module.scss'
+
+describe('Avatar', () => {
+  const mockAvatarUrl = 'https://bit.ly/dan-abramov'
+  const mockFallbackUrl = 'https://www.google.com'
+
+  const renderAvatar = (props?: Partial<AvatarProps>) =>
+    render(
+      <Avatar
+        avatarUrl={mockAvatarUrl}
+        fallbackUrl={mockFallbackUrl}
+        name="Name"
+        {...props}
+      />
+    )
+
+  it('should render with default style', () => {
+    const { container } = renderAvatar()
+    const avatar = container.firstElementChild
+
+    expect(avatar).toHaveClass(styles.Avatar)
+    expect(avatar).toHaveClass(styles['size-24'])
+    expect(avatar).toHaveAttribute('data-disabled', 'false')
+  })
+
+  it('should render disabled style', () => {
+    const { container } = renderAvatar({ disabled: true })
+    const avatar = container.firstElementChild
+
+    expect(avatar).toHaveClass(styles.disabled)
+    expect(avatar).toHaveAttribute('data-disabled', 'true')
+  })
+
+  it('should forward ref to avatar image', () => {
+    const ref = React.createRef<HTMLDivElement>()
+
+    render(
+      <Avatar
+        ref={ref}
+        avatarUrl={mockAvatarUrl}
+        fallbackUrl={mockFallbackUrl}
+        name="Name"
+      />
+    )
+
+    expect(ref.current).toBeInTheDocument()
+    expect(ref.current).toHaveAttribute('aria-description', 'Name')
+  })
+
+  it('should render status when status is given', () => {
+    const { container } = renderAvatar({ status: 'online-dnd' })
+    const icon = container.querySelector('svg')
+
+    expect(icon).toBeInTheDocument()
+  })
+
+  it('should render custom status children', () => {
+    const { container } = renderAvatar({
+      children: (
+        <Status
+          type="lock"
+          size="m"
+        />
+      ),
+    })
+    const icon = container.querySelector('svg')
+
+    expect(icon).toBeInTheDocument()
+  })
+})

--- a/packages/bezier-react/src/v3/Avatar/Avatar.tsx
+++ b/packages/bezier-react/src/v3/Avatar/Avatar.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { forwardRef, isValidElement, useMemo } from 'react'
+
+import classNames from 'classnames'
+
+import { isEmpty } from '~/src/utils/type'
+import {
+  SmoothCornersBox,
+  type SmoothCornersBoxProps,
+} from '~/src/v3/SmoothCornersBox'
+import { Status, type StatusSize } from '~/src/v3/Status'
+
+import type { AvatarProps } from './Avatar.types'
+import defaultAvatarUrl from './assets/default-avatar.svg'
+import useProgressiveImage from './useProgressiveImage'
+
+import styles from './Avatar.module.scss'
+
+const shadow: SmoothCornersBoxProps['shadow'] = {
+  spreadRadius: 2,
+  color: 'surface-high',
+}
+
+export function useAvatarRadiusToken() {
+  return '42%' as const
+}
+
+/**
+ * `Avatar` is a component for representing some profile image.
+ * @example
+ *
+ * ```tsx
+ * <Avatar
+ *   avatarUrl="https://..."
+ *   name="channel"
+ *   size="48"
+ *   showBorder
+ *   disabled
+ * />
+ * ```
+ */
+export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(function Avatar(
+  {
+    avatarUrl = '',
+    fallbackUrl = defaultAvatarUrl,
+    size = '24',
+    name,
+    disabled = false,
+    showBorder = false,
+    smoothCorners = true,
+    status,
+    className,
+    children,
+    ...rest
+  },
+  forwardedRef
+) {
+  const loadedAvatarUrl = useProgressiveImage(avatarUrl, fallbackUrl)
+  const AVATAR_BORDER_RADIUS = useAvatarRadiusToken()
+
+  const StatusComponent = useMemo(() => {
+    if (
+      (isEmpty(children) && !status) ||
+      (children && !isValidElement(children))
+    ) {
+      return null
+    }
+
+    const statusSize: StatusSize = (() => {
+      switch (size) {
+        case '90':
+        case '120':
+          return 'l'
+        default:
+          return 'm'
+      }
+    })()
+
+    const Contents = (() => {
+      if (children) {
+        return children
+      }
+      if (status) {
+        return (
+          <Status
+            type={status}
+            size={statusSize}
+          />
+        )
+      }
+      return null
+    })()
+
+    return Contents && <div className={styles.StatusWrapper}>{Contents}</div>
+  }, [status, size, children])
+
+  return (
+    <div
+      className={classNames(
+        styles.Avatar,
+        styles[`size-${size}`],
+        disabled && styles.disabled,
+        className
+      )}
+      data-disabled={disabled}
+      {...rest}
+    >
+      <SmoothCornersBox
+        ref={forwardedRef}
+        aria-description={name}
+        className={classNames(
+          styles.AvatarImage,
+          Number(size) >= 72 && styles['big-size'],
+          showBorder && styles.bordered
+        )}
+        disabled={!smoothCorners}
+        borderRadius={AVATAR_BORDER_RADIUS}
+        shadow={showBorder ? shadow : undefined}
+        backgroundColor="surface"
+        backgroundImage={loadedAvatarUrl}
+      >
+        {StatusComponent}
+      </SmoothCornersBox>
+    </div>
+  )
+})

--- a/packages/bezier-react/src/v3/Avatar/Avatar.types.ts
+++ b/packages/bezier-react/src/v3/Avatar/Avatar.types.ts
@@ -1,0 +1,61 @@
+import type {
+  BezierComponentProps,
+  ChildrenProps,
+  DisableProps,
+  SizeProps,
+} from '~/src/types/props'
+import { type StatusType } from '~/src/v3/Status'
+
+export type AvatarSize =
+  | '20'
+  | '24'
+  | '30'
+  | '36'
+  | '42'
+  | '48'
+  | '72'
+  | '90'
+  | '120'
+
+interface AvatarOwnProps {
+  /**
+   * Semantic name of the avatar.
+   */
+  name: string
+  /**
+   * Asset image URL of the avatar.
+   * @default ''
+   */
+  avatarUrl?: string
+  /**
+   * Fallback image URL for the avatar.
+   * @default DEFAULT_AVATAR_URL
+   */
+  fallbackUrl?: string
+  /**
+   * Additional status type for this avatar.
+   * Typically, this is used to indicate the status of the user (online, offline, etc).
+   *
+   * If additional customization of the status component is needed,
+   * pass the custom status component as `children` of the Avatar component.
+   */
+  status?: StatusType
+  /**
+   * Whether to display the border of the avatar.
+   * @default false
+   */
+  showBorder?: boolean
+  /**
+   * Whether to use the smooth corners feature.
+   * Overrides whether the smooth corners feature is applied when it is enabled.
+   * @default true
+   */
+  smoothCorners?: boolean
+}
+
+export interface AvatarProps
+  extends BezierComponentProps<'div'>,
+    SizeProps<AvatarSize>,
+    DisableProps,
+    ChildrenProps,
+    AvatarOwnProps {}

--- a/packages/bezier-react/src/v3/Avatar/assets/default-avatar.svg
+++ b/packages/bezier-react/src/v3/Avatar/assets/default-avatar.svg
@@ -1,0 +1,11 @@
+<svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<rect width="60" height="60" fill="#cfccfb"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M41 23C41 29.0744 36.0744 34 30 34C23.9256 34 19 29.0744 19 23C19 16.9256 23.9256 12 30 12C36.0744 12 41 16.9256 41 23ZM30 37C16.1929 37 5 48.1929 5 62V90H55V62C55 48.1929 43.8071 37 30 37Z" fill="white" fill-opacity="0.4"/>
+</g>
+<defs>
+<clipPath id="clip0">
+<rect width="60" height="60" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/bezier-react/src/v3/Avatar/index.ts
+++ b/packages/bezier-react/src/v3/Avatar/index.ts
@@ -1,0 +1,2 @@
+export { Avatar, useAvatarRadiusToken } from './Avatar'
+export type { AvatarProps, AvatarSize } from './Avatar.types'

--- a/packages/bezier-react/src/v3/Avatar/useProgressiveImage.test.ts
+++ b/packages/bezier-react/src/v3/Avatar/useProgressiveImage.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from '~/src/utils/test'
+
+import useProgressiveImage, { type CachedImage } from './useProgressiveImage'
+
+describe('useProgressiveImage', () => {
+  const mockValidImageUrlFoo = 'valid_foo'
+  const mockValidImageUrlBar = 'valid_bar'
+  const mockInvalidImageUrl = 'invalid'
+  const mockFallbackImageUrl = 'fallback'
+
+  const mockImageCache = new Map<string, CachedImage>()
+
+  mockImageCache.set(mockValidImageUrlFoo, {
+    src: mockValidImageUrlFoo,
+    isLoaded: true,
+  })
+  mockImageCache.set(mockInvalidImageUrl, {
+    src: mockInvalidImageUrl,
+    isLoaded: false,
+  })
+
+  it('should return given url when cached image is loaded', () => {
+    const { result } = renderHook(() =>
+      useProgressiveImage(
+        mockValidImageUrlFoo,
+        mockFallbackImageUrl,
+        mockImageCache
+      )
+    )
+
+    expect(result.current).toStrictEqual(mockValidImageUrlFoo)
+  })
+
+  it('should return fallback url when cached image is not loaded', () => {
+    const { result } = renderHook(() =>
+      useProgressiveImage(
+        mockInvalidImageUrl,
+        mockFallbackImageUrl,
+        mockImageCache
+      )
+    )
+
+    expect(result.current).toStrictEqual(mockFallbackImageUrl)
+  })
+
+  it('should update url when cached image is loaded', () => {
+    const { result, rerender } = renderHook(
+      ({ src, defaultSrc, imageCache }) =>
+        useProgressiveImage(src, defaultSrc, imageCache),
+      {
+        initialProps: {
+          src: mockValidImageUrlFoo,
+          defaultSrc: mockFallbackImageUrl,
+          imageCache: mockImageCache,
+        },
+      }
+    )
+
+    expect(result.current).toStrictEqual(mockValidImageUrlFoo)
+
+    mockImageCache.set(mockValidImageUrlBar, {
+      src: mockValidImageUrlBar,
+      isLoaded: true,
+    })
+
+    rerender({
+      src: mockValidImageUrlBar,
+      defaultSrc: mockFallbackImageUrl,
+      imageCache: mockImageCache,
+    })
+
+    expect(result.current).toStrictEqual(mockValidImageUrlBar)
+  })
+})

--- a/packages/bezier-react/src/v3/Avatar/useProgressiveImage.ts
+++ b/packages/bezier-react/src/v3/Avatar/useProgressiveImage.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+
+enum ImageEventType {
+  Load = 'load',
+  Error = 'error',
+}
+
+export interface CachedImage {
+  src: string
+  isLoaded: boolean
+}
+
+type ImageCacheMap = Map<string, CachedImage>
+
+const defaultImageCache = new Map<string, CachedImage>()
+
+function getCachedImage(src: string, imageCache: ImageCacheMap) {
+  const cachedImage = imageCache.get(src)
+  if (!cachedImage) {
+    return null
+  }
+  return cachedImage
+}
+
+export default function useProgressiveImage(
+  src: string,
+  defaultSrc: string,
+  imageCache: ImageCacheMap = defaultImageCache
+) {
+  const [source, setSource] = useState<CachedImage | null>(() =>
+    getCachedImage(src, imageCache)
+  )
+
+  useEffect(
+    function updateSource() {
+      if (source?.src === src) {
+        return undefined
+      }
+
+      const cachedImage = getCachedImage(src, imageCache)
+
+      if (cachedImage?.isLoaded) {
+        setSource(cachedImage)
+        return undefined
+      }
+
+      const image = new Image()
+      image.src = src
+
+      function loadImage(event: Event) {
+        const loadedImage = {
+          src,
+          isLoaded: event.type === ImageEventType.Load,
+        }
+        setSource(loadedImage)
+        imageCache.set(src, loadedImage)
+      }
+
+      image.addEventListener(ImageEventType.Load, loadImage)
+      image.addEventListener(ImageEventType.Error, loadImage)
+
+      return function cleanup() {
+        image.removeEventListener(ImageEventType.Load, loadImage)
+        image.removeEventListener(ImageEventType.Error, loadImage)
+      }
+    },
+    [src, source, imageCache]
+  )
+
+  if (!source || !source.isLoaded) {
+    return defaultSrc
+  }
+
+  return source.src
+}

--- a/packages/bezier-react/src/v3/AvatarGroup/AvatarGroup.module.scss
+++ b/packages/bezier-react/src/v3/AvatarGroup/AvatarGroup.module.scss
@@ -1,0 +1,75 @@
+$avatar-sizes: 20, 24, 30, 36, 42, 48, 72, 90, 120;
+
+.AvatarGroup {
+  --b-avatar-group-spacing: 0;
+  --b-avatar-group-size: 0;
+
+  position: relative;
+  z-index: var(--layer-z-index-base);
+  display: flex;
+
+  @each $size in $avatar-sizes {
+    :where(.size-#{$size}) {
+      --b-avatar-group-size: #{$size}px;
+    }
+  }
+
+  & > * + * {
+    margin-left: var(--b-avatar-group-spacing);
+  }
+}
+
+.AvatarEllipsisIconWrapper {
+  position: relative;
+}
+
+.AvatarEllipsisIcon {
+  position: absolute;
+  z-index: var(--layer-z-index-floating);
+  top: 0;
+  right: 0;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  height: 100%;
+
+  outline: none;
+}
+
+.AvatarEllipsisCountWrapper {
+  --b-avatar-group-ellipsis-pr: 0;
+  --b-avatar-group-ellipsis-ml: 0;
+
+  margin-left: var(--b-avatar-group-ellipsis-ml);
+  padding-right: var(--b-avatar-group-ellipsis-pr);
+
+  &:where(.size-20) {
+    --b-avatar-group-ellipsis-pr: 4px;
+  }
+
+  &:where(.size-24) {
+    --b-avatar-group-ellipsis-pr: 5px;
+  }
+
+  &:where(
+      .size-30,
+      .size-36,
+      .size-42,
+      .size-48,
+      .size-72,
+      .size-90,
+      .size-120
+    ) {
+    --b-avatar-group-ellipsis-pr: 6px;
+  }
+}
+
+.AvatarEllipsisCount {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: var(--b-avatar-group-size);
+}

--- a/packages/bezier-react/src/v3/AvatarGroup/AvatarGroup.stories.tsx
+++ b/packages/bezier-react/src/v3/AvatarGroup/AvatarGroup.stories.tsx
@@ -1,0 +1,61 @@
+import { type Meta, type StoryFn, type StoryObj } from '@storybook/react'
+
+import { Avatar } from '~/src/v3/Avatar'
+
+import { AvatarGroup } from './AvatarGroup'
+import { type AvatarGroupProps } from './AvatarGroup.types'
+import MOCK_AVATAR_LIST from './__mocks__/avatarList'
+
+const meta: Meta<typeof AvatarGroup> = {
+  title: 'V3 components/AvatarGroup',
+  component: AvatarGroup,
+  argTypes: {
+    max: {
+      control: {
+        type: 'range',
+        min: 1,
+        max: MOCK_AVATAR_LIST.length,
+        step: 1,
+      },
+    },
+    spacing: {
+      control: {
+        type: 'range',
+        min: -50,
+        max: 50,
+        step: 1,
+      },
+    },
+    onMouseEnterEllipsis: {
+      action: 'mouseEnter',
+    },
+    onMouseLeaveEllipsis: {
+      action: 'mouseLeave',
+    },
+  },
+}
+
+export default meta
+
+const Template: StoryFn<AvatarGroupProps> = (args) => (
+  <AvatarGroup {...args}>
+    {MOCK_AVATAR_LIST.map(({ id, avatarUrl, name }) => (
+      <Avatar
+        key={id}
+        avatarUrl={avatarUrl}
+        name={name}
+      />
+    ))}
+  </AvatarGroup>
+)
+
+export const Primary: StoryObj<AvatarGroupProps> = {
+  render: Template,
+
+  args: {
+    max: 5,
+    ellipsisType: 'icon',
+    size: '30',
+    spacing: 4,
+  },
+}

--- a/packages/bezier-react/src/v3/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/bezier-react/src/v3/AvatarGroup/AvatarGroup.test.tsx
@@ -1,0 +1,69 @@
+import { render } from '~/src/utils/test'
+import { Avatar } from '~/src/v3/Avatar'
+
+import { AvatarGroup } from './AvatarGroup'
+import { type AvatarGroupProps } from './AvatarGroup.types'
+import MOCK_AVATAR_LIST from './__mocks__/avatarList'
+
+import styles from './AvatarGroup.module.scss'
+
+describe('AvatarGroup', () => {
+  const mockFallbackUrl = 'https://www.google.com'
+
+  const renderAvatarGroup = (props?: Partial<AvatarGroupProps>) =>
+    render(
+      <AvatarGroup
+        max={MOCK_AVATAR_LIST.length - 1}
+        spacing={4}
+        ellipsisType="icon"
+        {...props}
+      >
+        {MOCK_AVATAR_LIST.map(({ id, avatarUrl, name }) => (
+          <Avatar
+            key={id}
+            avatarUrl={avatarUrl}
+            fallbackUrl={mockFallbackUrl}
+            name={name}
+          />
+        ))}
+      </AvatarGroup>
+    )
+
+  it('should render with default style', () => {
+    const { getByRole } = renderAvatarGroup()
+    const avatarGroup = getByRole('group')
+
+    expect(avatarGroup).toHaveClass(styles.AvatarGroup)
+    expect(avatarGroup).toHaveClass(styles['size-24'])
+    expect(avatarGroup).toHaveStyle('--b-avatar-group-spacing: 4px')
+  })
+
+  it('should render ellipsis icon when avatar count is more than max', () => {
+    const { container } = renderAvatarGroup({ ellipsisType: 'icon' })
+    const icon = container.querySelector('svg')
+
+    expect(icon).toBeInTheDocument()
+  })
+
+  it('should not render ellipsis icon when avatar count is less than max', () => {
+    const { container } = renderAvatarGroup({ max: MOCK_AVATAR_LIST.length })
+    const icon = container.querySelector('svg')
+
+    expect(icon).not.toBeInTheDocument()
+  })
+
+  it('should render ellipsis count when avatar count is more than max', () => {
+    const { getByText } = renderAvatarGroup({ ellipsisType: 'count' })
+
+    expect(getByText('+1')).toBeInTheDocument()
+  })
+
+  it('should not render ellipsis count when avatar count is less than max', () => {
+    const { queryByText } = renderAvatarGroup({
+      max: MOCK_AVATAR_LIST.length,
+      ellipsisType: 'count',
+    })
+
+    expect(queryByText('+1')).not.toBeInTheDocument()
+  })
+})

--- a/packages/bezier-react/src/v3/AvatarGroup/AvatarGroup.tsx
+++ b/packages/bezier-react/src/v3/AvatarGroup/AvatarGroup.tsx
@@ -1,0 +1,237 @@
+'use client'
+
+import { forwardRef, useCallback, useMemo } from 'react'
+import * as React from 'react'
+
+import { MoreIcon } from '@channel.io/bezier-icons'
+import classNames from 'classnames'
+
+import { isLastIndex } from '~/src/utils/array'
+import { px } from '~/src/utils/style'
+import {
+  type AvatarProps,
+  type AvatarSize,
+  useAvatarRadiusToken,
+} from '~/src/v3/Avatar'
+import { Icon } from '~/src/v3/Icon'
+import { SmoothCornersBox } from '~/src/v3/SmoothCornersBox'
+import { Text } from '~/src/v3/Text'
+
+import { type AvatarGroupProps } from './AvatarGroup.types'
+
+import styles from './AvatarGroup.module.scss'
+
+const MAX_AVATAR_LIST_COUNT = 99
+const AVATAR_GROUP_DEFAULT_SPACING = 4
+
+function getRestAvatarListCountText(count: number, max: number) {
+  const restCount = count - max
+  return `+${restCount > MAX_AVATAR_LIST_COUNT ? MAX_AVATAR_LIST_COUNT : restCount}`
+}
+
+// TODO: Not specified
+function getProperIconSize(avatarSize: AvatarSize) {
+  return (
+    {
+      20: '12',
+      24: '16',
+      30: '20',
+      36: '24',
+      42: '24',
+      48: '36',
+      72: '36',
+      90: '36',
+      120: '36',
+    } as const
+  )[avatarSize]
+}
+
+// TODO: Not specified
+function getProperTypoSize(avatarSize: AvatarSize) {
+  return (
+    {
+      20: '12',
+      24: '13',
+      30: '15',
+      36: '16',
+      42: '18',
+      48: '24',
+      72: '24',
+      90: '24',
+      120: '24',
+    } as const
+  )[avatarSize]
+}
+
+/**
+ * `AvatarGroup` is a component for grouping `Avatar` components
+ * @example
+ *
+ * ```tsx
+ * <AvatarGroup
+ *  max={2}
+ *  spacing={4}
+ *  ellipsisType="icon"
+ * >
+ *    <Avatar />
+ *    <Avatar />
+ *    <Avatar />
+ * </AvatarGroup>
+ * ```
+ */
+export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
+  function AvatarGroup(
+    {
+      max,
+      size = '24',
+      spacing = AVATAR_GROUP_DEFAULT_SPACING,
+      ellipsisType = 'icon',
+      onMouseEnterEllipsis,
+      onMouseLeaveEllipsis,
+      style,
+      className,
+      children,
+      ...rest
+    },
+    forwardedRef
+  ) {
+    const AVATAR_BORDER_RADIUS = useAvatarRadiusToken()
+
+    const renderAvatarElement = useCallback(
+      (avatar: React.ReactElement<AvatarProps>, avatarListCount: number) => {
+        const key =
+          avatar.key ?? `${avatar.props.name}-${avatar.props.avatarUrl}`
+        const shouldShowBorder = avatarListCount > 1 && spacing < 0
+        const showBorder = avatar.props.showBorder || shouldShowBorder
+        return React.cloneElement(avatar, { key, size, showBorder })
+      },
+      [size, spacing]
+    )
+
+    const avatarListCount = useMemo(
+      () => React.Children.count(children),
+      [children]
+    )
+
+    const AvatarListComponent = useMemo(() => {
+      if (avatarListCount <= max) {
+        return React.Children.map(
+          children,
+          (avatar) =>
+            React.isValidElement<AvatarProps>(avatar) &&
+            renderAvatarElement(avatar, avatarListCount)
+        )
+      }
+
+      const sliceEndIndex = max - avatarListCount
+      const slicedAvatarList = React.Children.toArray(children).slice(
+        0,
+        sliceEndIndex
+      )
+
+      return slicedAvatarList.map((avatar, index, arr) => {
+        if (!React.isValidElement<AvatarProps>(avatar)) {
+          return null
+        }
+
+        const AvatarElement = renderAvatarElement(
+          avatar,
+          slicedAvatarList.length
+        )
+
+        if (!isLastIndex(arr, index)) {
+          return AvatarElement
+        }
+
+        if (ellipsisType === 'icon') {
+          return (
+            <div
+              key="ellipsis"
+              className={styles.AvatarEllipsisIconWrapper}
+              onMouseEnter={onMouseEnterEllipsis}
+              onMouseLeave={onMouseLeaveEllipsis}
+            >
+              <SmoothCornersBox
+                borderRadius={AVATAR_BORDER_RADIUS}
+                backgroundColor="fill-absolute-black-light"
+                className={styles.AvatarEllipsisIcon}
+              >
+                <Icon
+                  source={MoreIcon}
+                  size={getProperIconSize(size)}
+                  color="text-absolute-white"
+                />
+              </SmoothCornersBox>
+              {AvatarElement}
+            </div>
+          )
+        }
+
+        if (ellipsisType === 'count') {
+          return (
+            <React.Fragment key="ellipsis">
+              {AvatarElement}
+              <div
+                style={
+                  {
+                    '--b-avatar-group-ellipsis-ml': px(
+                      Math.max(spacing, AVATAR_GROUP_DEFAULT_SPACING)
+                    ),
+                  } as React.CSSProperties
+                }
+                className={classNames(
+                  styles.AvatarEllipsisCountWrapper,
+                  styles[`size-${size}`]
+                )}
+                onMouseEnter={onMouseEnterEllipsis}
+                onMouseLeave={onMouseLeaveEllipsis}
+              >
+                <Text
+                  typo={getProperTypoSize(size)}
+                  color="text-neutral-lighter"
+                  className={styles.AvatarEllipsisCount}
+                >
+                  {getRestAvatarListCountText(avatarListCount, max)}
+                </Text>
+              </div>
+            </React.Fragment>
+          )
+        }
+
+        return null
+      })
+    }, [
+      avatarListCount,
+      max,
+      children,
+      renderAvatarElement,
+      ellipsisType,
+      onMouseEnterEllipsis,
+      onMouseLeaveEllipsis,
+      AVATAR_BORDER_RADIUS,
+      size,
+      spacing,
+    ])
+
+    return (
+      <div
+        role="group"
+        ref={forwardedRef}
+        className={classNames(
+          styles.AvatarGroup,
+          styles[`size-${size}`],
+          className
+        )}
+        style={
+          {
+            '--b-avatar-group-spacing': px(spacing),
+            ...style,
+          } as React.CSSProperties
+        }
+        {...rest}
+      >
+        {AvatarListComponent}
+      </div>
+    )
+  }
+)

--- a/packages/bezier-react/src/v3/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/bezier-react/src/v3/AvatarGroup/AvatarGroup.types.ts
@@ -1,0 +1,50 @@
+import type {
+  AdditionalOverridableStyleProps,
+  BezierComponentProps,
+  ChildrenProps,
+  SizeProps,
+} from '~/src/types/props'
+import { type AvatarSize } from '~/src/v3/Avatar'
+
+export type AvatarGroupEllipsisType = 'icon' | 'count'
+
+type MouseEventHandler = React.MouseEventHandler<HTMLDivElement>
+
+interface AvatarGroupOwnProps {
+  /**
+   * Maximum number of avatars to display.
+   *
+   * If the number of avatars exceeds this number, ellipsis will be displayed.
+   */
+  max: number
+
+  /**
+   * Spacing between the avatars.
+   * Spacing could be negative, which will make the avatars overlap each other.
+   * @default 4
+   */
+  spacing?: number
+
+  /**
+   * Controls how the ellipsis is displayed.
+   * @default 'icon'
+   */
+  ellipsisType?: AvatarGroupEllipsisType
+
+  /**
+   * Handler to be called when the mouse enters the ellipsis area.
+   */
+  onMouseEnterEllipsis?: MouseEventHandler
+
+  /**
+   * Handler to be called when the mouse leaves the ellipsis area.
+   */
+  onMouseLeaveEllipsis?: MouseEventHandler
+}
+
+export interface AvatarGroupProps
+  extends BezierComponentProps<'div'>,
+    ChildrenProps,
+    SizeProps<AvatarSize>,
+    AdditionalOverridableStyleProps<'ellipsis'>,
+    AvatarGroupOwnProps {}

--- a/packages/bezier-react/src/v3/AvatarGroup/__mocks__/avatarList.ts
+++ b/packages/bezier-react/src/v3/AvatarGroup/__mocks__/avatarList.ts
@@ -1,0 +1,39 @@
+const MOCK_AVATAR_LIST = [
+  {
+    id: 1,
+    avatarUrl: 'https://bit.ly/code-beast',
+    name: 'Christian Nwamba',
+  },
+  {
+    id: 2,
+    avatarUrl: 'https://bit.ly/tioluwani-kolawole',
+    name: 'Kola Tioluwani',
+  },
+  {
+    id: 3,
+    avatarUrl: 'https://bit.ly/kent-c-dodds',
+    name: 'Kent Dodds',
+  },
+  {
+    id: 4,
+    avatarUrl: 'https://bit.ly/ryan-florence',
+    name: 'Ryan Florence',
+  },
+  {
+    id: 5,
+    avatarUrl: 'https://bit.ly/dan-abramov',
+    name: 'Dan Abrahmov',
+  },
+  {
+    id: 6,
+    avatarUrl: 'https://bit.ly/prosper-baba',
+    name: 'Prosper Otemuyiwa',
+  },
+  {
+    id: 7,
+    avatarUrl: 'https://bit.ly/sage-adebayo',
+    name: 'Segun Adebayo',
+  },
+]
+
+export default MOCK_AVATAR_LIST

--- a/packages/bezier-react/src/v3/AvatarGroup/index.ts
+++ b/packages/bezier-react/src/v3/AvatarGroup/index.ts
@@ -1,0 +1,5 @@
+export { AvatarGroup } from './AvatarGroup'
+export {
+  type AvatarGroupEllipsisType,
+  type AvatarGroupProps,
+} from './AvatarGroup.types'

--- a/packages/bezier-react/src/v3/Badge/Badge.stories.tsx
+++ b/packages/bezier-react/src/v3/Badge/Badge.stories.tsx
@@ -1,0 +1,154 @@
+import * as BezierIcons from '@channel.io/bezier-icons'
+import { type Meta, type StoryObj } from '@storybook/react'
+
+import { Box } from '~/src/v3/Box'
+
+import { Badge } from './Badge'
+import {
+  type BadgeProps,
+  type BadgeSize,
+  type BadgeVariant,
+} from './Badge.types'
+
+const iconOptions = Object.fromEntries(
+  Object.entries(BezierIcons).filter(([key]) => key.endsWith('Icon'))
+)
+
+const SIZES: BadgeSize[] = ['xs', 's', 'm', 'l']
+
+const VARIANTS: BadgeVariant[] = [
+  'default',
+  'neutral-light',
+  'neutral-dark',
+  'blue',
+  'cobalt',
+  'teal',
+  'green',
+  'olive',
+  'pink',
+  'navy',
+  'yellow',
+  'orange',
+  'red',
+  'purple',
+]
+
+const meta: Meta<typeof Badge> = {
+  title: 'V3 components/Badge',
+  component: Badge,
+  args: {
+    children: 'Label',
+    size: 'm',
+    variant: 'default',
+    icon: 'PlusIcon' as unknown as BadgeProps['icon'],
+    truncated: false,
+  },
+  argTypes: {
+    icon: {
+      control: 'select',
+      options: ['none', ...Object.keys(iconOptions)],
+      mapping: { none: undefined, ...iconOptions },
+    },
+    variant: {
+      control: 'select',
+      options: VARIANTS,
+    },
+    size: {
+      control: 'select',
+      options: SIZES,
+    },
+    truncated: {
+      control: 'boolean',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Badge>
+
+const rowStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+} as const
+
+const labelStyle = {
+  fontSize: 12,
+  color: '#888',
+} as const
+
+/**
+ * Adjust `size` / `variant` / `icon` with the controls panel.
+ */
+export const Primary: Story = {}
+
+/**
+ * Each size (based on the `default` variant).
+ */
+export const Sizes: Story = {
+  tags: ['!autodocs'],
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {SIZES.map((size) => (
+        <div
+          key={size}
+          style={rowStyle}
+        >
+          <span style={{ ...labelStyle, width: 24 }}>{size}</span>
+          <Badge
+            size={size}
+            variant="default"
+            icon={BezierIcons.PlusIcon}
+          >
+            Label
+          </Badge>
+        </div>
+      ))}
+    </div>
+  ),
+}
+
+/**
+ * Each variant (based on the `m` size).
+ */
+export const Variants: Story = {
+  tags: ['!autodocs'],
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {VARIANTS.map((variant) => (
+        <div
+          key={variant}
+          style={rowStyle}
+        >
+          <span style={{ ...labelStyle, width: 132 }}>{variant}</span>
+          <Badge
+            size="m"
+            variant={variant}
+            icon={BezierIcons.PlusIcon}
+          >
+            Label
+          </Badge>
+        </div>
+      ))}
+    </div>
+  ),
+}
+
+/**
+ * Truncated (in a narrow container).
+ */
+export const Truncated: Story = {
+  tags: ['!autodocs'],
+  args: {
+    children: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    truncated: true,
+  },
+  render: (args) => (
+    <Box width={200}>
+      <Badge {...args} />
+    </Box>
+  ),
+}

--- a/packages/bezier-react/src/v3/Badge/Badge.test.tsx
+++ b/packages/bezier-react/src/v3/Badge/Badge.test.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+
+import { AllIcon } from '@channel.io/bezier-icons'
+
+import { render } from '~/src/utils/test'
+import baseTagBadgeStyles from '~/src/v3/BaseTagBadge/BaseTagBadge.module.scss'
+
+import { Badge } from './Badge'
+import { type BadgeProps } from './Badge.types'
+
+describe('Badge', () => {
+  const renderBadge = (props?: Partial<BadgeProps>) =>
+    render(<Badge {...props}>Badge</Badge>)
+
+  it('should render with default style', () => {
+    const { getByText } = renderBadge()
+    const rendered = getByText('Badge').parentElement
+
+    expect(rendered).toHaveClass(baseTagBadgeStyles.BaseTagBadge)
+    expect(rendered).toHaveClass(baseTagBadgeStyles['size-m'])
+    expect(rendered).toHaveClass(baseTagBadgeStyles['variant-default'])
+  })
+
+  it('should forward ref', () => {
+    const ref = React.createRef<HTMLDivElement>()
+
+    render(<Badge ref={ref}>Badge</Badge>)
+
+    expect(ref.current).toBeInTheDocument()
+  })
+
+  it('should render icon when icon is given', () => {
+    const { container } = renderBadge({ icon: AllIcon })
+    const icon = container.querySelector('svg')
+
+    expect(icon).toBeInTheDocument()
+  })
+
+  it('should render without text when children is empty', () => {
+    const { container, queryByText } = render(<Badge icon={AllIcon} />)
+    const icon = container.querySelector('svg')
+
+    expect(icon).toBeInTheDocument()
+    expect(queryByText('Badge')).not.toBeInTheDocument()
+  })
+
+  it('should receive aria-label when truncated text is string', () => {
+    const { getByLabelText } = renderBadge({ truncated: true })
+
+    expect(getByLabelText('Badge')).toBeInTheDocument()
+  })
+})

--- a/packages/bezier-react/src/v3/Badge/Badge.tsx
+++ b/packages/bezier-react/src/v3/Badge/Badge.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { forwardRef } from 'react'
+
+import { isEmpty } from '~/src/utils/type'
+import { BaseTagBadge, BaseTagBadgeText } from '~/src/v3/BaseTagBadge'
+import { Icon } from '~/src/v3/Icon'
+
+import { type BadgeProps } from './Badge.types'
+
+/**
+ * `Badge` is a component for representing badge, which consists of text and icon.
+ * @example
+ * ```tsx
+ * <Badge
+ *   size="xs"
+ *   variant="blue"
+ *   icon={AppleIcon}
+ * >
+ *   Beta
+ * </Badge>
+ * ```
+ */
+export const Badge = forwardRef<HTMLDivElement, BadgeProps>(function Badge(
+  { size = 'm', variant = 'default', truncated, icon, children, ...rest },
+  forwardedRef
+) {
+  const ariaLabel =
+    truncated && typeof children === 'string' ? children : undefined
+
+  return (
+    <BaseTagBadge
+      ref={forwardedRef}
+      size={size}
+      variant={variant}
+      aria-label={ariaLabel}
+      {...rest}
+    >
+      {icon && (
+        <Icon
+          source={icon}
+          size={size === 'xs' ? '12' : '16'}
+        />
+      )}
+
+      {!isEmpty(children) && (
+        <BaseTagBadgeText
+          size={size}
+          truncated={truncated}
+        >
+          {children}
+        </BaseTagBadgeText>
+      )}
+    </BaseTagBadge>
+  )
+})

--- a/packages/bezier-react/src/v3/Badge/Badge.types.ts
+++ b/packages/bezier-react/src/v3/Badge/Badge.types.ts
@@ -1,0 +1,36 @@
+import { type BezierIcon } from '@channel.io/bezier-icons'
+
+import {
+  type BezierComponentProps,
+  type ChildrenProps,
+  type SizeProps,
+  type VariantProps,
+} from '~/src/types/props'
+import {
+  type BaseTagBadgeSize,
+  type BaseTagBadgeVariant,
+} from '~/src/v3/BaseTagBadge'
+
+export type BadgeSize = BaseTagBadgeSize
+
+export type BadgeVariant = BaseTagBadgeVariant
+
+interface BadgeOwnProps {
+  /**
+   * Icon to be shown on the left side of the badge.
+   */
+  icon?: BezierIcon
+  /**
+   * Whether the text is truncated.
+   * If it is a positive integer, it means the maximum number of lines.
+   * @default false
+   */
+  truncated?: boolean | number
+}
+
+export interface BadgeProps
+  extends BezierComponentProps<'div'>,
+    ChildrenProps,
+    SizeProps<BadgeSize>,
+    VariantProps<BadgeVariant>,
+    BadgeOwnProps {}

--- a/packages/bezier-react/src/v3/Badge/index.ts
+++ b/packages/bezier-react/src/v3/Badge/index.ts
@@ -1,0 +1,2 @@
+export { Badge } from './Badge'
+export type { BadgeProps, BadgeSize, BadgeVariant } from './Badge.types'

--- a/packages/bezier-react/src/v3/BaseTagBadge/BaseTagBadge.module.scss
+++ b/packages/bezier-react/src/v3/BaseTagBadge/BaseTagBadge.module.scss
@@ -1,0 +1,91 @@
+.BaseTagBadge {
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+
+  box-sizing: border-box;
+  padding: 1px 4px;
+
+  color: var(--b-tag-badge-color);
+
+  background-color: var(--b-tag-badge-background-color);
+  border-radius: var(--radius-32);
+
+  &:where(.variant-default) {
+    --b-tag-badge-background-color: var(--color-fill-neutral-light);
+    --b-tag-badge-color: var(--color-text-neutral);
+  }
+
+  &:where(.variant-neutral-light) {
+    --b-tag-badge-background-color: var(--color-fill-neutral-light);
+    --b-tag-badge-color: var(--color-text-neutral-lighter);
+  }
+
+  &:where(.variant-neutral-dark) {
+    --b-tag-badge-background-color: var(--color-fill-neutral-heavier);
+    --b-tag-badge-color: var(--color-text-absolute-white);
+  }
+
+  &:where(.variant-blue) {
+    --b-tag-badge-background-color: var(--color-fill-accent-blue-heavy);
+    --b-tag-badge-color: var(--color-text-accent-blue);
+  }
+
+  &:where(.variant-cobalt) {
+    --b-tag-badge-background-color: var(--color-fill-accent-cobalt-heavy);
+    --b-tag-badge-color: var(--color-text-accent-cobalt);
+  }
+
+  &:where(.variant-teal) {
+    --b-tag-badge-background-color: var(--color-fill-accent-teal-heavy);
+    --b-tag-badge-color: var(--color-text-accent-teal);
+  }
+
+  &:where(.variant-green) {
+    --b-tag-badge-background-color: var(--color-fill-accent-green-heavy);
+    --b-tag-badge-color: var(--color-text-accent-green);
+  }
+
+  &:where(.variant-olive) {
+    --b-tag-badge-background-color: var(--color-fill-accent-olive-heavy);
+    --b-tag-badge-color: var(--color-fill-accent-olive-heavier);
+  }
+
+  &:where(.variant-pink) {
+    --b-tag-badge-background-color: var(--color-fill-accent-pink-heavy);
+    --b-tag-badge-color: var(--color-text-accent-pink);
+  }
+
+  &:where(.variant-navy) {
+    --b-tag-badge-background-color: var(--color-fill-accent-navy-heavy);
+    --b-tag-badge-color: var(--color-text-accent-navy);
+  }
+
+  &:where(.variant-yellow) {
+    --b-tag-badge-background-color: var(--color-fill-accent-yellow-heavy);
+    --b-tag-badge-color: var(--color-text-accent-yellow);
+  }
+
+  &:where(.variant-orange) {
+    --b-tag-badge-background-color: var(--color-fill-accent-orange-heavy);
+    --b-tag-badge-color: var(--color-text-accent-orange);
+  }
+
+  &:where(.variant-red) {
+    --b-tag-badge-background-color: var(--color-fill-accent-red-heavy);
+    --b-tag-badge-color: var(--color-text-accent-red);
+  }
+
+  &:where(.variant-purple) {
+    --b-tag-badge-background-color: var(--color-fill-accent-purple-heavy);
+    --b-tag-badge-color: var(--color-text-accent-purple);
+  }
+}
+
+.label {
+  padding: 0 4px;
+}
+
+.label-xs {
+  padding: 0 2px;
+}

--- a/packages/bezier-react/src/v3/BaseTagBadge/BaseTagBadge.test.tsx
+++ b/packages/bezier-react/src/v3/BaseTagBadge/BaseTagBadge.test.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+
+import { render } from '~/src/utils/test'
+
+import { BaseTagBadge, BaseTagBadgeText } from './BaseTagBadge'
+
+import styles from './BaseTagBadge.module.scss'
+
+describe('BaseTagBadge', () => {
+  it('should render with size and variant style', () => {
+    const { getByText } = render(
+      <BaseTagBadge
+        size="m"
+        variant="blue"
+      >
+        Badge
+      </BaseTagBadge>
+    )
+    const rendered = getByText('Badge')
+
+    expect(rendered).toHaveClass(styles.BaseTagBadge)
+    expect(rendered).toHaveClass(styles['size-m'])
+    expect(rendered).toHaveClass(styles['variant-blue'])
+  })
+
+  it('should forward ref', () => {
+    const ref = React.createRef<HTMLDivElement>()
+
+    render(
+      <BaseTagBadge
+        ref={ref}
+        size="m"
+        variant="blue"
+      />
+    )
+
+    expect(ref.current).toBeInTheDocument()
+  })
+})
+
+describe('BaseTagBadgeText', () => {
+  it('should render text with proper style', () => {
+    const { getByText } = render(
+      <BaseTagBadgeText size="xs">Badge</BaseTagBadgeText>
+    )
+    const rendered = getByText('Badge')
+
+    expect(rendered).toHaveClass(styles.label)
+    expect(rendered).toHaveClass(styles['label-xs'])
+    expect(rendered).toHaveClass('typo-11')
+    expect(rendered).toHaveStyle(
+      '--b-text-font-weight: var(--typography-font-weight-400)'
+    )
+  })
+})

--- a/packages/bezier-react/src/v3/BaseTagBadge/BaseTagBadge.tsx
+++ b/packages/bezier-react/src/v3/BaseTagBadge/BaseTagBadge.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { forwardRef } from 'react'
+
+import classNames from 'classnames'
+
+import { Text } from '~/src/v3/Text'
+
+import {
+  type BaseTagBadgeProps,
+  type BaseTagBadgeSize,
+  type BaseTagBadgeTextProps,
+} from './BaseTagBadge.types'
+
+import styles from './BaseTagBadge.module.scss'
+
+function getProperTypo(size: BaseTagBadgeSize) {
+  return (
+    {
+      xs: '11',
+      s: '12',
+      m: '14',
+      l: '15',
+    } as const
+  )[size]
+}
+
+/**
+ * `BaseTagBadge` is the component on which `Tag` and `Badge` components are based.
+ */
+export const BaseTagBadge = forwardRef<HTMLDivElement, BaseTagBadgeProps>(
+  function BaseTagBadge(
+    { size, variant, children, className, ...rest },
+    forwardedRef
+  ) {
+    return (
+      <div
+        ref={forwardedRef}
+        className={classNames(
+          styles.BaseTagBadge,
+          styles[`size-${size}`],
+          styles[`variant-${variant}`],
+          className
+        )}
+        {...rest}
+      >
+        {children}
+      </div>
+    )
+  }
+)
+
+/**
+ * `BaseTagBadgeText` is the component on which `Tag` and `Badge` components are based.
+ */
+export const BaseTagBadgeText = forwardRef<HTMLElement, BaseTagBadgeTextProps>(
+  function BaseTagBadgeText(
+    { size, children, className, ...rest },
+    forwardedRef
+  ) {
+    return (
+      <Text
+        {...rest}
+        ref={forwardedRef}
+        typo={getProperTypo(size)}
+        fontWeight={size === 'xs' ? '400' : '500'}
+        className={classNames(
+          styles.label,
+          size === 'xs' && styles['label-xs'],
+          className
+        )}
+      >
+        {children}
+      </Text>
+    )
+  }
+)

--- a/packages/bezier-react/src/v3/BaseTagBadge/BaseTagBadge.types.ts
+++ b/packages/bezier-react/src/v3/BaseTagBadge/BaseTagBadge.types.ts
@@ -1,0 +1,35 @@
+import {
+  type BezierComponentProps,
+  type ChildrenProps,
+  type SizeProps,
+  type VariantProps,
+} from '~/src/types/props'
+import { type TextProps } from '~/src/v3/Text'
+
+export type BaseTagBadgeSize = 'xs' | 's' | 'm' | 'l'
+
+export type BaseTagBadgeVariant =
+  | 'default'
+  | 'neutral-light'
+  | 'neutral-dark'
+  | 'blue'
+  | 'cobalt'
+  | 'teal'
+  | 'green'
+  | 'olive'
+  | 'pink'
+  | 'navy'
+  | 'yellow'
+  | 'orange'
+  | 'red'
+  | 'purple'
+
+export interface BaseTagBadgeProps
+  extends BezierComponentProps<'div'>,
+    ChildrenProps,
+    Required<SizeProps<BaseTagBadgeSize>>,
+    Required<VariantProps<BaseTagBadgeVariant>> {}
+
+export interface BaseTagBadgeTextProps
+  extends Omit<TextProps, 'typo'>,
+    Required<SizeProps<BaseTagBadgeSize>> {}

--- a/packages/bezier-react/src/v3/BaseTagBadge/index.ts
+++ b/packages/bezier-react/src/v3/BaseTagBadge/index.ts
@@ -1,0 +1,5 @@
+export { BaseTagBadge, BaseTagBadgeText } from './BaseTagBadge'
+export type {
+  BaseTagBadgeSize,
+  BaseTagBadgeVariant,
+} from './BaseTagBadge.types'

--- a/packages/bezier-react/src/v3/Status/Status.module.scss
+++ b/packages/bezier-react/src/v3/Status/Status.module.scss
@@ -1,0 +1,50 @@
+@use '../../styles/mixins/position';
+
+.Status {
+  --b-status-size: 0;
+  --b-status-border-width: 0;
+  --b-status-bg-color: initial;
+
+  position: relative;
+  z-index: var(--layer-z-index-base);
+
+  box-sizing: content-box;
+  width: var(--b-status-size);
+  height: var(--b-status-size);
+
+  background-color: var(--color-surface-high);
+  border: var(--b-status-border-width) solid var(--color-surface-highest);
+  border-radius: 50%;
+
+  &::after {
+    content: '';
+
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    display: block;
+
+    width: var(--b-status-size);
+    height: var(--b-status-size);
+
+    background-color: var(--b-status-bg-color);
+    border-radius: 50%;
+  }
+
+  &:where(.size-m) {
+    --b-status-size: 8px;
+    --b-status-border-width: 2px;
+  }
+
+  &:where(.size-l) {
+    --b-status-size: 14px;
+    --b-status-border-width: 3px;
+  }
+}
+
+.Icon {
+  @include position.absolute-center;
+
+  z-index: var(--layer-z-index-floating);
+}

--- a/packages/bezier-react/src/v3/Status/Status.stories.tsx
+++ b/packages/bezier-react/src/v3/Status/Status.stories.tsx
@@ -1,0 +1,103 @@
+import { type Meta, type StoryObj } from '@storybook/react'
+
+import { HStack } from '~/src/v3/HStack'
+
+import { Status } from './Status'
+import {
+  type StatusProps,
+  type StatusSize,
+  type StatusType,
+} from './Status.types'
+
+const TYPES: StatusType[] = [
+  'online',
+  'offline',
+  'online-dnd',
+  'offline-dnd',
+  'lock',
+]
+
+const SIZES: StatusSize[] = ['m', 'l']
+
+const meta: Meta<typeof Status> = {
+  title: 'V3 components/Status',
+  component: Status,
+  args: {
+    type: 'online',
+    size: 'm',
+  },
+  argTypes: {
+    type: {
+      control: 'select',
+      options: TYPES,
+    },
+    size: {
+      control: 'select',
+      options: SIZES,
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<StatusProps>
+
+/**
+ * Adjust `type` / `size` with the controls panel.
+ */
+export const Primary: Story = {
+  render: (args) => (
+    <HStack
+      align="center"
+      justify="center"
+      width={200}
+      height={200}
+      backgroundColor="fill-neutral-light"
+    >
+      <Status {...args} />
+    </HStack>
+  ),
+}
+
+/**
+ * Each type (based on the `m` size).
+ */
+export const Types: Story = {
+  tags: ['!autodocs'],
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <HStack
+      align="center"
+      spacing={16}
+    >
+      {TYPES.map((type) => (
+        <Status
+          key={type}
+          type={type}
+        />
+      ))}
+    </HStack>
+  ),
+}
+
+/**
+ * Each size (based on the `online` type).
+ */
+export const Sizes: Story = {
+  tags: ['!autodocs'],
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <HStack
+      align="center"
+      spacing={16}
+    >
+      {SIZES.map((size) => (
+        <Status
+          key={size}
+          type="online"
+          size={size}
+        />
+      ))}
+    </HStack>
+  ),
+}

--- a/packages/bezier-react/src/v3/Status/Status.test.tsx
+++ b/packages/bezier-react/src/v3/Status/Status.test.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react'
+
+import { colorTokenCssVar } from '~/src/utils/style'
+import { render } from '~/src/utils/test'
+
+import { Status } from './Status'
+import type { StatusProps } from './Status.types'
+
+import styles from './Status.module.scss'
+
+describe('Status', () => {
+  const renderStatus = (props: StatusProps) => render(<Status {...props} />)
+
+  it('should render', () => {
+    const { container } = renderStatus({ type: 'online' })
+    const status = container.querySelector('div')
+
+    expect(status).toBeInTheDocument()
+    expect(status).toHaveClass(styles.Status)
+  })
+
+  it('should forward ref', () => {
+    const ref = React.createRef<HTMLDivElement>()
+
+    render(
+      <Status
+        ref={ref}
+        type="online"
+      />
+    )
+
+    expect(ref.current).toBeInTheDocument()
+  })
+
+  it('should apply size class', () => {
+    const { container } = renderStatus({ type: 'online', size: 'l' })
+    const status = container.querySelector('div')
+
+    expect(status).toHaveClass(styles['size-l'])
+  })
+
+  describe('icon rendering', () => {
+    it('should render icon for online-dnd type', () => {
+      const { container } = renderStatus({ type: 'online-dnd' })
+      const icon = container.querySelector('svg')
+
+      expect(icon).toBeInTheDocument()
+    })
+
+    it('should render icon for offline-dnd type', () => {
+      const { container } = renderStatus({ type: 'offline-dnd' })
+      const icon = container.querySelector('svg')
+
+      expect(icon).toBeInTheDocument()
+    })
+
+    it('should render icon for lock type', () => {
+      const { container } = renderStatus({ type: 'lock' })
+      const icon = container.querySelector('svg')
+
+      expect(icon).toBeInTheDocument()
+    })
+
+    it('should not render icon for online type', () => {
+      const { container } = renderStatus({ type: 'online' })
+      const icon = container.querySelector('svg')
+
+      expect(icon).not.toBeInTheDocument()
+    })
+
+    it('should not render icon for offline type', () => {
+      const { container } = renderStatus({ type: 'offline' })
+      const icon = container.querySelector('svg')
+
+      expect(icon).not.toBeInTheDocument()
+    })
+  })
+
+  describe('backgroundColor logic', () => {
+    it('should use surface-high when type has icon', () => {
+      const { container } = renderStatus({ type: 'online-dnd' })
+      const status = container.querySelector('div')
+      const expectedColor = colorTokenCssVar('surface-high')
+
+      expect(status).toHaveStyle(`--b-status-bg-color: ${expectedColor}`)
+    })
+
+    it('should use statusColor when type does not have icon', () => {
+      const { container } = renderStatus({ type: 'online' })
+      const status = container.querySelector('div')
+      const expectedColor = colorTokenCssVar('text-accent-green')
+
+      expect(status).toHaveStyle(`--b-status-bg-color: ${expectedColor}`)
+    })
+  })
+})

--- a/packages/bezier-react/src/v3/Status/Status.tsx
+++ b/packages/bezier-react/src/v3/Status/Status.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { type CSSProperties, forwardRef, memo } from 'react'
+
+import { LockIcon, MoonFilledIcon } from '@channel.io/bezier-icons'
+import classNames from 'classnames'
+
+import { type BetaSemanticColor } from '~/src/types/beta-tokens'
+import { colorTokenCssVar } from '~/src/utils/style'
+import { Icon } from '~/src/v3/Icon'
+
+import { type StatusProps, type StatusType } from './Status.types'
+
+import styles from './Status.module.scss'
+
+const statusTypesWithIcon: Readonly<StatusType[]> = [
+  'online-dnd',
+  'offline-dnd',
+  'lock',
+]
+
+const statusColor: Readonly<Record<StatusType, BetaSemanticColor>> = {
+  online: 'text-accent-green',
+  offline: 'fill-neutral-heavy',
+  'online-dnd': 'text-accent-green',
+  'offline-dnd': 'text-accent-yellow',
+  lock: 'text-neutral-light',
+}
+
+/**
+ * `Status` is a component to indicate user status.
+ */
+export const Status = memo(
+  forwardRef<HTMLDivElement, StatusProps>(function Status(
+    { type, size = 'm', style, className, ...rest },
+    forwardedRef
+  ) {
+    const withIcon = statusTypesWithIcon.includes(type)
+    const backgroundColor = withIcon ? 'surface-high' : statusColor[type]
+
+    return (
+      <div
+        ref={forwardedRef}
+        style={
+          {
+            '--b-status-bg-color': colorTokenCssVar(backgroundColor),
+            ...style,
+          } as CSSProperties
+        }
+        className={classNames(styles.Status, styles[`size-${size}`], className)}
+        {...rest}
+      >
+        {withIcon && (
+          <Icon
+            source={type === 'lock' ? LockIcon : MoonFilledIcon}
+            size={size === 'm' ? '10' : '16'}
+            color={statusColor[type]}
+            className={styles.Icon}
+          />
+        )}
+      </div>
+    )
+  })
+)

--- a/packages/bezier-react/src/v3/Status/Status.types.ts
+++ b/packages/bezier-react/src/v3/Status/Status.types.ts
@@ -1,0 +1,22 @@
+import type { BezierComponentProps, SizeProps } from '~/src/types/props'
+
+export type StatusType =
+  | 'online'
+  | 'offline'
+  | 'lock'
+  | 'online-dnd'
+  | 'offline-dnd'
+
+export type StatusSize = 'm' | 'l'
+
+interface StatusOwnProps {
+  /**
+   * Type of Status image.
+   */
+  type: StatusType
+}
+
+export interface StatusProps
+  extends BezierComponentProps<'div'>,
+    SizeProps<StatusSize>,
+    StatusOwnProps {}

--- a/packages/bezier-react/src/v3/Status/index.ts
+++ b/packages/bezier-react/src/v3/Status/index.ts
@@ -1,0 +1,2 @@
+export { Status } from './Status'
+export type { StatusProps, StatusSize, StatusType } from './Status.types'

--- a/packages/bezier-react/src/v3/index.ts
+++ b/packages/bezier-react/src/v3/index.ts
@@ -1,10 +1,14 @@
 // Prefer this subpath for new Bezier React usage.
 // Root exports are kept for compatibility with older component APIs.
+export * from './Avatar'
+export * from './AvatarGroup'
+export * from './Badge'
 export * from './Box'
 export * from './Divider'
 export * from './HStack'
 export * from './Icon'
 export * from './SmoothCornersBox'
 export * from './Spinner'
+export * from './Status'
 export * from './Text'
 export * from './VStack'


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

WEBTECH-8094

## Summary

v3 서브패스에 composite 컴포넌트인 `Avatar`, `AvatarGroup`, `Badge`, `Status`와 이를 지원하는 `BaseTagBadge`를 추가합니다.

## Details

- `Avatar`, `AvatarGroup`, `Badge`, `Status`, `BaseTagBadge` 컴포넌트의 구현, 타입, 스타일, 스토리를 추가했습니다.
- `Avatar`와 `AvatarGroup`은 v3 primitive 컴포넌트와 beta semantic token을 사용하도록 구성했습니다.
- `Avatar` status 값은 `online-dnd`, `offline-dnd` 네이밍을 사용합니다.
- `Badge` variant는 `neutral-light`, `neutral-dark` 네이밍을 포함합니다.
- 각 컴포넌트와 `useProgressiveImage`에 대한 테스트를 추가했습니다.
- 릴리즈를 위한 changeset을 추가했습니다.

### Breaking change? (Yes/No)

No

기존 root export의 public API를 변경하지 않고 `/v3` 서브패스에 새 컴포넌트를 추가하는 변경입니다.

## References

- 선행 PR: #2830
