### PR TITLE
fix(stylelint-bezier): handle css variable fallbacks

### DIFF
--- a/.changeset/sweet-timers-drum.md
+++ b/.changeset/sweet-timers-drum.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/stylelint-bezier': patch
+---
+
+Handle CSS variable fallbacks when validating design token names.

--- a/packages/stylelint-bezier/src/plugins/validate-token/index.ts
+++ b/packages/stylelint-bezier/src/plugins/validate-token/index.ts
@@ -123,7 +123,8 @@ const pluginRule: Rule<boolean> = (primary, secondaryOptions = {}) => {
       const matches = value.matchAll(/var\(--([^)]+)\)/g)
 
       for (const match of matches) {
-        const [, tokenName] = match
+        const [, tokenNameWithFallback] = match
+        const tokenName = tokenNameWithFallback.split(',')[0].trim()
 
         const hasTemplateLiteral = tokenName.includes('${')
 


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Fixes #0000 -->

## Summary

`stylelint-bezier`의 token validation이 CSS variable fallback을 토큰명으로 오인하지 않도록 수정합니다.

## Details

- `var(--token, fallback)` 형태를 검사할 때 comma 앞의 custom property 이름만 token name으로 사용합니다.
- v3 token fallback 사용은 통과하고, v1/v2 token fallback 사용은 기존 invalid token 메시지로 계속 실패합니다.
- deprecated beta token warning, `ignorePrefix`, template literal skip 동작은 유지합니다.

검증:

- `node node_modules/typescript/bin/tsc --noEmit -p packages/stylelint-bezier/tsconfig.json`
- `node node_modules/typescript/bin/tsc --build --verbose packages/stylelint-bezier/tsconfig.json`
- `../../node_modules/.bin/eslint --cache .` (`packages/stylelint-bezier`)
- dist 기준 fixture 검증
  - `var(--dimension-1, 1px)` 통과
  - `var(--blue-300, #fff)` reject
  - `var(--state-error, none)` deprecated warning 유지
- `ch-desk-web` 임시 stylelint 검증
  - fallback false positive 제거 확인
  - legacy token error 36건 유지

### Breaking change? (Yes/No)

No.

v3-only token validation에서 CSS variable fallback을 올바르게 파싱하도록 보완하는 수정입니다.

## References

- 기존 v3-only 변경은 최신 `v4`에 반영되어 있어, 이 PR은 fallback parsing 보완만 포함합니다.
