### PR TITLE
fix(react): surface legacy component deprecations

### DIFF
--- a/.changeset/quiet-deprecations-warn.md
+++ b/.changeset/quiet-deprecations-warn.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Fix legacy component deprecation annotations so TypeScript consumers can see them at usage sites.

--- a/packages/bezier-react/src/components/AlphaAvatar/Avatar.tsx
+++ b/packages/bezier-react/src/components/AlphaAvatar/Avatar.tsx
@@ -47,6 +47,9 @@ function getShadow(size: AvatarSize): SmoothCornersBoxProps['shadow'] {
   }
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export function useAvatarRadiusToken() {
   return '42%' as const
 }
@@ -57,6 +60,7 @@ const STATUS_WRAPPER_TEST_ID = 'bezier-status-wrapper'
 
 /**
  * `Avatar` is a component for representing some profile image.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/AlphaAvatar/Avatar.types.ts
+++ b/packages/bezier-react/src/components/AlphaAvatar/Avatar.types.ts
@@ -8,6 +8,9 @@ import {
 // TODO: Replace this with AlphaStatusBadgeType
 import { type StatusType } from '~/src/components/Status'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type AvatarSize =
   | '16'
   | '20'
@@ -56,6 +59,9 @@ interface AvatarOwnProps {
   smoothCorners?: boolean
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface AvatarProps
   extends BezierComponentProps<'div'>,
     SizeProps<AvatarSize>,

--- a/packages/bezier-react/src/components/AlphaAvatar/index.ts
+++ b/packages/bezier-react/src/components/AlphaAvatar/index.ts
@@ -1,9 +1,9 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   Avatar as AlphaAvatar,
   useAvatarRadiusToken as useAlphaAvatarRadiusToken,
 } from './Avatar'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   AvatarProps as AlphaAvatarProps,
   AvatarSize as AlphaAvatarSize,

--- a/packages/bezier-react/src/components/AlphaAvatarGroup/AvatarGroup.tsx
+++ b/packages/bezier-react/src/components/AlphaAvatarGroup/AvatarGroup.tsx
@@ -71,6 +71,7 @@ function getProperTypoSize(size: AlphaAvatarSize) {
 
 /**
  * `AvatarGroup` is a component for grouping `Avatar` components
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/AlphaAvatarGroup/AvatarGroup.types.ts
+++ b/packages/bezier-react/src/components/AlphaAvatarGroup/AvatarGroup.types.ts
@@ -30,6 +30,9 @@ interface AvatarGroupOwnProps {
   ellipsisType?: AvatarGroupEllipsisType
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface AvatarGroupProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/AlphaAvatarGroup/index.ts
+++ b/packages/bezier-react/src/components/AlphaAvatarGroup/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { AvatarGroup as AlphaAvatarGroup } from './AvatarGroup'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { type AvatarGroupProps as AlphaAvatarGroupProps } from './AvatarGroup.types'

--- a/packages/bezier-react/src/components/AlphaButton/Button.tsx
+++ b/packages/bezier-react/src/components/AlphaButton/Button.tsx
@@ -58,6 +58,9 @@ function getTypography(size: ButtonSize) {
   )[size]
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   function Button(
     {

--- a/packages/bezier-react/src/components/AlphaButton/Button.types.ts
+++ b/packages/bezier-react/src/components/AlphaButton/Button.types.ts
@@ -9,8 +9,14 @@ import {
   type SizeProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ButtonVariant = 'primary' | 'secondary' | 'tertiary'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ButtonColor =
   | 'blue'
   | 'cobalt'
@@ -23,6 +29,9 @@ export type ButtonColor =
   | 'light-grey'
   | 'white-absolute'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ButtonSize = 'xs' | 's' | 'm' | 'l' | 'xl'
 
 interface ButtonOwnProps {
@@ -67,6 +76,9 @@ interface ButtonOwnProps {
   suffixContent?: BezierIcon | ReactNode
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ButtonProps
   extends Omit<BezierComponentProps<'button'>, 'color'>,
     PolymorphicProps,

--- a/packages/bezier-react/src/components/AlphaButton/index.ts
+++ b/packages/bezier-react/src/components/AlphaButton/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Button as AlphaButton } from './Button'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   ButtonColor as AlphaButtonColor,
   ButtonProps as AlphaButtonProps,

--- a/packages/bezier-react/src/components/AlphaDialogPrimitive/DialogPrimitive.tsx
+++ b/packages/bezier-react/src/components/AlphaDialogPrimitive/DialogPrimitive.tsx
@@ -12,41 +12,49 @@ import {
 } from '@radix-ui/react-dialog'
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#root}
  */
 export const DialogPrimitive = Dialog
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#close}
  */
 export const DialogPrimitiveClose = DialogClose
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#content}
  */
 export const DialogPrimitiveContent = DialogContent
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#description}
  */
 export const DialogPrimitiveDescription = DialogDescription
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#overlay}
  */
 export const DialogPrimitiveOverlay = DialogOverlay
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#portal}
  */
 export const DialogPrimitivePortal = DialogPortal
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#title}
  */
 export const DialogPrimitiveTitle = DialogTitle
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#trigger}
  */
 export const DialogPrimitiveTrigger = DialogTrigger

--- a/packages/bezier-react/src/components/AlphaDialogPrimitive/DialogPrimitive.types.ts
+++ b/packages/bezier-react/src/components/AlphaDialogPrimitive/DialogPrimitive.types.ts
@@ -10,41 +10,49 @@ import type {
 } from '@radix-ui/react-dialog'
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#root}
  */
 export type DialogPrimitiveProps = DialogProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#close}
  */
 export type DialogPrimitiveCloseProps = DialogCloseProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#content}
  */
 export type DialogPrimitiveContentProps = DialogContentProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#description}
  */
 export type DialogPrimitiveDescriptionProps = DialogDescriptionProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#overlay}
  */
 export type DialogPrimitiveOverlayProps = DialogOverlayProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#portal}
  */
 export type DialogPrimitivePortalProps = DialogPortalProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#title}
  */
 export type DialogPrimitiveTitleProps = DialogTitleProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#trigger}
  */
 export type DialogPrimitiveTriggerProps = DialogTriggerProps

--- a/packages/bezier-react/src/components/AlphaDialogPrimitive/index.ts
+++ b/packages/bezier-react/src/components/AlphaDialogPrimitive/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   DialogPrimitive as AlphaDialogPrimitive,
   DialogPrimitiveClose as AlphaDialogPrimitiveClose,
@@ -9,7 +9,7 @@ export {
   DialogPrimitiveTitle as AlphaDialogPrimitiveTitle,
   DialogPrimitiveTrigger as AlphaDialogPrimitiveTrigger,
 } from './DialogPrimitive'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   DialogPrimitiveProps as AlphaDialogPrimitiveProps,
   DialogPrimitiveCloseProps as AlphaDialogPrimitiveCloseProps,

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.tsx
@@ -58,6 +58,9 @@ function getTypography(size: FloatingButtonSize) {
   )[size]
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const FloatingButton = forwardRef<
   HTMLButtonElement,
   FloatingButtonProps

