### PR TITLE
feat(stylelint-bezier): restrict token validation to v3

### DIFF
--- a/.changeset/smart-walls-bow.md
+++ b/.changeset/smart-walls-bow.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/stylelint-bezier': minor
+---
+
+Restrict token validation to beta(v3) design tokens.

--- a/packages/stylelint-bezier/README.md
+++ b/packages/stylelint-bezier/README.md
@@ -30,7 +30,7 @@ Extend @channel.io/stylelint-bezier in your stylelint config.
 
 ### validate-token
 
-Disallows use of tokens not in bezier-tokens. It also reports beta tokens marked as deprecated in bezier-tokens metadata as warnings.
+Disallows use of tokens not in the beta(v3) bezier-tokens set. It also reports beta tokens marked as deprecated in bezier-tokens metadata as warnings.
 
 If you want to use css variable other than bezier design token, you can set a specific prefix and add it to ignorePrefix.
 

--- a/packages/stylelint-bezier/src/plugins/validate-token/index.ts
+++ b/packages/stylelint-bezier/src/plugins/validate-token/index.ts
@@ -1,5 +1,3 @@
-import { tokens } from '@channel.io/bezier-tokens'
-import { tokens as alphaTokens } from '@channel.io/bezier-tokens/alpha'
 import { tokens as betaTokens } from '@channel.io/bezier-tokens/beta'
 import stylelint, { type Rule } from 'stylelint'
 
@@ -10,40 +8,6 @@ const {
 
 function isString(value: unknown): value is string {
   return typeof value === 'string'
-}
-
-function flattenObject(obj: object, result: Record<string, unknown> = {}) {
-  for (const [key, value] of Object.entries(obj)) {
-    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-      flattenObject(value, result)
-    } else {
-      result[key] = value
-    }
-  }
-  return result
-}
-
-function flattenAlphaToken(obj: object, result: Record<string, unknown> = {}) {
-  for (const [key, value] of Object.entries(obj)) {
-    if (
-      typeof value === 'object' &&
-      value !== null &&
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (value as any).value !== undefined &&
-      !Array.isArray(value)
-    ) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      result[key] = (value as any).value
-    } else if (
-      typeof value === 'object' &&
-      value !== null &&
-      !Array.isArray(value)
-    ) {
-      flattenAlphaToken(value, result)
-    }
-  }
-
-  return result
 }
 
 function flattenBetaToken(obj: object, result: Record<string, unknown> = {}) {
@@ -105,10 +69,6 @@ function flattenDeprecatedBetaToken(
 }
 
 const allTokens = {
-  ...flattenObject(tokens.global),
-  ...flattenObject(tokens.lightTheme),
-  ...flattenAlphaToken(alphaTokens.global),
-  ...flattenAlphaToken(alphaTokens.lightTheme),
   ...flattenBetaToken(betaTokens.global),
   ...flattenBetaToken(betaTokens.lightTheme),
 }


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Fixes #0000 -->

## Summary

`stylelint-bezier`의 token validation 허용 범위를 beta(v3) 토큰으로 제한합니다.

## Details

- `@channel.io/bezier-tokens` stable(v1), alpha(v2) 토큰 import와 flatten 로직을 제거했습니다.
- `@channel.io/bezier-tokens/beta`의 `global`, `lightTheme` 토큰만 유효 토큰으로 판단합니다.
- 기존 invalid token 메시지, deprecated beta token warning, `ignorePrefix`, template literal skip, 한 선언 내 복수 `var()` 검사 동작은 유지했습니다.
- beta(v3) 토큰 전용 검증 정책을 README에 반영했습니다.
- `@channel.io/stylelint-bezier` minor changeset을 추가했습니다.

검증:

- `node node_modules/typescript/bin/tsc --noEmit -p packages/stylelint-bezier/tsconfig.json`
- `node node_modules/typescript/bin/tsc --build --verbose packages/stylelint-bezier/tsconfig.json`
- `../../node_modules/.bin/eslint --cache .` (`packages/stylelint-bezier`)
- dist 기준 stylelint fixture 검증
  - v3 token 통과
  - v1/v2 token reject
  - deprecated beta token warning 유지
  - `ignorePrefix`, template literal skip 유지
  - 복수 `var()` 선언에서 v1 token만 reject

### Breaking change? (Yes/No)

Yes.

기존에 lint를 통과하던 stable(v1), alpha(v2) token 사용처가 이 버전부터 `bezier/validate-token` error로 보고됩니다. v1/v2 토큰 제거 전 migration 누락을 찾기 위한 의도적인 lint contract 변경입니다.

## References

- prerelease 검증 목적의 변경이며 downstream 소비 repo 설치 검증은 별도 단계에서 진행합니다.
