### PR TITLE
refactor(react): simplify beta state ring styles

### DIFF
--- a/.changeset/fresh-rings-smile.md
+++ b/.changeset/fresh-rings-smile.md
@@ -1,0 +1,12 @@
+---
+'@channel.io/bezier-react': patch
+'@channel.io/bezier-tokens': patch
+---
+
+Update beta state tokens and state ring styling.
+
+- Add beta `state.default`, `state.active`, and `state.warning` shadow tokens for input state styling, and keep the previous `state.input.*` tokens as deprecated aliases.
+- Add beta typography `label` and `caption` tokens, and add `xx*` typography aliases while deprecating the previous `2x*` names.
+- Replace beta input state mixins with direct state token usage.
+- Rename beta non-input ring mixins to `focus-ring` and `error-ring`, and use outline-based rings.
+- Update the Foundation color Storybook page ordering, swatch sizing, and text readability.

--- a/packages/bezier-react/.storybook/preview.tsx
+++ b/packages/bezier-react/.storybook/preview.tsx
@@ -32,6 +32,7 @@ const preview: Preview = {
         order: [
           'ReadMe',
           'Changelog',
+          'Foundation',
           'Beta components',
           'Deprecated v2 components',
           'Deprecated v1 components',

--- a/packages/bezier-react/src/beta/BaseButton/BaseButton.module.scss
+++ b/packages/bezier-react/src/beta/BaseButton/BaseButton.module.scss
@@ -13,7 +13,7 @@
   border: none;
 
   &:where(:focus-visible) {
-    @include state.focus(0);
+    @include state.focus-ring;
   }
 
   &:where(:focus:not(:focus-visible)) {

--- a/packages/bezier-react/src/beta/BaseItem/BaseItem.module.scss
+++ b/packages/bezier-react/src/beta/BaseItem/BaseItem.module.scss
@@ -54,7 +54,7 @@
   }
 
   &:where(:focus-visible) {
-    @include state.focus(var(--radius-8), $gap: 0);
+    @include state.focus-ring($gap: 0);
   }
 
   &:where(.interactive:not(.disabled, .active, [data-highlighted])) {

--- a/packages/bezier-react/src/beta/BaseSelect/BaseSelect.module.scss
+++ b/packages/bezier-react/src/beta/BaseSelect/BaseSelect.module.scss
@@ -1,5 +1,3 @@
-@use '../../styles/mixins/state';
-
 .BaseSelect {
   position: relative;
   display: inline-flex;
@@ -33,9 +31,7 @@
   border: 0;
   border-radius: var(--b-beta-select-trigger-radius);
   outline: none;
-
-  /* stylelint-disable-next-line order/order */
-  @include state.input(var(--b-beta-select-trigger-radius));
+  box-shadow: var(--state-default);
 
   transition:
     box-shadow var(--motion-transition-fast),
@@ -49,13 +45,12 @@
   }
 
   &:where(.open, :focus-visible) {
-    @include state.input-active(var(--b-beta-select-trigger-radius));
-
     background-color: var(--color-fill-grey-light);
+    box-shadow: var(--state-active);
   }
 
   &:where(.invalid) {
-    @include state.input-error(var(--b-beta-select-trigger-radius));
+    box-shadow: var(--state-warning);
   }
 
   &:where(.readonly) {

--- a/packages/bezier-react/src/beta/BaseTextInput/BaseTextInput.module.scss
+++ b/packages/bezier-react/src/beta/BaseTextInput/BaseTextInput.module.scss
@@ -1,5 +1,3 @@
-@use '../../styles/mixins/state';
-
 .BaseTextInput {
   --b-beta-text-input-height: 36px;
   --b-beta-text-input-radius: var(--radius-12);
@@ -22,9 +20,7 @@
 
   background-color: var(--b-beta-text-input-background-color);
   border-radius: var(--b-beta-text-input-radius);
-
-  /* stylelint-disable-next-line order/order */
-  @include state.input(var(--b-beta-text-input-radius));
+  box-shadow: var(--state-default);
 
   transition:
     box-shadow var(--motion-transition-fast),
@@ -46,11 +42,11 @@
   }
 
   &:where(:has(.Input:focus)) {
-    @include state.input-active(var(--b-beta-text-input-radius));
+    box-shadow: var(--state-active);
   }
 
   &:where(:has(.Input[aria-invalid='true'])) {
-    @include state.input-error(var(--b-beta-text-input-radius));
+    box-shadow: var(--state-warning);
   }
 }
 

--- a/packages/bezier-react/src/beta/Checkbox/Checkbox.module.scss
+++ b/packages/bezier-react/src/beta/Checkbox/Checkbox.module.scss
@@ -41,10 +41,6 @@
     box-shadow: inset 0 0 0 2px var(--color-border-neutral-heavy);
   }
 
-  &:where([data-invalid]:not([data-disabled])) {
-    @include state.error(var(--radius-8));
-  }
-
   &:where([data-state='checked'], [data-state='indeterminate']) {
     background-color: var(--color-fill-neutral-heaviest);
 
@@ -63,11 +59,15 @@
   }
 
   &:where(:focus-visible) {
-    @include state.focus(var(--radius-8));
+    @include state.focus-ring;
 
     &:where(:not([data-disabled])[data-state='unchecked']) .CheckIcon {
       visibility: visible;
     }
+  }
+
+  &:where([data-invalid]:not([data-disabled])) {
+    @include state.error-ring;
   }
 }
 

--- a/packages/bezier-react/src/beta/RadioGroup/RadioGroup.module.scss
+++ b/packages/bezier-react/src/beta/RadioGroup/RadioGroup.module.scss
@@ -9,12 +9,6 @@ $inner-indicator-size: 8px;
 
 .RadioGroup {
   width: fit-content;
-
-  &:where([aria-invalid='true']) {
-    :where(.Radio:not([data-disabled]))::before {
-      @include state.error-outline(50%);
-    }
-  }
 }
 
 .Radio {
@@ -93,7 +87,7 @@ $inner-indicator-size: 8px;
     outline: none;
 
     &::before {
-      @include state.focus(50%);
+      @include state.focus-ring;
     }
 
     &:where(:not([data-disabled])[data-state='unchecked'])::after {
@@ -103,6 +97,12 @@ $inner-indicator-size: 8px;
 
   &:where(:has(.Label)) {
     height: var(--b-form-field-size);
+  }
+}
+
+.RadioGroup:where([aria-invalid='true']) {
+  :where(.Radio:not([data-disabled]))::before {
+    @include state.error-ring;
   }
 }
 

--- a/packages/bezier-react/src/beta/Section/Section.module.scss
+++ b/packages/bezier-react/src/beta/Section/Section.module.scss
@@ -24,6 +24,12 @@
   &:where([role='button']) {
     cursor: pointer;
     user-select: none;
+    border-radius: var(--radius-8);
+    outline: none;
+
+    &:where(:focus-visible) {
+      @include state.focus-ring;
+    }
   }
 
   &:where([aria-disabled='true']) {
@@ -127,7 +133,7 @@
   }
 
   &:where(:focus-visible) {
-    @include state.focus(var(--radius-8));
+    @include state.focus-ring($gap: 0);
   }
 
   &:where(.interactive:not(.disabled, .active)) {

--- a/packages/bezier-react/src/beta/SegmentedControl/SegmentedControl.module.scss
+++ b/packages/bezier-react/src/beta/SegmentedControl/SegmentedControl.module.scss
@@ -167,7 +167,7 @@ $divider-side-indent: 6px;
   }
 
   &:where(:focus-visible) {
-    @include state.focus(9999px);
+    @include state.focus-ring;
   }
 }
 

--- a/packages/bezier-react/src/beta/Slider/Slider.module.scss
+++ b/packages/bezier-react/src/beta/Slider/Slider.module.scss
@@ -84,6 +84,6 @@
   }
 
   &:where(:focus-visible) {
-    @include state.focus(9999px);
+    @include state.focus-ring;
   }
 }

