### PR TITLE
fix: update v3 state styling

### DIFF
--- a/.changeset/soft-controls-glow.md
+++ b/.changeset/soft-controls-glow.md
@@ -1,0 +1,18 @@
+---
+'@channel.io/bezier-react': patch
+'@channel.io/bezier-tokens': patch
+'@channel.io/stylelint-bezier': patch
+---
+
+Add shared state color tokens and improve v3 state styling.
+
+- Add semantic state color tokens and surface deprecated token warnings through
+  `stylelint-bezier`.
+- Add shared v3 state ring mixins and apply them to input and non-input control
+  states.
+- Remove the v3 `Tooltip` icon prop, tighten Tooltip spacing, and update its
+  radius.
+- Fix v3 `CollapsibleSection` trigger chevron behavior and Help tooltip
+  placement.
+- Improve dark mode colors for v3 radio, switch, slider, and progress bar
+  controls.

--- a/.changeset/soft-controls-glow.md
+++ b/.changeset/soft-controls-glow.md
@@ -12,7 +12,11 @@ Add shared state color tokens and improve v3 state styling.
   states.
 - Remove the v3 `Tooltip` icon prop, tighten Tooltip spacing, and update its
   radius.
-- Fix v3 `CollapsibleSection` trigger chevron behavior and Help tooltip
-  placement.
+- Rename the v3 row foundation component from `ItemBase` to `BaseItem` and
+  update its DropdownMenu and Select usages.
+- Fix v3 `CollapsibleSection` trigger chevron behavior, keep trigger trailing
+  content at the right edge, and add Section / CollapsibleSection rich label
+  stories for leading, help, and trailing content.
+- Update the v3 `Help` tooltip default placement.
 - Improve dark mode colors for v3 radio, switch, slider, and progress bar
   controls.

--- a/packages/bezier-react/src/stories/color.mdx
+++ b/packages/bezier-react/src/stories/color.mdx
@@ -39,7 +39,7 @@ export const sortNumericLeafEntries = (entries) => {
   return [...entries].sort((a, b) => Number(a[0]) - Number(b[0]))
 }
 
