### PR TITLE
fix(storybook): load v3 typography font weights

### DIFF
--- a/packages/bezier-react/.storybook/preview-head.html
+++ b/packages/bezier-react/.storybook/preview-head.html
@@ -1,8 +1,14 @@
 <link
   rel="preconnect"
-  href="https://cf.channel.io"
+  href="https://fonts.googleapis.com"
 />
 <link
+  rel="preconnect"
+  href="https://fonts.gstatic.com"
+  crossorigin
+/>
+<!-- Keep Storybook font coverage aligned with v3 typography token weights. -->
+<link
   rel="stylesheet"
-  href="https://cf.channel.io/asset/font/Inter/inter.css"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
 />


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [ ] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

WEBTECH-8098

## Summary

Storybook preview에서 Inter `400`, `500`, `600`, `700` font weight를 명시적으로 로드하도록 수정합니다.

## Details

v3 Bezier typography token이 제공하는 font weight 범위가 `400`, `500`, `600`, `700`으로 확장되었습니다. Storybook preview도 같은 weight를 실제 font face로 로드해야 각 token weight를 구분해서 렌더링할 수 있습니다.

이 문제는 Modal/ConfirmModal 작업 중 title weight 비교에서 먼저 드러났습니다. 앱 환경에서는 `500`, `600`도 실제로 로드되어 `400`과 구분되었지만, Bezier Storybook에서는 중간 weight가 명확히 식별되지 않아 component spec 문제처럼 보일 수 있었습니다.

이번 변경은 Storybook preview fidelity를 v3 typography token 범위에 맞추는 작업입니다. 컴포넌트 런타임 API나 배포 패키지 동작을 바꾸지 않으므로 changeset은 추가하지 않았습니다.

결정 사항:

- 현재 Bezier v3 typography token이 제공하는 weight인 `400`, `500`, `600`, `700`만 명시적으로 로드합니다.
- 더 넓은 range/variable font 로딩도 가능하지만, 현재 지원 token 범위보다 넓게 열 필요는 없다고 판단했습니다.
- Storybook에서 다국어/전체 weight range 검증을 주목적으로 삼지 않으므로, 명시 weight 로드가 현재 목적에 더 직접적입니다.

### Breaking change? (Yes/No)

No

## References

- `yarn workspace @channel.io/bezier-react build-storybook`

브라우저별 수동 테스트는 별도로 수행하지 않았습니다.
