### PR TITLE
refactor(react): refine beta component interfaces

### DIFF
--- a/.changeset/neat-buttons-sparkle.md
+++ b/.changeset/neat-buttons-sparkle.md
@@ -1,0 +1,10 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Refine beta component interfaces.
+
+- Add native anchor support to beta Button and IconButton while keeping custom `as` wrappers available.
+- Remove per-toast `zIndex` and keep stacking control on ToastProvider.
+- Share leading/trailing content prop typing across beta components.
+- Keep AlphaDialogPrimitive available without legacy deprecation warnings.

--- a/packages/bezier-react/src/beta/Banner/Banner.types.ts
+++ b/packages/bezier-react/src/beta/Banner/Banner.types.ts
@@ -1,8 +1,7 @@
-import type { JSX, ReactNode } from 'react'
+import type { JSX, MouseEventHandler, ReactNode } from 'react'
 
 import { type BezierIcon } from '@channel.io/bezier-icons'
 
-import type { IconButtonProps } from '~/src/beta/IconButton'
 import type {
   BezierComponentProps,
   ContentProps,
@@ -69,7 +68,7 @@ interface BannerOwnProps {
   /**
    * Handler to be executed when the action icon button is clicked.
    */
-  onClickAction?: IconButtonProps['onClick']
+  onClickAction?: MouseEventHandler<HTMLButtonElement>
 }
 
 export interface BannerProps

--- a/packages/bezier-react/src/beta/BaseButton/BaseButton.tsx
+++ b/packages/bezier-react/src/beta/BaseButton/BaseButton.tsx
@@ -11,17 +11,49 @@ import styles from './BaseButton.module.scss'
 /**
  * `BaseButton` is a reset-style button component with a focus ring, intended for internal use only.
  */
-export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
+export const BaseButton = forwardRef<
+  HTMLAnchorElement | HTMLButtonElement,
+  BaseButtonProps
+>(
   function BaseButton(
-    { className, children, type = 'button', ...rest },
+    { as = 'button', className, children, disabled, type = 'button', ...rest },
     forwardedRef
   ) {
+    if (as === 'a') {
+      const { onClick, tabIndex, ...anchorRest } =
+        rest as React.AnchorHTMLAttributes<HTMLAnchorElement>
+
+      return (
+        <a
+          className={classNames(styles.BaseButton, className)}
+          ref={forwardedRef as React.Ref<HTMLAnchorElement>}
+          {...anchorRest}
+          aria-disabled={disabled || undefined}
+          tabIndex={disabled ? -1 : tabIndex}
+          onClick={(event) => {
+            if (disabled) {
+              event.preventDefault()
+              event.stopPropagation()
+              return
+            }
+
+            onClick?.(event)
+          }}
+        >
+          {children}
+        </a>
+      )
+    }
+
+    const buttonRest = rest as React.ButtonHTMLAttributes<HTMLButtonElement>
+
     return (
       <button
         className={classNames(styles.BaseButton, className)}
-        ref={forwardedRef}
+        ref={forwardedRef as React.Ref<HTMLButtonElement>}
+        {...buttonRest}
         type={type}
-        {...rest}
+        disabled={disabled}
       >
         {children}
       </button>

--- a/packages/bezier-react/src/beta/BaseButton/BaseButton.types.ts
+++ b/packages/bezier-react/src/beta/BaseButton/BaseButton.types.ts
@@ -1,8 +1,25 @@
 import {
   type BezierComponentProps,
   type ChildrenProps,
+  type DisableProps,
 } from '~/src/types/props'
 
-export interface BaseButtonProps
-  extends BezierComponentProps<'button'>,
-    ChildrenProps {}
+interface BaseButtonOwnProps extends ChildrenProps, DisableProps {}
+
+type BaseButtonButtonProps = Omit<
+  BezierComponentProps<'button'>,
+  keyof BaseButtonOwnProps | 'as'
+> & {
+  as?: 'button'
+}
+
+type BaseButtonAnchorProps = Omit<
+  BezierComponentProps<'a'>,
+  keyof BaseButtonOwnProps | 'as' | 'type'
+> & {
+  as: 'a'
+  type?: never
+}
+
+export type BaseButtonProps = BaseButtonOwnProps &
+  (BaseButtonButtonProps | BaseButtonAnchorProps)

--- a/packages/bezier-react/src/beta/BaseButton/BaseButton.types.ts
+++ b/packages/bezier-react/src/beta/BaseButton/BaseButton.types.ts
@@ -6,14 +6,14 @@ import {
 
 interface BaseButtonOwnProps extends ChildrenProps, DisableProps {}
 
-type BaseButtonButtonProps = Omit<
+export type BaseButtonButtonProps = Omit<
   BezierComponentProps<'button'>,
   keyof BaseButtonOwnProps | 'as'
 > & {
   as?: 'button'
 }
 
-type BaseButtonAnchorProps = Omit<
+export type BaseButtonAnchorProps = Omit<
   BezierComponentProps<'a'>,
   keyof BaseButtonOwnProps | 'as' | 'type'
 > & {

--- a/packages/bezier-react/src/beta/BaseButton/index.ts
+++ b/packages/bezier-react/src/beta/BaseButton/index.ts
@@ -1,2 +1,6 @@
 export { BaseButton } from './BaseButton'
-export type { BaseButtonProps } from './BaseButton.types'
+export type {
+  BaseButtonAnchorProps,
+  BaseButtonButtonProps,
+  BaseButtonProps,
+} from './BaseButton.types'

--- a/packages/bezier-react/src/beta/BaseItem/BaseItem.types.ts
+++ b/packages/bezier-react/src/beta/BaseItem/BaseItem.types.ts
@@ -7,6 +7,7 @@ import type {
   BezierComponentProps,
   ChildrenProps,
   DisableProps,
+  LeadingTrailingContentProps,
   SizeProps,
   VariantProps,
 } from '~/src/types/props'
@@ -24,19 +25,12 @@ export type BaseItemSideContent = BezierIcon | ReactNode
  * Purpose-built components such as `DropdownMenuItem` should own roles,
  * keyboard interaction, and selection behavior.
  */
-interface BaseItemOwnProps {
+interface BaseItemOwnProps
+  extends LeadingTrailingContentProps<BaseItemSideContent> {
   /**
    * Additional content below the main content.
    */
   description?: ReactNode
-  /**
-   * Content on the left.
-   */
-  leadingContent?: BaseItemSideContent
-  /**
-   * Content on the right.
-   */
-  trailingContent?: BaseItemSideContent
 }
 
 export interface BaseItemProps

--- a/packages/bezier-react/src/beta/Button/Button.module.scss
+++ b/packages/bezier-react/src/beta/Button/Button.module.scss
@@ -1,6 +1,6 @@
 @use '../../styles/mixins/dimension';
 
-$active-selector: ':where(.active, :hover):where(:not(:disabled))';
+$active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled="true"]))';
 
 .ButtonText {
   flex: 0 1 auto;
@@ -161,7 +161,7 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled))';
     pointer-events: none;
   }
 
-  &:disabled {
+  &:where(:disabled, [aria-disabled='true']) {
     cursor: not-allowed;
     opacity: var(--opacity-disabled);
   }

--- a/packages/bezier-react/src/beta/Button/Button.stories.tsx
+++ b/packages/bezier-react/src/beta/Button/Button.stories.tsx
@@ -55,7 +55,7 @@ export const Primary: StoryObj<ButtonProps> = {
 }
 
 export const Variants: StoryObj<ButtonProps> = {
-  render: (args) => (
+  render: (args: ButtonProps) => (
     <VStack spacing={16}>
       {(['filled', 'outlined', 'ghost'] as const).map((variant) => (
         <HStack
@@ -102,7 +102,7 @@ export const Variants: StoryObj<ButtonProps> = {
 }
 
 export const Sizes: StoryObj<ButtonProps> = {
-  render: (args) => (
+  render: (args: ButtonProps) => (
     <HStack
       spacing={8}
       align="center"

--- a/packages/bezier-react/src/beta/Button/Button.test.tsx
+++ b/packages/bezier-react/src/beta/Button/Button.test.tsx
@@ -1,13 +1,10 @@
 import { PlusIcon } from '@channel.io/bezier-icons'
 import userEvent from '@testing-library/user-event'
 
+import { BaseButton } from '~/src/beta/BaseButton'
 import { render } from '~/src/utils/test'
 
-import { BaseButton } from '~/src/beta/BaseButton'
-
 import { Button } from './Button'
-
-
 
 describe('Button', () => {
   it('should render label', () => {

--- a/packages/bezier-react/src/beta/Button/Button.test.tsx
+++ b/packages/bezier-react/src/beta/Button/Button.test.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event'
 
 import { render } from '~/src/utils/test'
 
+import { BaseButton } from '~/src/beta/BaseButton'
+
 import { Button } from './Button'
 
 
@@ -44,6 +46,55 @@ describe('Button', () => {
     await user.click(getByRole('button', { name: 'Button' }))
 
     expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('should render as a link when as is anchor', () => {
+    const { getByRole } = render(
+      <Button
+        as="a"
+        href="/settings"
+        label="Settings"
+      />
+    )
+
+    expect(getByRole('link', { name: 'Settings' })).toHaveAttribute(
+      'href',
+      '/settings'
+    )
+  })
+
+  it('should render with a custom component when as is provided', () => {
+    const { getByRole } = render(
+      <Button
+        as={BaseButton}
+        label="Custom"
+      />
+    )
+
+    expect(getByRole('button', { name: 'Custom' })).toBeInTheDocument()
+  })
+
+  it('should prevent anchor activation when disabled', async () => {
+    const user = userEvent.setup()
+    const onClick = jest.fn()
+    const { getByRole } = render(
+      <Button
+        as="a"
+        href="/settings"
+        label="Settings"
+        disabled
+        onClick={onClick}
+      />
+    )
+
+    const link = getByRole('link', { name: 'Settings' })
+
+    expect(link).toHaveAttribute('aria-disabled', 'true')
+    expect(link).toHaveAttribute('tabindex', '-1')
+
+    await user.click(link)
+
+    expect(onClick).not.toHaveBeenCalled()
   })
 
   it('should be disabled when disabled prop is true', () => {

--- a/packages/bezier-react/src/beta/Button/Button.tsx
+++ b/packages/bezier-react/src/beta/Button/Button.tsx
@@ -75,10 +75,13 @@ function ButtonSideContentElement({
  * />
  * ```
  */
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = forwardRef<
+  HTMLAnchorElement | HTMLButtonElement,
+  ButtonProps
+>(
   function Button(
     {
-      as = BaseButton,
+      as = 'button',
       className,
       label,
       loading = false,
@@ -93,25 +96,32 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     forwardedRef
   ) {
-    const Comp = as as typeof BaseButton
     const disabled = loading || disabledProp
-
-    return (
-      <Comp
-        ref={forwardedRef}
-        className={classNames(
-          styles.Button,
-          styles[`size-${size}`],
-          styles[`variant-${variant}`],
-          styles[`semantic-${semantic}`],
-          active && styles.active,
-          loading && styles.loading,
-          className
-        )}
-        disabled={disabled}
-        aria-busy={loading || undefined}
-        {...rest}
-      >
+    const buttonClassName = classNames(
+      styles.Button,
+      styles[`size-${size}`],
+      styles[`variant-${variant}`],
+      styles[`semantic-${semantic}`],
+      active && styles.active,
+      loading && styles.loading,
+      className
+    )
+    const isNativeButton = as === 'button'
+    const isNativeAnchor = as === 'a'
+    const Comp = isNativeButton || isNativeAnchor ? BaseButton : as
+    const compProps = isNativeAnchor
+      ? {
+          ...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>),
+          as: 'a' as const,
+        }
+      : isNativeButton
+        ? {
+            ...(rest as React.ButtonHTMLAttributes<HTMLButtonElement>),
+            as: 'button' as const,
+          }
+        : rest
+    const buttonContent = (
+      <>
         <div
           className={classNames(
             styles.ButtonContent,
@@ -149,6 +159,18 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             />
           </div>
         )}
+      </>
+    )
+
+    return (
+      <Comp
+        ref={forwardedRef}
+        {...compProps}
+        className={buttonClassName}
+        disabled={disabled}
+        aria-busy={loading || undefined}
+      >
+        {buttonContent}
       </Comp>
     )
   }

--- a/packages/bezier-react/src/beta/Button/Button.types.ts
+++ b/packages/bezier-react/src/beta/Button/Button.types.ts
@@ -5,7 +5,7 @@ import { type BezierIcon } from '@channel.io/bezier-icons'
 import {
   type BezierComponentProps,
   type DisableProps,
-  type PolymorphicProps,
+  type LeadingTrailingContentProps,
   type SizeProps,
 } from '~/src/types/props'
 
@@ -17,15 +17,8 @@ export type ButtonSize = 'xs' | 's' | 'm' | 'l'
 
 export type ButtonSideContent = BezierIcon | ReactNode
 
-interface ButtonOwnProps {
-  /**
-   * `type` attribute of typical HTML button.
-   *
-   * You may want to set `type` to `submit` to the button
-   * which is used as a submit button in `<form>` component.
-   * @default 'button'
-   */
-  type?: 'button' | 'reset' | 'submit'
+interface ButtonOwnProps
+  extends LeadingTrailingContentProps<ButtonSideContent> {
   /**
    * The label content in the button.
    */
@@ -52,19 +45,48 @@ interface ButtonOwnProps {
    * @default 'primary'
    */
   semantic?: ButtonSemantic
-  /**
-   * Content on the left.
-   */
-  leadingContent?: ButtonSideContent
-  /**
-   * Content on the right.
-   */
-  trailingContent?: ButtonSideContent
 }
 
-export interface ButtonProps
-  extends Omit<BezierComponentProps<'button'>, 'children' | 'color'>,
-    PolymorphicProps,
-    SizeProps<ButtonSize>,
-    DisableProps,
-    ButtonOwnProps {}
+interface ButtonButtonProps
+  extends Omit<
+    BezierComponentProps<'button'>,
+    keyof ButtonOwnProps | 'children' | 'color' | 'as'
+  > {
+  as?: 'button'
+  /**
+   * `type` attribute of typical HTML button.
+   *
+   * You may want to set `type` to `submit` to the button
+   * which is used as a submit button in `<form>` component.
+   * @default 'button'
+   */
+  type?: 'button' | 'reset' | 'submit'
+}
+
+interface ButtonAnchorProps
+  extends Omit<
+    BezierComponentProps<'a'>,
+    keyof ButtonOwnProps | 'children' | 'color' | 'as' | 'type'
+  > {
+  as: 'a'
+  type?: never
+}
+
+interface ButtonCustomElementProps
+  extends Omit<
+    BezierComponentProps,
+    keyof ButtonOwnProps | 'children' | 'color' | 'as'
+  > {
+  /**
+   * Custom element type to render.
+   *
+   * Prefer the default button or `as="a"` when possible. Custom elements are
+   * kept as an escape hatch for wrapper components.
+   */
+  as: React.ElementType
+}
+
+export type ButtonProps = ButtonOwnProps &
+  SizeProps<ButtonSize> &
+  DisableProps &
+  (ButtonButtonProps | ButtonAnchorProps | ButtonCustomElementProps)

--- a/packages/bezier-react/src/beta/Button/Button.types.ts
+++ b/packages/bezier-react/src/beta/Button/Button.types.ts
@@ -3,7 +3,10 @@ import { type ReactNode } from 'react'
 import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import {
-  type BezierComponentProps,
+  type BaseButtonAnchorProps,
+  type BaseButtonButtonProps,
+} from '~/src/beta/BaseButton'
+import {
   type DisableProps,
   type LeadingTrailingContentProps,
   type SizeProps,
@@ -49,8 +52,8 @@ interface ButtonOwnProps
 
 interface ButtonButtonProps
   extends Omit<
-    BezierComponentProps<'button'>,
-    keyof ButtonOwnProps | 'children' | 'color' | 'as'
+    BaseButtonButtonProps,
+    keyof ButtonOwnProps | 'color' | 'type'
   > {
   as?: 'button'
   /**
@@ -65,16 +68,13 @@ interface ButtonButtonProps
 
 interface ButtonAnchorProps
   extends Omit<
-    BezierComponentProps<'a'>,
-    keyof ButtonOwnProps | 'children' | 'color' | 'as' | 'type'
-  > {
-  as: 'a'
-  type?: never
-}
+    BaseButtonAnchorProps,
+    keyof ButtonOwnProps | 'color'
+  > {}
 
 interface ButtonCustomElementProps
   extends Omit<
-    BezierComponentProps,
+    React.HTMLAttributes<HTMLElement>,
     keyof ButtonOwnProps | 'children' | 'color' | 'as'
   > {
   /**

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.types.ts
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.types.ts
@@ -9,6 +9,7 @@ import type {
   ChildrenProps,
   ContentProps,
   DisableProps,
+  LeadingTrailingContentProps,
   VariantProps,
 } from '~/src/types/props'
 
@@ -126,19 +127,12 @@ interface DropdownMenuItemContentProps extends ContentProps<ReactNode> {
 }
 
 interface DropdownMenuItemOwnProps
-  extends VariantProps<DropdownMenuItemVariant> {
+  extends VariantProps<DropdownMenuItemVariant>,
+    LeadingTrailingContentProps<DropdownMenuItemSideContent> {
   /**
    * Content below the main content.
    */
   description?: ReactNode
-  /**
-   * Content on the left.
-   */
-  leadingContent?: DropdownMenuItemSideContent
-  /**
-   * Content on the right.
-   */
-  trailingContent?: DropdownMenuItemSideContent
   /**
    * Whether selecting the item closes the menu.
    * @default true

--- a/packages/bezier-react/src/beta/IconButton/IconButton.module.scss
+++ b/packages/bezier-react/src/beta/IconButton/IconButton.module.scss
@@ -1,6 +1,6 @@
 @use '../../styles/mixins/dimension';
 
-$active-selector: ':where(.active, :hover):where(:not(:disabled))';
+$active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled="true"]))';
 
 .IconButton {
   --b-beta-icon-button-icon-color: initial;
@@ -146,7 +146,7 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled))';
     pointer-events: none;
   }
 
-  &:disabled {
+  &:where(:disabled, [aria-disabled='true']) {
     cursor: not-allowed;
     opacity: var(--opacity-disabled);
   }

--- a/packages/bezier-react/src/beta/IconButton/IconButton.stories.tsx
+++ b/packages/bezier-react/src/beta/IconButton/IconButton.stories.tsx
@@ -56,7 +56,7 @@ export const Primary: StoryObj<IconButtonProps> = {
 }
 
 export const Variants: StoryObj<IconButtonProps> = {
-  render: (args) => (
+  render: (args: IconButtonProps) => (
     <VStack spacing={16}>
       {(['filled', 'outlined', 'ghost'] as const).map((variant) => (
         <HStack
@@ -107,7 +107,7 @@ export const Variants: StoryObj<IconButtonProps> = {
 }
 
 export const Sizes: StoryObj<IconButtonProps> = {
-  render: (args) => (
+  render: (args: IconButtonProps) => (
     <HStack
       spacing={8}
       align="center"
@@ -147,7 +147,7 @@ export const Sizes: StoryObj<IconButtonProps> = {
 }
 
 export const Loading: StoryObj<IconButtonProps> = {
-  render: (args) => (
+  render: (args: IconButtonProps) => (
     <HStack
       spacing={8}
       align="center"

--- a/packages/bezier-react/src/beta/IconButton/IconButton.test.tsx
+++ b/packages/bezier-react/src/beta/IconButton/IconButton.test.tsx
@@ -1,13 +1,10 @@
 import { PlusIcon } from '@channel.io/bezier-icons'
 import userEvent from '@testing-library/user-event'
 
+import { BaseButton } from '~/src/beta/BaseButton'
 import { render } from '~/src/utils/test'
 
-import { BaseButton } from '~/src/beta/BaseButton'
-
 import { IconButton } from './IconButton'
-
-
 
 describe('IconButton', () => {
   it('should render an accessible icon-only button', () => {

--- a/packages/bezier-react/src/beta/IconButton/IconButton.test.tsx
+++ b/packages/bezier-react/src/beta/IconButton/IconButton.test.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event'
 
 import { render } from '~/src/utils/test'
 
+import { BaseButton } from '~/src/beta/BaseButton'
+
 import { IconButton } from './IconButton'
 
 
@@ -56,6 +58,55 @@ describe('IconButton', () => {
     await user.click(getByRole('button', { name: 'Add' }))
 
     expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('should render as a link when as is anchor', () => {
+    const { getByRole } = render(
+      <IconButton
+        as="a"
+        href="/add"
+        content={PlusIcon}
+        aria-label="Add"
+      />
+    )
+
+    expect(getByRole('link', { name: 'Add' })).toHaveAttribute('href', '/add')
+  })
+
+  it('should render with a custom component when as is provided', () => {
+    const { getByRole } = render(
+      <IconButton
+        as={BaseButton}
+        content={PlusIcon}
+        aria-label="Add"
+      />
+    )
+
+    expect(getByRole('button', { name: 'Add' })).toBeInTheDocument()
+  })
+
+  it('should prevent anchor activation when disabled', async () => {
+    const user = userEvent.setup()
+    const onClick = jest.fn()
+    const { getByRole } = render(
+      <IconButton
+        as="a"
+        href="/add"
+        content={PlusIcon}
+        aria-label="Add"
+        disabled
+        onClick={onClick}
+      />
+    )
+
+    const link = getByRole('link', { name: 'Add' })
+
+    expect(link).toHaveAttribute('aria-disabled', 'true')
+    expect(link).toHaveAttribute('tabindex', '-1')
+
+    await user.click(link)
+
+    expect(onClick).not.toHaveBeenCalled()
   })
 
   it('should be disabled when disabled prop is true', () => {

--- a/packages/bezier-react/src/beta/IconButton/IconButton.tsx
+++ b/packages/bezier-react/src/beta/IconButton/IconButton.tsx
@@ -57,10 +57,13 @@ function IconButtonContentElement({ content }: { content: IconButtonContent }) {
  * />
  * ```
  */
-export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+export const IconButton = forwardRef<
+  HTMLAnchorElement | HTMLButtonElement,
+  IconButtonProps
+>(
   function IconButton(
     {
-      as = BaseButton,
+      as = 'button',
       className,
       content,
       loading = false,
@@ -73,24 +76,38 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     },
     forwardedRef
   ) {
-    const Comp = as as typeof BaseButton
     const disabled = loading || disabledProp
+    const iconButtonClassName = classNames(
+      styles.IconButton,
+      styles[`size-${size}`],
+      styles[`variant-${variant}`],
+      styles[`semantic-${semantic}`],
+      active && styles.active,
+      loading && styles.loading,
+      className
+    )
+    const isNativeButton = as === 'button'
+    const isNativeAnchor = as === 'a'
+    const Comp = isNativeButton || isNativeAnchor ? BaseButton : as
+    const compProps = isNativeAnchor
+      ? {
+          ...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>),
+          as: 'a' as const,
+        }
+      : isNativeButton
+        ? {
+            ...(rest as React.ButtonHTMLAttributes<HTMLButtonElement>),
+            as: 'button' as const,
+          }
+        : rest
 
     return (
       <Comp
         ref={forwardedRef}
-        className={classNames(
-          styles.IconButton,
-          styles[`size-${size}`],
-          styles[`variant-${variant}`],
-          styles[`semantic-${semantic}`],
-          active && styles.active,
-          loading && styles.loading,
-          className
-        )}
+        {...compProps}
+        className={iconButtonClassName}
         disabled={disabled}
         aria-busy={loading || undefined}
-        {...rest}
       >
         <div
           className={classNames(

--- a/packages/bezier-react/src/beta/IconButton/IconButton.types.ts
+++ b/packages/bezier-react/src/beta/IconButton/IconButton.types.ts
@@ -10,7 +10,6 @@ import {
 import {
   type BezierComponentProps,
   type DisableProps,
-  type PolymorphicProps,
   type SizeProps,
 } from '~/src/types/props'
 
@@ -23,14 +22,6 @@ export type IconButtonSize = ButtonSize
 export type IconButtonContent = BezierIcon | ReactNode
 
 interface IconButtonOwnProps {
-  /**
-   * `type` attribute of typical HTML button.
-   *
-   * You may want to set `type` to `submit` to the button
-   * which is used as a submit button in `<form>` component.
-   * @default 'button'
-   */
-  type?: 'button' | 'reset' | 'submit'
   /**
    * Icon content inside the button.
    */
@@ -59,12 +50,46 @@ interface IconButtonOwnProps {
   semantic?: IconButtonSemantic
 }
 
-export interface IconButtonProps
+interface IconButtonButtonProps
   extends Omit<
-      BezierComponentProps<'button'>,
-      'children' | 'color' | 'content'
-    >,
-    PolymorphicProps,
-    SizeProps<IconButtonSize>,
-    DisableProps,
-    IconButtonOwnProps {}
+    BezierComponentProps<'button'>,
+    keyof IconButtonOwnProps | 'children' | 'color' | 'as'
+  > {
+  as?: 'button'
+  /**
+   * `type` attribute of typical HTML button.
+   *
+   * You may want to set `type` to `submit` to the button
+   * which is used as a submit button in `<form>` component.
+   * @default 'button'
+   */
+  type?: 'button' | 'reset' | 'submit'
+}
+
+interface IconButtonAnchorProps
+  extends Omit<
+    BezierComponentProps<'a'>,
+    keyof IconButtonOwnProps | 'children' | 'color' | 'as' | 'type'
+  > {
+  as: 'a'
+  type?: never
+}
+
+interface IconButtonCustomElementProps
+  extends Omit<
+    BezierComponentProps,
+    keyof IconButtonOwnProps | 'children' | 'color' | 'as'
+  > {
+  /**
+   * Custom element type to render.
+   *
+   * Prefer the default button or `as="a"` when possible. Custom elements are
+   * kept as an escape hatch for wrapper components.
+   */
+  as: React.ElementType
+}
+
+export type IconButtonProps = IconButtonOwnProps &
+  SizeProps<IconButtonSize> &
+  DisableProps &
+  (IconButtonButtonProps | IconButtonAnchorProps | IconButtonCustomElementProps)

--- a/packages/bezier-react/src/beta/IconButton/IconButton.types.ts
+++ b/packages/bezier-react/src/beta/IconButton/IconButton.types.ts
@@ -3,12 +3,15 @@ import { type ReactNode } from 'react'
 import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import {
+  type BaseButtonAnchorProps,
+  type BaseButtonButtonProps,
+} from '~/src/beta/BaseButton'
+import {
   type ButtonSemantic,
   type ButtonSize,
   type ButtonVariant,
 } from '~/src/beta/Button'
 import {
-  type BezierComponentProps,
   type DisableProps,
   type SizeProps,
 } from '~/src/types/props'
@@ -52,8 +55,8 @@ interface IconButtonOwnProps {
 
 interface IconButtonButtonProps
   extends Omit<
-    BezierComponentProps<'button'>,
-    keyof IconButtonOwnProps | 'children' | 'color' | 'as'
+    BaseButtonButtonProps,
+    keyof IconButtonOwnProps | 'color' | 'type'
   > {
   as?: 'button'
   /**
@@ -68,16 +71,13 @@ interface IconButtonButtonProps
 
 interface IconButtonAnchorProps
   extends Omit<
-    BezierComponentProps<'a'>,
-    keyof IconButtonOwnProps | 'children' | 'color' | 'as' | 'type'
-  > {
-  as: 'a'
-  type?: never
-}
+    BaseButtonAnchorProps,
+    keyof IconButtonOwnProps | 'color'
+  > {}
 
 interface IconButtonCustomElementProps
   extends Omit<
-    BezierComponentProps,
+    React.HTMLAttributes<HTMLElement>,
     keyof IconButtonOwnProps | 'children' | 'color' | 'as'
   > {
   /**

--- a/packages/bezier-react/src/beta/Modal/Modal.module.scss
+++ b/packages/bezier-react/src/beta/Modal/Modal.module.scss
@@ -148,6 +148,8 @@ $close-icon-button-margin: -6;
 
   flex: 0 0 auto;
 
+  width: 32px;
+  height: 32px;
   margin-top: #{$close-icon-button-margin}px;
   margin-right: #{$close-icon-button-margin}px;
 

--- a/packages/bezier-react/src/beta/Modal/Modal.tsx
+++ b/packages/bezier-react/src/beta/Modal/Modal.tsx
@@ -379,11 +379,8 @@ export const ModalHeader = forwardRef<HTMLElement, ModalHeaderProps>(
               )}
 
               {showCloseIcon && (
-                <IconButton
+                <div
                   className={styles.CloseIconButtonSpacer}
-                  as="div"
-                  size="m"
-                  content={CancelIcon}
                   aria-hidden
                 />
               )}

--- a/packages/bezier-react/src/beta/Section/Section.types.ts
+++ b/packages/bezier-react/src/beta/Section/Section.types.ts
@@ -9,25 +9,20 @@ import type {
   ChildrenProps,
   ContentProps,
   DisableProps,
+  LeadingTrailingContentProps,
 } from '~/src/types/props'
 
 export type SectionItemSideContent = BezierIcon | ReactNode
 
 export type SectionLabelSideContent = BezierIcon | ReactNode
 
-interface SectionLabelOwnProps extends ContentProps<ReactNode> {
+interface SectionLabelOwnProps
+  extends ContentProps<ReactNode>,
+    LeadingTrailingContentProps<SectionLabelSideContent> {
   /**
    * Primary visible content of the section label.
    */
   content: ReactNode
-  /**
-   * Content on the left side of the section label.
-   */
-  leadingContent?: SectionLabelSideContent
-  /**
-   * Content on the right side of the section label.
-   */
-  trailingContent?: SectionLabelSideContent
   /**
    * Tooltip content rendered next to the section label.
    */
@@ -48,19 +43,12 @@ interface SectionItemContentProps extends ContentProps<ReactNode> {
 interface SectionItemOwnProps
   extends SectionItemContentProps,
     DisableProps,
-    ActivatableProps {
+    ActivatableProps,
+    LeadingTrailingContentProps<SectionItemSideContent> {
   /**
    * Content below the main content.
    */
   description?: ReactNode
-  /**
-   * Content on the left.
-   */
-  leadingContent?: SectionItemSideContent
-  /**
-   * Content on the right.
-   */
-  trailingContent?: SectionItemSideContent
 }
 
 export interface SectionProps

--- a/packages/bezier-react/src/beta/SegmentedControl/SegmentedControl.types.ts
+++ b/packages/bezier-react/src/beta/SegmentedControl/SegmentedControl.types.ts
@@ -8,6 +8,7 @@ import {
   type ChildrenProps,
   type DisableProps,
   type FormFieldProps,
+  type LeadingTrailingContentProps,
   type SizeProps,
 } from '~/src/types/props'
 
@@ -70,19 +71,12 @@ interface SegmentedControlItemBaseOwnProps<Value extends string> {
 }
 
 interface SegmentedControlItemLabelOwnProps<Value extends string>
-  extends SegmentedControlItemBaseOwnProps<Value> {
+  extends SegmentedControlItemBaseOwnProps<Value>,
+    LeadingTrailingContentProps<SegmentedControlItemSideContent> {
   /**
    * A visible text label of the item.
    */
   children: string
-  /**
-   * Content on the left.
-   */
-  leadingContent?: SegmentedControlItemSideContent
-  /**
-   * Content on the right. Use this for non-interactive adornments such as count badges or status marks.
-   */
-  trailingContent?: SegmentedControlItemSideContent
   icon?: never
   'aria-label'?: string
 }

--- a/packages/bezier-react/src/beta/Tabs/Tabs.types.ts
+++ b/packages/bezier-react/src/beta/Tabs/Tabs.types.ts
@@ -8,6 +8,7 @@ import {
   type BezierComponentProps,
   type ChildrenProps,
   type DisableProps,
+  type LeadingTrailingContentProps,
   type SizeProps,
 } from '~/src/types/props'
 
@@ -51,19 +52,15 @@ interface TabsOwnProps {
   onValueChange?: (value: string) => void
 }
 
-interface TabItemOwnProps {
+interface TabItemOwnProps
+  extends LeadingTrailingContentProps<
+    TabItemLeadingContent,
+    TabItemTrailingContent
+  > {
   /**
    * A unique value that associates the trigger with a content.
    */
   value: string
-  /**
-   * Content on the left.
-   */
-  leadingContent?: TabItemLeadingContent
-  /**
-   * Content on the right. Use this for non-interactive adornments such as count badges or status marks.
-   */
-  trailingContent?: TabItemTrailingContent
   maxWidth?: CSSProperties['maxWidth']
 }
 

--- a/packages/bezier-react/src/beta/TextInput/TextInput.types.ts
+++ b/packages/bezier-react/src/beta/TextInput/TextInput.types.ts
@@ -7,7 +7,10 @@ import type {
   TextInputElementType,
   TextInputRef,
 } from '~/src/beta/BaseTextInput'
-import type { FormFieldProps } from '~/src/types/props'
+import type {
+  FormFieldProps,
+  LeadingTrailingContentProps,
+} from '~/src/types/props'
 
 export type TextInputType = Exclude<TextInputElementType, 'search'>
 
@@ -15,11 +18,10 @@ export type TextInputVariant = 'primary' | 'secondary'
 
 export type TextInputSideContent = string | BezierIcon | ReactNode
 
-interface TextInputOwnProps {
+interface TextInputOwnProps
+  extends LeadingTrailingContentProps<TextInputSideContent> {
   type?: TextInputType
   variant?: TextInputVariant
-  leadingContent?: TextInputSideContent
-  trailingContent?: TextInputSideContent
   withoutLeadingContentWrapper?: boolean
   withoutTrailingContentWrapper?: boolean
 }

--- a/packages/bezier-react/src/beta/Toast/Toast.tsx
+++ b/packages/bezier-react/src/beta/Toast/Toast.tsx
@@ -71,7 +71,6 @@ export function Toast({
   preset = 'info',
   icon: iconProp,
   content,
-  zIndex = 'toast',
   autoDismiss = true,
   autoDismissTimeout,
   version = 0,
@@ -85,7 +84,6 @@ export function Toast({
 
   const className = classNames(
     styles.ToastElement,
-    getZIndexClassName(zIndex),
     placement && styles[`placement-${placement}`],
     isSlidingOut && styles['slide-out']
   )

--- a/packages/bezier-react/src/beta/Toast/Toast.types.ts
+++ b/packages/bezier-react/src/beta/Toast/Toast.types.ts
@@ -18,10 +18,6 @@ interface ToastOwnProps {
    */
   preset?: ToastPreset
   icon?: BezierIcon
-  /**
-   * @deprecated Use `zIndex` of `ToastProvider` instead.
-   */
-  zIndex?: ZIndex
   autoDismiss?: boolean
   autoDismissTimeout?: number
   /**
@@ -63,7 +59,7 @@ export type OnDismissCallback = (id: ToastId) => void
 
 export type ToastOptions = Pick<
   ToastProps,
-  'preset' | 'icon' | 'autoDismiss' | 'zIndex'
+  'preset' | 'icon' | 'autoDismiss'
 > & {
   rightSide?: boolean
   onDismiss?: OnDismissCallback

--- a/packages/bezier-react/src/components/AlphaDialogPrimitive/AlphaDialogPrimitive.stories.tsx
+++ b/packages/bezier-react/src/components/AlphaDialogPrimitive/AlphaDialogPrimitive.stories.tsx
@@ -43,9 +43,9 @@ function DialogComposition() {
 }
 
 const meta: Meta<typeof DialogComposition> = {
-  title: 'Deprecated v2 components/AlphaDialogPrimitive',
+  title: 'v2 components/AlphaDialogPrimitive',
   component: DialogComposition,
-  tags: ['deprecated', '!autodocs'],
+  tags: ['!autodocs'],
 }
 
 export const Primary: StoryObj = {}

--- a/packages/bezier-react/src/components/AlphaDialogPrimitive/DialogPrimitive.tsx
+++ b/packages/bezier-react/src/components/AlphaDialogPrimitive/DialogPrimitive.tsx
@@ -11,50 +11,26 @@ import {
   DialogTrigger,
 } from '@radix-ui/react-dialog'
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#root}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#root} */
 export const DialogPrimitive = Dialog
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#close}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#close} */
 export const DialogPrimitiveClose = DialogClose
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#content}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#content} */
 export const DialogPrimitiveContent = DialogContent
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#description}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#description} */
 export const DialogPrimitiveDescription = DialogDescription
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#overlay}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#overlay} */
 export const DialogPrimitiveOverlay = DialogOverlay
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#portal}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#portal} */
 export const DialogPrimitivePortal = DialogPortal
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#title}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#title} */
 export const DialogPrimitiveTitle = DialogTitle
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#trigger}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#trigger} */
 export const DialogPrimitiveTrigger = DialogTrigger

--- a/packages/bezier-react/src/components/AlphaDialogPrimitive/DialogPrimitive.types.ts
+++ b/packages/bezier-react/src/components/AlphaDialogPrimitive/DialogPrimitive.types.ts
@@ -9,50 +9,26 @@ import type {
   DialogTriggerProps,
 } from '@radix-ui/react-dialog'
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#root}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#root} */
 export type DialogPrimitiveProps = DialogProps
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#close}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#close} */
 export type DialogPrimitiveCloseProps = DialogCloseProps
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#content}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#content} */
 export type DialogPrimitiveContentProps = DialogContentProps
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#description}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#description} */
 export type DialogPrimitiveDescriptionProps = DialogDescriptionProps
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#overlay}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#overlay} */
 export type DialogPrimitiveOverlayProps = DialogOverlayProps
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#portal}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#portal} */
 export type DialogPrimitivePortalProps = DialogPortalProps
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#title}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#title} */
 export type DialogPrimitiveTitleProps = DialogTitleProps
 
-/**
- * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
- * @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#trigger}
- */
+/** @see {@link https://www.radix-ui.com/primitives/docs/components/dialog#trigger} */
 export type DialogPrimitiveTriggerProps = DialogTriggerProps

--- a/packages/bezier-react/src/components/AlphaDialogPrimitive/index.ts
+++ b/packages/bezier-react/src/components/AlphaDialogPrimitive/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
+// TODO(beta): Remove the Alpha prefix when alpha components are removed; this primitive will be exposed as DialogPrimitive.
 export {
   DialogPrimitive as AlphaDialogPrimitive,
   DialogPrimitiveClose as AlphaDialogPrimitiveClose,
@@ -9,7 +9,6 @@ export {
   DialogPrimitiveTitle as AlphaDialogPrimitiveTitle,
   DialogPrimitiveTrigger as AlphaDialogPrimitiveTrigger,
 } from './DialogPrimitive'
-/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export type {
   DialogPrimitiveProps as AlphaDialogPrimitiveProps,
   DialogPrimitiveCloseProps as AlphaDialogPrimitiveCloseProps,

--- a/packages/bezier-react/src/index.ts
+++ b/packages/bezier-react/src/index.ts
@@ -15,7 +15,6 @@ export * from '~/src/components/AlphaAvatar'
 export * from '~/src/components/AlphaAvatarGroup'
 /** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaButton'
-/** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaDialogPrimitive'
 /** @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead. */
 export * from '~/src/components/AlphaFloatingButton'

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -132,6 +132,23 @@ export interface SideContentProps<
 }
 
 /**
+ * Props for components that have content before and after their main content.
+ */
+export interface LeadingTrailingContentProps<
+  LeadingContent = React.ReactNode,
+  TrailingContent = LeadingContent,
+> {
+  /**
+   * Content to be displayed before the main content.
+   */
+  leadingContent?: LeadingContent
+  /**
+   * Content to be displayed after the main content.
+   */
+  trailingContent?: TrailingContent
+}
+
+/**
  * Props for components that can be disabled.
  */
 export interface DisableProps {
@@ -512,6 +529,9 @@ export interface BetaLayoutProps
 
 /**
  * Enumeration of form field sizes. (TextField, Select)
+ *
+ * @deprecated Legacy form field sizes are deprecated. Use beta component size
+ * types from `@channel.io/bezier-react/beta` instead.
  */
 export type FormFieldSize = 'xl' | 'l' | 'm' | 'xs'
 

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -529,7 +529,6 @@ export interface BetaLayoutProps
 
 /**
  * Enumeration of form field sizes. (TextField, Select)
- *
  * @deprecated Legacy form field sizes are deprecated. Use beta component size
  * types from `@channel.io/bezier-react/beta` instead.
  */


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

-

## Summary

베타 컴포넌트 인터페이스를 정리합니다.

- `Button`, `IconButton`에서 `button` / `a` 경로를 명시적으로 처리하고 custom `as` escape hatch는 유지합니다.
- 여러 베타 컴포넌트의 `leadingContent` / `trailingContent` 타입을 공통 prop 타입으로 정리합니다.
- `Toast`의 개별 `zIndex`를 제거하고 provider가 stacking context를 소유하도록 정리합니다.
- `AlphaDialogPrimitive`는 아직 deprecate하지 않는 방향으로 JSDoc과 스토리 표시를 되돌립니다.

## Details

`Button`, `IconButton`은 기본적으로 native button으로 렌더링하고, `as="a"`를 명시하면 anchor props를 사용할 수 있게 했습니다. anchor disabled/loading 상태에서는 navigation과 click handler 호출을 막습니다. `as={BaseButton}` 같은 기존 custom wrapper 사용은 계속 허용합니다.

`ModalHeader`의 close icon spacer는 액션 컴포넌트가 아니므로 `IconButton as="div"` 대신 비인터랙티브 `div`로 변경했습니다.

`LeadingTrailingContentProps`를 추가해 `BaseItem`, `DropdownMenuItem`, `SectionLabel`, `SectionItem`, `Tabs`, `SegmentedControl`, `TextInput`의 side content prop 타입을 같은 기준으로 맞췄습니다.

`Toast`는 per-toast `zIndex`를 제거했습니다. stacking context가 필요한 경우 `ToastProvider`에서 제어합니다.

### Breaking change? (Yes/No)

Yes.

베타 API 기준으로 `Toast` / `ToastOptions`의 `zIndex`가 제거됩니다. 기존에 개별 toast에서 `zIndex`를 넘기던 사용처는 `ToastProvider`의 `zIndex`로 이동해야 합니다.

`Button`, `IconButton`은 native `button` / `a` 경로가 더 명확해졌습니다. 일반 사용처는 동일하게 동작하며, 링크 버튼은 `as="a"`와 `href`를 함께 사용해야 합니다.

## References

- `yarn typecheck`에 해당하는 `tsc --noEmit` 통과
- `Button`, `IconButton` 관련 Jest 테스트 통과
- 관련 SCSS stylelint 통과
