### PR TITLE
fix: align beta component styles with v3 specs

### DIFF
--- a/.changeset/beta-alignment-patch.md
+++ b/.changeset/beta-alignment-patch.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Align beta Tag, Badge, MultiSelect, Section, Select, and DropdownMenu styles with v3 specs.

--- a/packages/bezier-react/src/beta/Badge/Badge.test.tsx
+++ b/packages/bezier-react/src/beta/Badge/Badge.test.tsx
@@ -4,6 +4,7 @@ import { AllIcon } from '@channel.io/bezier-icons'
 
 
 import baseTagBadgeStyles from '~/src/beta/BaseTagBadge/BaseTagBadge.module.scss'
+import { colorTokenCssVar } from '~/src/utils/style'
 import { render } from '~/src/utils/test'
 
 import { Badge } from './Badge'
@@ -32,10 +33,16 @@ describe('Badge', () => {
   })
 
   it('should render icon when icon is given', () => {
-    const { container } = renderBadge({ icon: AllIcon })
+    const { container } = renderBadge({
+      icon: AllIcon,
+      variant: 'blue',
+    })
     const icon = container.querySelector('svg')
 
     expect(icon).toBeInTheDocument()
+    expect(icon).toHaveStyle(
+      `--b-beta-icon-color: ${colorTokenCssVar('icon-accent-blue')}`
+    )
   })
 
   it('should render without text when children is empty', () => {

--- a/packages/bezier-react/src/beta/Badge/Badge.tsx
+++ b/packages/bezier-react/src/beta/Badge/Badge.tsx
@@ -5,9 +5,28 @@ import { forwardRef } from 'react'
 
 import { BaseTagBadge, BaseTagBadgeText } from '~/src/beta/BaseTagBadge'
 import { Icon } from '~/src/beta/Icon'
+import { type BetaIconSemanticColor } from '~/src/types/beta-tokens'
 import { isEmpty } from '~/src/utils/type'
 
-import { type BadgeProps } from './Badge.types'
+import { type BadgeProps, type BadgeVariant } from './Badge.types'
+
+
+const BADGE_ICON_COLOR_BY_VARIANT = {
+  default: 'icon-neutral-heavier',
+  'neutral-light': 'icon-neutral',
+  'neutral-dark': 'icon-absolute-white',
+  blue: 'icon-accent-blue',
+  cobalt: 'icon-accent-cobalt',
+  teal: 'icon-accent-teal',
+  green: 'icon-accent-green',
+  olive: 'icon-accent-olive',
+  pink: 'icon-accent-pink',
+  navy: 'icon-accent-navy',
+  yellow: 'icon-accent-yellow',
+  orange: 'icon-accent-orange',
+  red: 'icon-accent-red',
+  purple: 'icon-accent-purple',
+} satisfies Record<BadgeVariant, BetaIconSemanticColor>
 
 
 /**
@@ -42,6 +61,7 @@ export const Badge = forwardRef<HTMLDivElement, BadgeProps>(function Badge(
         <Icon
           source={icon}
           size={size === 'xs' ? '12' : '16'}
+          color={BADGE_ICON_COLOR_BY_VARIANT[variant]}
         />
       )}
 

--- a/packages/bezier-react/src/beta/BaseSelect/BaseSelect.module.scss
+++ b/packages/bezier-react/src/beta/BaseSelect/BaseSelect.module.scss
@@ -135,13 +135,20 @@
 }
 
 .GroupLabel {
-  padding: 6px 8px 4px;
+  display: flex;
+  align-items: center;
+
+  box-sizing: border-box;
+  height: 32px;
+  padding: 0 8px;
 
   font-family: var(--typography-text-font-family);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
-  line-height: 16px;
+  line-height: 18px;
   color: var(--color-text-neutral-lighter);
+
+  border-radius: var(--radius-8);
 }
 
 .GroupContent {

--- a/packages/bezier-react/src/beta/BaseTagBadge/BaseTagBadge.module.scss
+++ b/packages/bezier-react/src/beta/BaseTagBadge/BaseTagBadge.module.scss
@@ -4,6 +4,7 @@
   align-items: center;
 
   box-sizing: border-box;
+  height: var(--b-tag-badge-height);
   padding: 1px 4px;
 
   color: var(--b-tag-badge-color);
@@ -79,6 +80,22 @@
   &:where(.variant-purple) {
     --b-tag-badge-background-color: var(--color-fill-accent-purple-heavy);
     --b-tag-badge-color: var(--color-text-accent-purple);
+  }
+
+  &:where(.size-xs) {
+    --b-tag-badge-height: 16px;
+  }
+
+  &:where(.size-s) {
+    --b-tag-badge-height: 20px;
+  }
+
+  &:where(.size-m) {
+    --b-tag-badge-height: 22px;
+  }
+
+  &:where(.size-l) {
+    --b-tag-badge-height: 24px;
   }
 }
 

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.module.scss
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.module.scss
@@ -1,3 +1,11 @@
+.Trigger {
+  &:where(:not([aria-disabled='true'])) {
+    &:hover {
+      background-color: var(--color-fill-neutral-lighter);
+    }
+  }
+}
+
 .TriggerContent {
   display: inline-flex;
   gap: 8px;

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.tsx
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.tsx
@@ -7,6 +7,7 @@ import {
   ChevronSmallDownIcon,
   ChevronSmallUpIcon,
 } from '@channel.io/bezier-icons'
+import classNames from 'classnames'
 
 
 
@@ -104,6 +105,7 @@ export const CollapsibleSection = forwardRef<
 })
 
 export function CollapsibleSectionTrigger({
+  className,
   content,
   disabled: disabledProp = false,
   help,
@@ -128,6 +130,7 @@ export function CollapsibleSectionTrigger({
           <SectionLabel
             {...labelProps}
             id={id}
+            className={classNames(styles.Trigger, className)}
             aria-controls={ariaControls}
             aria-expanded={ariaExpanded}
             aria-disabled={ariaDisabled}

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.module.scss
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.module.scss
@@ -36,13 +36,20 @@
 }
 
 .DropdownMenuGroupLabel {
-  padding: 6px 8px 4px;
+  display: flex;
+  align-items: center;
+
+  box-sizing: border-box;
+  height: 32px;
+  padding: 0 8px;
 
   font-family: var(--typography-text-font-family);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
-  line-height: 16px;
+  line-height: 18px;
   color: var(--color-text-neutral-lighter);
+
+  border-radius: var(--radius-8);
 }
 
 .DropdownMenuGroupContent {

--- a/packages/bezier-react/src/beta/MultiSelect/MultiSelect.test.tsx
+++ b/packages/bezier-react/src/beta/MultiSelect/MultiSelect.test.tsx
@@ -1,6 +1,7 @@
 import { TagIcon } from '@channel.io/bezier-icons'
 import userEvent from '@testing-library/user-event'
 
+import baseTagBadgeStyles from '~/src/beta/BaseTagBadge/BaseTagBadge.module.scss'
 import { render } from '~/src/utils/test'
 
 import {
@@ -61,7 +62,7 @@ describe('MultiSelect', () => {
     const user = userEvent.setup()
     const onValueChange = jest.fn()
 
-    const { getAllByRole } = render(
+    const { getAllByRole, getByText } = render(
       <MultiSelect
         value={['sales', 'support']}
         onValueChange={onValueChange}
@@ -77,9 +78,31 @@ describe('MultiSelect', () => {
       </MultiSelect>
     )
 
+    expect(getByText('Sales').parentElement).toHaveClass(
+      baseTagBadgeStyles['size-s']
+    )
+
     await user.click(getAllByRole('button', { name: 'Delete tag' })[0])
 
     expect(onValueChange).toHaveBeenCalledWith(['support'])
+  })
+
+  it('renders selected values with medium tags when trigger size is large', () => {
+    const { getByText } = render(
+      <MultiSelect
+        value={['sales']}
+        triggerSize="l"
+      >
+        <MultiSelectOption
+          value="sales"
+          label="Sales"
+        />
+      </MultiSelect>
+    )
+
+    expect(getByText('Sales').parentElement).toHaveClass(
+      baseTagBadgeStyles['size-m']
+    )
   })
 
   it('keeps the dropdown open when a selected tag is removed from the default trigger', async () => {

--- a/packages/bezier-react/src/beta/MultiSelect/MultiSelect.tsx
+++ b/packages/bezier-react/src/beta/MultiSelect/MultiSelect.tsx
@@ -51,6 +51,12 @@ const SELECT_SELECTED_VALUE_COUNT_GAP = 8
 
 const noop = () => {}
 
+function getMultiSelectTagSize(
+  triggerSize: NonNullable<MultiSelectProps['triggerSize']>
+) {
+  return triggerSize === 'l' ? 'm' : 's'
+}
+
 export const MultiSelect = forwardRef(function MultiSelect<
   Value extends MultiSelectValue,
 >(
@@ -373,6 +379,7 @@ function DefaultMultiSelectTrigger<Value extends MultiSelectValue>({
   const triggerRef = useMergeRefs(
     triggerProps.ref as React.RefCallback<HTMLDivElement>
   )
+  const tagSize = getMultiSelectTagSize(triggerSize)
 
   return (
     <div
@@ -415,7 +422,7 @@ function DefaultMultiSelectTrigger<Value extends MultiSelectValue>({
               {visibleSelectedOptions.map((option) => (
                 <Tag
                   key={option.value}
-                  size={triggerSize === 'l' ? 'l' : 'm'}
+                  size={tagSize}
                   variant="default"
                   onDelete={(event) => {
                     event.preventDefault()
@@ -437,7 +444,7 @@ function DefaultMultiSelectTrigger<Value extends MultiSelectValue>({
                       data-b-select-measure-tag="true"
                     >
                       <Tag
-                        size={triggerSize === 'l' ? 'l' : 'm'}
+                        size={tagSize}
                         variant="default"
                         onDelete={noop}
                       >

--- a/packages/bezier-react/src/beta/Section/Section.module.scss
+++ b/packages/bezier-react/src/beta/Section/Section.module.scss
@@ -10,16 +10,17 @@
 .SectionHeader {
   min-width: 0;
   margin-bottom: 6px;
-  padding: 0 6px;
 }
 
 .SectionLabelRow {
   display: flex;
   align-items: center;
 
+  box-sizing: border-box;
   width: 100%;
   min-width: 0;
-  height: 28px;
+  height: 32px;
+  padding: 0 8px;
 
   &:where([role='button']) {
     cursor: pointer;
@@ -28,12 +29,12 @@
     outline: none;
 
     &:where(:focus-visible) {
-      @include state.focus-ring;
+      @include state.focus-ring($gap: 0);
     }
-  }
 
-  &:where([aria-disabled='true']) {
-    cursor: not-allowed;
+    &:where([aria-disabled='true']) {
+      cursor: not-allowed;
+    }
   }
 }
 


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

closes WEBTECH-8800 WEBTECH-8802 WEBTECH-8803 WEBTECH-8814 WEBTECH-8846

## Summary

Bezier beta 컴포넌트들의 v3 디자인 스펙 정합을 맞췄습니다.

- Tag/Badge size별 높이를 스펙에 맞게 조정했습니다.
- Badge 아이콘 색상이 variant 색상과 맞도록 정리했습니다.
- MultiSelect trigger 내부 선택 Tag가 trigger보다 한 단계 작은 size를 사용하도록 변경했습니다.
- Select, MultiSelect, DropdownMenu의 group label 수치를 BaseGroupLabel 스펙에 맞췄습니다.
- CollapsibleSection trigger hover 배경을 전용 trigger 스타일로 적용하고, Section label의 padding/focus 영역을 정리했습니다.

## Details

Tag와 Badge가 공유하는 `BaseTagBadge`에 size별 고정 높이를 추가했습니다. 이에 맞춰 MultiSelect의 기본 trigger에서는 `m` trigger가 `s` Tag를, `l` trigger가 `m` Tag를 렌더하도록 변경했고, ellipsis 측정용 hidden Tag에도 동일한 size 매핑을 사용하게 했습니다.

Badge는 `Icon`의 기본 색상인 `icon-neutral`을 그대로 쓰고 있어 accent variant에서도 아이콘만 중립색으로 보였습니다. Badge 내부에서 variant별 icon semantic token을 명시적으로 전달해 텍스트와 아이콘의 색상 의도를 맞췄습니다.

Overlay group label은 Figma의 `_BaseGroupLabel` 기준으로 `height: 32px`, `padding: 0 8px`, `font-size: 13px`, `line-height: 18px`, `radius-8`을 적용했습니다.

CollapsibleSection trigger hover는 일반 Section label에 번지지 않도록 CollapsibleSection 전용 class에서만 처리합니다. 또한 Section label row 자체가 Figma 기준의 32px 높이와 내부 padding을 갖도록 정리해 hover/focus 영역과 시각 박스가 일치하도록 했습니다.

### Breaking change? (Yes/No)

No

## References

- Figma `_BaseGroupLabel`: `8751:399`
- 검증:
  - `../../node_modules/.bin/eslint --cache .` (`packages/bezier-react` 기준)
  - `../../node_modules/.bin/stylelint --cache '**/*.scss'` (`packages/bezier-react` 기준, 기존 deprecated token warning만 발생)
  - `../../node_modules/.bin/tsc --noEmit` (`packages/bezier-react` 기준)
  - 관련 Jest 5 suites / 34 tests 통과
