### PR TITLE
fix: v3 컴포넌트 QA 사항 반영

### DIFF
--- a/.changeset/quiet-items-breathe.md
+++ b/.changeset/quiet-items-breathe.md
@@ -1,0 +1,11 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Refine v3 tooltip, menu, select, and item row APIs.
+
+Tooltip now defaults to `top-center` placement and renders description above content. `Help` follows the Tooltip default placement unless a placement is explicitly provided.
+
+DropdownMenu item rows are fixed to the design-system medium item size. Select and MultiSelect option rows are also fixed to medium, while their root `size` prop has been replaced with `triggerSize` to describe the default trigger size explicitly.
+
+String descriptions in BaseItem and SectionItem no longer apply multiline truncation by default.

--- a/packages/bezier-react/src/v3/BaseItem/BaseItem.module.scss
+++ b/packages/bezier-react/src/v3/BaseItem/BaseItem.module.scss
@@ -32,11 +32,6 @@
     padding: 4px 8px;
   }
 
-  &:where(.size-l) {
-    min-height: 36px;
-    padding: 6px 8px;
-  }
-
   &:where(.interactive) {
     cursor: pointer;
   }

--- a/packages/bezier-react/src/v3/BaseItem/BaseItem.test.tsx
+++ b/packages/bezier-react/src/v3/BaseItem/BaseItem.test.tsx
@@ -1,6 +1,7 @@
 import { PlusIcon } from '@channel.io/bezier-icons'
 
 import { render } from '~/src/utils/test'
+import textStyles from '~/src/v3/Text/Text.module.scss'
 
 import { BaseItem } from './BaseItem'
 
@@ -22,13 +23,25 @@ describe('BaseItem', () => {
     expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
   })
 
