### PR TITLE
fix(tokens): add system dark theme fallback

### DIFF
--- a/.changeset/theme-fallback-system-dark.md
+++ b/.changeset/theme-fallback-system-dark.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-tokens': patch
+---
+
+Add a dark theme CSS variable fallback for system dark mode before `data-bezier-theme` is set.

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -292,7 +292,7 @@ async function main() {
     `${BUILD_PATH.BASE_ALPHA}/${BUILD_PATH.CSS}`,
     `${BUILD_PATH.BASE_BETA}/${BUILD_PATH.CSS}`,
   ]) {
-    await mergeCss(buildPath)
+    await mergeCss(buildPath, { addSystemDarkThemeFallback: true })
   }
 
   for (const buildPath of [

--- a/packages/bezier-tokens/scripts/merge-css.ts
+++ b/packages/bezier-tokens/scripts/merge-css.ts
@@ -1,11 +1,36 @@
 import fs from 'fs/promises'
 import path from 'path'
 
-export async function mergeCss(buildPath: string) {
+const MERGED_CSS_FILE = 'styles.css'
+const DARK_THEME_CSS_FILE = 'darkTheme.css'
+const DARK_THEME_SELECTOR = '[data-bezier-theme="dark"]'
+const SYSTEM_DARK_THEME_FALLBACK_SELECTOR =
+  ':where(:root:not([data-bezier-theme]), :host(:not([data-bezier-theme])))'
+
+interface MergeCssOptions {
+  addSystemDarkThemeFallback?: boolean
+}
+
+function createSystemDarkThemeFallbackCss(css: string) {
+  if (!css.includes(DARK_THEME_SELECTOR)) {
+    throw new Error(`Dark theme CSS must include ${DARK_THEME_SELECTOR}`)
+  }
+
+  return `@media (prefers-color-scheme: dark) {\n${css.replace(
+    DARK_THEME_SELECTOR,
+    SYSTEM_DARK_THEME_FALLBACK_SELECTOR
+  )}}\n`
+}
+
+export async function mergeCss(
+  buildPath: string,
+  { addSystemDarkThemeFallback = false }: MergeCssOptions = {}
+) {
   try {
-    const destination = path.join(buildPath, 'styles.css')
+    const destination = path.join(buildPath, MERGED_CSS_FILE)
     const files = await fs.readdir(buildPath)
     const result: string[] = []
+    let darkThemeCss: string | null = null
 
     for (const file of files.filter((file) => file.endsWith('.css'))) {
       if (file === path.basename(destination)) continue
@@ -14,7 +39,23 @@ export async function mergeCss(buildPath: string) {
       const data = await fs.readFile(filePath, 'utf8')
       result.push(data)
 
+      if (file === DARK_THEME_CSS_FILE) {
+        darkThemeCss = data
+      }
+
       await fs.unlink(filePath)
+    }
+
+    if (addSystemDarkThemeFallback && !darkThemeCss) {
+      throw new Error(
+        `${DARK_THEME_CSS_FILE} is required to create system dark theme fallback`
+      )
+    }
+
+    if (addSystemDarkThemeFallback && darkThemeCss) {
+      // Append after light theme defaults so system-dark users do not see a
+      // light first paint before data-bezier-theme is set by the app.
+      result.push(createSystemDarkThemeFallbackCss(darkThemeCss))
     }
 
     await fs.writeFile(destination, result.join('\n'))


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

WEBTECH-8555

## Summary

명시적인 `data-bezier-theme`가 아직 설정되기 전, 사용자의 시스템 테마가 dark인 경우 Bezier dark theme CSS variables를 적용할 수 있는 fallback CSS를 생성합니다.

이 변경은 소비자 앱이 마운트된 뒤 `data-bezier-theme`를 설정하기 전까지 발생할 수 있는 light first paint를 줄이기 위한 것입니다.

## Details

### 문제 배경과 원인

Bezier 라이브러리 관점에서 보면, `@channel.io/bezier-tokens`는 현재 light theme variables를 기본 `:root` / `:host` theme으로 생성하고, dark theme variables는 `[data-bezier-theme="dark"]` 아래에만 생성합니다.

소비자 앱 관점에서 보면, `ch-desk-web` 같은 앱은 초기 HTML이 로드되고 React 앱이 마운트된 뒤에야 최종 theme을 판단하고 `data-bezier-theme`를 적용합니다. 따라서 앱 마운트 전의 짧은 구간에는 문서에 `data-bezier-theme` attribute가 없습니다. 이 구간에서는 사용자의 시스템 테마가 dark여도 Bezier CSS variables가 light 기본값으로 resolve되고, 이후 앱이 최종 theme을 적용하면서 light flash가 발생할 수 있습니다.

즉, 이 문제는 Bezier의 기본 token CSS가 light fallback을 제공하는 구조와, 소비자 앱이 초기 paint 전에 theme attribute를 확정하지 못하는 구조가 만나는 지점에서 발생합니다.

### 시도한 해결 방법

Bezier를 수정하기 전에, `ch-desk-web`에 설치된 Bezier stylesheet를 Yarn patch로 수정해서 같은 접근을 검증했습니다. 해당 patch는 `data-bezier-theme`가 없는 상태에 대해 `prefers-color-scheme: dark` fallback을 추가했고, 브라우저 QA에서 관찰되던 flash가 사라지는 것을 확인했습니다.

이 PR은 그 임시 patch를 Bezier token build pipeline으로 옮깁니다.

- `mergeCss`가 `darkTheme.css`를 기반으로 system dark fallback block을 append할 수 있게 합니다.
- fallback selector는 `data-bezier-theme`가 없을 때만 적용됩니다.
  - `:where(:root:not([data-bezier-theme]), :host(:not([data-bezier-theme])))`
- fallback block은 light theme defaults 뒤에 append되어, 초기 no-attribute 상태에서 light default보다 우선 적용됩니다.
- 소비자 앱이 `[data-bezier-theme="light"]` 또는 `[data-bezier-theme="dark"]`를 명시적으로 설정한 뒤에는 기존처럼 앱이 설정한 attribute가 source of truth가 됩니다.

### 후속으로 개선 가능한 부분

Bezier 라이브러리 관점:

- fallback selector 생성을 현재처럼 generated dark theme CSS에서 파생하지 않고, token build의 명시적인 개념으로 만들 수 있습니다.
- generated CSS의 selector 순서와 fallback 존재 여부를 확인하는 작은 build-level assertion 또는 snapshot을 추가할 수 있습니다.
- web component 소비자를 위해 `:host` fallback 지원 범위를 문서화할 수 있습니다.

소비자 앱 관점:

- 가장 결정적인 해결은 서버가 초기 HTML을 내려줄 때 이미 올바른 `data-bezier-theme`를 포함하는 것입니다. 예를 들어 서버에서 알 수 있는 유저 선호값이나 cookie 기반 theme 값을 사용할 수 있습니다.
- 앱의 명시적 theme 선호가 시스템 theme과 다르고, 그 선호를 mount 전까지 알 수 없다면 여전히 한 번의 초기 전환은 발생할 수 있습니다.
- 소비자 앱은 React effect가 실행되기 전에 theme preference를 알 수 있게 만들수록 이 종류의 flash를 더 줄일 수 있습니다.

### Breaking change? (Yes/No)

No.

이 변경은 `data-bezier-theme`가 없는 초기 상태에서, 시스템 테마가 dark인 사용자에게만 영향을 줍니다. 명시적인 `data-bezier-theme` 값은 계속 우선 적용됩니다.

## References

이 브랜치에서 수행한 검증:

- `yarn workspace @channel.io/bezier-tokens build:tokens`
- `yarn workspace @channel.io/bezier-tokens typecheck`
- `yarn workspace @channel.io/bezier-react build:js`
- generated CSS 확인:
  - `packages/bezier-tokens/dist/css/styles.css`: `prefers=1`, `fallbackRoot=1`, `fallbackHost=1`
  - `packages/bezier-tokens/dist/alpha/css/styles.css`: `prefers=1`, `fallbackRoot=1`, `fallbackHost=1`
  - `packages/bezier-tokens/dist/beta/css/styles.css`: `prefers=1`, `fallbackRoot=1`, `fallbackHost=1`
  - `packages/bezier-react/dist/cjs/styles.css`: `prefers=3`, `fallbackRoot=3`, `fallbackHost=3`
  - `packages/bezier-react/dist/esm/styles.css`: `prefers=3`, `fallbackRoot=3`, `fallbackHost=3`

참고:

- `build:tokens`는 기존과 동일하게 filtered token references에 대한 Style Dictionary `outputReferences` warning을 출력하지만, 빌드는 성공합니다.
- 브라우저 레벨 검증은 동일한 fallback을 `ch-desk-web`에서 Yarn patch로 적용해 먼저 확인했습니다. 이 PR에서는 Bezier package output이 동일한 종류의 fallback을 자체 생성하는지를 확인했습니다.
