### PR TITLE
fix(bezier-react): restrict token props to beta tokens

### DIFF
--- a/.changeset/clean-token-props.md
+++ b/.changeset/clean-token-props.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Restrict component token props to beta tokens.

--- a/packages/bezier-react/src/beta/BaseStack/BaseStack.tsx
+++ b/packages/bezier-react/src/beta/BaseStack/BaseStack.tsx
@@ -5,10 +5,10 @@ import { createElement, forwardRef } from 'react'
 import classNames from 'classnames'
 
 import {
-  getBetaLayoutStyles,
-  getBetaMarginStyles,
-  splitByBetaLayoutProps,
-  splitByBetaMarginProps,
+  getLayoutStyles,
+  getMarginStyles,
+  splitByLayoutProps,
+  splitByMarginProps,
 } from '~/src/types/props-helpers'
 import { cssDimension } from '~/src/utils/style'
 
@@ -24,10 +24,10 @@ import styles from './BaseStack.module.scss'
  */
 export const BaseStack = forwardRef<HTMLElement, BaseStackProps>(
   function BaseStack(props, forwardedRef) {
-    const [marginProps, marginRest] = splitByBetaMarginProps(props)
-    const [layoutProps, layoutRest] = splitByBetaLayoutProps(marginRest)
-    const marginStyles = getBetaMarginStyles(marginProps)
-    const layoutStyles = getBetaLayoutStyles(layoutProps)
+    const [marginProps, marginRest] = splitByMarginProps(props)
+    const [layoutProps, layoutRest] = splitByLayoutProps(marginRest)
+    const marginStyles = getMarginStyles(marginProps)
+    const layoutStyles = getLayoutStyles(layoutProps)
 
     const {
       children,

--- a/packages/bezier-react/src/beta/BaseStack/BaseStack.types.ts
+++ b/packages/bezier-react/src/beta/BaseStack/BaseStack.types.ts
@@ -1,8 +1,8 @@
 import {
-  type BetaLayoutProps,
-  type BetaMarginProps,
   type BezierComponentProps,
   type ChildrenProps,
+  type LayoutProps,
+  type MarginProps,
   type PolymorphicProps,
 } from '~/src/types/props'
 
@@ -50,8 +50,8 @@ export interface BaseStackProps
   extends BezierComponentProps,
     PolymorphicProps,
     ChildrenProps,
-    BetaLayoutProps,
-    BetaMarginProps,
+    LayoutProps,
+    MarginProps,
     BaseStackOwnProps {}
 
 export interface HStackProps extends Omit<BaseStackProps, 'direction'> {}

--- a/packages/bezier-react/src/beta/Box/Box.tsx
+++ b/packages/bezier-react/src/beta/Box/Box.tsx
@@ -7,10 +7,10 @@ import classNames from 'classnames'
 
 
 import {
-  getBetaLayoutStyles,
-  getBetaMarginStyles,
-  splitByBetaLayoutProps,
-  splitByBetaMarginProps,
+  getLayoutStyles,
+  getMarginStyles,
+  splitByLayoutProps,
+  splitByMarginProps,
 } from '~/src/types/props-helpers'
 
 import type { BoxProps } from './Box.types'
@@ -36,10 +36,10 @@ import styles from './Box.module.scss'
  */
 export const Box = forwardRef<HTMLElement, BoxProps>(
   function Box(props, forwardedRef) {
-    const [marginProps, marginRest] = splitByBetaMarginProps(props)
-    const [layoutProps, layoutRest] = splitByBetaLayoutProps(marginRest)
-    const marginStyles = getBetaMarginStyles(marginProps)
-    const layoutStyles = getBetaLayoutStyles(layoutProps)
+    const [marginProps, marginRest] = splitByMarginProps(props)
+    const [layoutProps, layoutRest] = splitByLayoutProps(marginRest)
+    const marginStyles = getMarginStyles(marginProps)
+    const layoutStyles = getLayoutStyles(layoutProps)
 
     const {
       children,

--- a/packages/bezier-react/src/beta/Box/Box.types.ts
+++ b/packages/bezier-react/src/beta/Box/Box.types.ts
@@ -1,8 +1,8 @@
 import type {
-  BetaLayoutProps,
-  BetaMarginProps,
   BezierComponentProps,
   ChildrenProps,
+  LayoutProps,
+  MarginProps,
   PolymorphicProps,
 } from '~/src/types/props'
 
@@ -19,6 +19,6 @@ export interface BoxProps
   extends Omit<BezierComponentProps<'div'>, keyof BoxOwnProps>,
     PolymorphicProps,
     ChildrenProps,
-    BetaMarginProps,
-    BetaLayoutProps,
+    MarginProps,
+    LayoutProps,
     BoxOwnProps {}

--- a/packages/bezier-react/src/beta/ButtonGroup/ButtonGroup.types.ts
+++ b/packages/bezier-react/src/beta/ButtonGroup/ButtonGroup.types.ts
@@ -1,8 +1,8 @@
 import { type HStackProps } from '~/src/beta/HStack'
 import type {
-  BetaMarginProps,
   BezierComponentProps,
   ChildrenProps,
+  MarginProps,
 } from '~/src/types/props'
 
 interface ButtonGroupOwnProps {
@@ -16,6 +16,6 @@ interface ButtonGroupOwnProps {
 export interface ButtonGroupProps
   extends Omit<BezierComponentProps<'div'>, 'role'>,
     ChildrenProps,
-    BetaMarginProps,
+    MarginProps,
     Pick<HStackProps, 'justify'>,
     ButtonGroupOwnProps {}

--- a/packages/bezier-react/src/beta/Form/Form.types.ts
+++ b/packages/bezier-react/src/beta/Form/Form.types.ts
@@ -1,10 +1,10 @@
 import { type TextProps } from '~/src/beta/Text'
 import type {
   FormFieldProps as BaseFormFieldProps,
-  BetaMarginProps,
   BezierComponentProps,
   ChildrenProps,
   IdentifierProps,
+  MarginProps,
   SizeProps,
 } from '~/src/types/props'
 
@@ -91,7 +91,7 @@ interface FormLabelOwnProps {
 }
 
 export interface FormLabelProps
-  extends Omit<TextProps, keyof BetaMarginProps>,
+  extends Omit<TextProps, keyof MarginProps>,
     ChildrenProps,
     Partial<IdentifierProps>,
     FormLabelOwnProps {}
@@ -101,7 +101,7 @@ interface BaseHelperTextOwnProps {
 }
 
 export interface BaseHelperTextProps
-  extends Omit<TextProps, keyof BetaMarginProps>,
+  extends Omit<TextProps, keyof MarginProps>,
     ChildrenProps,
     Partial<IdentifierProps>,
     BaseHelperTextOwnProps {}

--- a/packages/bezier-react/src/beta/Icon/Icon.stories.tsx
+++ b/packages/bezier-react/src/beta/Icon/Icon.stories.tsx
@@ -49,7 +49,7 @@ const meta: Meta<typeof Icon> = {
         defaultValue: { summary: '"24"' },
       },
     },
-    // `color` accepts any beta semantic color token (`BetaColorProps`), so it is
+    // `color` accepts any beta semantic color token (`ColorProps`), so it is
     // left as a free-text control rather than a restricted option list.
     color: {
       control: 'text',

--- a/packages/bezier-react/src/beta/Icon/Icon.types.ts
+++ b/packages/bezier-react/src/beta/Icon/Icon.types.ts
@@ -1,9 +1,9 @@
 import { type BezierIcon } from '@channel.io/bezier-icons'
 
 import {
-  type BetaColorProps,
-  type BetaMarginProps,
   type BezierComponentProps,
+  type ColorProps,
+  type MarginProps,
   type SizeProps,
 } from '~/src/types/props'
 
@@ -25,8 +25,8 @@ interface IconOwnProps {
 }
 
 export interface IconProps
-  extends Omit<BezierComponentProps<'svg'>, keyof BetaColorProps>,
-    BetaMarginProps,
+  extends Omit<BezierComponentProps<'svg'>, keyof ColorProps>,
+    MarginProps,
     SizeProps<IconSize>,
-    BetaColorProps,
+    ColorProps,
     IconOwnProps {}

--- a/packages/bezier-react/src/beta/Modal/Modal.types.ts
+++ b/packages/bezier-react/src/beta/Modal/Modal.types.ts
@@ -1,9 +1,9 @@
+import { type BetaZIndex } from '~/src/types/beta-tokens'
 import {
   type BezierComponentProps,
   type ChildrenProps,
   type SideContentProps,
 } from '~/src/types/props'
-import { type ZIndex } from '~/src/types/tokens'
 
 export type ModalTitleSize = 'l' | 'm'
 export type ModalContentType = 'default' | 'confirm'
@@ -80,7 +80,7 @@ interface ModalContentOwnProps {
    * Rather than using this option, Please check modal is positioned in the proper stacking context.
    * @default 'modal'
    */
-  zIndex?: ZIndex
+  zIndex?: BetaZIndex
 
   /**
    * Determine padding of overlay that contains modal content.

--- a/packages/bezier-react/src/beta/Overlay/Overlay.types.ts
+++ b/packages/bezier-react/src/beta/Overlay/Overlay.types.ts
@@ -1,9 +1,9 @@
+import { type BetaZIndex } from '~/src/types/beta-tokens'
 import {
   type AdditionalOverridableStyleProps,
   type BezierComponentProps,
   type ChildrenProps,
 } from '~/src/types/props'
-import { type ZIndex } from '~/src/types/tokens'
 
 export interface ContainerRectAttr {
   containerWidth: number
@@ -80,7 +80,7 @@ interface OverlayOwnProps {
    * z-index of the overlay.
    * @default 'overlay'
    */
-  zIndex?: ZIndex
+  zIndex?: BetaZIndex
 }
 
 export interface OverlayProps

--- a/packages/bezier-react/src/beta/Section/Section.tsx
+++ b/packages/bezier-react/src/beta/Section/Section.tsx
@@ -11,8 +11,8 @@ import classNames from 'classnames'
 import { Help } from '~/src/beta/Help'
 import { Text } from '~/src/beta/Text'
 import {
-  getBetaMarginStyles,
-  splitByBetaMarginProps,
+  getMarginStyles,
+  splitByMarginProps,
 } from '~/src/types/props-helpers'
 import { createContext } from '~/src/utils/react'
 
@@ -261,8 +261,8 @@ export const SectionLabel = forwardRef<HTMLDivElement, SectionLabelProps>(
 
 const SectionRoot = forwardRef<HTMLElement, SectionProps>(
   function Section(props, forwardedRef) {
-    const [marginProps, marginRest] = splitByBetaMarginProps(props)
-    const marginStyles = getBetaMarginStyles(marginProps)
+    const [marginProps, marginRest] = splitByMarginProps(props)
+    const marginStyles = getMarginStyles(marginProps)
     const generatedLabelId = useId()
     const [labelCount, setLabelCount] = useState(0)
 

--- a/packages/bezier-react/src/beta/Section/Section.types.ts
+++ b/packages/bezier-react/src/beta/Section/Section.types.ts
@@ -4,12 +4,12 @@ import type { BezierIcon } from '@channel.io/bezier-icons'
 
 import type {
   ActivatableProps,
-  BetaMarginProps,
   BezierComponentProps,
   ChildrenProps,
   ContentProps,
   DisableProps,
   LeadingTrailingContentProps,
+  MarginProps,
 } from '~/src/types/props'
 
 export type SectionItemSideContent = BezierIcon | ReactNode
@@ -54,7 +54,7 @@ interface SectionItemOwnProps
 export interface SectionProps
   extends Omit<BezierComponentProps<'section'>, 'children'>,
     ChildrenProps,
-    BetaMarginProps {}
+    MarginProps {}
 
 export interface SectionLabelProps
   extends Omit<

--- a/packages/bezier-react/src/beta/Spinner/Spinner.types.ts
+++ b/packages/bezier-react/src/beta/Spinner/Spinner.types.ts
@@ -1,6 +1,6 @@
 import type {
-  BetaColorProps,
   BezierComponentProps,
+  ColorProps,
   SizeProps,
 } from '~/src/types/props'
 
@@ -16,6 +16,6 @@ export type SpinnerSize =
   | '48'
 
 export interface SpinnerProps
-  extends Omit<BezierComponentProps<'div'>, keyof BetaColorProps>,
+  extends Omit<BezierComponentProps<'div'>, keyof ColorProps>,
     SizeProps<SpinnerSize>,
-    BetaColorProps {}
+    ColorProps {}

--- a/packages/bezier-react/src/beta/Text/Text.types.ts
+++ b/packages/bezier-react/src/beta/Text/Text.types.ts
@@ -3,9 +3,9 @@ import {
   type BetaTypographyFontWeight,
 } from '~/src/types/beta-tokens'
 import {
-  type BetaMarginProps,
   type BezierComponentProps,
   type ChildrenProps,
+  type MarginProps,
   type PolymorphicProps,
 } from '~/src/types/props'
 
@@ -66,5 +66,5 @@ export interface TextProps
   extends Omit<BezierComponentProps, keyof TextOwnProps>,
     PolymorphicProps,
     ChildrenProps,
-    BetaMarginProps,
+    MarginProps,
     TextOwnProps {}

--- a/packages/bezier-react/src/beta/Toast/Toast.types.ts
+++ b/packages/bezier-react/src/beta/Toast/Toast.types.ts
@@ -2,8 +2,8 @@ import type React from 'react'
 
 import { type BezierIcon } from '@channel.io/bezier-icons'
 
+import { type BetaZIndex } from '~/src/types/beta-tokens'
 import { type ChildrenProps, type ContentProps } from '~/src/types/props'
-import { type ZIndex } from '~/src/types/tokens'
 
 export type ToastPlacement = 'bottom-left' | 'bottom-right'
 
@@ -45,7 +45,7 @@ interface ToastProviderOwnProps {
    * z-index level of the Toast container.
    * @default 'toast'
    */
-  zIndex?: ZIndex
+  zIndex?: BetaZIndex
 }
 
 export interface ToastProviderProps

--- a/packages/bezier-react/src/components/Modal/Modal.types.ts
+++ b/packages/bezier-react/src/components/Modal/Modal.types.ts
@@ -1,9 +1,9 @@
+import { type BetaZIndex } from '~/src/types/beta-tokens'
 import {
   type BezierComponentProps,
   type ChildrenProps,
   type SideContentProps,
 } from '~/src/types/props'
-import { type ZIndex } from '~/src/types/tokens'
 
 /**
  * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
@@ -72,7 +72,7 @@ interface ModalContentOwnProps {
    * Rather than using this option, Please check modal is positioned in the proper stacking context.
    * @default 'modal'
    */
-  zIndex?: ZIndex
+  zIndex?: BetaZIndex
 
   /**
    * Determine padding of overlay that contains modal content.

--- a/packages/bezier-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/bezier-react/src/components/Overlay/Overlay.types.ts
@@ -1,9 +1,9 @@
+import { type BetaZIndex } from '~/src/types/beta-tokens'
 import {
   type AdditionalOverridableStyleProps,
   type BezierComponentProps,
   type ChildrenProps,
 } from '~/src/types/props'
-import { type ZIndex } from '~/src/types/tokens'
 
 export interface ContainerRectAttr {
   containerWidth: number
@@ -65,7 +65,7 @@ interface OverlayOwnProps {
    * z-index of the overlay.
    * @default 'overlay'
    */
-  zIndex?: ZIndex
+  zIndex?: BetaZIndex
 }
 
 /**

--- a/packages/bezier-react/src/components/Select/Select.types.ts
+++ b/packages/bezier-react/src/components/Select/Select.types.ts
@@ -13,7 +13,6 @@ import type {
   SideContentProps,
   SizeProps,
 } from '~/src/types/props'
-import { type ZIndex } from '~/src/types/tokens'
 
 import type { OverlayProps } from '~/src/components/Overlay'
 
@@ -34,7 +33,7 @@ interface SelectOwnProps {
   dropdownContainer?: HTMLElement | null
   dropdownMarginX?: OverlayProps['marginX']
   dropdownMarginY?: OverlayProps['marginY']
-  dropdownZIndex?: ZIndex | BetaZIndex
+  dropdownZIndex?: BetaZIndex
   dropdownPosition?: OverlayProps['position']
   dropdownKeepInContainer?: OverlayProps['keepInContainer']
   onClickTrigger?: React.MouseEventHandler

--- a/packages/bezier-react/src/components/SmoothCornersBox/SmoothCornersBox.types.ts
+++ b/packages/bezier-react/src/components/SmoothCornersBox/SmoothCornersBox.types.ts
@@ -4,7 +4,6 @@ import type {
   ChildrenProps,
   DisableProps,
 } from '~/src/types/props'
-import { type SemanticColor } from '~/src/types/tokens'
 
 /**
  * NOTE: The `inset` property is not currently supported.
@@ -34,7 +33,7 @@ interface BoxShadow {
    * The color of the shadow.
    * @default transparent
    */
-  color?: SemanticColor | BetaSemanticColor
+  color?: BetaSemanticColor
 }
 
 interface SmoothCornersBoxOwnProps {
@@ -56,7 +55,7 @@ interface SmoothCornersBoxOwnProps {
    * The background color of an element.
    * @default 'transparent'
    */
-  backgroundColor?: SemanticColor | BetaSemanticColor
+  backgroundColor?: BetaSemanticColor
   /**
    * The background image url of an element.
    */

--- a/packages/bezier-react/src/components/Text/Text.types.ts
+++ b/packages/bezier-react/src/components/Text/Text.types.ts
@@ -5,7 +5,6 @@ import {
   type MarginProps,
   type PolymorphicProps,
 } from '~/src/types/props'
-import { type SemanticColor } from '~/src/types/tokens'
 
 type Typography =
   | '11'
@@ -33,7 +32,7 @@ interface TextOwnProps {
   /**
    * Color of the text. If no value is specified, it inherits the color of the parent element.
    */
-  color?: SemanticColor | BetaSemanticColor
+  color?: BetaSemanticColor
   /**
    * Whether the text is bold.
    * @default false

--- a/packages/bezier-react/src/components/Toast/Toast.types.ts
+++ b/packages/bezier-react/src/components/Toast/Toast.types.ts
@@ -2,8 +2,8 @@ import type React from 'react'
 
 import { type BezierIcon } from '@channel.io/bezier-icons'
 
+import { type BetaZIndex } from '~/src/types/beta-tokens'
 import { type ChildrenProps, type ContentProps } from '~/src/types/props'
-import { type ZIndex } from '~/src/types/tokens'
 
 /**
  * @deprecated These components are deprecated. Use beta components from `@channel.io/bezier-react/beta` instead.
@@ -28,7 +28,7 @@ interface ToastOwnProps {
   /**
    * @deprecated Use `zIndex` of `ToastProvider` instead
    */
-  zIndex?: ZIndex
+  zIndex?: BetaZIndex
   autoDismiss?: boolean
   autoDismissTimeout?: number
   /**
@@ -62,7 +62,7 @@ interface ToastProviderOwnProps {
    * z-index level of the Toast container
    * @default 'toast'
    */
-  zIndex?: ZIndex
+  zIndex?: BetaZIndex
 }
 
 /**

--- a/packages/bezier-react/src/types/props-helpers.test.ts
+++ b/packages/bezier-react/src/types/props-helpers.test.ts
@@ -1,0 +1,17 @@
+import { getLayoutStyles } from './props-helpers'
+
+describe('props-helpers', () => {
+  describe('getLayoutStyles', () => {
+    it('maps beta layout token props to CSS module class names', () => {
+      const result = getLayoutStyles({
+        borderRadius: '8',
+        elevation: '1',
+        zIndex: 'modal',
+      })
+
+      expect(result.className).toContain('elevation-1')
+      expect(result.className).toContain('radius-8')
+      expect(result.className).toContain('z-index-modal')
+    })
+  })
+})

--- a/packages/bezier-react/src/types/props-helpers.ts
+++ b/packages/bezier-react/src/types/props-helpers.ts
@@ -1,6 +1,5 @@
 import classNames from 'classnames'
 
-
 // NOTE: 'typescript-plugin-css-modules' does not support path alias
 /* eslint-disable no-restricted-imports */
 import { colorTokenCssVar, cssDimension } from '~/src/utils/style'
@@ -18,15 +17,7 @@ import {
   type BetaRadius,
   type BetaZIndex,
 } from './beta-tokens'
-import {
-  type BetaLayoutProps,
-  type BetaMarginProps,
-  type FormFieldSize,
-  type LayoutProps,
-  type MarginProps,
-} from './props'
-import { type Elevation, type Radius, type ZIndex } from './tokens'
-
+import { type FormFieldSize, type LayoutProps, type MarginProps } from './props'
 
 export const splitByMarginProps = <Props extends MarginProps>({
   margin,
@@ -128,25 +119,15 @@ export const splitByLayoutProps = <Props extends LayoutProps>({
   rest,
 ]
 
-export const splitByBetaMarginProps = <Props extends BetaMarginProps>(
-  props: Props
-): [BetaMarginProps, Omit<Props, keyof BetaMarginProps>] =>
-  splitByMarginProps(props)
-
-export const splitByBetaLayoutProps = <Props extends BetaLayoutProps>(
-  props: Props
-): [BetaLayoutProps, Omit<Props, keyof BetaLayoutProps>] =>
-  splitByLayoutProps(props) as [BetaLayoutProps, Omit<Props, keyof BetaLayoutProps>]
-
-function getElevationClassName(elevation: Elevation | BetaElevation) {
+function getElevationClassName(elevation: BetaElevation) {
   return elevationStyles[`elevation-${elevation}`]
 }
 
-function getRadiusClassName(radius: Radius | BetaRadius) {
+function getRadiusClassName(radius: BetaRadius) {
   return radiusStyles[`radius-${radius}`]
 }
 
-export function getZIndexClassName(zIndex: ZIndex | BetaZIndex) {
+export function getZIndexClassName(zIndex: BetaZIndex) {
   return zIndexStyles[`z-index-${zIndex}`]
 }
 
@@ -249,11 +230,6 @@ export const getLayoutStyles = ({
     zIndex && getZIndexClassName(zIndex)
   ),
 })
-
-export const getBetaMarginStyles = getMarginStyles
-
-export const getBetaLayoutStyles = (props: BetaLayoutProps) =>
-  getLayoutStyles(props)
 
 export function getFormFieldSizeClassName(size: FormFieldSize) {
   return formFieldSizeStyles[`size-${size}`]

--- a/packages/bezier-react/src/types/props.ts
+++ b/packages/bezier-react/src/types/props.ts
@@ -9,15 +9,6 @@ import type {
   BetaTextSemanticColor,
   BetaZIndex,
 } from './beta-tokens'
-import type {
-  BackgroundSemanticColor,
-  BackgroundTextSemanticColor,
-  BorderSemanticColor,
-  Elevation,
-  Radius,
-  SemanticColor,
-  ZIndex,
-} from './tokens'
 
 /**
  * Props for overriding default styles of components. Intended for exceptional use cases where default styles need customization.
@@ -166,7 +157,7 @@ export interface ColorProps {
   /**
    * Color from the design system's semantic color.
    */
-  color?: SemanticColor | BetaSemanticColor
+  color?: BetaSemanticColor
 }
 
 /**
@@ -205,7 +196,7 @@ export type AdditionalOverridableStyleProps<ElementName extends PropNameType> =
  * Props for adding color properties to named elements within a component.
  */
 export type AdditionalColorProps<ElementName extends PropNameType> =
-  AdditionalProps<ElementName, 'color', SemanticColor | BetaSemanticColor>
+  AdditionalProps<ElementName, 'color', BetaSemanticColor>
 
 /**
  * Props for components that can be activated or deactivated.
@@ -286,11 +277,8 @@ export interface MarginProps {
   marginLeft?: React.CSSProperties['marginLeft']
 }
 
-type Position = 'absolute' | 'fixed' | 'relative' | 'sticky'
-type Overflow = 'auto' | 'hidden' | 'scroll' | 'visible'
-
-export type BetaPosition = Position
-export type BetaOverflow = Overflow
+export type Position = 'absolute' | 'fixed' | 'relative' | 'sticky'
+export type Overflow = 'auto' | 'hidden' | 'scroll' | 'visible'
 
 /**
  * Props for defining layout-related properties of a component, such as padding, size, and position.
@@ -408,24 +396,22 @@ export interface LayoutProps {
   grow?: React.CSSProperties['flexGrow']
   /**
    * the background color of an element.
-   * @todo @timo BetaTextSemanticColor is included for v1 component compatibility. beta components should use only BetaBackgroundSemanticColor for proper semantic usage.
+   * @todo @timo BetaTextSemanticColor is included for existing component compatibility. components should use only BetaBackgroundSemanticColor for proper semantic usage.
    * @default initial
    */
   backgroundColor?:
-    | BackgroundSemanticColor
-    | BackgroundTextSemanticColor
     | BetaBackgroundSemanticColor
     | BetaTextSemanticColor
   /**
    * the border color of an element.
    * @default initial
    */
-  borderColor?: BorderSemanticColor | BetaBorderSemanticColor
+  borderColor?: BetaBorderSemanticColor
   /**
    * the border radius of an element.
    * @default initial
    */
-  borderRadius?: Radius | BetaRadius
+  borderRadius?: BetaRadius
   /**
    * the border width of an element.
    * @default 0
@@ -455,12 +441,12 @@ export interface LayoutProps {
    * the elevation of an element. (box-shadow)
    * @default initial
    */
-  elevation?: Elevation | BetaElevation
+  elevation?: BetaElevation
   /**
    * the z-index of an element.
    * @default initial
    */
-  zIndex?: ZIndex | BetaZIndex
+  zIndex?: BetaZIndex
   /**
    * the overflow of an element.
    * @default initial
@@ -476,55 +462,6 @@ export interface LayoutProps {
    * @default initial
    */
   overflowY?: Overflow
-}
-
-export type BetaMarginProps = MarginProps
-
-/**
- * Beta color props mirror ColorProps but only allow beta semantic color tokens.
- * TODO: Fold this into ColorProps when legacy token unions are removed for 4.0.0.
- */
-export interface BetaColorProps {
-  /**
-   * Color from the design system's semantic color.
-   */
-  color?: BetaSemanticColor
-}
-
-/**
- * Beta layout props mirror LayoutProps while keeping token-typed fields narrow.
- * TODO: Fold this into LayoutProps when legacy token unions are removed for 4.0.0.
- */
-export interface BetaLayoutProps
-  extends Omit<
-    LayoutProps,
-    'backgroundColor' | 'borderColor' | 'borderRadius' | 'elevation' | 'zIndex'
-  > {
-  /**
-   * the background color of an element.
-   * @default initial
-   */
-  backgroundColor?: BetaBackgroundSemanticColor
-  /**
-   * the border color of an element.
-   * @default initial
-   */
-  borderColor?: BetaBorderSemanticColor
-  /**
-   * the border radius of an element.
-   * @default initial
-   */
-  borderRadius?: BetaRadius
-  /**
-   * the elevation of an element. (box-shadow)
-   * @default initial
-   */
-  elevation?: BetaElevation
-  /**
-   * the z-index of an element.
-   * @default initial
-   */
-  zIndex?: BetaZIndex
 }
 
 /**

--- a/packages/bezier-react/src/utils/style.test.ts
+++ b/packages/bezier-react/src/utils/style.test.ts
@@ -91,17 +91,6 @@ describe('style', () => {
       )
     })
 
-    it('formats v1 semantic color tokens without color- prefix', () => {
-      expect(colorTokenCssVar('bg-black-light' as any)).toBe(
-        'var(--bg-black-light)'
-      )
-      expect(colorTokenCssVar('bgtxt-blue-normal' as any)).toBe(
-        'var(--bgtxt-blue-normal)'
-      )
-      expect(colorTokenCssVar('bdr-black-dark' as any)).toBe(
-        'var(--bdr-black-dark)'
-      )
-    })
   })
 
   describe('cssUrl', () => {

--- a/packages/bezier-react/src/utils/style.ts
+++ b/packages/bezier-react/src/utils/style.ts
@@ -2,7 +2,6 @@ import type {
   BetaFlattenAllToken,
   BetaSemanticColor,
 } from '~/src/types/beta-tokens'
-import type { FlattenAllToken, SemanticColor } from '~/src/types/tokens'
 
 import { isNil, isString } from './type'
 
@@ -54,7 +53,6 @@ export function cssVar<PropertyName extends string | undefined>(
  */
 export function tokenCssVar<
   PropertyName extends
-    | FlattenAllToken
     | Exclude<BetaFlattenAllToken, BetaSemanticColor>
     | undefined,
 >(propertyName: PropertyName) {
@@ -67,28 +65,10 @@ export function tokenCssVar<
  * (e.g. `text-neutral` -> `var(--color-text-neutral)`).
  */
 export function colorTokenCssVar<
-  PropertyName extends SemanticColor | BetaSemanticColor | undefined,
+  PropertyName extends BetaSemanticColor | undefined,
 >(propertyName: PropertyName) {
   if (!propertyName) {
     return undefined
-  }
-
-  const betaColorTokenPrefixes = [
-    'text',
-    'icon',
-    'fill',
-    'border',
-    'surface',
-    'dim',
-    'state',
-    'elevation',
-  ]
-
-  /** @todo @timo Remove this condition in the next major release. */
-  if (
-    !betaColorTokenPrefixes.some((prefix) => propertyName.startsWith(prefix))
-  ) {
-    return cssVar(`${propertyName}`)
   }
 
   return cssVar(`color-${propertyName}`)


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

WEBTECH-4641

## Summary

v4 토큰 승격 작업 전에 사용처에 남아 있는 구 토큰 사용을 타입 단계에서 먼저 잡을 수 있도록, `bezier-react` 컴포넌트 props의 토큰 타입을 beta 토큰 기준으로 제한했습니다.

## Details

- 공용 props 타입(`ColorProps`, `LayoutProps`)에서 v1 토큰 타입 union을 제거하고 beta 토큰 타입만 허용하도록 정리했습니다.
- beta 컴포넌트에서 임시로 사용하던 `BetaColorProps`, `BetaLayoutProps`, `BetaMarginProps` 및 `getBeta*`, `splitByBeta*` 헬퍼를 제거하고 공용 props/helper로 통일했습니다.
- `Modal`, `Overlay`, `Toast` 등의 `zIndex` 타입도 beta z-index 토큰만 받도록 변경했습니다.
- v1 제거 이후 불필요해진 `colorTokenCssVar`의 레거시 prefix 보정 로직과 관련 테스트를 제거했습니다.
- 릴리즈 반영을 위해 `@channel.io/bezier-react` patch changeset을 추가했습니다.

검증:

- `yarn workspace @channel.io/bezier-react build:types`

### Breaking change? (Yes/No)

Yes

TypeScript 기준으로 기존 v1 토큰 타입을 넘기던 사용처는 더 이상 통과하지 않습니다. 이 PR은 v3(beta) 토큰을 기본 토큰으로 승격하기 전, 잔류 구 토큰 사용처를 먼저 발견하고 마이그레이션하기 위한 준비 단계입니다.

## References

- PR에는 changeset만 포함했고, 작업 중 생성된 별도 md 조사 문서는 커밋 대상에서 제외했습니다.