+  it('does not truncate string description', () => {
+    const { getByText } = render(
+      <BaseItem description="Long description">
+        Content
+      </BaseItem>
+    )
+
+    expect(getByText('Long description')).not.toHaveClass(
+      textStyles['multi-line-truncated']
+    )
+  })
+
   it('renders ReactNode content and applies interactive state classes', () => {
     const { getByText } = render(
       <BaseItem
         role="button"
         active
         disabled
-        size="l"
+        size="m"
         variant="destructive"
         description={<span>Custom description</span>}
       >
@@ -43,7 +56,7 @@ describe('BaseItem', () => {
     expect(item?.className).toContain('active')
     expect(item?.className).toContain('disabled')
     expect(item?.className).toContain('interactive')
-    expect(item?.className).toContain('size-l')
+    expect(item?.className).toContain('size-m')
     expect(item?.className).toContain('destructive')
   })
 })

--- a/packages/bezier-react/src/v3/BaseItem/BaseItem.tsx
+++ b/packages/bezier-react/src/v3/BaseItem/BaseItem.tsx
@@ -84,7 +84,7 @@ export const BaseItem = forwardRef<HTMLDivElement, BaseItemProps>(
           <div className={styles.MainContent}>
             {typeof children === 'string' ? (
               <Text
-                typo={size === 'l' ? '15' : '14'}
+                typo="14"
                 truncated
               >
                 {children}
@@ -100,7 +100,6 @@ export const BaseItem = forwardRef<HTMLDivElement, BaseItemProps>(
                 <Text
                   typo="12"
                   color="text-neutral-light"
-                  truncated={2}
                 >
                   {description}
                 </Text>

--- a/packages/bezier-react/src/v3/BaseItem/BaseItem.types.ts
+++ b/packages/bezier-react/src/v3/BaseItem/BaseItem.types.ts
@@ -11,7 +11,7 @@ import type {
   VariantProps,
 } from '~/src/types/props'
 
-export type BaseItemSize = 'm' | 'l'
+export type BaseItemSize = 'm'
 
 export type BaseItemVariant = 'neutral' | 'destructive'
 

--- a/packages/bezier-react/src/v3/BaseSelect/BaseSelect.tsx
+++ b/packages/bezier-react/src/v3/BaseSelect/BaseSelect.tsx
@@ -64,7 +64,6 @@ type SelectTriggerInjectedProps =
 
 interface SelectContextValue {
   open: boolean
-  size: NonNullable<SelectProps['size']>
   listboxId: string
   selectedValues: readonly string[]
   selectValue: (value: string) => void
@@ -179,6 +178,10 @@ function getOverlayMargins({
   return isSidePosition(position)
     ? { marginX: offset, marginY: 0 }
     : { marginX: 0, marginY: offset }
+}
+
+function isSelectTriggerSize(size: unknown): size is 'm' | 'l' {
+  return size === 'm' || size === 'l'
 }
 
 function getFocusableOptions(container: HTMLElement | null) {
@@ -311,7 +314,7 @@ function SelectImpl<Value extends SelectValue>(
     keepInContainer = false,
     dropdownWidth,
     dropdownMaxHeight,
-    size = 'm',
+    triggerSize,
     onShow,
     onHide,
     ...rest
@@ -327,7 +330,8 @@ function SelectImpl<Value extends SelectValue>(
     size: formFieldSize,
     ...triggerOwnProps
   } = useFormFieldProps(rest)
-  const selectSize = size ?? formFieldSize ?? 'm'
+  const resolvedTriggerSize =
+    triggerSize ?? (isSelectTriggerSize(formFieldSize) ? formFieldSize : 'm')
   const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultShow)
   const [selectElement, setSelectElement] = useState<HTMLDivElement | null>(
     null
@@ -399,7 +403,6 @@ function SelectImpl<Value extends SelectValue>(
   const contextValue = useMemo(
     (): SelectContextValue => ({
       open,
-      size: selectSize,
       listboxId,
       selectedValues: resolvedSelectedValues,
       selectValue,
@@ -412,7 +415,6 @@ function SelectImpl<Value extends SelectValue>(
       open,
       registerOption,
       resolvedSelectedValues,
-      selectSize,
       selectValue,
     ]
   )
@@ -474,7 +476,7 @@ function SelectImpl<Value extends SelectValue>(
           open,
           selectedOption: selectedOption as SelectOptionData<Value> | null,
           selectedOptions: selectedOptions as SelectOptionData<Value>[],
-          size: selectSize,
+          triggerSize: resolvedTriggerSize,
           disabled,
           readOnly,
           hasError,
@@ -528,7 +530,7 @@ function BaseSelectOptionElement<Value extends SelectValue>({
     onKeyDown,
     ...rest
   } = props
-  const { size, selectedValues, selectValue, registerOption } =
+  const { selectedValues, selectValue, registerOption } =
     useSelectContext('SelectOption')
   const optionLabel = getOptionLabel({ value, label, content })
   const selected = selectedValues.includes(value)
@@ -568,7 +570,6 @@ function BaseSelectOptionElement<Value extends SelectValue>({
       aria-disabled={disabled || undefined}
       data-b-select-option="true"
       disabled={disabled}
-      size={size}
       description={description}
       leadingContent={leadingContent}
       trailingContent={optionTrailingContent}

--- a/packages/bezier-react/src/v3/BaseSelect/BaseSelect.types.ts
+++ b/packages/bezier-react/src/v3/BaseSelect/BaseSelect.types.ts
@@ -7,13 +7,12 @@ import type {
   ChildrenProps,
   DisableProps,
   FormFieldProps,
-  SizeProps,
 } from '~/src/types/props'
 import type { OverlayPosition } from '~/src/v3/Overlay'
 
 export type BaseSelectValue = string
 
-export type BaseSelectSize = 'm' | 'l'
+export type BaseSelectTriggerSize = 'm' | 'l'
 
 export type BaseSelectOptionSideContent = BezierIcon | ReactNode
 
@@ -107,8 +106,16 @@ export interface BaseSelectCommonProps
     >,
     ChildrenProps,
     FormFieldProps,
-    SizeProps<BaseSelectSize>,
-    BaseSelectOverlayProps {}
+    BaseSelectOverlayProps {
+  /**
+   * Size of the default trigger.
+   *
+   * Option rows are fixed to the design-system item size. This value is only
+   * used by the built-in trigger, and is passed to custom trigger render
+   * functions for consumers that want to mirror the same sizing.
+   */
+  triggerSize?: BaseSelectTriggerSize
+}
 
 interface BaseSelectOptionCommonProps<Value extends BaseSelectValue>
   extends DisableProps {
@@ -213,6 +220,7 @@ export interface BaseSelectTriggerRenderProps<
   open: boolean
   selectedOption: BaseSelectOptionData<Value> | null
   placeholder: ReactNode
+  triggerSize: NonNullable<BaseSelectCommonProps['triggerSize']>
 }
 
 export interface BaseMultiSelectTriggerRenderProps<
@@ -248,7 +256,7 @@ export interface BaseSelectRenderTriggerProps<
   open: boolean
   selectedOption: BaseSelectOptionData<Value> | null
   selectedOptions: readonly BaseSelectOptionData<Value>[]
-  size: NonNullable<BaseSelectCommonProps['size']>
+  triggerSize: NonNullable<BaseSelectCommonProps['triggerSize']>
   disabled: boolean
   readOnly: boolean
   hasError: boolean

--- a/packages/bezier-react/src/v3/DropdownMenu/DropdownMenu.tsx
+++ b/packages/bezier-react/src/v3/DropdownMenu/DropdownMenu.tsx
@@ -47,7 +47,6 @@ const MENU_ITEM_SELECTOR =
 
 type DropdownMenuContextValue = {
   open: boolean
-  size: NonNullable<DropdownMenuProps['size']>
   menuId: string
   overlayContainer: HTMLElement | null
   close: () => void
@@ -56,7 +55,6 @@ type DropdownMenuContextValue = {
 const [DropdownMenuContextProvider, useDropdownMenuContext] =
   createContext<DropdownMenuContextValue>({
     open: false,
-    size: 'm',
     menuId: '',
     overlayContainer: null,
     close: () => {},
@@ -268,7 +266,6 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
       keepInContainer = false,
       width = 224,
       maxHeight,
-      size = 'm',
       onShow,
       onHide,
       ...rest
@@ -313,12 +310,11 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
     const contextValue = useMemo(
       (): DropdownMenuContextValue => ({
         open,
-        size,
         menuId,
         overlayContainer,
         close,
       }),
-      [close, menuId, open, overlayContainer, size]
+      [close, menuId, open, overlayContainer]
     )
 
     const overlayMargins = getOverlayMargins({ position, offset })
@@ -454,7 +450,7 @@ export const DropdownMenuItem = forwardRef<
   },
   forwardedRef
 ) {
-  const { size, close } = useDropdownMenuContext()
+  const { close } = useDropdownMenuContext()
 
   const handleSelect = useCallback(
     (
@@ -486,7 +482,6 @@ export const DropdownMenuItem = forwardRef<
       aria-disabled={disabled || undefined}
       data-b-dropdown-menu-item="true"
       disabled={disabled}
-      size={size}
       variant={variant}
       description={description}
       leadingContent={leadingContent}
@@ -700,14 +695,12 @@ export const DropdownMenuSubContent = forwardRef<
     keepInContainer = false,
     width = 224,
     maxHeight,
-    size,
     onHide,
     ...rest
   },
   forwardedRef
 ) {
   const rootContext = useDropdownMenuContext()
-  const { size: rootSize } = rootContext
   const {
     open,
     focusOnOpen,
@@ -794,12 +787,7 @@ export const DropdownMenuSubContent = forwardRef<
       }}
       {...rest}
     >
-      <DropdownMenuContextProvider
-        value={{
-          ...rootContext,
-          size: size ?? rootSize,
-        }}
-      >
+      <DropdownMenuContextProvider value={rootContext}>
         <DropdownMenuContent autoFocusOnMount={focusOnOpen}>
           {children}
         </DropdownMenuContent>

--- a/packages/bezier-react/src/v3/DropdownMenu/DropdownMenu.types.ts
+++ b/packages/bezier-react/src/v3/DropdownMenu/DropdownMenu.types.ts
@@ -7,16 +7,10 @@ import type {
   ChildrenProps,
   ContentProps,
   DisableProps,
-  SizeProps,
   VariantProps,
 } from '~/src/types/props'
-import type {
-  BaseItemSize,
-  BaseItemVariant,
-} from '~/src/v3/BaseItem/BaseItem.types'
+import type { BaseItemVariant } from '~/src/v3/BaseItem/BaseItem.types'
 import type { OverlayPosition, OverlayTarget } from '~/src/v3/Overlay'
-
-export type DropdownMenuSize = BaseItemSize
 
 export type DropdownMenuItemVariant = BaseItemVariant
 
@@ -170,7 +164,6 @@ interface DropdownMenuItemOwnProps
 export interface DropdownMenuProps
   extends Omit<BezierComponentProps<'div'>, 'children'>,
     ChildrenProps,
-    SizeProps<DropdownMenuSize>,
     DropdownMenuOwnProps {}
 
 /**
@@ -251,5 +244,4 @@ export interface DropdownMenuSubTriggerProps
 export interface DropdownMenuSubContentProps
   extends Omit<BezierComponentProps<'div'>, 'children'>,
     ChildrenProps,
-    SizeProps<DropdownMenuSize>,
     DropdownMenuSubContentOwnProps {}

--- a/packages/bezier-react/src/v3/DropdownMenu/index.ts
+++ b/packages/bezier-react/src/v3/DropdownMenu/index.ts
@@ -14,7 +14,6 @@ export type {
   DropdownMenuItemVariant,
   DropdownMenuProps,
   DropdownMenuSeparatorProps,
-  DropdownMenuSize,
   DropdownMenuSubContentProps,
   DropdownMenuSubProps,
   DropdownMenuSubTriggerProps,

--- a/packages/bezier-react/src/v3/Help/Help.tsx
+++ b/packages/bezier-react/src/v3/Help/Help.tsx
@@ -19,7 +19,7 @@ export const HELP_DISPLAY_NAME = 'Help'
  * `Help` shows a help icon with tooltip content.
  */
 export const Help = forwardRef<HTMLDivElement, HelpProps>(function Help(
-  { children, placement = 'top-center', ...rest },
+  { children, ...rest },
   forwardedRef
 ) {
   if (isEmpty(children)) {
@@ -31,7 +31,6 @@ export const Help = forwardRef<HTMLDivElement, HelpProps>(function Help(
       {...rest}
       ref={forwardedRef}
       content={children}
-      placement={placement}
     >
       <div className={styles.Help}>
         <Icon

--- a/packages/bezier-react/src/v3/MultiSelect/MultiSelect.stories.tsx
+++ b/packages/bezier-react/src/v3/MultiSelect/MultiSelect.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta<typeof MultiSelect> = {
   ],
   args: {
     placeholder: 'Select tags',
-    size: 'm',
+    triggerSize: 'm',
     position: 'bottom-left',
     offset: 6,
     withoutChevron: false,
@@ -38,7 +38,7 @@ const meta: Meta<typeof MultiSelect> = {
     selectedValuesOverflow: 'wrap',
   },
   argTypes: {
-    size: {
+    triggerSize: {
       control: 'select',
       options: ['m', 'l'],
     },
@@ -105,7 +105,7 @@ function CustomTriggerExample() {
       dropdownWidth={188}
     >
       <MultiSelectTrigger>
-        {({ triggerProps, open, selectedOptions, placeholder }) => {
+        {({ triggerProps, open, selectedOptions, placeholder, triggerSize }) => {
           const label =
             selectedOptions.length > 0
               ? selectedOptions.map((option) => option.label).join(', ')
@@ -115,6 +115,7 @@ function CustomTriggerExample() {
             <Button
               {...triggerProps}
               label={String(label ?? '')}
+              size={triggerSize}
               variant="filled"
               semantic="secondary"
               active={open}
@@ -173,7 +174,7 @@ function CustomTriggerExample() {
         dropdownWidth={188}
       >
         <MultiSelectTrigger>
-          {({ triggerProps, open, selectedOptions, placeholder }) => {
+          {({ triggerProps, open, selectedOptions, placeholder, triggerSize }) => {
             const label =
               selectedOptions.length > 0
                 ? selectedOptions.map((option) => option.label).join(', ')
@@ -183,6 +184,7 @@ function CustomTriggerExample() {
               <Button
                 {...triggerProps}
                 label={String(label ?? '')}
+                size={triggerSize}
                 variant="filled"
                 semantic="secondary"
                 active={open}

--- a/packages/bezier-react/src/v3/MultiSelect/MultiSelect.tsx
+++ b/packages/bezier-react/src/v3/MultiSelect/MultiSelect.tsx
@@ -108,7 +108,7 @@ export const MultiSelect = forwardRef(function MultiSelect<
         triggerProps,
         open,
         selectedOptions,
-        size,
+        triggerSize,
         disabled,
         readOnly,
         hasError,
@@ -123,6 +123,7 @@ export const MultiSelect = forwardRef(function MultiSelect<
               selectedOptions as readonly MultiSelectOptionData<Value>[],
             value: selectedValues,
             placeholder,
+            triggerSize,
             onValueChange: handleValueChange,
           })
         }
@@ -131,7 +132,7 @@ export const MultiSelect = forwardRef(function MultiSelect<
           <DefaultMultiSelectTrigger
             triggerProps={triggerProps}
             open={open}
-            size={size}
+            triggerSize={triggerSize}
             disabled={disabled}
             readOnly={readOnly}
             invalid={hasError}
@@ -319,7 +320,7 @@ function useEllipsisSelectedValues({
 function DefaultMultiSelectTrigger<Value extends MultiSelectValue>({
   triggerProps,
   open,
-  size,
+  triggerSize,
   disabled,
   invalid,
   readOnly,
@@ -333,7 +334,7 @@ function DefaultMultiSelectTrigger<Value extends MultiSelectValue>({
 }: {
   triggerProps: MultiSelectTriggerRenderProps['triggerProps']
   open: boolean
-  size: MultiSelectProps['size']
+  triggerSize: NonNullable<MultiSelectProps['triggerSize']>
   disabled?: boolean
   invalid?: boolean
   readOnly?: boolean
@@ -379,7 +380,7 @@ function DefaultMultiSelectTrigger<Value extends MultiSelectValue>({
       tabIndex={disabled ? undefined : 0}
       className={classNames(
         baseStyles.Trigger,
-        baseStyles[`size-${size}`],
+        baseStyles[`size-${triggerSize}`],
         open && baseStyles.open,
         invalid && baseStyles.invalid,
         readOnly && baseStyles.readonly,
@@ -412,7 +413,7 @@ function DefaultMultiSelectTrigger<Value extends MultiSelectValue>({
               {visibleSelectedOptions.map((option) => (
                 <Tag
                   key={option.value}
-                  size={size === 'l' ? 'l' : 'm'}
+                  size={triggerSize === 'l' ? 'l' : 'm'}
                   variant="default"
                   onDelete={(event) => {
                     event.preventDefault()
@@ -434,7 +435,7 @@ function DefaultMultiSelectTrigger<Value extends MultiSelectValue>({
                       data-b-select-measure-tag="true"
                     >
                       <Tag
-                        size={size === 'l' ? 'l' : 'm'}
+                        size={triggerSize === 'l' ? 'l' : 'm'}
                         variant="default"
                         onDelete={noop}
                       >

--- a/packages/bezier-react/src/v3/MultiSelect/MultiSelect.types.ts
+++ b/packages/bezier-react/src/v3/MultiSelect/MultiSelect.types.ts
@@ -6,14 +6,14 @@ import type {
   BaseSelectOptionData,
   BaseSelectOptionProps,
   BaseSelectOptionSideContent,
-  BaseSelectSize,
+  BaseSelectTriggerSize,
   BaseSelectTriggerVisualProps,
   BaseSelectValue,
 } from '~/src/v3/BaseSelect/BaseSelect.types'
 
 export type MultiSelectValue = BaseSelectValue
 
-export type MultiSelectSize = BaseSelectSize
+export type MultiSelectTriggerSize = BaseSelectTriggerSize
 
 export type MultiSelectOptionSideContent = BaseSelectOptionSideContent
 

--- a/packages/bezier-react/src/v3/MultiSelect/index.ts
+++ b/packages/bezier-react/src/v3/MultiSelect/index.ts
@@ -11,7 +11,7 @@ export type {
   MultiSelectOptionSideContent,
   MultiSelectProps,
   MultiSelectSelectedValuesOverflow,
-  MultiSelectSize,
+  MultiSelectTriggerSize,
   MultiSelectTriggerProps,
   MultiSelectTriggerRenderProps,
   MultiSelectValue,

--- a/packages/bezier-react/src/v3/Section/Section.module.scss
+++ b/packages/bezier-react/src/v3/Section/Section.module.scss
@@ -92,6 +92,8 @@
 
   box-sizing: border-box;
   width: 100%;
+  min-height: 32px;
+  padding: 4px 8px;
 
   font: inherit;
   color: var(--color-text-neutral);
@@ -106,16 +108,6 @@
   transition:
     background-color var(--motion-transition-fast),
     color var(--motion-transition-fast);
-
-  &:where(.size-m) {
-    min-height: 32px;
-    padding: 4px 8px;
-  }
-
-  &:where(.size-l) {
-    min-height: 40px;
-    padding: 7px 8px;
-  }
 
   &:where(.interactive) {
     cursor: pointer;

--- a/packages/bezier-react/src/v3/Section/Section.stories.tsx
+++ b/packages/bezier-react/src/v3/Section/Section.stories.tsx
@@ -12,7 +12,6 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { noop } from '~/src/utils/function'
 import { Box } from '~/src/v3/Box'
 import { Text } from '~/src/v3/Text'
-import { VStack } from '~/src/v3/VStack'
 
 import { Section, SectionItem, SectionLabel } from './Section'
 
@@ -171,36 +170,5 @@ export const RichLabel: Story = {
         />
       </Section>
     </Box>
-  ),
-}
-
-export const Sizes: Story = {
-  tags: ['!autodocs'],
-  parameters: { controls: { disable: true } },
-  render: () => (
-    <VStack spacing={16}>
-      <Box width={320}>
-        <Section>
-          <SectionLabel content="Size m" />
-          <SectionItem
-            size="m"
-            content="Default item"
-            description="32px minimum height."
-            leadingContent={InfoIcon}
-          />
-        </Section>
-      </Box>
-      <Box width={320}>
-        <Section>
-          <SectionLabel content="Size l" />
-          <SectionItem
-            size="l"
-            content="Large item"
-            description="For roomier list rows."
-            leadingContent={InfoIcon}
-          />
-        </Section>
-      </Box>
-    </VStack>
   ),
 }

--- a/packages/bezier-react/src/v3/Section/Section.test.tsx
+++ b/packages/bezier-react/src/v3/Section/Section.test.tsx
@@ -3,6 +3,7 @@ import { waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { render } from '~/src/utils/test'
+import textStyles from '~/src/v3/Text/Text.module.scss'
 
 import {
   SECTION_ITEM_TEST_ID,
@@ -147,6 +148,9 @@ describe('Section', () => {
         (_content, element) => element?.textContent === 'First lineSecond line'
       )
     ).not.toHaveLength(0)
+    expect(getByText('First line', { exact: false })).not.toHaveClass(
+      textStyles['multi-line-truncated']
+    )
   })
 
   it('prevents disabled anchor item interaction', async () => {

--- a/packages/bezier-react/src/v3/Section/Section.tsx
+++ b/packages/bezier-react/src/v3/Section/Section.tsx
@@ -90,10 +90,8 @@ export const SectionItem = forwardRef<HTMLElement, SectionItemProps>(
       className,
       content,
       description,
-      descriptionMaxLines = 2,
       leadingContent,
       trailingContent,
-      size = 'm',
       active = false,
       disabled = false,
       ...rest
@@ -121,7 +119,6 @@ export const SectionItem = forwardRef<HTMLElement, SectionItemProps>(
         ref={forwardedRef as React.Ref<HTMLElement>}
         className={classNames(
           styles.SectionItem,
-          styles[`size-${size}`],
           active && styles.active,
           disabled && styles.disabled,
           isInteractive && styles.interactive,
@@ -154,7 +151,7 @@ export const SectionItem = forwardRef<HTMLElement, SectionItemProps>(
           <div className={styles.ItemMainContent}>
             {typeof content === 'string' ? (
               <Text
-                typo={size === 'l' ? '15' : '14'}
+                typo="14"
                 truncated
               >
                 {content}
@@ -170,7 +167,6 @@ export const SectionItem = forwardRef<HTMLElement, SectionItemProps>(
                 <Text
                   typo="12"
                   color="text-neutral-light"
-                  truncated={descriptionMaxLines}
                 >
                   {renderTextWithNewLine(description)}
                 </Text>

--- a/packages/bezier-react/src/v3/Section/Section.types.ts
+++ b/packages/bezier-react/src/v3/Section/Section.types.ts
@@ -8,11 +8,8 @@ import type {
   ChildrenProps,
   ContentProps,
   DisableProps,
-  SizeProps,
   V3MarginProps,
 } from '~/src/types/props'
-
-export type SectionItemSize = 'm' | 'l'
 
 export type SectionItemSideContent = BezierIcon | ReactNode
 
@@ -51,17 +48,11 @@ interface SectionItemContentProps extends ContentProps<ReactNode> {
 interface SectionItemOwnProps
   extends SectionItemContentProps,
     DisableProps,
-    ActivatableProps,
-    SizeProps<SectionItemSize> {
+    ActivatableProps {
   /**
    * Content below the main content.
    */
   description?: ReactNode
-  /**
-   * Max line count for string descriptions.
-   * @default 2
-   */
-  descriptionMaxLines?: number
   /**
    * Content on the left.
    */

--- a/packages/bezier-react/src/v3/Section/index.ts
+++ b/packages/bezier-react/src/v3/Section/index.ts
@@ -2,7 +2,6 @@ export { Section, SectionItem, SectionLabel } from './Section'
 export type {
   SectionItemProps,
   SectionItemSideContent,
-  SectionItemSize,
   SectionLabelProps,
   SectionLabelSideContent,
   SectionProps,

--- a/packages/bezier-react/src/v3/Select/Select.stories.tsx
+++ b/packages/bezier-react/src/v3/Select/Select.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<typeof Select> = {
   ],
   args: {
     placeholder: 'Select option',
-    size: 'm',
+    triggerSize: 'm',
     position: 'bottom-left',
     offset: 6,
     withoutChevron: false,
@@ -34,7 +34,7 @@ const meta: Meta<typeof Select> = {
     dropdownMaxHeight: undefined,
   },
   argTypes: {
-    size: {
+    triggerSize: {
       control: 'select',
       options: ['m', 'l'],
     },
@@ -97,10 +97,11 @@ function CustomTriggerExample() {
       dropdownWidth={188}
     >
       <SelectTrigger>
-        {({ triggerProps, open, selectedOption, placeholder }) => (
+        {({ triggerProps, open, selectedOption, placeholder, triggerSize }) => (
           <Button
             {...triggerProps}
             label={selectedOption?.label ?? String(placeholder ?? '')}
+            size={triggerSize}
             variant="filled"
             semantic="secondary"
             active={open}
@@ -193,10 +194,11 @@ function CustomTriggerExample() {
         dropdownWidth={188}
       >
         <SelectTrigger>
-          {({ triggerProps, open, selectedOption, placeholder }) => (
+          {({ triggerProps, open, selectedOption, placeholder, triggerSize }) => (
             <Button
               {...triggerProps}
               label={selectedOption?.label ?? String(placeholder ?? '')}
+              size={triggerSize}
               variant="filled"
               semantic="secondary"
               active={open}

--- a/packages/bezier-react/src/v3/Select/Select.tsx
+++ b/packages/bezier-react/src/v3/Select/Select.tsx
@@ -76,7 +76,7 @@ export const Select = forwardRef(function Select<Value extends SelectValue>(
         triggerProps,
         open,
         selectedOption,
-        size,
+        triggerSize,
         readOnly,
         hasError,
       }) => {
@@ -88,6 +88,7 @@ export const Select = forwardRef(function Select<Value extends SelectValue>(
             open,
             selectedOption: selectedOption as SelectOptionData<Value> | null,
             placeholder,
+            triggerSize,
           })
         }
 
@@ -95,7 +96,7 @@ export const Select = forwardRef(function Select<Value extends SelectValue>(
           <DefaultSelectTrigger
             triggerProps={triggerProps}
             open={open}
-            size={size}
+            triggerSize={triggerSize}
             readOnly={readOnly}
             invalid={hasError}
             selectedOption={selectedOption}
@@ -135,7 +136,7 @@ function SelectSideContentElement({
 function DefaultSelectTrigger({
   triggerProps,
   open,
-  size,
+  triggerSize,
   invalid,
   readOnly,
   selectedOption,
@@ -145,7 +146,7 @@ function DefaultSelectTrigger({
 }: {
   triggerProps: SelectTriggerRenderProps['triggerProps']
   open: boolean
-  size: SelectProps['size']
+  triggerSize: NonNullable<SelectProps['triggerSize']>
   invalid?: boolean
   readOnly?: boolean
   selectedOption: SelectOptionData | null
@@ -162,7 +163,7 @@ function DefaultSelectTrigger({
       ref={triggerRef}
       className={classNames(
         baseStyles.Trigger,
-        baseStyles[`size-${size}`],
+        baseStyles[`size-${triggerSize}`],
         open && baseStyles.open,
         invalid && baseStyles.invalid,
         readOnly && baseStyles.readonly,

--- a/packages/bezier-react/src/v3/Select/Select.types.ts
+++ b/packages/bezier-react/src/v3/Select/Select.types.ts
@@ -4,16 +4,16 @@ import type {
   BaseSelectOptionData,
   BaseSelectOptionProps,
   BaseSelectOptionSideContent,
-  BaseSelectSize,
   BaseSelectTriggerProps,
   BaseSelectTriggerRenderProps,
+  BaseSelectTriggerSize,
   BaseSelectTriggerVisualProps,
   BaseSelectValue,
 } from '~/src/v3/BaseSelect/BaseSelect.types'
 
 export type SelectValue = BaseSelectValue
 
-export type SelectSize = BaseSelectSize
+export type SelectTriggerSize = BaseSelectTriggerSize
 
 export type SelectOptionSideContent = BaseSelectOptionSideContent
 

--- a/packages/bezier-react/src/v3/Select/index.ts
+++ b/packages/bezier-react/src/v3/Select/index.ts
@@ -5,7 +5,7 @@ export type {
   SelectOptionProps,
   SelectOptionSideContent,
   SelectProps,
-  SelectSize,
+  SelectTriggerSize,
   SelectTriggerProps,
   SelectTriggerRenderProps,
   SelectValue,

--- a/packages/bezier-react/src/v3/Tooltip/Tooltip.stories.tsx
+++ b/packages/bezier-react/src/v3/Tooltip/Tooltip.stories.tsx
@@ -24,7 +24,7 @@ export const Primary: Story = {
   render: (args) => <Tooltip {...args} />,
   args: {
     defaultShow: false,
-    placement: 'bottom-center',
+    placement: 'top-center',
     offset: 4,
     disabled: false,
     keepInContainer: true,

--- a/packages/bezier-react/src/v3/Tooltip/Tooltip.test.tsx
+++ b/packages/bezier-react/src/v3/Tooltip/Tooltip.test.tsx
@@ -45,7 +45,7 @@ describe('Tooltip', () => {
   })
 
   it('renders optional title, description, and custom class name', () => {
-    const { getAllByText } = renderTooltip({
+    const { getAllByText, getByRole } = renderTooltip({
       defaultShow: true,
       title: 'Tooltip title',
       content: 'Tooltip content',
@@ -57,6 +57,21 @@ describe('Tooltip', () => {
     expect(getAllByText('Tooltip title')).toHaveLength(2)
     expect(getAllByText('Tooltip content')).toHaveLength(2)
     expect(getAllByText('Tooltip description')).toHaveLength(2)
+
+    expect(getByRole('tooltip').textContent).toContain(
+      'Tooltip titleTooltip descriptionTooltip content'
+    )
+  })
+
+  it('uses top-center placement by default', () => {
+    const { getByRole } = renderTooltip({
+      defaultShow: true,
+      content: 'Tooltip content',
+    })
+    const tooltipPositioner = getByRole('tooltip').closest('[data-side]')
+
+    expect(tooltipPositioner).toHaveAttribute('data-side', 'top')
+    expect(tooltipPositioner).toHaveAttribute('data-align', 'center')
   })
 
   it('connects trigger and tooltip with aria-describedby', () => {

--- a/packages/bezier-react/src/v3/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/v3/Tooltip/Tooltip.tsx
@@ -118,7 +118,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       title,
       content,
       description,
-      placement = 'bottom-center',
+      placement = 'top-center',
       offset = 4,
       container: containerProp,
       keepInContainer = true,
@@ -233,15 +233,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
                       </Text>
                     )}
 
-                    <Text
-                      typo="13"
-                      color="text-neutral"
-                      truncated={20}
-                      className={styles.TooltipContent}
-                    >
-                      {content}
-                    </Text>
-
                     {description && (
                       <Text
                         typo="12"
@@ -250,6 +241,15 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
                         {description}
                       </Text>
                     )}
+
+                    <Text
+                      typo="13"
+                      color="text-neutral"
+                      truncated={20}
+                      className={styles.TooltipContent}
+                    >
+                      {content}
+                    </Text>
                   </div>
                 </div>
               </AlphaTooltipPrimitiveContent>

--- a/packages/bezier-react/src/v3/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/v3/Tooltip/Tooltip.types.ts
@@ -31,12 +31,12 @@ interface TooltipOwnProps {
    */
   title?: ReactNode
   /**
-   * An element that sits below the tooltip content.
+   * An element that sits above the tooltip content.
    */
   description?: ReactNode
   /**
    * Options to determine the location from the trigger.
-   * @default 'bottom-center'
+   * @default 'top-center'
    */
   placement?: TooltipPosition
   /**


### PR DESCRIPTION
## Self Checklist

- [x] PR 제목은 작업 맥락에 맞게 작성했습니다.
- [x] 커밋 메시지는 영어로 작성했고 Conventional Commits 형식을 따랐습니다.
- [x] 릴리스가 필요한 변경에 대한 changeset을 추가했습니다.
- [x] 관련 스토리/테스트를 업데이트했습니다.
- [x] 관련 테스트, typecheck, lint를 실행했습니다.
- [ ] 여러 브라우저에서 직접 확인하지는 않았습니다.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

- WEBTECH-8728

## Summary

v3 Tooltip, Help, DropdownMenu, Select, MultiSelect, BaseItem, SectionItem의 QA 수정 사항을 반영했습니다.

## Details

- Tooltip 기본 placement를 `top-center`로 변경하고 description이 content 위에 렌더되도록 조정했습니다.
- Help는 별도 기본 placement를 두지 않고 Tooltip 기본값을 따르도록 수정했습니다.
- BaseItem은 future extension을 고려해 `size?: 'm'` 단일값만 남기고 large 스타일 분기를 제거했습니다.
- DropdownMenu item row와 Select/MultiSelect option row는 BaseItem 기본 크기를 사용하도록 하고, 각 컴포넌트 사용처에서는 item size prop을 열지 않도록 정리했습니다.
- SectionItem의 public `size` prop, `SectionItemSize` export, size 스토리를 제거하고 Figma BaseItem medium 스펙인 32px row 기준으로 고정했습니다.
- Select/MultiSelect root `size` prop을 기본 trigger 전용 의미가 드러나는 `triggerSize`로 변경했습니다.
- custom trigger render props에도 `triggerSize`를 전달하고 스토리 예시에서 Bezier Button에 반영했습니다.
- BaseItem/SectionItem의 string description에서 multiline truncation을 제거했습니다.
- 관련 회귀 테스트와 changeset을 추가했습니다.

### Breaking change? (Yes/No)

Yes.

v3 DropdownMenu의 `size` prop과 `DropdownMenuSize` export가 제거되었습니다. v3 Select/MultiSelect의 root `size` prop과 `SelectSize` / `MultiSelectSize` export는 `triggerSize` / `SelectTriggerSize` / `MultiSelectTriggerSize`로 변경되었습니다. v3 SectionItem의 `size` prop과 `SectionItemSize` export도 제거되었습니다. BaseItem은 `size`가 `'m'` 단일값만 허용됩니다.

## References

검증:

- `yarn jest --config packages/bezier-react/jest.config.js --runTestsByPath packages/bezier-react/src/v3/BaseItem/BaseItem.test.tsx packages/bezier-react/src/v3/Section/Section.test.tsx packages/bezier-react/src/v3/DropdownMenu/DropdownMenu.test.tsx packages/bezier-react/src/v3/Select/Select.test.tsx packages/bezier-react/src/v3/MultiSelect/MultiSelect.test.tsx packages/bezier-react/src/v3/Tooltip/Tooltip.test.tsx packages/bezier-react/src/v3/Help/Help.test.tsx --coverage=false`
- `yarn jest --config packages/bezier-react/jest.config.js --runTestsByPath packages/bezier-react/src/v3/BaseItem/BaseItem.test.tsx packages/bezier-react/src/v3/Section/Section.test.tsx packages/bezier-react/src/v3/DropdownMenu/DropdownMenu.test.tsx packages/bezier-react/src/v3/Select/Select.test.tsx packages/bezier-react/src/v3/MultiSelect/MultiSelect.test.tsx --coverage=false`
- `yarn typecheck --filter=@channel.io/bezier-react`
- `yarn turbo run lint --filter=@channel.io/bezier-react`