--- a/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.types.ts
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/FloatingButton.types.ts
@@ -9,8 +9,14 @@ import {
   type SizeProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type FloatingButtonVariant = 'primary' | 'secondary'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type FloatingButtonColor =
   | 'blue'
   | 'cobalt'
@@ -22,6 +28,9 @@ export type FloatingButtonColor =
   | 'dark-grey'
   | 'light-grey'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type FloatingButtonSize = 'xs' | 's' | 'm' | 'l' | 'xl'
 
 interface FloatingButtonOwnProps {
@@ -65,6 +74,9 @@ interface FloatingButtonOwnProps {
   suffixContent?: BezierIcon | ReactNode
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface FloatingButtonProps
   extends Omit<BezierComponentProps<'button'>, 'color'>,
     PolymorphicProps,

--- a/packages/bezier-react/src/components/AlphaFloatingButton/index.ts
+++ b/packages/bezier-react/src/components/AlphaFloatingButton/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { FloatingButton as AlphaFloatingButton } from './FloatingButton'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   FloatingButtonColor as AlphaFloatingButtonColor,
   FloatingButtonProps as AlphaFloatingButtonProps,

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.tsx
@@ -25,6 +25,9 @@ function getIconSize(size: ButtonSize) {
   )[size]
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const FloatingIconButton = forwardRef<
   HTMLButtonElement,
   AlphaFloatingIconButtonProps

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.types.ts
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/FloatingIconButton.types.ts
@@ -56,6 +56,9 @@ interface FloatingIconButtonOwnProps {
   content: BezierIcon | ReactNode
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface FloatingIconButtonProps
   extends Omit<BezierComponentProps<'button'>, 'color' | 'content'>,
     PolymorphicProps,

--- a/packages/bezier-react/src/components/AlphaFloatingIconButton/index.ts
+++ b/packages/bezier-react/src/components/AlphaFloatingIconButton/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { FloatingIconButton as AlphaFloatingIconButton } from './FloatingIconButton'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { FloatingIconButtonProps as AlphaFloatingIconButtonProps } from './FloatingIconButton.types'

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.tsx
@@ -25,6 +25,9 @@ function getIconSize(size: ButtonSize) {
   )[size]
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const IconButton = forwardRef<HTMLButtonElement, AlphaIconButtonProps>(
   function IconButton(
     {

--- a/packages/bezier-react/src/components/AlphaIconButton/IconButton.types.ts
+++ b/packages/bezier-react/src/components/AlphaIconButton/IconButton.types.ts
@@ -63,6 +63,9 @@ interface IconButtonOwnProps {
   shape?: 'rectangle' | 'circle'
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface IconButtonProps
   extends Omit<BezierComponentProps<'button'>, 'color' | 'content'>,
     PolymorphicProps,

--- a/packages/bezier-react/src/components/AlphaIconButton/index.ts
+++ b/packages/bezier-react/src/components/AlphaIconButton/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { IconButton as AlphaIconButton } from './IconButton'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { IconButtonProps as AlphaIconButtonProps } from './IconButton.types'

--- a/packages/bezier-react/src/components/AlphaLoader/Loader.tsx
+++ b/packages/bezier-react/src/components/AlphaLoader/Loader.tsx
@@ -10,6 +10,9 @@ import styles from './Loader.module.scss'
 
 export const LOADER_TEST_ID = 'bezier-loader'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const Loader = forwardRef<HTMLSpanElement, LoaderProps>(function Loader(
   { className, size, variant = 'secondary', ...rest },
   forwardedRef

--- a/packages/bezier-react/src/components/AlphaLoader/Loader.types.ts
+++ b/packages/bezier-react/src/components/AlphaLoader/Loader.types.ts
@@ -14,6 +14,9 @@ interface LoaderOwnProps {
   variant?: 'primary' | 'secondary' | 'on-overlay'
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface LoaderProps
   extends Omit<BezierComponentProps<'span'>, keyof ColorProps>,
     Required<SizeProps<LoaderSize>>,

--- a/packages/bezier-react/src/components/AlphaLoader/index.ts
+++ b/packages/bezier-react/src/components/AlphaLoader/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Loader as AlphaLoader } from './Loader'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { type LoaderProps as AlphaLoaderProps } from './Loader.types'

--- a/packages/bezier-react/src/components/AlphaStatusBadge/StatusBadge.tsx
+++ b/packages/bezier-react/src/components/AlphaStatusBadge/StatusBadge.tsx
@@ -18,6 +18,7 @@ import styles from './StatusBadge.module.scss'
 
 /**
  * `StatusBadge` is a component to indicate user status.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/AlphaStatusBadge/StatusBadge.types.ts
+++ b/packages/bezier-react/src/components/AlphaStatusBadge/StatusBadge.types.ts
@@ -1,5 +1,8 @@
 import type { BezierComponentProps, SizeProps } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type StatusBadgeSize = 'm' | 'l'
 
 interface StatusBadgeOwnProps {
@@ -20,6 +23,9 @@ interface StatusBadgeOwnProps {
   doNotDisturb?: boolean
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface StatusBadgeProps
   extends BezierComponentProps<'div'>,
     SizeProps<StatusBadgeSize>,

--- a/packages/bezier-react/src/components/AlphaStatusBadge/index.ts
+++ b/packages/bezier-react/src/components/AlphaStatusBadge/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { StatusBadge as AlphaStatusBadge } from './StatusBadge'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   StatusBadgeProps as AlphaStatusBadgeProps,
   StatusBadgeSize as AlphaStatusBadgeSize,

--- a/packages/bezier-react/src/components/AlphaToggleButton/ToggleButton.tsx
+++ b/packages/bezier-react/src/components/AlphaToggleButton/ToggleButton.tsx
@@ -33,6 +33,9 @@ function SideContent({
   )
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const ToggleButton = forwardRef<HTMLButtonElement, ToggleButtonProps>(
   function ToggleButton(
     {

--- a/packages/bezier-react/src/components/AlphaToggleButton/ToggleButton.types.ts
+++ b/packages/bezier-react/src/components/AlphaToggleButton/ToggleButton.types.ts
@@ -62,6 +62,9 @@ interface ToggleButtonOwnProps {
   onSelectedChange?: (selected: boolean) => void
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ToggleButtonProps
   extends Omit<BezierComponentProps<'button'>, keyof ToggleButtonOwnProps>,
     PolymorphicProps,

--- a/packages/bezier-react/src/components/AlphaToggleButton/index.ts
+++ b/packages/bezier-react/src/components/AlphaToggleButton/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { ToggleButton as AlphaToggleButton } from './ToggleButton'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { ToggleButtonProps as AlphaToggleButtonProps } from './ToggleButton.types'

--- a/packages/bezier-react/src/components/AlphaToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/bezier-react/src/components/AlphaToggleButtonGroup/ToggleButtonGroup.tsx
@@ -38,6 +38,7 @@ import styles from './ToggleButtonGroup.module.scss'
  *   />
  * </ToggleButtonGroup>
  * ```
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const ToggleButtonGroup = forwardRef<
   HTMLDivElement,

--- a/packages/bezier-react/src/components/AlphaToggleButtonGroup/ToggleButtonGroup.types.ts
+++ b/packages/bezier-react/src/components/AlphaToggleButtonGroup/ToggleButtonGroup.types.ts
@@ -47,6 +47,9 @@ interface ToggleButtonGroupOwnProps<T extends string = 'single' | 'multiple'> {
     : (value: string[]) => void
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ToggleButtonSingleGroupProps
   extends Omit<
       BezierComponentProps<'div'>,
@@ -56,6 +59,9 @@ export interface ToggleButtonSingleGroupProps
     PolymorphicProps,
     ToggleButtonGroupOwnProps<'single'> {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ToggleButtonMultipleGroupProps
   extends Omit<
       BezierComponentProps<'div'>,

--- a/packages/bezier-react/src/components/AlphaToggleButtonGroup/index.ts
+++ b/packages/bezier-react/src/components/AlphaToggleButtonGroup/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { ToggleButtonGroup } from './ToggleButtonGroup'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   ToggleButtonMultipleGroupProps,
   ToggleButtonSingleGroupProps,

--- a/packages/bezier-react/src/components/AlphaToggleEmojiButtonGroup/ToggleEmojiButtonGroup.tsx
+++ b/packages/bezier-react/src/components/AlphaToggleEmojiButtonGroup/ToggleEmojiButtonGroup.tsx
@@ -27,6 +27,7 @@ const EMOJI_SIZE = 30
 /**
  * Toggle Button that contains `Emoji` component with size fixed to 30.
  * It should be used with `ToggleEmojiButtonGroup` component.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <ToggleEmojiButtonSource
@@ -74,6 +75,7 @@ export const ToggleEmojiButtonSource = forwardRef<
 
 /**
  * Component for grouping `ToggleEmojiButtonSource`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <ToggleEmojiButtonGroup

--- a/packages/bezier-react/src/components/AlphaToggleEmojiButtonGroup/ToggleEmojiButtonGroup.types.ts
+++ b/packages/bezier-react/src/components/AlphaToggleEmojiButtonGroup/ToggleEmojiButtonGroup.types.ts
@@ -49,10 +49,16 @@ interface ToggleEmojiButtonGroupOwnProps {
   onValueChange?: (value: string) => void
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ToggleEmojiButtonGroupProps
   extends Omit<BezierComponentProps<'div'>, 'dir' | 'defaultValue'>,
     ToggleEmojiButtonGroupOwnProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ToggleEmojiButtonSourceProps
   extends Omit<
       BezierComponentProps<'button'>,

--- a/packages/bezier-react/src/components/AlphaToggleEmojiButtonGroup/index.ts
+++ b/packages/bezier-react/src/components/AlphaToggleEmojiButtonGroup/index.ts
@@ -1,10 +1,10 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   ToggleEmojiButtonGroupProps as AlphaToggleEmojiButtonGroupProps,
   ToggleEmojiButtonSourceProps as AlphaToggleEmojiButtonSourceProps,
 } from './ToggleEmojiButtonGroup.types'
 
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   ToggleEmojiButtonGroup as AlphaToggleEmojiButtonGroup,
   ToggleEmojiButtonSource as AlphaToggleEmojiButtonSource,

--- a/packages/bezier-react/src/components/AlphaTooltipPrimitive/TooltipPrimitive.tsx
+++ b/packages/bezier-react/src/components/AlphaTooltipPrimitive/TooltipPrimitive.tsx
@@ -10,31 +10,37 @@ import {
 } from '@radix-ui/react-tooltip'
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#provider}
  */
 export const TooltipPrimitiveProvider = TooltipProvider
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#root}
  */
 export const TooltipPrimitive = Tooltip
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#trigger}
  */
 export const TooltipPrimitiveTrigger = TooltipTrigger
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#portal}
  */
 export const TooltipPrimitivePortal = TooltipPortal
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#content}
  */
 export const TooltipPrimitiveContent = TooltipContent
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#arrow}
  */
 export const TooltipPrimitiveArrow = TooltipArrow

--- a/packages/bezier-react/src/components/AlphaTooltipPrimitive/TooltipPrimitive.types.ts
+++ b/packages/bezier-react/src/components/AlphaTooltipPrimitive/TooltipPrimitive.types.ts
@@ -8,31 +8,37 @@ import type {
 } from '@radix-ui/react-tooltip'
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#provider}
  */
 export type TooltipPrimitiveProviderProps = TooltipProviderProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#root}
  */
 export type TooltipPrimitiveProps = TooltipProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#trigger}
  */
 export type TooltipPrimitiveTriggerProps = TooltipTriggerProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#portal}
  */
 export type TooltipPrimitivePortalProps = TooltipPortalProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#content}
  */
 export type TooltipPrimitiveContentProps = TooltipContentProps
 
 /**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see {@link https://www.radix-ui.com/primitives/docs/components/tooltip#arrow}
  */
 export type TooltipPrimitiveArrowProps = TooltipArrowProps

--- a/packages/bezier-react/src/components/AlphaTooltipPrimitive/index.ts
+++ b/packages/bezier-react/src/components/AlphaTooltipPrimitive/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   TooltipPrimitive as AlphaTooltipPrimitive,
   TooltipPrimitiveArrow as AlphaTooltipPrimitiveArrow,
@@ -7,7 +7,7 @@ export {
   TooltipPrimitiveProvider as AlphaTooltipPrimitiveProvider,
   TooltipPrimitiveTrigger as AlphaTooltipPrimitiveTrigger,
 } from './TooltipPrimitive'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   TooltipPrimitiveArrowProps as AlphaTooltipPrimitiveArrowProps,
   TooltipPrimitiveContentProps as AlphaTooltipPrimitiveContentProps,

--- a/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
+++ b/packages/bezier-react/src/components/AutoFocus/AutoFocus.tsx
@@ -13,6 +13,7 @@ import { type AutoFocusProps } from './AutoFocus.types'
  * `AutoFocus` is a component that automatically focuses its child element when they are added to the document.
  * It is useful when you want to focus on a specific element when the component is mounted.
  * It doesn't render any DOM node.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/AutoFocus/AutoFocus.types.ts
+++ b/packages/bezier-react/src/components/AutoFocus/AutoFocus.types.ts
@@ -8,6 +8,9 @@ interface AutoFocusOptions {
   when?: boolean
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface AutoFocusProps
   extends ChildrenProps,
     React.HTMLAttributes<HTMLElement>,

--- a/packages/bezier-react/src/components/AutoFocus/index.ts
+++ b/packages/bezier-react/src/components/AutoFocus/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { AutoFocus } from './AutoFocus'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { AutoFocusProps } from './AutoFocus.types'

--- a/packages/bezier-react/src/components/Avatar/Avatar.tsx
+++ b/packages/bezier-react/src/components/Avatar/Avatar.tsx
@@ -23,6 +23,9 @@ const shadow: SmoothCornersBoxProps['shadow'] = {
   color: 'surface-high',
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export function useAvatarRadiusToken() {
   return '42%' as const
 }
@@ -33,6 +36,7 @@ const STATUS_WRAPPER_TEST_ID = 'bezier-status-wrapper'
 
 /**
  * `Avatar` is a component for representing some profile image.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Avatar/Avatar.types.ts
+++ b/packages/bezier-react/src/components/Avatar/Avatar.types.ts
@@ -7,6 +7,9 @@ import type {
 
 import { type StatusType } from '~/src/components/Status'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type AvatarSize =
   | '20'
   | '24'
@@ -54,6 +57,9 @@ interface AvatarOwnProps {
   smoothCorners?: boolean
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface AvatarProps
   extends BezierComponentProps<'div'>,
     SizeProps<AvatarSize>,

--- a/packages/bezier-react/src/components/Avatar/index.ts
+++ b/packages/bezier-react/src/components/Avatar/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Avatar, useAvatarRadiusToken } from './Avatar'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { AvatarProps, AvatarSize } from './Avatar.types'

--- a/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.tsx
+++ b/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.tsx
@@ -68,6 +68,7 @@ function getProperTypoSize(avatarSize: AvatarSize) {
 
 /**
  * `AvatarGroup` is a component for grouping `Avatar` components
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.types.ts
+++ b/packages/bezier-react/src/components/AvatarGroup/AvatarGroup.types.ts
@@ -7,6 +7,9 @@ import type {
 
 import { type AvatarSize } from '~/src/components/Avatar'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type AvatarGroupEllipsisType = 'icon' | 'count'
 
 type MouseEventHandler = React.MouseEventHandler<HTMLDivElement>
@@ -43,6 +46,9 @@ interface AvatarGroupOwnProps {
   onMouseLeaveEllipsis?: MouseEventHandler
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface AvatarGroupProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/AvatarGroup/index.ts
+++ b/packages/bezier-react/src/components/AvatarGroup/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { AvatarGroup } from './AvatarGroup'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   type AvatarGroupEllipsisType,
   type AvatarGroupProps,

--- a/packages/bezier-react/src/components/Badge/Badge.tsx
+++ b/packages/bezier-react/src/components/Badge/Badge.tsx
@@ -13,6 +13,7 @@ const BADGE_TEST_ID = 'bezier-badge'
 
 /**
  * `Badge` is a component for representing badge, which consists of text and icon.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <Badge

--- a/packages/bezier-react/src/components/Badge/Badge.types.ts
+++ b/packages/bezier-react/src/components/Badge/Badge.types.ts
@@ -12,8 +12,14 @@ import {
   type BaseTagBadgeVariant,
 } from '~/src/components/BaseTagBadge'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type BadgeSize = BaseTagBadgeSize
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type BadgeVariant = BaseTagBadgeVariant
 
 interface BadgeOwnProps {
@@ -29,6 +35,9 @@ interface BadgeOwnProps {
   truncated?: boolean | number
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface BadgeProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/Badge/index.ts
+++ b/packages/bezier-react/src/components/Badge/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Badge } from './Badge'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { BadgeProps, BadgeSize, BadgeVariant } from './Badge.types'

--- a/packages/bezier-react/src/components/Banner/Banner.tsx
+++ b/packages/bezier-react/src/components/Banner/Banner.tsx
@@ -49,6 +49,7 @@ const externalLinkRenderer: RenderLinkFunc = ({ content, linkTo }) => (
 
 /**
  * `Banner` is a component you use when you want to communicate instructions, warnings, recommendations, and other information well.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <Banner

--- a/packages/bezier-react/src/components/Banner/Banner.types.ts
+++ b/packages/bezier-react/src/components/Banner/Banner.types.ts
@@ -11,6 +11,9 @@ import type {
 
 import type { ButtonProps } from '~/src/components/Button'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type BannerVariant =
   | 'default'
   | 'blue'
@@ -76,6 +79,9 @@ interface BannerOwnProps {
   onClickAction?: ButtonProps['onClick']
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface BannerProps
   extends Omit<BezierComponentProps<'div'>, keyof ContentProps>,
     ContentProps,

--- a/packages/bezier-react/src/components/Banner/index.ts
+++ b/packages/bezier-react/src/components/Banner/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Banner } from './Banner'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { BannerProps, BannerVariant } from './Banner.types'

--- a/packages/bezier-react/src/components/Box/Box.tsx
+++ b/packages/bezier-react/src/components/Box/Box.tsx
@@ -17,6 +17,7 @@ import styles from './Box.module.scss'
 
 /**
  * `Box` is a primitive layout component. It provides an easy way to access design tokens.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Box/Box.types.ts
+++ b/packages/bezier-react/src/components/Box/Box.types.ts
@@ -15,6 +15,9 @@ interface BoxOwnProps {
   display?: Display
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface BoxProps
   extends BezierComponentProps<'div'>,
     PolymorphicProps,

--- a/packages/bezier-react/src/components/Box/index.ts
+++ b/packages/bezier-react/src/components/Box/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Box } from './Box'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { BoxProps } from './Box.types'

--- a/packages/bezier-react/src/components/Button/Button.tsx
+++ b/packages/bezier-react/src/components/Button/Button.tsx
@@ -89,6 +89,9 @@ function ButtonSideContent({
   return <>{children}</>
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   function Button(
     {

--- a/packages/bezier-react/src/components/Button/Button.types.ts
+++ b/packages/bezier-react/src/components/Button/Button.types.ts
@@ -8,6 +8,9 @@ import {
   type SizeProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ButtonStyleVariant =
   | 'primary'
   | 'secondary'
@@ -15,6 +18,9 @@ export type ButtonStyleVariant =
   | 'floating'
   | 'floating-alt'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ButtonColorVariant =
   | 'blue'
   | 'red'
@@ -30,6 +36,9 @@ export type ButtonColorVariant =
   | 'monochrome-light'
   | 'monochrome-dark'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ButtonSize = 'xs' | 's' | 'm' | 'l' | 'xl'
 
 export type SideContent = React.ReactNode | BezierIcon
@@ -78,6 +87,9 @@ interface ButtonOwnProps {
   colorVariant?: ButtonColorVariant
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ButtonProps
   extends Omit<BezierComponentProps<'button'>, 'children'>,
     PolymorphicProps,

--- a/packages/bezier-react/src/components/Button/index.ts
+++ b/packages/bezier-react/src/components/Button/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Button } from './Button'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   ButtonColorVariant,
   ButtonProps,

--- a/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.tsx
@@ -8,6 +8,7 @@ import type { ButtonGroupProps } from './ButtonGroup.types'
 
 /**
  * `ButtonGroup` is a component that groups buttons together.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <ButtonGroup>

--- a/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.types.ts
+++ b/packages/bezier-react/src/components/ButtonGroup/ButtonGroup.types.ts
@@ -14,6 +14,9 @@ interface ButtonGroupOwnProps {
   withoutSpacing?: boolean
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ButtonGroupProps
   extends Omit<BezierComponentProps<'div'>, 'role'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/ButtonGroup/index.ts
+++ b/packages/bezier-react/src/components/ButtonGroup/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { ButtonGroup } from './ButtonGroup'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { ButtonGroupProps } from './ButtonGroup.types'

--- a/packages/bezier-react/src/components/Center/Center.tsx
+++ b/packages/bezier-react/src/components/Center/Center.tsx
@@ -17,6 +17,7 @@ import styles from './Center.module.scss'
 
 /**
  * `Center` is a layout component that centers its child within itself.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Center/Center.types.ts
+++ b/packages/bezier-react/src/components/Center/Center.types.ts
@@ -15,6 +15,9 @@ interface CenterOwnProps {
   display?: Display
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface CenterProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/Center/index.ts
+++ b/packages/bezier-react/src/components/Center/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Center } from './Center'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { CenterProps } from './Center.types'

--- a/packages/bezier-react/src/components/CheckableAvatar/CheckableAvatar.tsx
+++ b/packages/bezier-react/src/components/CheckableAvatar/CheckableAvatar.tsx
@@ -19,6 +19,7 @@ import styles from './CheckableAvatar.module.scss'
 
 /**
  * `CheckableAvatar` is a checkbox component that looks like `Avatar`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/CheckableAvatar/CheckableAvatar.types.ts
+++ b/packages/bezier-react/src/components/CheckableAvatar/CheckableAvatar.types.ts
@@ -29,6 +29,9 @@ interface CheckableAvatarPropsOwnProps {
   onCheckedChange?: (checked: boolean) => void
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface CheckableAvatarProps
   extends Omit<AvatarProps, keyof React.HTMLAttributes<HTMLDivElement>>,
     React.HTMLAttributes<HTMLButtonElement>,

--- a/packages/bezier-react/src/components/CheckableAvatar/index.ts
+++ b/packages/bezier-react/src/components/CheckableAvatar/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { CheckableAvatar } from './CheckableAvatar'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { CheckableAvatarProps } from './CheckableAvatar.types'

--- a/packages/bezier-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/bezier-react/src/components/Checkbox/Checkbox.tsx
@@ -106,6 +106,7 @@ type ReturnTypeOfCheckboxImpl<Checked extends CheckedState> = ReturnType<
 /**
  * `Checkbox` is a control that allows the user to toggle between checked and not checked.
  * It can be used with labels or standalone.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/bezier-react/src/components/Checkbox/Checkbox.types.ts
@@ -5,8 +5,14 @@ import {
   type SizeProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type CheckedState = boolean | 'indeterminate'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type CheckboxSize = 's' | 'm'
 
 interface CheckboxOwnProps<Checked extends CheckedState> {
@@ -41,6 +47,9 @@ interface CheckboxOwnProps<Checked extends CheckedState> {
   onCheckedChange?: (checked: Checked) => void
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface CheckboxProps<Checked extends CheckedState>
   extends Omit<BezierComponentProps<'button'>, keyof CheckboxOwnProps<Checked>>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/Checkbox/index.ts
+++ b/packages/bezier-react/src/components/Checkbox/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Checkbox } from './Checkbox'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   CheckboxProps,
   CheckedState,

--- a/packages/bezier-react/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/bezier-react/src/components/ConfirmModal/ConfirmModal.tsx
@@ -28,6 +28,7 @@ import {
  * `ConfirmModal` is a context of the ConfirmModal-related components. It doesn't render any DOM node.
  * It controls the visibility of the entire component and provides
  * handlers and accessibility properties to ConfirmModal-related components.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx
@@ -50,6 +51,7 @@ export function ConfirmModal({ children, ...rest }: ConfirmModalProps) {
  * `ConfirmModalContent` is a container of the modal content.
  * It creates a portal to render the modal content outside of the DOM tree
  * and renders overlay behind the modal content too.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const ConfirmModalContent = forwardRef(function ConfirmModalContent(
   { children, ...rest }: ConfirmModalContentProps,
@@ -70,6 +72,7 @@ export const ConfirmModalContent = forwardRef(function ConfirmModalContent(
 /**
  * `ConfirmModalHeader` is a header of the modal content.
  * It renders the accessible title and description of the modal.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const ConfirmModalHeader = forwardRef(function ConfirmModalHeader(
   props: ConfirmModalHeaderProps,
@@ -87,6 +90,7 @@ export const ConfirmModalHeader = forwardRef(function ConfirmModalHeader(
 
 /**
  * `ConfirmModalBody` is a simple wrapper of the main modal content.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const ConfirmModalBody = forwardRef(function ConfirmModalBody(
   { children, ...rest }: ConfirmModalBodyProps,
@@ -105,6 +109,7 @@ export const ConfirmModalBody = forwardRef(function ConfirmModalBody(
 /**
  * `ConfirmModalFooter` is a simple wrapper of the footer of the modal content.
  * Usually, it contains the action buttons of the modal.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const ConfirmModalFooter = forwardRef(function ConfirmModalFooter(
   props: ConfirmModalFooterProps,
@@ -123,6 +128,7 @@ export const ConfirmModalFooter = forwardRef(function ConfirmModalFooter(
  * It passes the handler that opens the modal and accessibility properties to the children.
  *
  * It **must** be placed outside of the `ConfirmModalContent`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export function ConfirmModalTrigger({ children }: ConfirmModalTriggerProps) {
   return <ModalTrigger>{children}</ModalTrigger>
@@ -131,6 +137,7 @@ export function ConfirmModalTrigger({ children }: ConfirmModalTriggerProps) {
 /**
  * `ConfirmModalClose` is a button that closes the modal. **It doesn't render any DOM node.**
  * It passes the handler that closes the modal to the children.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export function ConfirmModalClose({ children }: ConfirmModalCloseProps) {
   return <ModalClose>{children}</ModalClose>

--- a/packages/bezier-react/src/components/ConfirmModal/ConfirmModal.types.ts
+++ b/packages/bezier-react/src/components/ConfirmModal/ConfirmModal.types.ts
@@ -9,18 +9,39 @@ import {
   type ModalTriggerProps,
 } from '~/src/components/Modal'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ConfirmModalProps extends ModalProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ConfirmModalContentProps
   extends Omit<ModalContentProps, 'showCloseIcon'> {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ConfirmModalHeaderProps
   extends Omit<ModalHeaderProps, 'subtitle' | 'titleSize' | 'hidden'> {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ConfirmModalBodyProps extends ModalBodyProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ConfirmModalFooterProps extends ModalFooterProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ConfirmModalTriggerProps extends ModalTriggerProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ConfirmModalCloseProps extends ModalCloseProps {}

--- a/packages/bezier-react/src/components/ConfirmModal/index.ts
+++ b/packages/bezier-react/src/components/ConfirmModal/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   ConfirmModal,
   ConfirmModalBody,
@@ -8,7 +8,7 @@ export {
   ConfirmModalHeader,
   ConfirmModalTrigger,
 } from './ConfirmModal'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   ConfirmModalBodyProps,
   ConfirmModalCloseProps,

--- a/packages/bezier-react/src/components/Divider/Divider.tsx
+++ b/packages/bezier-react/src/components/Divider/Divider.tsx
@@ -16,6 +16,7 @@ const DIVIDER_TEST_ID = 'bezier-divider'
 
 /**
  * `Divider` is a component to visually or semantically separate content.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Divider/Divider.types.ts
+++ b/packages/bezier-react/src/components/Divider/Divider.types.ts
@@ -26,6 +26,9 @@ interface DividerOwnProps {
   withoutIndent?: boolean
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface DividerProps
   extends BezierComponentProps<'div'>,
     SeparatorPrimitiveProps,

--- a/packages/bezier-react/src/components/Divider/index.ts
+++ b/packages/bezier-react/src/components/Divider/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Divider } from './Divider'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { DividerProps } from './Divider.types'

--- a/packages/bezier-react/src/components/Emoji/Emoji.tsx
+++ b/packages/bezier-react/src/components/Emoji/Emoji.tsx
@@ -22,6 +22,7 @@ const getEmojiUrl = (name: EmojiProps['name'], size: '160' | '80' | '44') => {
 
 /**
  * `Emoji` is a component for representing emoji with variant size.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <Emoji

--- a/packages/bezier-react/src/components/Emoji/Emoji.types.ts
+++ b/packages/bezier-react/src/components/Emoji/Emoji.types.ts
@@ -1,5 +1,8 @@
 import type { BezierComponentProps, SizeProps } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type EmojiSize =
   | '16'
   | '20'
@@ -25,6 +28,9 @@ interface EmojiOwnProps {
   imageUrl?: string
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface EmojiProps
   extends BezierComponentProps<'div'>,
     SizeProps<EmojiSize>,

--- a/packages/bezier-react/src/components/Emoji/index.ts
+++ b/packages/bezier-react/src/components/Emoji/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Emoji } from './Emoji'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { EmojiProps, EmojiSize } from './Emoji.types'

--- a/packages/bezier-react/src/components/FormControl/FormControl.tsx
+++ b/packages/bezier-react/src/components/FormControl/FormControl.tsx
@@ -30,11 +30,14 @@ import {
 
 import styles from './FormControl.module.scss'
 
-const [FormControlContextProvider, useFormControlContext] = createContext<
+const [FormControlContextProvider, _useFormControlContext] = createContext<
   FormControlContextValue | undefined
 >(undefined)
 
-export { useFormControlContext }
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
+export const useFormControlContext = _useFormControlContext
 
 const FORM_CONTROL_TEST_ID = 'bezier-form-control'
 
@@ -69,6 +72,9 @@ const Container = forwardRef<HTMLElement, ContainerProps>(function Container(
   }
 })
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const FormControl = forwardRef<HTMLElement, FormControlProps>(
   function FormControl(
     {
@@ -238,6 +244,9 @@ export const FormControl = forwardRef<HTMLElement, FormControlProps>(
   }
 )
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export function useFormFieldProps<
   Props extends FormFieldProps & SizeProps<FormFieldSize>,
 >(props?: Props) {

--- a/packages/bezier-react/src/components/FormControl/FormControl.types.ts
+++ b/packages/bezier-react/src/components/FormControl/FormControl.types.ts
@@ -17,6 +17,9 @@ interface FormControlClassNameProps {
   className: string
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface FormControlAriaProps {
   'aria-labelledby'?: string
   'aria-describedby'?: string
@@ -49,6 +52,9 @@ export type HelperTextPropsGetter = PropsGetter<
 
 export type ErrorMessagePropsGetter = HelperTextPropsGetter
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface FormControlContextValue extends FormFieldProps {
   id: string
   labelId: string
@@ -66,6 +72,9 @@ export interface ContainerProps
     ChildrenProps,
     Pick<FormControlOwnProps, 'labelPosition'> {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface FormControlProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/FormControl/index.ts
+++ b/packages/bezier-react/src/components/FormControl/index.ts
@@ -1,10 +1,10 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   FormControl,
   useFormControlContext,
   useFormFieldProps,
 } from './FormControl'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   FormControlAriaProps,
   FormControlContextValue,

--- a/packages/bezier-react/src/components/FormGroup/FormGroup.tsx
+++ b/packages/bezier-react/src/components/FormGroup/FormGroup.tsx
@@ -12,6 +12,9 @@ import { type FormGroupProps } from './FormGroup.types'
 
 const FORM_GROUP_TEST_ID = 'bezier-form-group'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const FormGroup = forwardRef<HTMLDivElement, FormGroupProps>(
   function FormGroup(
     { spacing = 6, direction = 'vertical', role = 'group', children, ...rest },

--- a/packages/bezier-react/src/components/FormGroup/FormGroup.types.ts
+++ b/packages/bezier-react/src/components/FormGroup/FormGroup.types.ts
@@ -2,6 +2,9 @@ import type { BezierComponentProps, ChildrenProps } from '~/src/types/props'
 
 import type { StackProps } from '~/src/components/Stack'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface FormGroupProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/FormGroup/index.ts
+++ b/packages/bezier-react/src/components/FormGroup/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { FormGroup } from './FormGroup'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { FormGroupProps } from './FormGroup.types'

--- a/packages/bezier-react/src/components/FormHelperText/FormHelperText.tsx
+++ b/packages/bezier-react/src/components/FormHelperText/FormHelperText.tsx
@@ -79,6 +79,7 @@ const BaseHelperText = forwardRef<HTMLSpanElement, BaseHelperTextProps>(
 /**
  * `FormHelperText` is a component to show the description of the input element.
  * `FormControl` component can handle its layout by `position` props.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <FormControl position="top">
@@ -113,6 +114,7 @@ export const FormHelperText = forwardRef<HTMLSpanElement, FormHelperTextProps>(
 /**
  * `FormErrorMessage` is a component to show error message when form values are invalid.
  * It should be used with `FormControl` component.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <FormControl>

--- a/packages/bezier-react/src/components/FormHelperText/FormHelperText.types.ts
+++ b/packages/bezier-react/src/components/FormHelperText/FormHelperText.types.ts
@@ -16,7 +16,13 @@ export interface BaseHelperTextProps
     Partial<IdentifierProps>,
     BaseHelperTextOwnProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface FormHelperTextProps
   extends Omit<BaseHelperTextProps, 'type'> {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface FormErrorMessageProps extends FormHelperTextProps {}

--- a/packages/bezier-react/src/components/FormHelperText/index.ts
+++ b/packages/bezier-react/src/components/FormHelperText/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { FormErrorMessage, FormHelperText } from './FormHelperText'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   FormErrorMessageProps,
   FormHelperTextProps,

--- a/packages/bezier-react/src/components/FormLabel/FormLabel.tsx
+++ b/packages/bezier-react/src/components/FormLabel/FormLabel.tsx
@@ -21,6 +21,7 @@ export const FORM_LABEL_TEST_ID = 'bezier-form-label'
 /**
  * `FormLabel` is a component to show label.
  * `FormControl` component can handle its layout by `position` props.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <FormControl position="top">

--- a/packages/bezier-react/src/components/FormLabel/FormLabel.types.ts
+++ b/packages/bezier-react/src/components/FormLabel/FormLabel.types.ts
@@ -11,6 +11,9 @@ interface FormLabelOwnProps {
   help?: React.ReactNode
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface FormLabelProps
   extends Omit<TextProps, keyof MarginProps>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/FormLabel/index.ts
+++ b/packages/bezier-react/src/components/FormLabel/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { FormLabel } from './FormLabel'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { FormLabelProps } from './FormLabel.types'

--- a/packages/bezier-react/src/components/Help/Help.tsx
+++ b/packages/bezier-react/src/components/Help/Help.tsx
@@ -16,6 +16,9 @@ import styles from './Help.module.scss'
 export const HELP_TEST_ID = 'bezier-help'
 export const HELP_DISPLAY_NAME = 'Help'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const Help = forwardRef<HTMLDivElement, HelpProps>(function Help(
   { children, ...rest },
   forwardedRef

--- a/packages/bezier-react/src/components/Help/Help.types.ts
+++ b/packages/bezier-react/src/components/Help/Help.types.ts
@@ -2,6 +2,9 @@ import { type ChildrenProps } from '~/src/types/props'
 
 import { type TooltipProps } from '~/src/components/Tooltip'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface HelpProps
   extends Omit<TooltipProps, 'content' | 'children'>,
     ChildrenProps {}

--- a/packages/bezier-react/src/components/Help/index.ts
+++ b/packages/bezier-react/src/components/Help/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Help } from './Help'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { HelpProps } from './Help.types'

--- a/packages/bezier-react/src/components/Icon/Icon.tsx
+++ b/packages/bezier-react/src/components/Icon/Icon.tsx
@@ -13,6 +13,9 @@ import styles from './Icon.module.scss'
 
 export const ICON_TEST_ID = 'bezier-icon'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const Icon = memo(
   forwardRef<SVGSVGElement, IconProps>(function Icon(props, forwardedRef) {
     const [marginProps, marginRest] = splitByMarginProps(props)

--- a/packages/bezier-react/src/components/Icon/Icon.types.ts
+++ b/packages/bezier-react/src/components/Icon/Icon.types.ts
@@ -7,6 +7,9 @@ import {
   type SizeProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type IconSize = 'xl' | 'l' | 'm' | 's' | 'xs' | 'xxs' | 'xxxs'
 
 interface IconOwnProps {
@@ -24,6 +27,9 @@ interface IconOwnProps {
   source: BezierIcon
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface IconProps
   extends Omit<BezierComponentProps<'svg'>, keyof ColorProps>,
     MarginProps,

--- a/packages/bezier-react/src/components/Icon/index.ts
+++ b/packages/bezier-react/src/components/Icon/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Icon } from './Icon'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { IconProps, IconSize } from './Icon.types'

--- a/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.tsx
+++ b/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.tsx
@@ -116,6 +116,9 @@ function ActionButtonGroup({
   )
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const KeyValueItem = forwardRef<HTMLDivElement, KeyValueItemProps>(
   function KeyValueListItem(
     {
@@ -179,6 +182,9 @@ export const KeyValueItem = forwardRef<HTMLDivElement, KeyValueItemProps>(
   }
 )
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const KeyValueMultiLineItem = forwardRef<
   HTMLDivElement,
   KeyValueItemProps

--- a/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.types.ts
+++ b/packages/bezier-react/src/components/KeyValueItem/KeyValueItem.types.ts
@@ -10,6 +10,9 @@ export type ItemActionWithIcon = {
   onClick?: React.MouseEventHandler<HTMLButtonElement>
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type KeyValueItemAction = ItemActionWithIcon | React.ReactElement
 
 interface KeyValueItemOwnProps {
@@ -20,6 +23,9 @@ interface KeyValueItemOwnProps {
   onClickValue?: React.MouseEventHandler<HTMLDivElement>
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface KeyValueItemProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/KeyValueItem/index.ts
+++ b/packages/bezier-react/src/components/KeyValueItem/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { KeyValueItem, KeyValueMultiLineItem } from './KeyValueItem'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   KeyValueItemAction,
   KeyValueItemProps,

--- a/packages/bezier-react/src/components/LegacyIcon/index.ts
+++ b/packages/bezier-react/src/components/LegacyIcon/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { LegacyIcon } from './LegacyIcon'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { LegacyIconProps } from './LegacyIcon.types'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { isIconName } from './utils'

--- a/packages/bezier-react/src/components/LegacyStack/index.ts
+++ b/packages/bezier-react/src/components/LegacyStack/index.ts
@@ -1,10 +1,10 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from './LegacyHStack'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from './LegacySpacer'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from './LegacyStack'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from './LegacyStackItem'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from './LegacyVStack'

--- a/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltip.types.ts
+++ b/packages/bezier-react/src/components/LegacyTooltip/LegacyTooltip.types.ts
@@ -20,6 +20,9 @@ interface LegacyTooltipOptions {
   lazy?: boolean
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface LegacyTooltipProps
   extends Omit<BezierComponentProps<'div'>, keyof ContentProps>,
     PolymorphicProps,
@@ -29,6 +32,9 @@ export interface LegacyTooltipProps
     AdditionalOverridableStyleProps<'content' | 'contentWrapper'>,
     LegacyTooltipOptions {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface LegacyTooltipContentProps
   extends Pick<
       LegacyTooltipOptions,
@@ -58,6 +64,9 @@ export interface GetReplacement
   rootElement: HTMLElement
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type LegacyTooltipPosition =
   | 'top-center'
   | 'top-left'

--- a/packages/bezier-react/src/components/LegacyTooltip/index.ts
+++ b/packages/bezier-react/src/components/LegacyTooltip/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { LegacyTooltip } from './LegacyTooltip'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   type LegacyTooltipContentProps,
   type LegacyTooltipPosition,

--- a/packages/bezier-react/src/components/ListItem/ListItem.tsx
+++ b/packages/bezier-react/src/components/ListItem/ListItem.tsx
@@ -27,6 +27,9 @@ function renderNewLineComponent(value: string) {
 
 export const LIST_ITEM_TEST_ID = 'bezier-list-item'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const ListItem = forwardRef<HTMLElement, ListItemProps>(
   function ListItem(
     {

--- a/packages/bezier-react/src/components/ListItem/ListItem.types.ts
+++ b/packages/bezier-react/src/components/ListItem/ListItem.types.ts
@@ -15,8 +15,14 @@ import type {
   VariantProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ListItemSize = 'xs' | 's' | 'm' | 'l'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ListItemVariant = 'blue' | 'red' | 'green' | 'cobalt' | 'monochrome'
 
 interface ListItemOwnProps {
@@ -24,6 +30,9 @@ interface ListItemOwnProps {
   descriptionMaxLines?: number
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ListItemProps
   extends Omit<BezierComponentProps, keyof ContentProps>,
     ContentProps,

--- a/packages/bezier-react/src/components/ListItem/index.ts
+++ b/packages/bezier-react/src/components/ListItem/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { ListItem } from './ListItem'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   ListItemProps,
   ListItemSize,

--- a/packages/bezier-react/src/components/Modal/Modal.tsx
+++ b/packages/bezier-react/src/components/Modal/Modal.tsx
@@ -42,11 +42,13 @@ import {
 
 import styles from './Modal.module.scss'
 
-const [ModalContainerContextProvider, useModalContainerContext] = createContext<
-  HTMLElement | undefined
->(undefined)
+const [ModalContainerContextProvider, _useModalContainerContext] =
+  createContext<HTMLElement | undefined>(undefined)
 
-export { useModalContainerContext }
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
+export const useModalContainerContext = _useModalContainerContext
 
 const [ModalContentPropsContextProvider, useModalContentPropsContext] =
   createContext<ModalContentPropsContextValue>({
@@ -59,6 +61,7 @@ const [ModalContentPropsContextProvider, useModalContentPropsContext] =
  * `Modal` is a context of the Modal-related components. It doesn't render any DOM node.
  * It controls the visibility of the entire component and provides
  * handlers and accessibility properties to Modal-related components.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx
@@ -105,6 +108,7 @@ export function Modal({
  * `ModalContent` is a container of the modal content.
  * It creates a portal to render the modal content outside of the DOM tree
  * and renders overlay behind the modal content too.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
   function ModalContent(
@@ -290,6 +294,7 @@ function ModalHeaderTitle({
  * `ModalHeader` is a header of the modal content.
  * It renders the accessible title and description of the modal.
  * If you want to hide the title and description, use `hidden` prop.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const ModalHeader = forwardRef<HTMLElement, ModalHeaderProps>(
   function ModalHeader(
@@ -359,6 +364,7 @@ export const ModalHeader = forwardRef<HTMLElement, ModalHeaderProps>(
 
 /**
  * `ModalBody` is a simple wrapper of the main modal content.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const ModalBody = forwardRef(function ModalBody(
   { children, className, ...rest }: ModalBodyProps,
@@ -378,6 +384,7 @@ export const ModalBody = forwardRef(function ModalBody(
 /**
  * `ModalFooter` is a simple wrapper of the footer of the modal content.
  * Usually, it contains the action buttons of the modal.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const ModalFooter = forwardRef<HTMLElement, ModalFooterProps>(
   function ModalFooter(
@@ -407,6 +414,7 @@ export const ModalFooter = forwardRef<HTMLElement, ModalFooterProps>(
  * It passes the handler that opens the modal and accessibility properties to the children.
  *
  * It **must** be placed outside of the `ModalContent`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export function ModalTrigger({ children }: ModalTriggerProps) {
   return (
@@ -419,6 +427,7 @@ export function ModalTrigger({ children }: ModalTriggerProps) {
 /**
  * `ModalClose` is a button that closes the modal. **It doesn't render any DOM node.**
  * It passes the handler that closes the modal to the children.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export function ModalClose({ children }: ModalCloseProps) {
   return (

--- a/packages/bezier-react/src/components/Modal/Modal.types.ts
+++ b/packages/bezier-react/src/components/Modal/Modal.types.ts
@@ -5,6 +5,9 @@ import {
 } from '~/src/types/props'
 import { type ZIndex } from '~/src/types/tokens'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ModalTitleSize = 'l' | 'm'
 
 type BoxSide = 'top' | 'right' | 'bottom' | 'left'
@@ -112,27 +115,48 @@ type ModalFooterSideContent = React.ReactNode
 interface ModalFooterOwnProps
   extends SideContentProps<ModalFooterSideContent, ModalFooterSideContent> {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ModalProps extends ChildrenProps, ModalOwnProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ModalContentProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,
     ModalContentOwnProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ModalHeaderProps
   extends Omit<BezierComponentProps<'header'>, keyof ModalHeaderOwnProps>,
     ModalHeaderOwnProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ModalBodyProps
   extends BezierComponentProps<'div'>,
     ChildrenProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ModalFooterProps
   extends BezierComponentProps<'footer'>,
     ModalFooterOwnProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ModalTriggerProps extends ChildrenProps<React.ReactElement> {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ModalCloseProps extends ChildrenProps<React.ReactElement> {}
 
 export interface ModalContentPropsContextValue

--- a/packages/bezier-react/src/components/Modal/index.ts
+++ b/packages/bezier-react/src/components/Modal/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   Modal,
   ModalBody,
@@ -9,7 +9,7 @@ export {
   ModalTrigger,
   useModalContainerContext,
 } from './Modal'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   ModalBodyProps,
   ModalCloseProps,

--- a/packages/bezier-react/src/components/NavGroup/NavGroup.tsx
+++ b/packages/bezier-react/src/components/NavGroup/NavGroup.tsx
@@ -31,6 +31,9 @@ const NAV_GROUP_TEST_ID = 'bezier-nav-group'
  */
 const NAV_GROUP_LEFT_ICON_TEST_ID = 'bezier-nav-group-left-icon'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const NavGroup = forwardRef<HTMLButtonElement, NavGroupProps>(
   function NavGroup(
     {

--- a/packages/bezier-react/src/components/NavGroup/NavGroup.types.ts
+++ b/packages/bezier-react/src/components/NavGroup/NavGroup.types.ts
@@ -14,6 +14,9 @@ interface NavGroupOwnProps {
   onClick?: (e?: React.MouseEvent, name?: string) => void
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface NavGroupProps
   extends Omit<
       BezierComponentProps<'button'>,

--- a/packages/bezier-react/src/components/NavGroup/index.ts
+++ b/packages/bezier-react/src/components/NavGroup/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { NavGroup } from './NavGroup'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { NavGroupProps } from './NavGroup.types'

--- a/packages/bezier-react/src/components/NavItem/NavItem.tsx
+++ b/packages/bezier-react/src/components/NavItem/NavItem.tsx
@@ -23,6 +23,7 @@ const NAV_ITEM_LEFT_ICON_TEST_ID = 'bezier-nav-item-left-icon'
 
 /**
  * `NavItem` is a component for an item where you can navigate to another link.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <NavItem

--- a/packages/bezier-react/src/components/NavItem/NavItem.types.ts
+++ b/packages/bezier-react/src/components/NavItem/NavItem.types.ts
@@ -14,6 +14,9 @@ interface NavItemOwnProps {
   onClick?: (e?: React.MouseEvent, name?: string) => void
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface NavItemProps
   extends Omit<
       BezierComponentProps<'a'>,

--- a/packages/bezier-react/src/components/NavItem/index.ts
+++ b/packages/bezier-react/src/components/NavItem/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { NavItem } from './NavItem'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { NavItemProps } from './NavItem.types'

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.tsx
@@ -31,6 +31,9 @@ const DEFAULT_INDENT = 16
 
 export const OUTLINE_ITEM_TEST_ID = 'bezier-outline-item'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const OutlineItem = forwardRef<HTMLElement, OutlineItemProps>(
   function OutlineItem(
     {

--- a/packages/bezier-react/src/components/OutlineItem/OutlineItem.types.ts
+++ b/packages/bezier-react/src/components/OutlineItem/OutlineItem.types.ts
@@ -20,6 +20,9 @@ interface OutlineItemOwnProps {
   disableChevron?: boolean
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface OutlineItemProps
   extends Omit<BezierComponentProps, keyof ContentProps>,
     PolymorphicProps,

--- a/packages/bezier-react/src/components/OutlineItem/index.ts
+++ b/packages/bezier-react/src/components/OutlineItem/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { OutlineItem } from './OutlineItem'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { OutlineItemProps } from './OutlineItem.types'

--- a/packages/bezier-react/src/components/Overlay/Overlay.tsx
+++ b/packages/bezier-react/src/components/Overlay/Overlay.tsx
@@ -34,6 +34,9 @@ export const CONTAINER_TEST_ID = 'bezier-container'
 export const OVERLAY_TEST_ID = 'bezier-overlay'
 export const ESCAPE_KEY = 'Escape'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(
   function Overlay(
     {

--- a/packages/bezier-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/bezier-react/src/components/Overlay/Overlay.types.ts
@@ -23,6 +23,9 @@ export interface TargetRectAttr {
   clientLeft: number
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type OverlayPosition =
   | 'top-center'
   | 'top-left'
@@ -65,6 +68,9 @@ interface OverlayOwnProps {
   zIndex?: ZIndex
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface OverlayProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/Overlay/index.ts
+++ b/packages/bezier-react/src/components/Overlay/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Overlay } from './Overlay'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { type OverlayPosition, type OverlayProps } from './Overlay.types'

--- a/packages/bezier-react/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/bezier-react/src/components/ProgressBar/ProgressBar.tsx
@@ -13,6 +13,9 @@ import type { ProgressBarProps } from './ProgressBar.types'
 
 import styles from './ProgressBar.module.scss'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
   function ProgressBar(
     {

--- a/packages/bezier-react/src/components/ProgressBar/ProgressBar.types.ts
+++ b/packages/bezier-react/src/components/ProgressBar/ProgressBar.types.ts
@@ -4,8 +4,14 @@ import type {
   VariantProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ProgressBarSize = 'm' | 's'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ProgressBarVariant = 'green' | 'green-alt' | 'monochrome'
 
 interface ProgressBarOwnProps {
@@ -23,6 +29,9 @@ interface ProgressBarOwnProps {
   value?: number
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ProgressBarProps
   extends BezierComponentProps<'div'>,
     SizeProps<ProgressBarSize>,

--- a/packages/bezier-react/src/components/ProgressBar/index.ts
+++ b/packages/bezier-react/src/components/ProgressBar/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { ProgressBar } from './ProgressBar'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   type ProgressBarProps,
   type ProgressBarSize,

--- a/packages/bezier-react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/bezier-react/src/components/RadioGroup/RadioGroup.tsx
@@ -52,6 +52,7 @@ function RadioGroupImpl<Value extends string>(
  *
  * `RadioGroup` is a context of the `Radio` components. also, it renders an element which has the 'radiogroup' role.
  * It controls all the parts of a radio group.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx
@@ -105,6 +106,7 @@ function RadioImpl<Value extends string>(
 /**
  * `Radio` is a checkable button, known as a radio button.
  * It should be a child of `RadioGroup`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const Radio = forwardRef(RadioImpl) as <Value extends string>(
   props: RadioProps<Value> & { ref?: React.ForwardedRef<HTMLButtonElement> }

--- a/packages/bezier-react/src/components/RadioGroup/RadioGroup.types.ts
+++ b/packages/bezier-react/src/components/RadioGroup/RadioGroup.types.ts
@@ -54,6 +54,9 @@ interface RadioOwnProps<Value extends string> {
 
 type RadioFormComponentProps = Pick<FormFieldProps, 'disabled' | 'required'>
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface RadioGroupProps<Value extends string>
   extends Omit<
       BezierComponentProps<'div'>,
@@ -64,6 +67,9 @@ export interface RadioGroupProps<Value extends string>
     RadioFormComponentProps,
     RadioGroupOwnProps<Value> {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface RadioProps<Value extends string>
   extends Omit<BezierComponentProps<'button'>, keyof RadioOwnProps<Value>>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/RadioGroup/index.ts
+++ b/packages/bezier-react/src/components/RadioGroup/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Radio, RadioGroup } from './RadioGroup'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { RadioGroupProps, RadioProps } from './RadioGroup.types'

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.tsx
@@ -101,6 +101,9 @@ function RightContent({ children }: { children: SectionLabelRightContent }) {
   )
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const SectionLabel = forwardRef<HTMLElement, SectionLabelProps>(
   function SectionLabel(
     {

--- a/packages/bezier-react/src/components/SectionLabel/SectionLabel.types.ts
+++ b/packages/bezier-react/src/components/SectionLabel/SectionLabel.types.ts
@@ -25,6 +25,9 @@ interface SectionLabelOwnProps {
   help?: React.ReactNode
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface SectionLabelProps
   extends Omit<BezierComponentProps, keyof ContentProps>,
     ContentProps,

--- a/packages/bezier-react/src/components/SectionLabel/index.ts
+++ b/packages/bezier-react/src/components/SectionLabel/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { SectionLabel } from './SectionLabel'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { SectionLabelProps } from './SectionLabel.types'

--- a/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.tsx
@@ -205,6 +205,7 @@ const SegmentedControlRadioGroup = forwardRef(
  * It can be used only when `SegmentedControl` component is used as the `tabs` type.
  *
  * It must be used as a child of `SegmentedControl`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const SegmentedControlTabList = SegmentedControlItemList as (
   props: SegmentedControlTabListProps & {
@@ -217,6 +218,7 @@ export const SegmentedControlTabList = SegmentedControlItemList as (
  * It can be used only when `SegmentedControl` component is used as the `tabs` type.
  *
  * It must be used as a child of `SegmentedControl`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const SegmentedControlTabContent = TabsPrimitive.Content as <
   Value extends string,
@@ -277,6 +279,7 @@ function SegmentedControlImpl<
  * If you have more than five items, use a different element, such as a dropdown.
  *
  * `SegmentedControl` can be used as a radio group, tabs element depending on its `type`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx
@@ -406,6 +409,7 @@ function SegmentedControlItemImpl<Value extends string>(
  *
  * If the type of `SegmentedControl` is `tabs`, this component acts as a tab item.
  * In this case, it must be used as a child of `SegmentedControlTabList`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const SegmentedControlItem = forwardRef(SegmentedControlItemImpl) as <
   Value extends string,

--- a/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.types.ts
+++ b/packages/bezier-react/src/components/SegmentedControl/SegmentedControl.types.ts
@@ -11,6 +11,9 @@ import {
   type SizeProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type SegmentedControlSize = 'xs' | 's' | 'm' | 'l'
 
 export type SegmentedControlType = 'radiogroup' | 'tabs'
@@ -81,6 +84,9 @@ type SegmentedControlOwnProps<
 
 type RadixTabsPredefinedPropKeys = 'dir'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type SegmentedControlProps<
   Type extends SegmentedControlType,
   Value extends string,
@@ -103,6 +109,9 @@ export interface SegmentedControlTabsProps<Value extends string>
 
 type RadixTabListPredefinedPropKeys = 'defaultValue'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface SegmentedControlTabListProps
   extends Omit<BezierComponentProps<'div'>, RadixTabListPredefinedPropKeys>,
     ChildrenProps {}
@@ -114,6 +123,9 @@ export type SegmentedControlItemListProps<
   ? SegmentedControlRadioGroupProps<Value>
   : SegmentedControlTabListProps
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface SegmentedControlItemProps<Value extends string>
   extends Omit<
       BezierComponentProps<'button'>,
@@ -124,6 +136,9 @@ export interface SegmentedControlItemProps<Value extends string>
     SideContentProps,
     SegmentedControlItemOwnProps<Value> {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface SegmentedControlTabContentProps<Value extends string>
   extends BezierComponentProps<'div'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/SegmentedControl/index.ts
+++ b/packages/bezier-react/src/components/SegmentedControl/index.ts
@@ -1,11 +1,11 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   SegmentedControl,
   SegmentedControlItem,
   SegmentedControlTabContent,
   SegmentedControlTabList,
 } from './SegmentedControl'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   SegmentedControlItemProps,
   SegmentedControlProps,

--- a/packages/bezier-react/src/components/Select/Select.tsx
+++ b/packages/bezier-react/src/components/Select/Select.tsx
@@ -33,6 +33,9 @@ import styles from './Select.module.scss'
 
 export const SELECT_DROPDOWN_TEST_ID = 'bezier-select-dropdown'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const Select = forwardRef<SelectRef, SelectProps>(function Select(
   {
     children,

--- a/packages/bezier-react/src/components/Select/Select.types.ts
+++ b/packages/bezier-react/src/components/Select/Select.types.ts
@@ -17,6 +17,9 @@ import { type ZIndex } from '~/src/types/tokens'
 
 import type { OverlayProps } from '~/src/components/Overlay'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface SelectRef {
   handleClickTrigger(event: React.MouseEvent): void
   handleHideDropdown(): void
@@ -38,6 +41,9 @@ interface SelectOwnProps {
   onHideDropdown?: () => void
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface SelectProps
   extends BezierComponentProps<'button'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/Select/index.ts
+++ b/packages/bezier-react/src/components/Select/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Select } from './Select'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { SelectProps, SelectRef } from './Select.types'

--- a/packages/bezier-react/src/components/Slider/Slider.tsx
+++ b/packages/bezier-react/src/components/Slider/Slider.tsx
@@ -67,6 +67,7 @@ const SliderThumb = forwardRef<
 /**
  * An input component where the user selects a value from within a given range.
  * The value of the slider is shown in a tooltip, and in some cases you can add a guide scale.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Slider/Slider.types.ts
+++ b/packages/bezier-react/src/components/Slider/Slider.types.ts
@@ -67,6 +67,9 @@ interface SliderOwnProps {
   onValueCommit?: (value: number[]) => void
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface SliderProps
   extends Omit<BezierComponentProps<'span'>, keyof SliderOwnProps>,
     DisableProps,

--- a/packages/bezier-react/src/components/Slider/index.ts
+++ b/packages/bezier-react/src/components/Slider/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Slider } from './Slider'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { SliderProps } from './Slider.types'

--- a/packages/bezier-react/src/components/SmoothCornersBox/SmoothCornersBox.tsx
+++ b/packages/bezier-react/src/components/SmoothCornersBox/SmoothCornersBox.tsx
@@ -16,6 +16,7 @@ import styles from './SmoothCornersBox.module.scss'
 /**
  * `SmoothCornersBox` is a simple `div` element with smooth corners.
  * It is available by enabling the `SmoothCornersFeature`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/SmoothCornersBox/SmoothCornersBox.types.ts
+++ b/packages/bezier-react/src/components/SmoothCornersBox/SmoothCornersBox.types.ts
@@ -63,6 +63,9 @@ interface SmoothCornersBoxOwnProps {
   backgroundImage?: string
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface SmoothCornersBoxProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/SmoothCornersBox/index.ts
+++ b/packages/bezier-react/src/components/SmoothCornersBox/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { SmoothCornersBox } from './SmoothCornersBox'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { SmoothCornersBoxProps } from './SmoothCornersBox.types'

--- a/packages/bezier-react/src/components/Spinner/Spinner.tsx
+++ b/packages/bezier-react/src/components/Spinner/Spinner.tsx
@@ -13,6 +13,9 @@ import styles from './Spinner.module.scss'
 
 export const SPINNER_TEST_ID = 'bezier-spinner'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(
   function Spinner(
     { style, className, size = 'm', color, ...rest },

--- a/packages/bezier-react/src/components/Spinner/Spinner.types.ts
+++ b/packages/bezier-react/src/components/Spinner/Spinner.types.ts
@@ -4,8 +4,14 @@ import {
   type SizeProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type SpinnerSize = 'xl' | 'l' | 'm' | 's' | 'xs'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface SpinnerProps
   extends Omit<BezierComponentProps<'div'>, keyof ColorProps>,
     SizeProps<SpinnerSize>,

--- a/packages/bezier-react/src/components/Spinner/index.ts
+++ b/packages/bezier-react/src/components/Spinner/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Spinner } from './Spinner'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { type SpinnerProps, type SpinnerSize } from './Spinner.types'

--- a/packages/bezier-react/src/components/Stack/Stack.tsx
+++ b/packages/bezier-react/src/components/Stack/Stack.tsx
@@ -18,6 +18,7 @@ import styles from './Stack.module.scss'
 
 /**
  * `Stack` is a layout component used to group elements together and apply a space between them.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx
@@ -84,6 +85,7 @@ export const Stack = forwardRef<HTMLElement, StackProps>(
 
 /**
  * `HStack` is a shorthand component equivalent to `Stack` with a horizontal direction property.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see Stack
  */
 export const HStack = forwardRef<HTMLElement, HStackProps>(
@@ -98,6 +100,7 @@ export const HStack = forwardRef<HTMLElement, HStackProps>(
 
 /**
  * `VStack` is a shorthand component equivalent to `Stack` with a vertical direction property.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @see Stack
  */
 export const VStack = forwardRef<HTMLElement, VStackProps>(

--- a/packages/bezier-react/src/components/Stack/Stack.types.ts
+++ b/packages/bezier-react/src/components/Stack/Stack.types.ts
@@ -46,6 +46,9 @@ interface StackOwnProps {
   wrap?: boolean
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface StackProps
   extends BezierComponentProps,
     PolymorphicProps,
@@ -54,6 +57,12 @@ export interface StackProps
     MarginProps,
     StackOwnProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface HStackProps extends Omit<StackProps, 'direction'> {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface VStackProps extends Omit<StackProps, 'direction'> {}

--- a/packages/bezier-react/src/components/Stack/index.ts
+++ b/packages/bezier-react/src/components/Stack/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { HStack, Stack, VStack } from './Stack'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { HStackProps, StackProps, VStackProps } from './Stack.types'

--- a/packages/bezier-react/src/components/Status/Status.tsx
+++ b/packages/bezier-react/src/components/Status/Status.tsx
@@ -30,6 +30,7 @@ const statusColor: Readonly<Record<StatusType, BetaSemanticColor>> = {
 
 /**
  * `Status` is a component to indicate user status.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const Status = memo(
   forwardRef<HTMLDivElement, StatusProps>(function Status(

--- a/packages/bezier-react/src/components/Status/Status.types.ts
+++ b/packages/bezier-react/src/components/Status/Status.types.ts
@@ -1,5 +1,8 @@
 import type { BezierComponentProps, SizeProps } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type StatusType =
   | 'online'
   | 'offline'
@@ -7,6 +10,9 @@ export type StatusType =
   | 'online-crescent'
   | 'offline-crescent'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type StatusSize = 'm' | 'l'
 
 interface StatusOwnProps {
@@ -16,6 +22,9 @@ interface StatusOwnProps {
   type: StatusType
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface StatusProps
   extends BezierComponentProps<'div'>,
     SizeProps<StatusSize>,

--- a/packages/bezier-react/src/components/Status/index.ts
+++ b/packages/bezier-react/src/components/Status/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Status } from './Status'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { StatusProps, StatusSize, StatusType } from './Status.types'

--- a/packages/bezier-react/src/components/Switch/Switch.tsx
+++ b/packages/bezier-react/src/components/Switch/Switch.tsx
@@ -19,6 +19,7 @@ const SWITCH_TEST_ID = 'bezier-switch'
 
 /**
  * `Switch` is an input component where user can toggle checked state of the element.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <Switch

--- a/packages/bezier-react/src/components/Switch/Switch.types.ts
+++ b/packages/bezier-react/src/components/Switch/Switch.types.ts
@@ -6,6 +6,9 @@ import type {
   SizeProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type SwitchSize = 'm' | 's'
 
 interface SwitchOwnProps extends Omit<SwitchPrimitiveProps, 'asChild'> {
@@ -49,6 +52,9 @@ interface SwitchOwnProps extends Omit<SwitchPrimitiveProps, 'asChild'> {
   value?: string
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface SwitchProps
   extends Omit<BezierComponentProps<'button'>, keyof SwitchOwnProps>,
     SizeProps<SwitchSize>,

--- a/packages/bezier-react/src/components/Switch/index.ts
+++ b/packages/bezier-react/src/components/Switch/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Switch } from './Switch'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { SwitchProps, SwitchSize } from './Switch.types'

--- a/packages/bezier-react/src/components/Tabs/Tabs.tsx
+++ b/packages/bezier-react/src/components/Tabs/Tabs.tsx
@@ -35,6 +35,7 @@ import styles from './Tabs.module.scss'
  * `Tabs` is a set of layered section of content.
  *
  * `Tabs` is a context of the Tab-related components and gives accessibility properties to Tab-related components.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx
@@ -76,6 +77,7 @@ const [TabListContextProvider, useTabListContext] =
 
 /**
  * `TabList` gives size context to its children and decides the layout of `TabItems` and `TabActions`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const TabList = forwardRef<HTMLDivElement, TabListProps>(
   function TabList({ className, children, size = 'm', ...rest }, forwardedRef) {
@@ -106,6 +108,7 @@ export const TabList = forwardRef<HTMLDivElement, TabListProps>(
 
 /**
  * `TabItems` is a flex container which has `TabItem` flex items.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const TabItems = forwardRef<HTMLDivElement, TabItemsProps>(
   function TabItems({ className, children, ...rest }, forwardedRef) {
@@ -185,6 +188,7 @@ const TabItemButton = forwardRef<HTMLButtonElement, TabItemProps>(
 
 /**
  * `TabItem` is a button that activates its associated content.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const TabItem = forwardRef<HTMLButtonElement, TabItemProps>(
   function TabItem(
@@ -219,6 +223,7 @@ export const TabItem = forwardRef<HTMLButtonElement, TabItemProps>(
 
 /**
  * `TabContent` has content associated with `TabItem`.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const TabContent = forwardRef<HTMLDivElement, TabContentProps>(
   function TabContent({ children, value, ...rest }, forwardedRef) {
@@ -237,6 +242,7 @@ export const TabContent = forwardRef<HTMLDivElement, TabContentProps>(
 /**
  * `TabActions` is a flex container which has `TabAction` flex items.
  *  It also gives accessibility properties to its children.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const TabActions = forwardRef<HTMLDivElement, TabActionsProps>(
   function TabActions({ className, dir, children, ...rest }, forwardedRef) {
@@ -277,6 +283,7 @@ function getIconSizeBy(size: TabSize) {
 /**
  * `TabAction` is a button for more action to open a new link or navigate to a different url.
  * If it has `href` props, it should act as a link.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  */
 export const TabAction = forwardRef<
   TabActionElement<string | undefined>,

--- a/packages/bezier-react/src/components/Tabs/Tabs.types.ts
+++ b/packages/bezier-react/src/components/Tabs/Tabs.types.ts
@@ -8,6 +8,9 @@ import {
   type SizeProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type TabSize = 'l' | 'm' | 's'
 
 export interface TabListContextValue {
@@ -63,11 +66,17 @@ interface TabContentOwnProps {
   value: string
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface TabsProps
   extends Omit<BezierComponentProps<'div'>, keyof TabsOwnProps>,
     ChildrenProps,
     TabsOwnProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface TabListProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,
@@ -77,6 +86,9 @@ export interface TabItemsProps
   extends BezierComponentProps<'div'>,
     ChildrenProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface TabItemProps
   extends Omit<BezierComponentProps<'button'>, keyof TabItemOwnProps>,
     ChildrenProps,
@@ -91,6 +103,9 @@ export type TabActionElement<Link> = [Link] extends [string]
   ? HTMLAnchorElement
   : HTMLButtonElement
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface TabActionProps<Link extends string | undefined>
   extends Omit<BezierComponentProps, keyof React.HTMLAttributes<HTMLElement>>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/Tabs/index.ts
+++ b/packages/bezier-react/src/components/Tabs/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   TabAction,
   TabActions,
@@ -8,7 +8,7 @@ export {
   TabList,
   Tabs,
 } from './Tabs'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   TabActionProps,
   TabItemProps,

--- a/packages/bezier-react/src/components/Tag/Tag.tsx
+++ b/packages/bezier-react/src/components/Tag/Tag.tsx
@@ -25,6 +25,7 @@ const TAG_DELETE_TEST_ID = 'bezier-tag-delete-icon'
 
 /**
  * `Tag` is a component for representing tag, which shows close icon when `onDelete` property is specified.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * <Tag

--- a/packages/bezier-react/src/components/Tag/Tag.types.ts
+++ b/packages/bezier-react/src/components/Tag/Tag.types.ts
@@ -10,8 +10,14 @@ import {
   type BaseTagBadgeVariant,
 } from '~/src/components/BaseTagBadge'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type TagSize = BaseTagBadgeSize
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type TagVariant = BaseTagBadgeVariant
 
 interface TagOwnProps {
@@ -23,6 +29,9 @@ interface TagOwnProps {
   onDelete?: React.MouseEventHandler
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface TagProps
   extends BezierComponentProps<'div'>,
     ChildrenProps,

--- a/packages/bezier-react/src/components/Tag/index.ts
+++ b/packages/bezier-react/src/components/Tag/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Tag } from './Tag'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { TagProps, TagSize, TagVariant } from './Tag.types'

--- a/packages/bezier-react/src/components/Text/Text.tsx
+++ b/packages/bezier-react/src/components/Text/Text.tsx
@@ -14,6 +14,7 @@ import styles from './Text.module.scss'
 
 /**
  * `Text` is a component for representing the typography of a design system.
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  *
  * ```tsx

--- a/packages/bezier-react/src/components/Text/Text.types.ts
+++ b/packages/bezier-react/src/components/Text/Text.types.ts
@@ -63,6 +63,9 @@ interface TextOwnProps {
   align?: TextAlign
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface TextProps
   extends Omit<BezierComponentProps, keyof TextOwnProps>,
     PolymorphicProps,

--- a/packages/bezier-react/src/components/Text/index.ts
+++ b/packages/bezier-react/src/components/Text/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Text } from './Text'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { TextProps } from './Text.types'

--- a/packages/bezier-react/src/components/TextArea/TextArea.tsx
+++ b/packages/bezier-react/src/components/TextArea/TextArea.tsx
@@ -18,6 +18,9 @@ import type { TextAreaProps } from './TextArea.types'
 
 import styles from './TextArea.module.scss'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   function TextArea(
     {

--- a/packages/bezier-react/src/components/TextArea/TextArea.types.ts
+++ b/packages/bezier-react/src/components/TextArea/TextArea.types.ts
@@ -2,6 +2,9 @@ import { type TextareaAutosizeProps } from 'react-textarea-autosize'
 
 import type { BezierComponentProps, FormFieldProps } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type TextAreaHeight = 3 | 6 | 10 | 16 | 24 | 36
 
 interface TextAreaOwnProps {
@@ -10,6 +13,9 @@ interface TextAreaOwnProps {
   autoFocus?: boolean
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface TextAreaProps
   extends Omit<BezierComponentProps<'textarea'>, 'style'>,
     Pick<TextareaAutosizeProps, 'style'>,

--- a/packages/bezier-react/src/components/TextArea/index.ts
+++ b/packages/bezier-react/src/components/TextArea/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { TextArea } from './TextArea'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { type TextAreaHeight, type TextAreaProps } from './TextArea.types'

--- a/packages/bezier-react/src/components/TextField/TextField.tsx
+++ b/packages/bezier-react/src/components/TextField/TextField.tsx
@@ -161,6 +161,9 @@ function TextFieldRightContent({
   )
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export const TextField = forwardRef<TextFieldRef, TextFieldProps>(
   function TextField(
     {

--- a/packages/bezier-react/src/components/TextField/TextField.types.ts
+++ b/packages/bezier-react/src/components/TextField/TextField.types.ts
@@ -13,6 +13,9 @@ import type {
   VariantProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type TextFieldType =
   | 'search'
   | 'text'
@@ -25,6 +28,9 @@ export type TextFieldType =
 
 export type SelectionRangeDirections = 'forward' | 'backward' | 'none'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type TextFieldVariant = 'primary' | 'secondary'
 
 export type TextFieldItemProps =
@@ -34,6 +40,9 @@ export type TextFieldItemProps =
     } & AdditionalColorProps<'icon'>)
   | React.ReactElement
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface TextFieldRef {
   focus(options?: FocusOptions): void
   blur(): void
@@ -72,6 +81,9 @@ type OmittedInputHTMLAttributes =
   | 'disabled'
   | 'onFocus'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface TextFieldProps
   extends Omit<BezierComponentProps<'input'>, OmittedInputHTMLAttributes>,
     AdditionalOverridableStyleProps<['wrapper', 'leftWrapper', 'rightWrapper']>,

--- a/packages/bezier-react/src/components/TextField/index.ts
+++ b/packages/bezier-react/src/components/TextField/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { TextField } from './TextField'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export {
   type TextFieldProps,
   type TextFieldRef,

--- a/packages/bezier-react/src/components/Toast/Toast.tsx
+++ b/packages/bezier-react/src/components/Toast/Toast.tsx
@@ -194,6 +194,9 @@ const DEFAULT_OFFSET = {
   bottom: 0,
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export function ToastProvider({
   autoDismissTimeout = 3000,
   container: givenContainer,
@@ -253,6 +256,9 @@ export function ToastProvider({
   )
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export function useToast() {
   const context = useToastContext()
 

--- a/packages/bezier-react/src/components/Toast/Toast.types.ts
+++ b/packages/bezier-react/src/components/Toast/Toast.types.ts
@@ -5,10 +5,19 @@ import { type BezierIcon } from '@channel.io/bezier-icons'
 import { type ChildrenProps, type ContentProps } from '~/src/types/props'
 import { type ZIndex } from '~/src/types/tokens'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ToastPlacement = 'bottom-left' | 'bottom-right'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ToastAppearance = 'success' | 'warning' | 'error' | 'info'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ToastPreset = 'default' | 'success' | 'error' | 'offline' | 'online'
 
 interface ToastOwnProps {
@@ -30,8 +39,14 @@ interface ToastOwnProps {
   onDismiss?: () => void
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ToastContent = NonNullable<React.ReactNode>
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ToastProps extends ContentProps<ToastContent>, ToastOwnProps {}
 
 type Offset = {
@@ -50,15 +65,24 @@ interface ToastProviderOwnProps {
   zIndex?: ZIndex
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface ToastProviderProps
   extends ChildrenProps,
     Pick<ToastProps, 'autoDismissTimeout'>,
     ToastProviderOwnProps {}
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ToastId = string
 
 export type OnDismissCallback = (id: ToastId) => void
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ToastOptions = Pick<
   ToastProps,
   'preset' | 'icon' | 'appearance' | 'autoDismiss' | 'zIndex'
@@ -67,6 +91,9 @@ export type ToastOptions = Pick<
   onDismiss?: OnDismissCallback
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type ToastType = ToastOptions & {
   id: ToastId
   content: ToastContent

--- a/packages/bezier-react/src/components/Toast/index.ts
+++ b/packages/bezier-react/src/components/Toast/index.ts
@@ -1,6 +1,6 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { ToastProvider, useToast } from './Toast'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   ToastAppearance,
   ToastContent,

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.tsx
@@ -106,6 +106,7 @@ function getSideAndAlign(
  * `Tooltip` is a component that shows additional information when the mouse hovers or the keyboard is focused.
  *
  * Components that pass to children **must spread props and forward ref.**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
  * @example
  * ```tsx
  * // Your component must spread props and forward ref.

--- a/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/bezier-react/src/components/Tooltip/Tooltip.types.ts
@@ -7,6 +7,9 @@ import {
   type DisableProps,
 } from '~/src/types/props'
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export type TooltipPosition =
   | 'top-center'
   | 'top-left'
@@ -97,6 +100,9 @@ interface TooltipOwnProps {
   ) => void
 }
 
+/**
+ * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
+ */
 export interface TooltipProps
   extends Omit<
       BezierComponentProps<'div'>,

--- a/packages/bezier-react/src/components/Tooltip/index.ts
+++ b/packages/bezier-react/src/components/Tooltip/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export { Tooltip } from './Tooltip'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type { TooltipPosition, TooltipProps } from './Tooltip.types'

--- a/packages/bezier-react/src/index.ts
+++ b/packages/bezier-react/src/index.ts
@@ -9,130 +9,130 @@ export { tokens as alphaTokens } from '@channel.io/bezier-tokens/alpha'
 export { tokens as betaTokens } from '@channel.io/bezier-tokens/beta'
 
 /* ------------------------------- COMPONENTS ------------------------------- */
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaAvatar'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaAvatarGroup'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaButton'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaDialogPrimitive'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaFloatingButton'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaFloatingIconButton'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaIconButton'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaLoader'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaStatusBadge'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaToggleButton'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaToggleButtonGroup'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaToggleEmojiButtonGroup'
-/** @deprecated v2 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaTooltipPrimitive'
 export * from '~/src/components/AppProvider'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AutoFocus'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Avatar'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AvatarGroup'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Badge'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Banner'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Box'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Button'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/ButtonGroup'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Center'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/CheckableAvatar'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Checkbox'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/ConfirmModal'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Divider'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Emoji'
 export * from '~/src/components/FeatureProvider'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/FormControl'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/FormGroup'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/FormHelperText'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/FormLabel'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Help'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Icon'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/KeyValueItem'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/LegacyIcon'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/LegacyStack'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/LegacyTooltip'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/ListItem'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Modal'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/NavGroup'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/NavItem'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/OutlineItem'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Overlay'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/ProgressBar'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/RadioGroup'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/SectionLabel'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/SegmentedControl'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Select'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Slider'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/SmoothCornersBox'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Spinner'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Stack'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Status'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Switch'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Tabs'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Tag'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Text'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/TextArea'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/TextField'
 export * from '~/src/components/ThemeProvider'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Toast'
-/** @deprecated v1 components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/Tooltip'
 export * from '~/src/components/VisuallyHidden'
 export * from '~/src/components/WindowProvider'


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

없음

## Summary

레거시 컴포넌트의 `@deprecated` JSDoc을 실제 exported symbol 선언부에 추가했습니다.

## Details

기존에는 root barrel 또는 각 컴포넌트 `index.ts`의 re-export 문장 위에만 `@deprecated`가 붙어 있었습니다. TypeScript 소비처에서는 이 주석이 실제 사용 심볼의 quick info로 전달되지 않아, `@channel.io/bezier-react`에서 import한 레거시 컴포넌트 사용부에 deprecated 표시가 나오지 않았습니다.

이번 변경에서는 `Badge`, `Button`, `FormControl` 등 deprecated 대상 컴포넌트와 관련 타입의 실제 선언부에 `@deprecated`를 추가했습니다. destructuring으로 만든 context hook처럼 주석이 심볼에 붙기 어려운 케이스는 내부 binding과 public export를 분리해서 declaration emit 결과에 deprecated tag가 남도록 했습니다.

공통 deprecated 문구는 아래 문장으로 통일했습니다.

```ts
These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
```

검증:

- `yarn workspace @channel.io/bezier-react build:types`
- `node ./node_modules/typescript/bin/tsc --noEmit -p packages/bezier-react/tsconfig.json`
- TypeScript language service quick info에서 `Badge`, `AlphaButton`, `useFormControlContext`의 deprecated tag 표시 확인

### Breaking change? (Yes/No)

No

런타임 API나 export 이름은 변경하지 않았고, 타입 선언의 JSDoc metadata만 보강했습니다.

## References

- `export *` / `export { Foo }` 위 JSDoc은 소비처 quick info에 안정적으로 전달되지 않아 실제 선언부에 `@deprecated`가 필요합니다.