-export const ColorSwatch = ({ name, value, reference }) => {
+export const ColorSwatch = ({ name, value, reference, deprecated }) => {
   const [isHovered, setIsHovered] = useState(false)
   const cssVar = `--${name}`
   const color = isHovered
@@ -47,6 +47,12 @@ export const ColorSwatch = ({ name, value, reference }) => {
     : `var(${cssVar})`
   const displayValue = reference || value
   const isReferenced = Boolean(reference)
+  const deprecatedMessage =
+    typeof deprecated === 'string'
+      ? deprecated
+      : deprecated
+        ? 'Deprecated'
+        : null
 
   return (
     <VStack spacing={6} style={{ width: 160 }}>
@@ -65,8 +71,34 @@ export const ColorSwatch = ({ name, value, reference }) => {
           setIsHovered(false)
         }}
       />
-      <div style={{ fontSize: 11, color: 'var(--color-text-neutral, #1a1a1a)' }}>
-        {name}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+          fontSize: 14,
+          color: 'var(--color-text-neutral, #1a1a1a)',
+        }}
+      >
+        <span style={{ minWidth: 0, overflowWrap: 'anywhere' }}>{name}</span>
+        {deprecatedMessage && (
+          <span
+            title={deprecatedMessage}
+            style={{
+              flex: '0 0 auto',
+              padding: '1px 4px',
+              borderRadius: 3,
+              border: '1px solid var(--color-border-warning, #f5b849)',
+              backgroundColor: 'var(--color-fill-warning-light, #fff6d6)',
+              color: 'var(--color-text-warning, #8a5a00)',
+              fontSize: 10,
+              fontWeight: 600,
+              lineHeight: '14px',
+            }}
+          >
+            Deprecated
+          </span>
+        )}
       </div>
       <div
         style={{
@@ -147,6 +179,7 @@ export const TokenGroup = ({
                 name={tokenName}
                 value={token.value || value.value}
                 reference={token.ref}
+                deprecated={token.deprecated}
               />
             )
           })}
@@ -256,4 +289,3 @@ export const Primary = () => (
 # Color
 
 <Primary />
-

--- a/packages/bezier-react/src/styles/mixins/_state.scss
+++ b/packages/bezier-react/src/styles/mixins/_state.scss
@@ -1,4 +1,4 @@
-@mixin error($radius, $gap: 3px, $thickness: 1.5px) {
+@mixin error($radius, $gap: 3px, $thickness: 2px) {
   &::after {
     pointer-events: none;
     content: '';
@@ -6,13 +6,33 @@
     position: absolute;
     inset: calc(-1 * (#{$gap} + #{$thickness}));
 
-    // TODO(@timo): Replace the hardcoded error border with the input state token after the token value is aligned.
-    border: $thickness solid #e67f2b;
+    border: $thickness solid var(--color-state-warning);
     border-radius: calc(#{$radius} + #{$gap} + #{$thickness});
   }
 }
 
-@mixin focus($color: var(--color-border-neutral-heavier), $gap: 3px, $thickness: 1.5px) {
-  outline: $thickness solid $color;
+@mixin error-outline($radius, $gap: 3px, $thickness: 2px) {
+  outline: $thickness solid var(--color-state-warning);
   outline-offset: $gap;
+}
+
+@mixin focus($radius, $gap: 3px, $thickness: 1.5px) {
+  outline: $thickness solid var(--color-state-focus);
+  outline-offset: $gap;
+}
+
+@mixin input($radius, $gap: 0, $thickness: 1.5px) {
+  box-shadow: inset 0 0 0 $thickness var(--color-border-neutral);
+}
+
+@mixin input-active($radius, $gap: 0, $thickness: 1.5px) {
+  box-shadow:
+    inset 0 0 0 $thickness var(--color-state-active),
+    0 1px 2px 0 var(--color-elevation-base);
+}
+
+@mixin input-error($radius, $gap: 0, $thickness: 1.5px) {
+  box-shadow:
+    inset 0 0 0 $thickness var(--color-state-warning),
+    0 1px 2px 0 var(--color-elevation-base);
 }

--- a/packages/bezier-react/src/v3/BaseButton/BaseButton.module.scss
+++ b/packages/bezier-react/src/v3/BaseButton/BaseButton.module.scss
@@ -13,7 +13,7 @@
   border: none;
 
   &:where(:focus-visible) {
-    @include state.focus;
+    @include state.focus(0);
   }
 
   &:where(:focus:not(:focus-visible)) {

--- a/packages/bezier-react/src/v3/BaseItem/BaseItem.module.scss
+++ b/packages/bezier-react/src/v3/BaseItem/BaseItem.module.scss
@@ -7,7 +7,7 @@
   color: var(--color-icon-neutral-heavy);
 }
 
-.ItemBase {
+.BaseItem {
   display: flex;
   align-items: center;
 

--- a/packages/bezier-react/src/v3/BaseItem/BaseItem.test.tsx
+++ b/packages/bezier-react/src/v3/BaseItem/BaseItem.test.tsx
@@ -2,18 +2,18 @@ import { PlusIcon } from '@channel.io/bezier-icons'
 
 import { render } from '~/src/utils/test'
 
-import { ItemBase } from './ItemBase'
+import { BaseItem } from './BaseItem'
 
-describe('ItemBase', () => {
+describe('BaseItem', () => {
   it('renders string content, description, and BezierIcon side content', () => {
     const { getByText, container } = render(
-      <ItemBase
+      <BaseItem
         leadingContent={PlusIcon}
         trailingContent="⌘K"
         description="Description"
       >
         Content
-      </ItemBase>
+      </BaseItem>
     )
 
     expect(getByText('Content')).toBeInTheDocument()
@@ -24,7 +24,7 @@ describe('ItemBase', () => {
 
   it('renders ReactNode content and applies interactive state classes', () => {
     const { getByText } = render(
-      <ItemBase
+      <BaseItem
         role="button"
         active
         disabled
@@ -33,7 +33,7 @@ describe('ItemBase', () => {
         description={<span>Custom description</span>}
       >
         <span>Custom content</span>
-      </ItemBase>
+      </BaseItem>
     )
 
     const item = getByText('Custom content').closest('div[role="button"]')

--- a/packages/bezier-react/src/v3/BaseItem/BaseItem.tsx
+++ b/packages/bezier-react/src/v3/BaseItem/BaseItem.tsx
@@ -8,14 +8,14 @@ import classNames from 'classnames'
 
 import { Text } from '~/src/v3/Text'
 
-import type { ItemBaseProps, ItemBaseSideContent } from './ItemBase.types'
+import type { BaseItemProps, BaseItemSideContent } from './BaseItem.types'
 
-import styles from './ItemBase.module.scss'
+import styles from './BaseItem.module.scss'
 
-function ItemBaseSideContentElement({
+function BaseItemSideContentElement({
   content,
 }: {
-  content?: ItemBaseSideContent
+  content?: BaseItemSideContent
 }) {
   if (isBezierIcon(content)) {
     const SourceElement = content
@@ -31,8 +31,8 @@ function ItemBaseSideContentElement({
   return content
 }
 
-export const ItemBase = forwardRef<HTMLDivElement, ItemBaseProps>(
-  function ItemBase(
+export const BaseItem = forwardRef<HTMLDivElement, BaseItemProps>(
+  function BaseItem(
     {
       className,
       children,
@@ -58,7 +58,7 @@ export const ItemBase = forwardRef<HTMLDivElement, ItemBaseProps>(
       <div
         ref={forwardedRef}
         className={classNames(
-          styles.ItemBase,
+          styles.BaseItem,
           styles[`size-${size}`],
           styles[variant],
           active && styles.active,
@@ -77,7 +77,7 @@ export const ItemBase = forwardRef<HTMLDivElement, ItemBaseProps>(
         >
           {hasLeadingContent && (
             <div className={styles.LeadingContent}>
-              <ItemBaseSideContentElement content={leadingContent} />
+              <BaseItemSideContentElement content={leadingContent} />
             </div>
           )}
 
@@ -113,7 +113,7 @@ export const ItemBase = forwardRef<HTMLDivElement, ItemBaseProps>(
 
         {trailingContent != null && (
           <div className={styles.TrailingContent}>
-            <ItemBaseSideContentElement content={trailingContent} />
+            <BaseItemSideContentElement content={trailingContent} />
           </div>
         )}
       </div>

--- a/packages/bezier-react/src/v3/BaseItem/BaseItem.types.ts
+++ b/packages/bezier-react/src/v3/BaseItem/BaseItem.types.ts
@@ -11,20 +11,20 @@ import type {
   VariantProps,
 } from '~/src/types/props'
 
-export type ItemBaseSize = 'm' | 'l'
+export type BaseItemSize = 'm' | 'l'
 
-export type ItemBaseVariant = 'neutral' | 'destructive'
+export type BaseItemVariant = 'neutral' | 'destructive'
 
-export type ItemBaseSideContent = BezierIcon | ReactNode
+export type BaseItemSideContent = BezierIcon | ReactNode
 
 /**
  * Visual foundation for row-like components.
  *
- * `ItemBase` does not provide menu, option, or button semantics by itself.
+ * `BaseItem` does not provide menu, option, or button semantics by itself.
  * Purpose-built components such as `DropdownMenuItem` should own roles,
  * keyboard interaction, and selection behavior.
  */
-interface ItemBaseOwnProps {
+interface BaseItemOwnProps {
   /**
    * Additional content below the main content.
    */
@@ -32,18 +32,18 @@ interface ItemBaseOwnProps {
   /**
    * Content on the left.
    */
-  leadingContent?: ItemBaseSideContent
+  leadingContent?: BaseItemSideContent
   /**
    * Content on the right.
    */
-  trailingContent?: ItemBaseSideContent
+  trailingContent?: BaseItemSideContent
 }
 
-export interface ItemBaseProps
+export interface BaseItemProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,
     DisableProps,
     ActivatableProps,
-    SizeProps<ItemBaseSize>,
-    VariantProps<ItemBaseVariant>,
-    ItemBaseOwnProps {}
+    SizeProps<BaseItemSize>,
+    VariantProps<BaseItemVariant>,
+    BaseItemOwnProps {}

--- a/packages/bezier-react/src/v3/BaseSelect/BaseSelect.module.scss
+++ b/packages/bezier-react/src/v3/BaseSelect/BaseSelect.module.scss
@@ -1,3 +1,5 @@
+@use '../../styles/mixins/state';
+
 .BaseSelect {
   position: relative;
   display: inline-flex;
@@ -9,8 +11,6 @@
   --b-v3-select-trigger-radius: var(--radius-12);
   --b-v3-select-trigger-font-size: 14px;
   --b-v3-select-trigger-line-height: 18px;
-  --b-v3-select-trigger-box-shadow: inset 0 0 0 1.5px
-    var(--color-border-neutral);
 
   cursor: pointer;
 
@@ -33,10 +33,9 @@
   border: 0;
   border-radius: var(--b-v3-select-trigger-radius);
   outline: none;
-  box-shadow: var(
-    --b-v3-select-trigger-state-box-shadow,
-    var(--b-v3-select-trigger-box-shadow)
-  );
+
+  /* stylelint-disable-next-line order/order */
+  @include state.input(var(--b-v3-select-trigger-radius));
 
   transition:
     box-shadow var(--motion-transition-fast),
@@ -50,17 +49,13 @@
   }
 
   &:where(.open, :focus-visible) {
-    --b-v3-select-trigger-state-box-shadow:
-      inset 0 0 0 1.5px #000,
-      0 1px 2px 0 var(--color-elevation-base);
+    @include state.input-active(var(--b-v3-select-trigger-radius));
 
     background-color: var(--color-fill-grey-light);
   }
 
   &:where(.invalid) {
-    --b-v3-select-trigger-state-box-shadow:
-      inset 0 0 0 1.5px #e67f2b,
-      0 1px 2px 0 var(--color-elevation-base);
+    @include state.input-error(var(--b-v3-select-trigger-radius));
   }
 
   &:where(.readonly) {

--- a/packages/bezier-react/src/v3/BaseSelect/BaseSelect.tsx
+++ b/packages/bezier-react/src/v3/BaseSelect/BaseSelect.tsx
@@ -22,8 +22,8 @@ import { ariaAttr } from '~/src/utils/aria'
 import { createContext } from '~/src/utils/react'
 import { cssDimension } from '~/src/utils/style'
 import { isNil } from '~/src/utils/type'
+import { BaseItem } from '~/src/v3/BaseItem/BaseItem'
 import { useFormFieldProps } from '~/src/v3/FormField'
-import { ItemBase } from '~/src/v3/ItemBase/ItemBase'
 import { Overlay } from '~/src/v3/Overlay'
 
 import { useWindow } from '~/src/components/WindowProvider'
@@ -562,7 +562,7 @@ function BaseSelectOptionElement<Value extends SelectValue>({
   }, [disabled, selectValue, value])
 
   return (
-    <ItemBase
+    <BaseItem
       ref={forwardedRef}
       className={className}
       role="option"
@@ -594,7 +594,7 @@ function BaseSelectOptionElement<Value extends SelectValue>({
       }}
     >
       {optionContent}
-    </ItemBase>
+    </BaseItem>
   )
 }
 

--- a/packages/bezier-react/src/v3/BaseTextInput/BaseTextInput.module.scss
+++ b/packages/bezier-react/src/v3/BaseTextInput/BaseTextInput.module.scss
@@ -1,3 +1,5 @@
+@use '../../styles/mixins/state';
+
 .BaseTextInput {
   --b-v3-text-input-height: 36px;
   --b-v3-text-input-radius: var(--radius-12);
@@ -20,10 +22,9 @@
 
   background-color: var(--b-v3-text-input-background-color);
   border-radius: var(--b-v3-text-input-radius);
-  box-shadow: var(
-    --b-v3-text-input-state-box-shadow,
-    var(--b-v3-text-input-box-shadow, none)
-  );
+
+  /* stylelint-disable-next-line order/order */
+  @include state.input(var(--b-v3-text-input-radius));
 
   transition:
     box-shadow var(--motion-transition-fast),
@@ -45,17 +46,11 @@
   }
 
   &:where(:has(.Input:focus)) {
-    // TODO(@timo): Replace the hardcoded active border with the input state token after the token value is aligned.
-    --b-v3-text-input-state-box-shadow:
-      inset 0 0 0 1.5px #000,
-      0 1px 2px 0 var(--color-elevation-base);
+    @include state.input-active(var(--b-v3-text-input-radius));
   }
 
   &:where(:has(.Input[aria-invalid='true'])) {
-    // TODO(@timo): Replace the hardcoded error border with the input state token after the token value is aligned.
-    --b-v3-text-input-state-box-shadow:
-      inset 0 0 0 1.5px #e67f2b,
-      0 1px 2px 0 var(--color-elevation-base);
+    @include state.input-error(var(--b-v3-text-input-radius));
   }
 }
 

--- a/packages/bezier-react/src/v3/Checkbox/Checkbox.module.scss
+++ b/packages/bezier-react/src/v3/Checkbox/Checkbox.module.scss
@@ -38,8 +38,7 @@
   }
 
   &[data-invalid] {
-    box-shadow:
-      inset 0 0 0 2px var(--color-border-neutral-heavy);
+    box-shadow: inset 0 0 0 2px var(--color-border-neutral-heavy);
   }
 
   &:where([data-invalid]:not([data-disabled])) {
@@ -64,6 +63,8 @@
   }
 
   &:where(:focus-visible) {
+    @include state.focus(var(--radius-8));
+
     &:where(:not([data-disabled])[data-state='unchecked']) .CheckIcon {
       visibility: visible;
     }

--- a/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.module.scss
+++ b/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.module.scss
@@ -1,0 +1,17 @@
+.TriggerContent {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+}
+
+.TriggerLabel {
+  min-width: 0;
+}
+
+.TriggerChevron {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--color-icon-neutral-heavy);
+}

--- a/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.stories.tsx
+++ b/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.stories.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react'
 
-import { InfoIcon } from '@channel.io/bezier-icons'
+import {
+  ChevronSmallRightIcon,
+  InfoIcon,
+  PlusIcon,
+} from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { Box } from '~/src/v3/Box'
@@ -75,23 +79,10 @@ export const RichLabel: Story = {
     <Box width={360}>
       <CollapsibleSection defaultOpen>
         <CollapsibleSectionTrigger
-          content={
-            <Text
-              typo="13"
-              color="text-neutral-lighter"
-              bold
-            >
-              Rich <Text color="text-accent-blue">trigger</Text>
-            </Text>
-          }
-          trailingContent={
-            <Text
-              typo="12"
-              color="text-neutral-lighter"
-            >
-              Right
-            </Text>
-          }
+          leadingContent={PlusIcon}
+          help="Help text"
+          content="Trigger"
+          trailingContent={ChevronSmallRightIcon}
         />
         <CollapsibleSectionItem
           content="Profile"

--- a/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.stories.tsx
+++ b/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.stories.tsx
@@ -1,10 +1,6 @@
 import { useState } from 'react'
 
-import {
-  ChevronDownIcon,
-  ChevronUpIcon,
-  InfoIcon,
-} from '@channel.io/bezier-icons'
+import { InfoIcon } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { Box } from '~/src/v3/Box'
@@ -34,10 +30,7 @@ function ControlledExample() {
         open={open}
         onOpenChange={setOpen}
       >
-        <CollapsibleSectionTrigger
-          content="Controlled section"
-          trailingContent={open ? ChevronUpIcon : ChevronDownIcon}
-        />
+        <CollapsibleSectionTrigger content="Controlled section" />
         <CollapsibleSectionItem
           content="Profile"
           description="This section is controlled externally."
@@ -54,7 +47,6 @@ export const Primary: Story = {
         <CollapsibleSectionTrigger
           content="General"
           leadingContent={InfoIcon}
-          trailingContent="Optional"
           help="These settings apply to the section."
         />
         <CollapsibleSectionItem

--- a/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.stories.tsx
+++ b/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.stories.tsx
@@ -68,6 +68,40 @@ export const Controlled: Story = {
   render: () => <ControlledExample />,
 }
 
+export const RichLabel: Story = {
+  tags: ['!autodocs'],
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <Box width={360}>
+      <CollapsibleSection defaultOpen>
+        <CollapsibleSectionTrigger
+          content={
+            <Text
+              typo="13"
+              color="text-neutral-lighter"
+              bold
+            >
+              Rich <Text color="text-accent-blue">trigger</Text>
+            </Text>
+          }
+          trailingContent={
+            <Text
+              typo="12"
+              color="text-neutral-lighter"
+            >
+              Right
+            </Text>
+          }
+        />
+        <CollapsibleSectionItem
+          content="Profile"
+          description="Chevron stays next to the label, trailing content stays at the right edge."
+        />
+      </CollapsibleSection>
+    </Box>
+  ),
+}
+
 export const WithoutTrigger: Story = {
   tags: ['!autodocs'],
   parameters: { controls: { disable: true } },

--- a/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.tsx
+++ b/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.tsx
@@ -4,17 +4,25 @@ import { Children, Fragment, forwardRef, isValidElement } from 'react'
 import * as React from 'react'
 
 import {
+  ChevronSmallDownIcon,
+  ChevronSmallUpIcon,
+} from '@channel.io/bezier-icons'
+
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from '~/src/v3/Collapsible'
 import { Section, SectionItem, SectionLabel } from '~/src/v3/Section'
+import { Text } from '~/src/v3/Text'
 
 import type {
   CollapsibleSectionItemProps,
   CollapsibleSectionProps,
   CollapsibleSectionTriggerProps,
 } from './CollapsibleSection.types'
+
+import styles from './CollapsibleSection.module.scss'
 
 function isCollapsibleSectionTriggerElement(
   child: React.ReactNode
@@ -91,7 +99,9 @@ export const CollapsibleSection = forwardRef<
 })
 
 export function CollapsibleSectionTrigger({
+  content,
   disabled: disabledProp = false,
+  trailingContent,
   ...labelProps
 }: CollapsibleSectionTriggerProps) {
   return (
@@ -117,6 +127,36 @@ export function CollapsibleSectionTrigger({
             aria-disabled={ariaDisabled}
             data-state={dataState}
             data-active={dataActive}
+            content={
+              <span className={styles.TriggerContent}>
+                {typeof content === 'string' ? (
+                  <Text
+                    as="span"
+                    className={styles.TriggerLabel}
+                    typo="13"
+                    color="text-neutral-lighter"
+                    bold
+                    truncated
+                  >
+                    {content}
+                  </Text>
+                ) : (
+                  <span className={styles.TriggerLabel}>{content}</span>
+                )}
+                {dataState === 'open' ? (
+                  <ChevronSmallUpIcon
+                    className={styles.TriggerChevron}
+                    aria-hidden
+                  />
+                ) : (
+                  <ChevronSmallDownIcon
+                    className={styles.TriggerChevron}
+                    aria-hidden
+                  />
+                )}
+              </span>
+            }
+            trailingContent={trailingContent}
             role="button"
             tabIndex={disabled ? -1 : 0}
             onClick={(event: React.MouseEvent<HTMLElement>) => {
@@ -150,10 +190,18 @@ export function CollapsibleSectionTrigger({
 /**
  * `CollapsibleSectionItem` is a row inside `CollapsibleSection`.
  *
- * It shares the same implementation as `SectionItem`; this alias keeps the
- * `CollapsibleSection` component family self-contained without duplicating row
- * behavior or styles.
+ * It delegates to `SectionItem`; the wrapper keeps the `CollapsibleSection`
+ * component family self-contained without changing `SectionItem`'s component
+ * identity in Storybook source previews.
  */
-export const CollapsibleSectionItem = SectionItem as React.ForwardRefExoticComponent<
-  CollapsibleSectionItemProps & React.RefAttributes<HTMLElement>
->
+export const CollapsibleSectionItem = forwardRef<
+  HTMLElement,
+  CollapsibleSectionItemProps
+>(function CollapsibleSectionItem(props, forwardedRef) {
+  return (
+    <SectionItem
+      ref={forwardedRef}
+      {...props}
+    />
+  )
+})

--- a/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.tsx
+++ b/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.tsx
@@ -13,6 +13,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '~/src/v3/Collapsible'
+import { Help } from '~/src/v3/Help'
 import { Section, SectionItem, SectionLabel } from '~/src/v3/Section'
 import { Text } from '~/src/v3/Text'
 
@@ -101,6 +102,7 @@ export const CollapsibleSection = forwardRef<
 export function CollapsibleSectionTrigger({
   content,
   disabled: disabledProp = false,
+  help,
   trailingContent,
   ...labelProps
 }: CollapsibleSectionTriggerProps) {
@@ -143,6 +145,7 @@ export function CollapsibleSectionTrigger({
                 ) : (
                   <span className={styles.TriggerLabel}>{content}</span>
                 )}
+                {help != null && <Help>{help}</Help>}
                 {dataState === 'open' ? (
                   <ChevronSmallUpIcon
                     className={styles.TriggerChevron}

--- a/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.types.ts
+++ b/packages/bezier-react/src/v3/CollapsibleSection/CollapsibleSection.types.ts
@@ -16,7 +16,11 @@ export interface CollapsibleSectionProps
 export interface CollapsibleSectionTriggerProps
   extends Omit<
     SectionLabelProps,
-    'children' | 'onClick' | 'onKeyDown' | 'role' | 'tabIndex'
+    | 'children'
+    | 'onClick'
+    | 'onKeyDown'
+    | 'role'
+    | 'tabIndex'
   > {
   /**
    * Whether the section trigger is disabled.

--- a/packages/bezier-react/src/v3/DropdownMenu/DropdownMenu.tsx
+++ b/packages/bezier-react/src/v3/DropdownMenu/DropdownMenu.tsx
@@ -23,8 +23,8 @@ import useMergeRefs from '~/src/hooks/useMergeRefs'
 import { createContext } from '~/src/utils/react'
 import { cssDimension } from '~/src/utils/style'
 import { isNil } from '~/src/utils/type'
+import { BaseItem } from '~/src/v3/BaseItem/BaseItem'
 import { Divider } from '~/src/v3/Divider'
-import { ItemBase } from '~/src/v3/ItemBase/ItemBase'
 import { Overlay } from '~/src/v3/Overlay'
 
 import { useWindow } from '~/src/components/WindowProvider'
@@ -478,7 +478,7 @@ export const DropdownMenuItem = forwardRef<
   )
 
   return (
-    <ItemBase
+    <BaseItem
       ref={forwardedRef}
       className={className}
       role="menuitem"
@@ -510,7 +510,7 @@ export const DropdownMenuItem = forwardRef<
       }}
     >
       {content}
-    </ItemBase>
+    </BaseItem>
   )
 })
 

--- a/packages/bezier-react/src/v3/DropdownMenu/DropdownMenu.types.ts
+++ b/packages/bezier-react/src/v3/DropdownMenu/DropdownMenu.types.ts
@@ -11,14 +11,14 @@ import type {
   VariantProps,
 } from '~/src/types/props'
 import type {
-  ItemBaseSize,
-  ItemBaseVariant,
-} from '~/src/v3/ItemBase/ItemBase.types'
+  BaseItemSize,
+  BaseItemVariant,
+} from '~/src/v3/BaseItem/BaseItem.types'
 import type { OverlayPosition, OverlayTarget } from '~/src/v3/Overlay'
 
-export type DropdownMenuSize = ItemBaseSize
+export type DropdownMenuSize = BaseItemSize
 
-export type DropdownMenuItemVariant = ItemBaseVariant
+export type DropdownMenuItemVariant = BaseItemVariant
 
 type DropdownMenuItemSideContent = BezierIcon | ReactNode
 

--- a/packages/bezier-react/src/v3/Help/Help.tsx
+++ b/packages/bezier-react/src/v3/Help/Help.tsx
@@ -19,7 +19,7 @@ export const HELP_DISPLAY_NAME = 'Help'
  * `Help` shows a help icon with tooltip content.
  */
 export const Help = forwardRef<HTMLDivElement, HelpProps>(function Help(
-  { children, ...rest },
+  { children, placement = 'top-center', ...rest },
   forwardedRef
 ) {
   if (isEmpty(children)) {
@@ -31,6 +31,7 @@ export const Help = forwardRef<HTMLDivElement, HelpProps>(function Help(
       {...rest}
       ref={forwardedRef}
       content={children}
+      placement={placement}
     >
       <div className={styles.Help}>
         <Icon

--- a/packages/bezier-react/src/v3/ItemBase/ItemBase.module.scss
+++ b/packages/bezier-react/src/v3/ItemBase/ItemBase.module.scss
@@ -59,7 +59,7 @@
   }
 
   &:where(:focus-visible) {
-    @include state.focus($gap: 0);
+    @include state.focus(var(--radius-8), $gap: 0);
   }
 
   &:where(.interactive:not(.disabled, .active, [data-highlighted])) {

--- a/packages/bezier-react/src/v3/ProgressBar/ProgressBar.module.scss
+++ b/packages/bezier-react/src/v3/ProgressBar/ProgressBar.module.scss
@@ -3,7 +3,7 @@
 
   width: var(--b-v3-progress-bar-width);
 
-  background-color: var(--color-fill-neutral-light);
+  background-color: var(--color-fill-neutral-heavy);
   border-radius: var(--radius-3);
 
   transition: width var(--motion-transition-fast);
@@ -17,7 +17,7 @@
   }
 
   &:where(.variant-overlaid) {
-    background-color: var(--color-fill-absolute-white);
+    background-color: var(--color-fill-grey-heavier);
   }
 }
 

--- a/packages/bezier-react/src/v3/RadioGroup/RadioGroup.module.scss
+++ b/packages/bezier-react/src/v3/RadioGroup/RadioGroup.module.scss
@@ -11,7 +11,7 @@ $inner-indicator-size: 8px;
   width: fit-content;
 
   &:where([aria-invalid='true']) {
-    .Radio:where(:not([data-disabled]))::before {
+    :where(.Radio:not([data-disabled]))::before {
       @include state.error-outline(50%);
     }
   }

--- a/packages/bezier-react/src/v3/RadioGroup/RadioGroup.module.scss
+++ b/packages/bezier-react/src/v3/RadioGroup/RadioGroup.module.scss
@@ -9,6 +9,12 @@ $inner-indicator-size: 8px;
 
 .RadioGroup {
   width: fit-content;
+
+  &:where([aria-invalid='true']) {
+    .Radio:where(:not([data-disabled]))::before {
+      @include state.error-outline(50%);
+    }
+  }
 }
 
 .Radio {
@@ -87,7 +93,7 @@ $inner-indicator-size: 8px;
     outline: none;
 
     &::before {
-      @include state.focus;
+      @include state.focus(50%);
     }
 
     &:where(:not([data-disabled])[data-state='unchecked'])::after {

--- a/packages/bezier-react/src/v3/RadioGroup/RadioGroup.module.scss
+++ b/packages/bezier-react/src/v3/RadioGroup/RadioGroup.module.scss
@@ -75,7 +75,7 @@ $inner-indicator-size: 8px;
     }
 
     &::after {
-      background-color: var(--color-text-inverse);
+      background-color: var(--color-icon-inverse-heavier);
     }
   }
 

--- a/packages/bezier-react/src/v3/Search/Search.module.scss
+++ b/packages/bezier-react/src/v3/Search/Search.module.scss
@@ -1,7 +1,5 @@
 .Search {
   --b-v3-text-input-background-color: var(--color-fill-grey);
-  --b-v3-text-input-box-shadow: inset 0 0 0 1.5px
-    var(--color-border-neutral);
   --b-v3-text-input-radius: var(--radius-12);
 
   gap: 6px;

--- a/packages/bezier-react/src/v3/Section/Section.module.scss
+++ b/packages/bezier-react/src/v3/Section/Section.module.scss
@@ -135,7 +135,7 @@
   }
 
   &:where(:focus-visible) {
-    @include state.focus;
+    @include state.focus(var(--radius-8));
   }
 
   &:where(.interactive:not(.disabled, .active)) {

--- a/packages/bezier-react/src/v3/Section/Section.stories.tsx
+++ b/packages/bezier-react/src/v3/Section/Section.stories.tsx
@@ -159,23 +159,10 @@ export const RichLabel: Story = {
     <Box width={360}>
       <Section>
         <SectionLabel
-          content={
-            <Text
-              typo="13"
-              color="text-neutral-lighter"
-              bold
-            >
-              Rich <Text color="text-accent-blue">label</Text>
-            </Text>
-          }
-          trailingContent={
-            <Text
-              typo="12"
-              color="text-neutral-lighter"
-            >
-              Right
-            </Text>
-          }
+          leadingContent={PlusIcon}
+          help="Help text"
+          content="Label"
+          trailingContent={ChevronSmallRightIcon}
         />
         <SectionItem
           content="Profile"

--- a/packages/bezier-react/src/v3/Section/Section.stories.tsx
+++ b/packages/bezier-react/src/v3/Section/Section.stories.tsx
@@ -152,6 +152,41 @@ export const RichContent: Story = {
   ),
 }
 
+export const RichLabel: Story = {
+  tags: ['!autodocs'],
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <Box width={360}>
+      <Section>
+        <SectionLabel
+          content={
+            <Text
+              typo="13"
+              color="text-neutral-lighter"
+              bold
+            >
+              Rich <Text color="text-accent-blue">label</Text>
+            </Text>
+          }
+          trailingContent={
+            <Text
+              typo="12"
+              color="text-neutral-lighter"
+            >
+              Right
+            </Text>
+          }
+        />
+        <SectionItem
+          content="Profile"
+          description="Trailing content stays at the right edge."
+          leadingContent={EditIcon}
+        />
+      </Section>
+    </Box>
+  ),
+}
+
 export const Sizes: Story = {
   tags: ['!autodocs'],
   parameters: { controls: { disable: true } },

--- a/packages/bezier-react/src/v3/SegmentedControl/SegmentedControl.module.scss
+++ b/packages/bezier-react/src/v3/SegmentedControl/SegmentedControl.module.scss
@@ -167,7 +167,7 @@ $divider-side-indent: 6px;
   }
 
   &:where(:focus-visible) {
-    @include state.focus;
+    @include state.focus(9999px);
   }
 }
 

--- a/packages/bezier-react/src/v3/Slider/Slider.module.scss
+++ b/packages/bezier-react/src/v3/Slider/Slider.module.scss
@@ -1,3 +1,5 @@
+@use '../../styles/mixins/state';
+
 .Slider {
   --b-v3-slider-width: initial;
   --b-v3-slider-thumb-size: 24px;
@@ -82,6 +84,6 @@
   }
 
   &:where(:focus-visible) {
-    outline: none;
+    @include state.focus(9999px);
   }
 }

--- a/packages/bezier-react/src/v3/Slider/Slider.module.scss
+++ b/packages/bezier-react/src/v3/Slider/Slider.module.scss
@@ -73,7 +73,7 @@
   width: var(--b-v3-slider-thumb-size);
   height: var(--b-v3-slider-thumb-size);
 
-  background-color: var(--color-fill-bright);
+  background-color: var(--color-fill-absolute-white);
   border-radius: 9999px;
   box-shadow: var(--elevation-2);
 

--- a/packages/bezier-react/src/v3/Switch/Switch.module.scss
+++ b/packages/bezier-react/src/v3/Switch/Switch.module.scss
@@ -70,7 +70,7 @@
   width: var(--b-v3-switch-thumb-size);
   height: var(--b-v3-switch-thumb-size);
 
-  background-color: var(--color-fill-bright);
+  background-color: var(--color-icon-inverse-heavier);
   border-radius: 9999px;
   box-shadow: var(--elevation-2);
 

--- a/packages/bezier-react/src/v3/Switch/Switch.module.scss
+++ b/packages/bezier-react/src/v3/Switch/Switch.module.scss
@@ -29,7 +29,7 @@
 
   position: relative;
 
-  overflow: hidden;
+  overflow: visible;
   flex: 0 0 auto;
 
   width: var(--b-v3-switch-width);
@@ -54,7 +54,11 @@
   }
 
   &:where(:focus-visible) {
-    @include state.focus;
+    @include state.focus(9999px);
+  }
+
+  &:where([data-invalid]:not([data-disabled])) {
+    @include state.error(9999px);
   }
 }
 

--- a/packages/bezier-react/src/v3/Tabs/Tabs.module.scss
+++ b/packages/bezier-react/src/v3/Tabs/Tabs.module.scss
@@ -85,7 +85,7 @@ $tab-item-indicator-height: 3px;
   }
 
   &:where(:focus-visible) {
-    @include state.focus;
+    @include state.focus(var(--radius-8));
   }
 
   &:where(.size-s) {
@@ -166,7 +166,7 @@ $tab-item-indicator-height: 3px;
   }
 
   &:where(:focus-visible) {
-    @include state.focus;
+    @include state.focus(var(--radius-8));
   }
 
   &:hover {

--- a/packages/bezier-react/src/v3/Tag/Tag.module.scss
+++ b/packages/bezier-react/src/v3/Tag/Tag.module.scss
@@ -23,7 +23,7 @@
   outline: none;
 
   &:where(:focus-visible) {
-    @include state.focus;
+    @include state.focus(9999px);
   }
 }
 

--- a/packages/bezier-react/src/v3/TextArea/TextArea.module.scss
+++ b/packages/bezier-react/src/v3/TextArea/TextArea.module.scss
@@ -1,7 +1,7 @@
+@use '../../styles/mixins/state';
+
 .TextArea {
   --b-v3-text-area-background-color: var(--color-fill-grey);
-  --b-v3-text-area-box-shadow: inset 0 0 0 1.5px
-    var(--color-border-neutral);
 
   resize: none;
 
@@ -22,10 +22,9 @@
   border: none;
   border-radius: var(--radius-12);
   outline: none;
-  box-shadow: var(
-    --b-v3-text-area-state-box-shadow,
-    var(--b-v3-text-area-box-shadow, none)
-  );
+
+  /* stylelint-disable-next-line order/order */
+  @include state.input(var(--radius-12));
 
   transition:
     background-color var(--motion-transition-fast),
@@ -47,19 +46,15 @@
   }
 
   &:focus {
-    // TODO(@timo): Replace the hardcoded active border with the input state token after the token value is aligned.
     --b-v3-text-area-background-color: var(--color-fill-grey-light);
-    --b-v3-text-area-state-box-shadow:
-      inset 0 0 0 1.5px #000,
-      0 1px 2px 0 var(--color-elevation-base);
+
+    @include state.input-active(var(--radius-12));
   }
 
   &[aria-invalid='true'] {
-    // TODO(@timo): Replace the hardcoded error border with the input state token after the token value is aligned.
     --b-v3-text-area-background-color: var(--color-fill-grey-light);
-    --b-v3-text-area-state-box-shadow:
-      inset 0 0 0 1.5px #e67f2b,
-      0 1px 2px 0 var(--color-elevation-base);
+
+    @include state.input-error(var(--radius-12));
   }
 
   &:read-only {

--- a/packages/bezier-react/src/v3/TextInput/TextInput.module.scss
+++ b/packages/bezier-react/src/v3/TextInput/TextInput.module.scss
@@ -1,8 +1,6 @@
 .TextInput {
   &:where(.variant-primary) {
     --b-v3-text-input-background-color: var(--color-fill-grey);
-    --b-v3-text-input-box-shadow: inset 0 0 0 1.5px
-      var(--color-border-neutral);
 
     &:where(:has(input:focus)) {
       --b-v3-text-input-background-color: var(--color-fill-grey-light);

--- a/packages/bezier-react/src/v3/Tooltip/Tooltip.module.scss
+++ b/packages/bezier-react/src/v3/Tooltip/Tooltip.module.scss
@@ -19,7 +19,6 @@
 
 .TooltipContainer {
   overflow: hidden;
-
   display: flex;
   flex-direction: column;
   gap: 2px;

--- a/packages/bezier-react/src/v3/Tooltip/Tooltip.module.scss
+++ b/packages/bezier-react/src/v3/Tooltip/Tooltip.module.scss
@@ -13,18 +13,18 @@
   word-wrap: break-word;
 
   background-color: var(--color-fill-grey-heavier);
-  border-radius: var(--radius-8);
+  border-radius: 10px;
   box-shadow: var(--elevation-2);
 }
 
 .TooltipContainer {
   overflow: hidden;
+
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .TooltipContent {
   white-space: pre-wrap;
-}
-
-.Icon {
-  flex-shrink: 0;
 }

--- a/packages/bezier-react/src/v3/Tooltip/Tooltip.stories.tsx
+++ b/packages/bezier-react/src/v3/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,3 @@
-import { TranslateIcon } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { Button } from '~/src/v3/Button'
@@ -43,7 +42,6 @@ export const RichContent: Story = {
       title="Title"
       content="Tooltip content"
       description="Description"
-      icon={TranslateIcon}
     >
       <Button label="Button" />
     </Tooltip>

--- a/packages/bezier-react/src/v3/Tooltip/Tooltip.test.tsx
+++ b/packages/bezier-react/src/v3/Tooltip/Tooltip.test.tsx
@@ -1,4 +1,3 @@
-import { CheckIcon } from '@channel.io/bezier-icons'
 import { isInaccessible, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
@@ -45,13 +44,12 @@ describe('Tooltip', () => {
     expect(getByRole('tooltip')).toHaveTextContent('Tooltip content')
   })
 
-  it('renders optional title, description, icon, and custom class name', () => {
+  it('renders optional title, description, and custom class name', () => {
     const { getAllByText, getByRole } = renderTooltip({
       defaultShow: true,
       title: 'Tooltip title',
       content: 'Tooltip content',
       description: 'Tooltip description',
-      icon: CheckIcon,
       className: 'custom-tooltip',
     })
 
@@ -61,7 +59,6 @@ describe('Tooltip', () => {
     expect(getAllByText('Tooltip title')).toHaveLength(2)
     expect(getAllByText('Tooltip content')).toHaveLength(2)
     expect(getAllByText('Tooltip description')).toHaveLength(2)
-    expect(tooltip.querySelector('svg')).toBeInTheDocument()
   })
 
   it('connects trigger and tooltip with aria-describedby', () => {

--- a/packages/bezier-react/src/v3/Tooltip/Tooltip.test.tsx
+++ b/packages/bezier-react/src/v3/Tooltip/Tooltip.test.tsx
@@ -45,15 +45,13 @@ describe('Tooltip', () => {
   })
 
   it('renders optional title, description, and custom class name', () => {
-    const { getAllByText, getByRole } = renderTooltip({
+    const { getAllByText } = renderTooltip({
       defaultShow: true,
       title: 'Tooltip title',
       content: 'Tooltip content',
       description: 'Tooltip description',
       className: 'custom-tooltip',
     })
-
-    const tooltip = getByRole('tooltip')
 
     expect(document.querySelector('.custom-tooltip')).toBeInTheDocument()
     expect(getAllByText('Tooltip title')).toHaveLength(2)

--- a/packages/bezier-react/src/v3/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/v3/Tooltip/Tooltip.tsx
@@ -12,8 +12,6 @@ import {
 import classNames from 'classnames'
 
 import { isEmpty } from '~/src/utils/type'
-import { HStack } from '~/src/v3/HStack'
-import { Icon } from '~/src/v3/Icon'
 import { Text } from '~/src/v3/Text'
 
 import {
@@ -120,7 +118,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       title,
       content,
       description,
-      icon,
       placement = 'bottom-center',
       offset = 4,
       container: containerProp,
@@ -224,16 +221,12 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
                 collisionPadding={8}
                 hideWhenDetached
               >
-                <HStack
-                  spacing={4}
-                  className={classNames(styles.Tooltip, className)}
-                >
+                <div className={classNames(styles.Tooltip, className)}>
                   <div className={styles.TooltipContainer}>
                     {title && (
                       <Text
                         typo="13"
                         fontWeight="600"
-                        marginBottom={2}
                         color="text-neutral"
                       >
                         {title}
@@ -258,16 +251,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
                       </Text>
                     )}
                   </div>
-
-                  {icon && (
-                    <Icon
-                      source={icon}
-                      size="16"
-                      color="icon-neutral"
-                      className={styles.Icon}
-                    />
-                  )}
-                </HStack>
+                </div>
               </AlphaTooltipPrimitiveContent>
             </InvertedThemeProvider>
           </AlphaTooltipPrimitivePortal>

--- a/packages/bezier-react/src/v3/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/v3/Tooltip/Tooltip.types.ts
@@ -1,7 +1,5 @@
 import { type ReactElement, type ReactNode } from 'react'
 
-import { type BezierIcon } from '@channel.io/bezier-icons'
-
 import {
   type BezierComponentProps,
   type ChildrenProps,
@@ -36,10 +34,6 @@ interface TooltipOwnProps {
    * An element that sits below the tooltip content.
    */
   description?: ReactNode
-  /**
-   * A decorative icon that sits right of the tooltip content.
-   */
-  icon?: BezierIcon
   /**
    * Options to determine the location from the trigger.
    * @default 'bottom-center'

--- a/packages/bezier-tokens/scripts/lib/format.ts
+++ b/packages/bezier-tokens/scripts/lib/format.ts
@@ -222,6 +222,10 @@ export const alphaCustomCss: CustomFormat = {
   },
 }
 
+function getDeprecatedMetadata(token: TransformedToken) {
+  return token.deprecated ?? token.original.deprecated ?? token.original.$deprecated
+}
+
 /**
  * A custom formatter for adding ref information to tokens for beta version.
  * TODO: Remove this formatter in the next major release.
@@ -276,6 +280,11 @@ export const betaCustomJsCjs: CustomFormat = {
                     ref,
                   }
                 : { value: token.value }
+
+              const deprecated = getDeprecatedMetadata(token)
+              if (deprecated !== undefined) {
+                Object.assign(valueObject, { deprecated })
+              }
 
               return `    "${token.name}": Object.freeze(${JSON.stringify(valueObject)}),`
             })
@@ -340,6 +349,11 @@ export const betaCustomJsEsm: CustomFormat = {
                     ref,
                   }
                 : { value: token.value }
+
+              const deprecated = getDeprecatedMetadata(token)
+              if (deprecated !== undefined) {
+                Object.assign(valueObject, { deprecated })
+              }
 
               return `    "${token.name}": Object.freeze(${JSON.stringify(valueObject)}),`
             })

--- a/packages/bezier-tokens/src/beta/semantic/dark-theme/color.json
+++ b/packages/bezier-tokens/src/beta/semantic/dark-theme/color.json
@@ -683,11 +683,13 @@
       "action": {
         "normal": {
           "value": "{color.blue.300}",
-          "type": "color"
+          "type": "color",
+          "$deprecated": "This token is no longer used due to the redesign."
         },
         "light": {
           "value": "{color.blue.300-45}",
-          "type": "color"
+          "type": "color",
+          "$deprecated": "This token is no longer used due to the redesign."
         }
       },
       "warning": {
@@ -697,7 +699,8 @@
         },
         "light": {
           "value": "{color.orange.300-30}",
-          "type": "color"
+          "type": "color",
+          "$deprecated": "This token is no longer used due to the redesign."
         }
       },
       "active": {

--- a/packages/bezier-tokens/src/beta/semantic/dark-theme/color.json
+++ b/packages/bezier-tokens/src/beta/semantic/dark-theme/color.json
@@ -699,6 +699,14 @@
           "value": "{color.orange.300-30}",
           "type": "color"
         }
+      },
+      "active": {
+        "value": "{color.white.80}",
+        "type": "color"
+      },
+      "focus": {
+        "value": "{color.white.40}",
+        "type": "color"
       }
     },
     "elevation": {

--- a/packages/bezier-tokens/src/beta/semantic/light-theme/color.json
+++ b/packages/bezier-tokens/src/beta/semantic/light-theme/color.json
@@ -699,6 +699,14 @@
           "value": "{color.orange.400-30}",
           "type": "color"
         }
+      },
+      "active": {
+        "value": "{color.black.85}",
+        "type": "color"
+      },
+      "focus": {
+        "value": "{color.black.40}",
+        "type": "color"
       }
     },
     "elevation": {

--- a/packages/bezier-tokens/src/beta/semantic/light-theme/color.json
+++ b/packages/bezier-tokens/src/beta/semantic/light-theme/color.json
@@ -683,11 +683,13 @@
       "action": {
         "normal": {
           "value": "{color.blue.400}",
-          "type": "color"
+          "type": "color",
+          "$deprecated": "This token is no longer used due to the redesign."
         },
         "light": {
           "value": "{color.blue.400-30}",
-          "type": "color"
+          "type": "color",
+          "$deprecated": "This token is no longer used due to the redesign."
         }
       },
       "warning": {
@@ -697,7 +699,8 @@
         },
         "light": {
           "value": "{color.orange.400-30}",
-          "type": "color"
+          "type": "color",
+          "$deprecated": "This token is no longer used due to the redesign."
         }
       },
       "active": {

--- a/packages/bezier-tokens/src/beta/semantic/state.json
+++ b/packages/bezier-tokens/src/beta/semantic/state.json
@@ -9,7 +9,8 @@
         "blur": "0",
         "spread": "{dimension.1}"
       },
-      "type": "shadow"
+      "type": "shadow",
+      "$deprecated": "This token is no longer used due to the redesign."
     },
     "active": {
       "value": {
@@ -20,7 +21,8 @@
         "blur": "0",
         "spread": "{dimension.1}"
       },
-      "type": "shadow"
+      "type": "shadow",
+      "$deprecated": "This token is no longer used due to the redesign."
     },
     "input": {
       "default": {
@@ -42,7 +44,8 @@
             "spread": "{dimension.1}"
           }
         ],
-        "type": "shadow"
+        "type": "shadow",
+        "$deprecated": "This token is no longer used due to the redesign."
       },
       "hovered": {
         "value": [
@@ -63,7 +66,8 @@
             "spread": "{dimension.1}"
           }
         ],
-        "type": "shadow"
+        "type": "shadow",
+        "$deprecated": "This token is no longer used due to the redesign."
       },
       "active": {
         "value": [
@@ -92,7 +96,8 @@
             "spread": "{dimension.1}"
           }
         ],
-        "type": "shadow"
+        "type": "shadow",
+        "$deprecated": "This token is no longer used due to the redesign."
       },
       "error": {
         "value": [
@@ -121,7 +126,8 @@
             "spread": "{dimension.1}"
           }
         ],
-        "type": "shadow"
+        "type": "shadow",
+        "$deprecated": "This token is no longer used due to the redesign."
       }
     }
   }

--- a/packages/stylelint-bezier/README.md
+++ b/packages/stylelint-bezier/README.md
@@ -30,7 +30,9 @@ Extend @channel.io/stylelint-bezier in your stylelint config.
 
 ### validate-token
 
-Disallows use of tokens not in bezier-tokens. If you want to use css variable other than bezier design token, you can set a specific prefix and add it to ignorePrefix.
+Disallows use of tokens not in bezier-tokens. It also reports beta tokens marked as deprecated in bezier-tokens metadata as warnings.
+
+If you want to use css variable other than bezier design token, you can set a specific prefix and add it to ignorePrefix.
 
 ```tsx
 {
@@ -42,6 +44,19 @@ Disallows use of tokens not in bezier-tokens. If you want to use css variable ot
         severity: 'warning',
       },
     ],
+  }
+}
+```
+
+Deprecated beta tokens should keep their token value but add `deprecated` or `$deprecated` metadata in the token JSON source.
+
+```json
+{
+  "color": {
+    "example": {
+      "value": "#000000",
+      "$deprecated": "Use color-text-neutral instead."
+    }
   }
 }
 ```

--- a/packages/stylelint-bezier/src/plugins/validate-token/index.ts
+++ b/packages/stylelint-bezier/src/plugins/validate-token/index.ts
@@ -69,6 +69,41 @@ function flattenBetaToken(obj: object, result: Record<string, unknown> = {}) {
   return result
 }
 
+interface BetaTokenMetadata {
+  value: unknown
+  deprecated?: boolean | string
+}
+
+function isBetaTokenMetadata(value: unknown): value is BetaTokenMetadata {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    'value' in value
+  )
+}
+
+function flattenDeprecatedBetaToken(
+  obj: object,
+  result: Record<string, boolean | string> = {}
+) {
+  for (const [key, value] of Object.entries(obj)) {
+    if (isBetaTokenMetadata(value)) {
+      if (value.deprecated !== undefined) {
+        result[key] = value.deprecated
+      }
+    } else if (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      flattenDeprecatedBetaToken(value, result)
+    }
+  }
+
+  return result
+}
+
 const allTokens = {
   ...flattenObject(tokens.global),
   ...flattenObject(tokens.lightTheme),
@@ -78,11 +113,20 @@ const allTokens = {
   ...flattenBetaToken(betaTokens.lightTheme),
 }
 
+const deprecatedBetaTokens = {
+  ...flattenDeprecatedBetaToken(betaTokens.global),
+  ...flattenDeprecatedBetaToken(betaTokens.lightTheme),
+}
+
 const ruleName = 'bezier/validate-token'
 
 const messages = ruleMessages(ruleName, {
   rejected: (token) =>
     `Invalid token: "${token}". Only tokens from @channel.io/bezier-tokens are allowed.`,
+  deprecated: (token, reason) =>
+    reason === true
+      ? `Deprecated token: "${token}". Use a replacement token instead.`
+      : `Deprecated token: "${token}". ${reason}`,
 })
 
 const pluginRule: Rule<boolean> = (primary, secondaryOptions = {}) => {
@@ -116,32 +160,46 @@ const pluginRule: Rule<boolean> = (primary, secondaryOptions = {}) => {
         return
       }
 
-      const matches = value.match(/var\(--([^)]+)\)/)
+      const matches = value.matchAll(/var\(--([^)]+)\)/g)
 
-      if (!matches) {
-        return
-      }
+      for (const match of matches) {
+        const [, tokenName] = match
 
-      const [, tokenName] = matches
+        const hasTemplateLiteral = tokenName.includes('${')
 
-      const hasTemplateLiteral = tokenName.includes('${')
+        if (hasTemplateLiteral) {
+          continue
+        }
 
-      if (hasTemplateLiteral) {
-        return
-      }
+        if (
+          ignorePrefix.some((prefix: string) => tokenName.startsWith(prefix))
+        ) {
+          continue
+        }
 
-      if (ignorePrefix.some((prefix: string) => tokenName.startsWith(prefix))) {
-        return
-      }
+        if (allTokens[tokenName as keyof typeof allTokens] === undefined) {
+          // Token not found in the design tokens
+          report({
+            message: messages.rejected(tokenName),
+            node: decl,
+            result,
+            ruleName,
+          })
+          continue
+        }
 
-      if (allTokens[tokenName as keyof typeof allTokens] === undefined) {
-        // Token not found in the design tokens
-        report({
-          message: messages.rejected(tokenName),
-          node: decl,
-          result,
-          ruleName,
-        })
+        const deprecatedReason =
+          deprecatedBetaTokens[tokenName as keyof typeof deprecatedBetaTokens]
+
+        if (deprecatedReason !== undefined) {
+          report({
+            message: messages.deprecated(tokenName, deprecatedReason),
+            node: decl,
+            result,
+            ruleName,
+            severity: 'warning',
+          })
+        }
       }
     })
   }


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Fixes #0000 -->

## Summary

v3 상태 링 스타일과 컨트롤 다크모드 색상, Tooltip / CollapsibleSection / Help의 세부 인터페이스와 스타일을 정리합니다.

## Details

- `@channel.io/bezier-tokens`
  - 상태 표현에 사용할 semantic state color token을 추가했습니다.
  - deprecated token 정보를 토큰 포맷에 포함했습니다.
- `@channel.io/stylelint-bezier`
  - deprecated token 사용 시 warning을 확인할 수 있도록 lint 검사를 보강했습니다.
- `@channel.io/bezier-react`
  - input / non-input 상태 링 mixin을 분리하고 v3 컴포넌트의 focus, active, error 스타일 적용을 정리했습니다.
  - v3 `Tooltip`의 `icon` prop을 제거하고, title / content / description 간격과 radius를 디자인에 맞게 조정했습니다.
  - `CollapsibleSectionTrigger`의 우측 영역을 chevron 고정으로 변경하고, chevron이 라벨 텍스트 옆 8px 간격으로 배치되도록 수정했습니다.
  - `Help`의 Tooltip 기본 placement를 `top-center`로 변경했습니다.
  - RadioGroup, Switch, Slider, ProgressBar의 다크모드 색상 토큰 적용을 개선했습니다.

### Breaking change? (Yes/No)

No

v3 `Tooltip`에서 `icon` prop을 제거했습니다. Tooltip 내부에 icon을 넣는 사용은 지양하고, 필요한 시각 정보는 trigger 또는 텍스트성 `title` / `content` / `description`으로 옮겨야 합니다.
- breaking change 일 수 있으나, v3는 아직 프리릴리즈 단계여서 v3 내에서의 breaking change는 아닙니다. 
- v1 -> v3 기준으로는 breaking change가 맞습니다. 추후 codemod로 마이그레이션 스크립트를 지원할 예정입니다.

## References

- 검증: `yarn typecheck`