--- a/packages/bezier-react/src/beta/Switch/Switch.module.scss
+++ b/packages/bezier-react/src/beta/Switch/Switch.module.scss
@@ -54,11 +54,11 @@
   }
 
   &:where(:focus-visible) {
-    @include state.focus(9999px);
+    @include state.focus-ring;
   }
 
   &:where([data-invalid]:not([data-disabled])) {
-    @include state.error(9999px);
+    @include state.error-ring;
   }
 }
 

--- a/packages/bezier-react/src/beta/Tabs/Tabs.module.scss
+++ b/packages/bezier-react/src/beta/Tabs/Tabs.module.scss
@@ -85,7 +85,7 @@ $tab-item-indicator-height: 3px;
   }
 
   &:where(:focus-visible) {
-    @include state.focus(var(--radius-8));
+    @include state.focus-ring($gap: 0);
   }
 
   &:where(.size-s) {
@@ -166,7 +166,7 @@ $tab-item-indicator-height: 3px;
   }
 
   &:where(:focus-visible) {
-    @include state.focus(var(--radius-8));
+    @include state.focus-ring;
   }
 
   &:hover {

--- a/packages/bezier-react/src/beta/Tag/Tag.module.scss
+++ b/packages/bezier-react/src/beta/Tag/Tag.module.scss
@@ -23,7 +23,7 @@
   outline: none;
 
   &:where(:focus-visible) {
-    @include state.focus(9999px);
+    @include state.focus-ring($gap: 0);
   }
 }
 

--- a/packages/bezier-react/src/beta/TextArea/TextArea.module.scss
+++ b/packages/bezier-react/src/beta/TextArea/TextArea.module.scss
@@ -1,5 +1,3 @@
-@use '../../styles/mixins/state';
-
 .TextArea {
   --b-beta-text-area-background-color: var(--color-fill-grey);
 
@@ -22,9 +20,7 @@
   border: none;
   border-radius: var(--radius-12);
   outline: none;
-
-  /* stylelint-disable-next-line order/order */
-  @include state.input(var(--radius-12));
+  box-shadow: var(--state-default);
 
   transition:
     background-color var(--motion-transition-fast),
@@ -48,13 +44,13 @@
   &:focus {
     --b-beta-text-area-background-color: var(--color-fill-grey-light);
 
-    @include state.input-active(var(--radius-12));
+    box-shadow: var(--state-active);
   }
 
   &[aria-invalid='true'] {
     --b-beta-text-area-background-color: var(--color-fill-grey-light);
 
-    @include state.input-error(var(--radius-12));
+    box-shadow: var(--state-warning);
   }
 
   &:read-only {

--- a/packages/bezier-react/src/stories/color.mdx
+++ b/packages/bezier-react/src/stories/color.mdx
@@ -12,7 +12,7 @@ import {
 } from '~/src/components/ThemeProvider'
 import { HStack, VStack } from '~/src/components/Stack'
 
-<Meta title="foundation/Color" />
+<Meta title="Foundation/Color" />
 
 export const formatTitle = (title) =>
   title
@@ -39,7 +39,15 @@ export const sortNumericLeafEntries = (entries) => {
   return [...entries].sort((a, b) => Number(a[0]) - Number(b[0]))
 }
 
-export const ColorSwatch = ({ name, value, reference, deprecated }) => {
+export const ColorSwatch = ({
+  name,
+  value,
+  reference,
+  deprecated,
+  textColor = '#1a1a1a',
+  mutedTextColor = '#666',
+  valueBackgroundColor = '#f2f2f2',
+}) => {
   const [isHovered, setIsHovered] = useState(false)
   const cssVar = `--${name}`
   const color = isHovered
@@ -55,11 +63,14 @@ export const ColorSwatch = ({ name, value, reference, deprecated }) => {
         : null
 
   return (
-    <VStack spacing={6} style={{ width: 160 }}>
+    <VStack
+      spacing={6}
+      style={{ width: 140 }}
+    >
       <div
         style={{
           width: '100%',
-          height: 24,
+          height: 28,
           borderRadius: 6,
           backgroundColor: color,
           border: '1px solid var(--color-border-neutral, #e5e5e5)',
@@ -77,7 +88,7 @@ export const ColorSwatch = ({ name, value, reference, deprecated }) => {
           alignItems: 'center',
           gap: 4,
           fontSize: 14,
-          color: 'var(--color-text-neutral, #1a1a1a)',
+          color: textColor,
         }}
       >
         <span style={{ minWidth: 0, overflowWrap: 'anywhere' }}>{name}</span>
@@ -105,8 +116,8 @@ export const ColorSwatch = ({ name, value, reference, deprecated }) => {
           display: 'flex',
           alignItems: 'center',
           gap: 4,
-          fontSize: 10,
-          color: 'var(--color-text-neutral-light, #666)',
+          fontSize: 14,
+          color: mutedTextColor,
         }}
       >
         {isReferenced ? 'var' : ''}
@@ -116,7 +127,7 @@ export const ColorSwatch = ({ name, value, reference, deprecated }) => {
             fontSize: 'inherit',
             lineHeight: 'inherit',
             padding: '1px 2px',
-            backgroundColor: 'var(--color-fill-neutral-light, #f2f2f2)',
+            backgroundColor: valueBackgroundColor,
             borderRadius: 3,
             border: '1px solid var(--color-border-neutral, #e5e5e5)',
           }}
@@ -135,6 +146,9 @@ export const TokenGroup = ({
   source,
   depth,
   columns,
+  textColor,
+  mutedTextColor,
+  valueBackgroundColor,
 }) => {
   const entries = Object.entries(data)
   const leafEntries = sortNumericLeafEntries(
@@ -144,12 +158,15 @@ export const TokenGroup = ({
   const headingSize = depth === 0 ? 20 : depth === 1 ? 16 : 14
 
   return (
-    <VStack spacing={10} style={{ marginTop: depth === 0 ? 8 : 16 }}>
+    <VStack
+      spacing={10}
+      style={{ marginTop: depth === 0 ? 8 : 16 }}
+    >
       <div
         style={{
           fontSize: headingSize,
           fontWeight: 600,
-          color: 'var(--color-text-neutral, #1a1a1a)',
+          color: textColor || '#1a1a1a',
         }}
       >
         {formatTitle(title)}
@@ -169,9 +186,7 @@ export const TokenGroup = ({
           {leafEntries.map(([key, value]) => {
             const tokenName = getTokenName([...path, key])
             const token =
-              source[tokenName] ||
-              source[`${tokenName}-normal`] ||
-              {}
+              source[tokenName] || source[`${tokenName}-normal`] || {}
 
             return (
               <ColorSwatch
@@ -180,6 +195,9 @@ export const TokenGroup = ({
                 value={token.value || value.value}
                 reference={token.ref}
                 deprecated={token.deprecated}
+                textColor={textColor}
+                mutedTextColor={mutedTextColor}
+                valueBackgroundColor={valueBackgroundColor}
               />
             )
           })}
@@ -194,6 +212,9 @@ export const TokenGroup = ({
           source={source}
           depth={depth + 1}
           columns={columns}
+          textColor={textColor}
+          mutedTextColor={mutedTextColor}
+          valueBackgroundColor={valueBackgroundColor}
         />
       ))}
     </VStack>
@@ -212,6 +233,9 @@ export const GlobalSection = () => (
         source={tokens.global.color}
         depth={0}
         columns={6}
+        textColor="#1a1a1a"
+        mutedTextColor="#666"
+        valueBackgroundColor="#f2f2f2"
       />
     ))}
   </VStack>
@@ -223,13 +247,19 @@ export const SemanticSection = ({
   source,
   titleColor,
   columns,
+  textColor,
+  mutedTextColor,
+  valueBackgroundColor,
 }) => (
-  <VStack spacing={16} style={{ flex: 1 }}>
+  <VStack
+    spacing={16}
+    style={{ flex: 1 }}
+  >
     <div
       style={{
         fontSize: 24,
         fontWeight: 700,
-        color: titleColor || 'var(--color-text-neutral, #1a1a1a)',
+        color: titleColor || textColor || '#1a1a1a',
       }}
     >
       {title}
@@ -243,6 +273,9 @@ export const SemanticSection = ({
         source={source}
         depth={0}
         columns={columns}
+        textColor={textColor}
+        mutedTextColor={mutedTextColor}
+        valueBackgroundColor={valueBackgroundColor}
       />
     ))}
   </VStack>
@@ -252,7 +285,10 @@ export const Primary = () => (
   <VStack spacing={32}>
     <GlobalSection />
 
-    <HStack spacing={40} align="flex-start">
+    <HStack
+      spacing={40}
+      align="flex-start"
+    >
       <LightThemeProvider>
         <div style={{ flex: 1, padding: 16 }}>
           <SemanticSection
@@ -260,6 +296,9 @@ export const Primary = () => (
             colorData={lightThemeColor}
             source={tokens.lightTheme.color}
             columns={1}
+            textColor="#1a1a1a"
+            mutedTextColor="#666"
+            valueBackgroundColor="#f2f2f2"
           />
         </div>
       </LightThemeProvider>
@@ -275,10 +314,12 @@ export const Primary = () => (
         >
           <SemanticSection
             title="Dark"
-            titleColor="var(--color-text-neutral, #ffffcc)"
             colorData={darkThemeColor}
             source={tokens.darkTheme.color}
             columns={1}
+            textColor="#f5f5f5"
+            mutedTextColor="#b8b8b8"
+            valueBackgroundColor="rgba(255, 255, 255, 0.12)"
           />
         </div>
       </DarkThemeProvider>

--- a/packages/bezier-react/src/styles/mixins/_state.scss
+++ b/packages/bezier-react/src/styles/mixins/_state.scss
@@ -1,38 +1,9 @@
-@mixin error($radius, $gap: 3px, $thickness: 2px) {
-  &::after {
-    pointer-events: none;
-    content: '';
-
-    position: absolute;
-    inset: calc(-1 * (#{$gap} + #{$thickness}));
-
-    border: $thickness solid var(--color-state-warning);
-    border-radius: calc(#{$radius} + #{$gap} + #{$thickness});
-  }
-}
-
-@mixin error-outline($radius, $gap: 3px, $thickness: 2px) {
-  outline: $thickness solid var(--color-state-warning);
-  outline-offset: $gap;
-}
-
-@mixin focus($radius, $gap: 3px, $thickness: 1.5px) {
+@mixin focus-ring($gap: 3px, $thickness: 1.5px) {
   outline: $thickness solid var(--color-state-focus);
   outline-offset: $gap;
 }
 
-@mixin input($radius, $gap: 0, $thickness: 1.5px) {
-  box-shadow: inset 0 0 0 $thickness var(--color-border-neutral);
-}
-
-@mixin input-active($radius, $gap: 0, $thickness: 1.5px) {
-  box-shadow:
-    inset 0 0 0 $thickness var(--color-state-active),
-    0 1px 2px 0 var(--color-elevation-base);
-}
-
-@mixin input-error($radius, $gap: 0, $thickness: 1.5px) {
-  box-shadow:
-    inset 0 0 0 $thickness var(--color-state-warning),
-    0 1px 2px 0 var(--color-elevation-base);
+@mixin error-ring($gap: 3px, $thickness: 1.5px) {
+  outline: $thickness solid var(--color-state-warning);
+  outline-offset: $gap;
 }

--- a/packages/bezier-tokens/src/beta/semantic/state.json
+++ b/packages/bezier-tokens/src/beta/semantic/state.json
@@ -1,28 +1,67 @@
 {
   "state": {
-    "error": {
-      "value": {
-        "color": "{color.state.warning.normal}",
-        "type": "dropShadow",
-        "offsetX": "0",
-        "offsetY": "0",
-        "blur": "0",
-        "spread": "{dimension.1}"
-      },
-      "type": "shadow",
-      "$deprecated": "This token is no longer used due to the redesign."
+    "default": {
+      "value": [
+        {
+          "color": "{color.elevation.base}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "{dimension.1}",
+          "blur": "{dimension.2}",
+          "spread": "0"
+        },
+        {
+          "color": "{color.state.default}",
+          "type": "innerShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "0",
+          "spread": "{dimension.1}"
+        }
+      ],
+      "type": "shadow"
     },
     "active": {
-      "value": {
-        "color": "{color.state.action.normal}",
-        "type": "dropShadow",
-        "offsetX": "0",
-        "offsetY": "0",
-        "blur": "0",
-        "spread": "{dimension.1}"
-      },
-      "type": "shadow",
-      "$deprecated": "This token is no longer used due to the redesign."
+      "value": [
+        {
+          "color": "{color.elevation.base}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "{dimension.1}",
+          "blur": "{dimension.2}",
+          "spread": "0"
+        },
+        {
+          "color": "{color.state.active}",
+          "type": "innerShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "0",
+          "spread": "{dimension.1}"
+        }
+      ],
+      "type": "shadow"
+    },
+    "warning": {
+      "value": [
+        {
+          "color": "{color.elevation.base}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "{dimension.1}",
+          "blur": "{dimension.2}",
+          "spread": "0"
+        },
+        {
+          "color": "{color.state.warning.normal}",
+          "type": "innerShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "0",
+          "spread": "{dimension.1}"
+        }
+      ],
+      "type": "shadow"
     },
     "input": {
       "default": {
@@ -45,29 +84,7 @@
           }
         ],
         "type": "shadow",
-        "$deprecated": "This token is no longer used due to the redesign."
-      },
-      "hovered": {
-        "value": [
-          {
-            "color": "{color.elevation.base}",
-            "type": "dropShadow",
-            "offsetX": "0",
-            "offsetY": "{dimension.2}",
-            "blur": "{dimension.6}",
-            "spread": "0"
-          },
-          {
-            "color": "{color.state.action.normal}",
-            "type": "innerShadow",
-            "offsetX": "0",
-            "offsetY": "0",
-            "blur": "0",
-            "spread": "{dimension.1}"
-          }
-        ],
-        "type": "shadow",
-        "$deprecated": "This token is no longer used due to the redesign."
+        "$deprecated": "Use state.default instead."
       },
       "active": {
         "value": [
@@ -75,20 +92,12 @@
             "color": "{color.elevation.base}",
             "type": "dropShadow",
             "offsetX": "0",
-            "offsetY": "{dimension.2}",
-            "blur": "{dimension.6}",
+            "offsetY": "{dimension.1}",
+            "blur": "{dimension.2}",
             "spread": "0"
           },
           {
-            "color": "{color.state.action.light}",
-            "type": "dropShadow",
-            "offsetX": "0",
-            "offsetY": "0",
-            "blur": "0",
-            "spread": "{dimension.3}"
-          },
-          {
-            "color": "{color.state.action.normal}",
+            "color": "{color.state.active}",
             "type": "innerShadow",
             "offsetX": "0",
             "offsetY": "0",
@@ -97,7 +106,7 @@
           }
         ],
         "type": "shadow",
-        "$deprecated": "This token is no longer used due to the redesign."
+        "$deprecated": "Use state.active instead."
       },
       "error": {
         "value": [
@@ -105,17 +114,9 @@
             "color": "{color.elevation.base}",
             "type": "dropShadow",
             "offsetX": "0",
-            "offsetY": "{dimension.2}",
-            "blur": "{dimension.6}",
+            "offsetY": "{dimension.1}",
+            "blur": "{dimension.2}",
             "spread": "0"
-          },
-          {
-            "color": "{color.state.warning.light}",
-            "type": "dropShadow",
-            "offsetX": "0",
-            "offsetY": "0",
-            "blur": "0",
-            "spread": "{dimension.3}"
           },
           {
             "color": "{color.state.warning.normal}",
@@ -127,7 +128,7 @@
           }
         ],
         "type": "shadow",
-        "$deprecated": "This token is no longer used due to the redesign."
+        "$deprecated": "Use state.warning instead."
       }
     }
   }

--- a/packages/bezier-tokens/src/beta/semantic/typography.json
+++ b/packages/bezier-tokens/src/beta/semantic/typography.json
@@ -20,8 +20,12 @@
         "xsmall": {
           "value": "{typography.font-size.16}"
         },
-        "2xsmall": {
+        "xxsmall": {
           "value": "{typography.font-size.15}"
+        },
+        "2xsmall": {
+          "value": "{typography.font-size.15}",
+          "$deprecated": "Use typography.heading.size.xxsmall instead."
         }
       },
       "weight": {
@@ -38,7 +42,11 @@
         "medium": { "value": "{typography.line-height.24}" },
         "small": { "value": "{typography.line-height.24}" },
         "xsmall": { "value": "{typography.line-height.24}" },
-        "2xsmall": { "value": "{typography.line-height.20}" }
+        "xxsmall": { "value": "{typography.line-height.20}" },
+        "2xsmall": {
+          "value": "{typography.line-height.20}",
+          "$deprecated": "Use typography.heading.line-height.xxsmall instead."
+        }
       }
     },
     "text": {
@@ -46,13 +54,21 @@
         "value": "{typography.font-family.sans.kr}"
       },
       "size": {
-        "2xlarge": { "value": "{typography.font-size.17}" },
+        "xxlarge": { "value": "{typography.font-size.17}" },
+        "2xlarge": {
+          "value": "{typography.font-size.17}",
+          "$deprecated": "Use typography.text.size.xxlarge instead."
+        },
         "xlarge": { "value": "{typography.font-size.16}" },
         "large": { "value": "{typography.font-size.15}" },
         "medium": { "value": "{typography.font-size.14}" },
         "small": { "value": "{typography.font-size.13}" },
         "xsmall": { "value": "{typography.font-size.12}" },
-        "2xsmall": { "value": "{typography.font-size.11}" }
+        "xxsmall": { "value": "{typography.font-size.11}" },
+        "2xsmall": {
+          "value": "{typography.font-size.11}",
+          "$deprecated": "Use typography.text.size.xxsmall instead."
+        }
       },
       "weight": {
         "bold": { "value": "{typography.font-weight.700}" },
@@ -63,13 +79,63 @@
         "tight": { "value": "{typography.letter-spacing.0-1}" }
       },
       "line-height": {
-        "2xlarge": { "value": "{typography.line-height.24}" },
+        "xxlarge": { "value": "{typography.line-height.24}" },
+        "2xlarge": {
+          "value": "{typography.line-height.24}",
+          "$deprecated": "Use typography.text.line-height.xxlarge instead."
+        },
         "xlarge": { "value": "{typography.line-height.24}" },
         "large": { "value": "{typography.line-height.20}" },
         "medium": { "value": "{typography.line-height.18}" },
         "small": { "value": "{typography.line-height.18}" },
         "xsmall": { "value": "{typography.line-height.16}" },
-        "2xsmall": { "value": "{typography.line-height.16}" }
+        "xxsmall": { "value": "{typography.line-height.16}" },
+        "2xsmall": {
+          "value": "{typography.line-height.16}",
+          "$deprecated": "Use typography.text.line-height.xxsmall instead."
+        }
+      }
+    },
+    "label": {
+      "font-family": {
+        "value": "{typography.font-family.sans.kr}"
+      },
+      "size": {
+        "large": { "value": "{typography.font-size.14}" },
+        "medium": { "value": "{typography.font-size.13}" },
+        "small": { "value": "{typography.font-size.12}" }
+      },
+      "weight": {
+        "bold": { "value": "{typography.font-weight.500}" },
+        "regular": { "value": "{typography.font-weight.400}" }
+      },
+      "letter-spacing": {
+        "normal": { "value": "{typography.letter-spacing.0}" }
+      },
+      "line-height": {
+        "large": { "value": "{typography.line-height.18}" },
+        "medium": { "value": "{typography.line-height.18}" },
+        "small": { "value": "{typography.line-height.16}" }
+      }
+    },
+    "caption": {
+      "font-family": {
+        "value": "{typography.font-family.sans.kr}"
+      },
+      "size": {
+        "medium": { "value": "{typography.font-size.12}" },
+        "small": { "value": "{typography.font-size.11}" }
+      },
+      "weight": {
+        "bold": { "value": "{typography.font-weight.600}" },
+        "regular": { "value": "{typography.font-weight.400}" }
+      },
+      "letter-spacing": {
+        "normal": { "value": "{typography.letter-spacing.0}" }
+      },
+      "line-height": {
+        "medium": { "value": "{typography.line-height.16}" },
+        "small": { "value": "{typography.line-height.16}" }
       }
     },
     "display": {


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [ ] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

<!-- Fixes #0000 -->

## Summary

Beta state 토큰과 state ring 스타일을 정리했습니다.

## Details

- beta input 상태용 `state.default`, `state.active`, `state.warning` shadow 토큰을 추가했습니다.
- 기존 `state.input.*` 토큰은 deprecated alias로 유지했습니다.
- beta typography에 `label`, `caption`, `xx*` 토큰을 추가하고 기존 `2x*` 이름은 deprecated 처리했습니다.
- beta input 스타일은 mixin 대신 `--state-*` box-shadow 토큰을 직접 사용하도록 변경했습니다.
- non-input ring mixin은 `focus-ring`, `error-ring`으로 정리하고 outline 기반으로 통일했습니다.
- Section item, CollapsibleSection trigger, Tag delete button의 focus ring QA 사항을 반영했습니다.
- Storybook에서 Foundation이 Beta components보다 먼저 보이도록 정렬하고, Color 문서의 swatch 크기와 텍스트 가독성을 조정했습니다.

### Breaking change? (Yes/No)

No

## References

검증:

- `git diff --check upstream/v4...HEAD`
- `../../node_modules/.bin/tsc --noEmit` (`packages/bezier-react`)
- `../../node_modules/.bin/stylelint --cache '**/*.scss'` (`packages/bezier-react`, deprecated token warning만 남음)
- `../../node_modules/.bin/eslint .storybook/preview.tsx`

참고: Storybook 전체 build는 기존 여러 MDX 문서 loader 문제로 실패했습니다. 이번 변경 대상인 `color.mdx` 단독 에러는 로그에 나타나지 않았습니다.
