### PR TITLE
feat: add beta base group label

### DIFF
--- a/.changeset/quiet-group-labels.md
+++ b/.changeset/quiet-group-labels.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": minor
+---
+
+Add shared beta BaseGroupLabel styles and expose group label variants across Section, CollapsibleSection, DropdownMenu, Select, and MultiSelect.

--- a/packages/bezier-react/src/beta/BaseGroupLabel/BaseGroupLabel.module.scss
+++ b/packages/bezier-react/src/beta/BaseGroupLabel/BaseGroupLabel.module.scss
@@ -1,0 +1,55 @@
+.BaseGroupLabel {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  height: 32px;
+  padding: 0 8px;
+
+  color: var(--b-beta-base-group-label-color);
+
+  border-radius: var(--radius-8);
+}
+
+.variant-neutral-dark {
+  --b-beta-base-group-label-color: var(--color-text-neutral);
+}
+
+.variant-neutral-light {
+  --b-beta-base-group-label-color: var(--color-text-neutral-lighter);
+}
+
+.MainContent {
+  display: inline-flex;
+  flex: 1 1 auto;
+  gap: 8px;
+  align-items: center;
+
+  min-width: 0;
+}
+
+.Content {
+  min-width: 0;
+  max-width: 200px;
+  margin: 0;
+}
+
+.Help {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+}
+
+.TrailingContent {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+
+  margin-left: auto;
+
+  color: var(--b-beta-base-group-label-color);
+  white-space: nowrap;
+}

--- a/packages/bezier-react/src/beta/BaseGroupLabel/BaseGroupLabel.test.tsx
+++ b/packages/bezier-react/src/beta/BaseGroupLabel/BaseGroupLabel.test.tsx
@@ -1,0 +1,60 @@
+import { HELP_TEST_ID } from '~/src/beta/Help/Help'
+import { render } from '~/src/utils/test'
+
+import { BaseGroupLabel } from './BaseGroupLabel'
+
+import styles from './BaseGroupLabel.module.scss'
+
+describe('BaseGroupLabel', () => {
+  it('renders neutral-dark variant by default', () => {
+    const { getByText } = render(<BaseGroupLabel content="General" />)
+
+    expect(getByText('General').parentElement?.parentElement).toHaveClass(
+      styles['variant-neutral-dark']
+    )
+  })
+
+  it('renders neutral-light variant', () => {
+    const { getByText } = render(
+      <BaseGroupLabel
+        content="General"
+        variant="neutral-light"
+      />
+    )
+
+    expect(getByText('General').parentElement?.parentElement).toHaveClass(
+      styles['variant-neutral-light']
+    )
+  })
+
+  it('renders help and trailing content', () => {
+    const { getByTestId, getByText } = render(
+      <BaseGroupLabel
+        content="General"
+        help="Help content"
+        trailingContent="Optional"
+      />
+    )
+
+    expect(getByText('General')).toBeInTheDocument()
+    expect(getByText('Optional')).toBeInTheDocument()
+    expect(getByTestId(HELP_TEST_ID)).toBeInTheDocument()
+  })
+
+  it('forwards root props and content id', () => {
+    const ref = jest.fn()
+    const { getByTestId, getByText } = render(
+      <BaseGroupLabel
+        ref={ref}
+        data-testid="group-label"
+        className="custom-class"
+        content="General"
+        contentId="group-label-content"
+      />
+    )
+
+    expect(getByTestId('group-label')).toHaveClass('custom-class')
+    expect(getByText('General')).toHaveAttribute('id', 'group-label-content')
+    expect(ref).toHaveBeenCalled()
+  })
+})

--- a/packages/bezier-react/src/beta/BaseGroupLabel/BaseGroupLabel.tsx
+++ b/packages/bezier-react/src/beta/BaseGroupLabel/BaseGroupLabel.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { forwardRef } from 'react'
+
+import classNames from 'classnames'
+
+import { Help } from '~/src/beta/Help'
+import { Text } from '~/src/beta/Text'
+
+import type {
+  BaseGroupLabelProps,
+  BaseGroupLabelVariant,
+} from './BaseGroupLabel.types'
+
+import styles from './BaseGroupLabel.module.scss'
+
+function getTextColor(variant: BaseGroupLabelVariant) {
+  return variant === 'neutral-dark' ? 'text-neutral' : 'text-neutral-lighter'
+}
+
+export const BaseGroupLabel = forwardRef<HTMLDivElement, BaseGroupLabelProps>(
+  function BaseGroupLabel(
+    {
+      className,
+      content,
+      contentAs = 'span',
+      contentId,
+      help,
+      trailingContent,
+      variant = 'neutral-dark',
+      ...rest
+    },
+    forwardedRef
+  ) {
+    return (
+      <div
+        ref={forwardedRef}
+        className={classNames(
+          styles.BaseGroupLabel,
+          styles[`variant-${variant}`],
+          className
+        )}
+        {...rest}
+      >
+        <div className={styles.MainContent}>
+          {typeof content === 'string' ? (
+            <Text
+              id={contentId}
+              as={contentAs}
+              className={styles.Content}
+              typo="13"
+              color={getTextColor(variant)}
+              bold
+              truncated
+            >
+              {content}
+            </Text>
+          ) : (
+            <div
+              id={contentId}
+              className={styles.Content}
+            >
+              {content}
+            </div>
+          )}
+
+          {help != null && (
+            <div className={styles.Help}>
+              <Help>{help}</Help>
+            </div>
+          )}
+        </div>
+
+        {trailingContent != null && (
+          <div className={styles.TrailingContent}>{trailingContent}</div>
+        )}
+      </div>
+    )
+  }
+)

--- a/packages/bezier-react/src/beta/BaseGroupLabel/BaseGroupLabel.types.ts
+++ b/packages/bezier-react/src/beta/BaseGroupLabel/BaseGroupLabel.types.ts
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react'
+
+import type { TextProps } from '~/src/beta/Text'
+import type { BezierComponentProps, ContentProps } from '~/src/types/props'
+
+export type BaseGroupLabelVariant = 'neutral-dark' | 'neutral-light'
+
+interface BaseGroupLabelOwnProps extends ContentProps<ReactNode> {
+  /**
+   * Visual variant of the group label.
+   * @default 'neutral-dark'
+   */
+  variant?: BaseGroupLabelVariant
+  /**
+   * Primary visible content of the group label.
+   */
+  content: ReactNode
+  /**
+   * Tooltip content rendered next to the group label.
+   */
+  help?: ReactNode
+  /**
+   * Content rendered at the end of the group label.
+   */
+  trailingContent?: ReactNode
+  /**
+   * Element type used when `content` is a string.
+   * @default 'span'
+   */
+  contentAs?: TextProps['as']
+  /**
+   * id applied to the primary content element.
+   */
+  contentId?: string
+}
+
+export interface BaseGroupLabelProps
+  extends Omit<
+      BezierComponentProps<'div'>,
+      keyof BaseGroupLabelOwnProps | 'children'
+    >,
+    BaseGroupLabelOwnProps {}

--- a/packages/bezier-react/src/beta/BaseGroupLabel/index.ts
+++ b/packages/bezier-react/src/beta/BaseGroupLabel/index.ts
@@ -1,0 +1,5 @@
+export { BaseGroupLabel } from './BaseGroupLabel'
+export type {
+  BaseGroupLabelProps,
+  BaseGroupLabelVariant,
+} from './BaseGroupLabel.types'

--- a/packages/bezier-react/src/beta/BaseSelect/BaseSelect.module.scss
+++ b/packages/bezier-react/src/beta/BaseSelect/BaseSelect.module.scss
@@ -134,23 +134,6 @@
   width: 100%;
 }
 
-.GroupLabel {
-  display: flex;
-  align-items: center;
-
-  box-sizing: border-box;
-  height: 32px;
-  padding: 0 8px;
-
-  font-family: var(--typography-text-font-family);
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 18px;
-  color: var(--color-text-neutral-lighter);
-
-  border-radius: var(--radius-8);
-}
-
 .GroupContent {
   display: flex;
   flex-direction: column;

--- a/packages/bezier-react/src/beta/BaseSelect/BaseSelect.tsx
+++ b/packages/bezier-react/src/beta/BaseSelect/BaseSelect.tsx
@@ -20,6 +20,7 @@ import classNames from 'classnames'
 
 
 
+import { BaseGroupLabel } from '~/src/beta/BaseGroupLabel'
 import { BaseItem } from '~/src/beta/BaseItem/BaseItem'
 import { useFormFieldProps } from '~/src/beta/Form'
 import { Overlay } from '~/src/beta/Overlay'
@@ -604,7 +605,7 @@ function BaseSelectOptionElement<Value extends SelectValue>({
 
 export const BaseSelectGroup = forwardRef<HTMLDivElement, SelectGroupProps>(
   function BaseSelectGroup(
-    { children, className, label, ...rest },
+    { children, className, label, variant = 'neutral-light', ...rest },
     forwardedRef
   ) {
     const generatedId = useId()
@@ -617,12 +618,11 @@ export const BaseSelectGroup = forwardRef<HTMLDivElement, SelectGroupProps>(
         aria-labelledby={generatedId}
         {...rest}
       >
-        <div
-          id={generatedId}
-          className={styles.GroupLabel}
-        >
-          {label}
-        </div>
+        <BaseGroupLabel
+          content={label}
+          contentId={generatedId}
+          variant={variant}
+        />
         <div className={styles.GroupContent}>{children}</div>
       </div>
     )

--- a/packages/bezier-react/src/beta/BaseSelect/BaseSelect.types.ts
+++ b/packages/bezier-react/src/beta/BaseSelect/BaseSelect.types.ts
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 
 import type { BezierIcon } from '@channel.io/bezier-icons'
 
+import type { BaseGroupLabelVariant } from '~/src/beta/BaseGroupLabel'
 import type { OverlayPosition } from '~/src/beta/Overlay'
 import type {
   BezierComponentProps,
@@ -208,6 +209,11 @@ export interface BaseSelectGroupProps
    * option keyboard navigation or selection.
    */
   label: string
+  /**
+   * Visual variant of the group label.
+   * @default 'neutral-light'
+   */
+  variant?: BaseGroupLabelVariant
 }
 
 export interface BaseSelectTriggerRenderProps<

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.module.scss
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.module.scss
@@ -6,15 +6,18 @@
   }
 }
 
-.TriggerContent {
+.TriggerTrailingContent {
   display: inline-flex;
   gap: 8px;
   align-items: center;
   min-width: 0;
 }
 
-.TriggerLabel {
-  min-width: 0;
+.TriggerTrailingIcon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--color-icon-neutral-heavy);
 }
 
 .TriggerChevron {

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.stories.tsx
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.stories.tsx
@@ -2,8 +2,6 @@ import { useState } from 'react'
 
 import {
   ChevronSmallRightIcon,
-  InfoIcon,
-  PlusIcon,
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
@@ -52,7 +50,6 @@ export const Primary: Story = {
       <CollapsibleSection defaultOpen>
         <CollapsibleSectionTrigger
           content="General"
-          leadingContent={InfoIcon}
           help="These settings apply to the section."
         />
         <CollapsibleSectionItem
@@ -81,7 +78,6 @@ export const RichLabel: Story = {
     <Box width={360}>
       <CollapsibleSection defaultOpen>
         <CollapsibleSectionTrigger
-          leadingContent={PlusIcon}
           help="Help text"
           content="Trigger"
           trailingContent={ChevronSmallRightIcon}

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.test.tsx
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.test.tsx
@@ -115,4 +115,23 @@ describe('CollapsibleSection', () => {
 
     expect(onClick).toHaveBeenCalledTimes(1)
   })
+
+  it('renders trailing content with the trigger chevron', () => {
+    const { container, getByRole, getByText } = render(
+      <CollapsibleSection defaultOpen>
+        <CollapsibleSectionTrigger
+          content="General"
+          trailingContent="Optional"
+        />
+        <SectionItem content="Profile" />
+      </CollapsibleSection>
+    )
+
+    expect(getByRole('button', { name: /General/ })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+    expect(getByText('Optional')).toBeInTheDocument()
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+  })
 })

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.tsx
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.tsx
@@ -6,6 +6,7 @@ import * as React from 'react'
 import {
   ChevronSmallDownIcon,
   ChevronSmallUpIcon,
+  isBezierIcon,
 } from '@channel.io/bezier-icons'
 import classNames from 'classnames'
 
@@ -16,9 +17,8 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '~/src/beta/Collapsible'
-import { Help } from '~/src/beta/Help'
 import { Section, SectionItem, SectionLabel } from '~/src/beta/Section'
-import { Text } from '~/src/beta/Text'
+import type { SectionLabelSideContent } from '~/src/beta/Section/Section.types'
 
 import type {
   CollapsibleSectionItemProps,
@@ -70,6 +70,25 @@ function splitCollapsibleSectionChildren(children: React.ReactNode) {
   )
 }
 
+function CollapsibleSectionTriggerTrailingContentElement({
+  content,
+}: {
+  content: SectionLabelSideContent
+}) {
+  if (isBezierIcon(content)) {
+    const SourceElement = content
+
+    return (
+      <SourceElement
+        className={styles.TriggerTrailingIcon}
+        aria-hidden
+      />
+    )
+  }
+
+  return content
+}
+
 export const CollapsibleSection = forwardRef<
   HTMLElement,
   CollapsibleSectionProps
@@ -110,6 +129,7 @@ export function CollapsibleSectionTrigger({
   disabled: disabledProp = false,
   help,
   trailingContent,
+  variant = 'neutral-dark',
   ...labelProps
 }: CollapsibleSectionTriggerProps) {
   return (
@@ -125,6 +145,8 @@ export function CollapsibleSectionTrigger({
           'data-state': dataState,
           'data-active': dataActive,
         } = triggerProps
+        const ChevronIcon =
+          dataState === 'open' ? ChevronSmallUpIcon : ChevronSmallDownIcon
 
         return (
           <SectionLabel
@@ -136,37 +158,22 @@ export function CollapsibleSectionTrigger({
             aria-disabled={ariaDisabled}
             data-state={dataState}
             data-active={dataActive}
-            content={
-              <span className={styles.TriggerContent}>
-                {typeof content === 'string' ? (
-                  <Text
-                    as="span"
-                    className={styles.TriggerLabel}
-                    typo="13"
-                    color="text-neutral-lighter"
-                    bold
-                    truncated
-                  >
-                    {content}
-                  </Text>
-                ) : (
-                  <span className={styles.TriggerLabel}>{content}</span>
-                )}
-                {help != null && <Help>{help}</Help>}
-                {dataState === 'open' ? (
-                  <ChevronSmallUpIcon
-                    className={styles.TriggerChevron}
-                    aria-hidden
-                  />
-                ) : (
-                  <ChevronSmallDownIcon
-                    className={styles.TriggerChevron}
-                    aria-hidden
+            content={content}
+            help={help}
+            variant={variant}
+            trailingContent={
+              <span className={styles.TriggerTrailingContent}>
+                {trailingContent != null && (
+                  <CollapsibleSectionTriggerTrailingContentElement
+                    content={trailingContent}
                   />
                 )}
+                <ChevronIcon
+                  className={styles.TriggerChevron}
+                  aria-hidden
+                />
               </span>
             }
-            trailingContent={trailingContent}
             role="button"
             tabIndex={disabled ? -1 : 0}
             onClick={(event: React.MouseEvent<HTMLElement>) => {

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.module.scss
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.module.scss
@@ -35,23 +35,6 @@
   width: 100%;
 }
 
-.DropdownMenuGroupLabel {
-  display: flex;
-  align-items: center;
-
-  box-sizing: border-box;
-  height: 32px;
-  padding: 0 8px;
-
-  font-family: var(--typography-text-font-family);
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 18px;
-  color: var(--color-text-neutral-lighter);
-
-  border-radius: var(--radius-8);
-}
-
 .DropdownMenuGroupContent {
   display: flex;
   flex-direction: column;

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
@@ -6,6 +6,7 @@ import { act, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 
+import baseGroupLabelStyles from '~/src/beta/BaseGroupLabel/BaseGroupLabel.module.scss'
 import { Button } from '~/src/beta/Button'
 import { IconButton } from '~/src/beta/IconButton'
 import { OVERLAY_TEST_ID } from '~/src/beta/Overlay/Overlay'
@@ -385,13 +386,19 @@ describe('DropdownMenu', () => {
           <DropdownMenuItem content="Edit" />
           <DropdownMenuItem content="Archive" />
         </DropdownMenuGroup>
-        <DropdownMenuGroup label="Danger zone">
+        <DropdownMenuGroup
+          label="Danger zone"
+          variant="neutral-dark"
+        >
           <DropdownMenuItem content="Delete" />
         </DropdownMenuGroup>
       </DropdownMenu>
     )
 
     expect(getByRole('group', { name: 'File' })).toBeInTheDocument()
+    expect(getByRole('group', { name: 'Danger zone' }).firstChild).toHaveClass(
+      baseGroupLabelStyles['variant-neutral-dark']
+    )
     expect(getAllByRole('menuitem')).toHaveLength(3)
 
     getByRole('menuitem', { name: 'Archive' }).focus()

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
@@ -21,6 +21,7 @@ import classNames from 'classnames'
 
 
 
+import { BaseGroupLabel } from '~/src/beta/BaseGroupLabel'
 import { BaseItem } from '~/src/beta/BaseItem/BaseItem'
 import { Divider } from '~/src/beta/Divider'
 import { Overlay } from '~/src/beta/Overlay'
@@ -519,7 +520,7 @@ export const DropdownMenuGroup = forwardRef<
   HTMLDivElement,
   DropdownMenuGroupProps
 >(function DropdownMenuGroup(
-  { children, className, label, ...rest },
+  { children, className, label, variant = 'neutral-light', ...rest },
   forwardedRef
 ) {
   const generatedId = useId()
@@ -532,12 +533,11 @@ export const DropdownMenuGroup = forwardRef<
       aria-labelledby={generatedId}
       {...rest}
     >
-      <div
-        id={generatedId}
-        className={styles.DropdownMenuGroupLabel}
-      >
-        {label}
-      </div>
+      <BaseGroupLabel
+        content={label}
+        contentId={generatedId}
+        variant={variant}
+      />
       <div className={styles.DropdownMenuGroupContent}>{children}</div>
     </div>
   )

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.types.ts
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.types.ts
@@ -2,6 +2,7 @@ import type { ReactElement, ReactNode } from 'react'
 
 import type { BezierIcon } from '@channel.io/bezier-icons'
 
+import type { BaseGroupLabelVariant } from '~/src/beta/BaseGroupLabel'
 import type { BaseItemVariant } from '~/src/beta/BaseItem/BaseItem.types'
 import type { OverlayPosition, OverlayTarget } from '~/src/beta/Overlay'
 import type {
@@ -202,6 +203,11 @@ export interface DropdownMenuGroupProps
    * item keyboard navigation or selection.
    */
   label: string
+  /**
+   * Visual variant of the group label.
+   * @default 'neutral-light'
+   */
+  variant?: BaseGroupLabelVariant
 }
 
 export interface DropdownMenuSeparatorProps

--- a/packages/bezier-react/src/beta/MultiSelect/MultiSelect.test.tsx
+++ b/packages/bezier-react/src/beta/MultiSelect/MultiSelect.test.tsx
@@ -1,6 +1,7 @@
 import { TagIcon } from '@channel.io/bezier-icons'
 import userEvent from '@testing-library/user-event'
 
+import baseGroupLabelStyles from '~/src/beta/BaseGroupLabel/BaseGroupLabel.module.scss'
 import baseTagBadgeStyles from '~/src/beta/BaseTagBadge/BaseTagBadge.module.scss'
 import { render } from '~/src/utils/test'
 
@@ -393,7 +394,10 @@ describe('MultiSelect', () => {
         value={['sales']}
         defaultShow
       >
-        <MultiSelectGroup label="Teams">
+        <MultiSelectGroup
+          label="Teams"
+          variant="neutral-dark"
+        >
           <MultiSelectOption
             value="sales"
             label="Sales"
@@ -407,6 +411,9 @@ describe('MultiSelect', () => {
     )
 
     expect(getByRole('group', { name: 'Teams' })).toBeInTheDocument()
+    expect(getByRole('group', { name: 'Teams' }).firstChild).toHaveClass(
+      baseGroupLabelStyles['variant-neutral-dark']
+    )
     expect(getByRole('button', { name: 'Delete tag' })).toBeInTheDocument()
     expect(getByRole('combobox')).toHaveTextContent('Sales')
     expect(getAllByRole('option')).toHaveLength(2)

--- a/packages/bezier-react/src/beta/Section/Section.module.scss
+++ b/packages/bezier-react/src/beta/Section/Section.module.scss
@@ -12,20 +12,10 @@
   margin-bottom: 6px;
 }
 
-.SectionLabelRow {
-  display: flex;
-  align-items: center;
-
-  box-sizing: border-box;
-  width: 100%;
-  min-width: 0;
-  height: 32px;
-  padding: 0 8px;
-
+.SectionLabel {
   &:where([role='button']) {
     cursor: pointer;
     user-select: none;
-    border-radius: var(--radius-8);
     outline: none;
 
     &:where(:focus-visible) {
@@ -38,45 +28,11 @@
   }
 }
 
-.SectionLabel {
-  min-width: 0;
-}
-
 .LabelIcon {
   flex-shrink: 0;
   width: 16px;
   height: 16px;
   color: var(--color-icon-neutral-heavy);
-}
-
-.SectionHeading {
-  min-width: 0;
-  margin: 0;
-}
-
-.SectionLabelLeadingContent {
-  display: flex;
-  flex-shrink: 0;
-  align-items: center;
-  margin-right: 6px;
-}
-
-.SectionHelp {
-  display: flex;
-  flex-shrink: 0;
-  align-items: center;
-  margin-left: 8px;
-}
-
-.SectionLabelTrailingContent {
-  display: flex;
-  flex-shrink: 0;
-  align-items: center;
-
-  margin-left: auto;
-
-  color: var(--color-text-neutral-light);
-  white-space: nowrap;
 }
 
 .SectionBody {

--- a/packages/bezier-react/src/beta/Section/Section.stories.tsx
+++ b/packages/bezier-react/src/beta/Section/Section.stories.tsx
@@ -61,7 +61,6 @@ export const WithHelp: Story = {
       <Section>
         <SectionLabel
           content="Assignment"
-          leadingContent={InfoIcon}
           trailingContent={
             <Text
               typo="12"
@@ -160,7 +159,6 @@ export const RichLabel: Story = {
     <Box width={360}>
       <Section>
         <SectionLabel
-          leadingContent={PlusIcon}
           help="Help text"
           content="Label"
           trailingContent={ChevronSmallRightIcon}

--- a/packages/bezier-react/src/beta/Section/Section.test.tsx
+++ b/packages/bezier-react/src/beta/Section/Section.test.tsx
@@ -3,6 +3,7 @@ import { waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 
+import { HELP_TEST_ID } from '~/src/beta/Help/Help'
 import textStyles from '~/src/beta/Text/Text.module.scss'
 import { render } from '~/src/utils/test'
 
@@ -33,12 +34,11 @@ describe('Section', () => {
     expect(getByText('Profile')).toBeInTheDocument()
   })
 
-  it('renders label side content and help', () => {
-    const { container, getByTestId, getByText } = render(
+  it('renders label trailing content and help', () => {
+    const { getByTestId, getByText } = render(
       <Section>
         <SectionLabel
           content="General"
-          leadingContent={CheckIcon}
           trailingContent="Optional"
           help="Help content"
         />
@@ -47,7 +47,7 @@ describe('Section', () => {
 
     expect(getByTestId(SECTION_TEST_ID)).toBeInTheDocument()
     expect(getByText('Optional')).toBeInTheDocument()
-    expect(container.querySelectorAll('svg')).toHaveLength(2)
+    expect(getByTestId(HELP_TEST_ID)).toBeInTheDocument()
   })
 
   it('preserves an explicit aria-labelledby value', () => {

--- a/packages/bezier-react/src/beta/Section/Section.tsx
+++ b/packages/bezier-react/src/beta/Section/Section.tsx
@@ -8,8 +8,8 @@ import classNames from 'classnames'
 
 
 
+import { BaseGroupLabel } from '~/src/beta/BaseGroupLabel'
 import { BaseItem } from '~/src/beta/BaseItem/BaseItem'
-import { Help } from '~/src/beta/Help'
 import { Text } from '~/src/beta/Text'
 import {
   getMarginStyles,
@@ -148,9 +148,9 @@ export const SectionLabel = forwardRef<HTMLDivElement, SectionLabelProps>(
     {
       className,
       content,
-      leadingContent,
       trailingContent,
       help,
+      variant,
       ...rest
     },
     forwardedRef
@@ -161,51 +161,22 @@ export const SectionLabel = forwardRef<HTMLDivElement, SectionLabelProps>(
 
     return (
       <div className={styles.SectionHeader}>
-        <div
+        <BaseGroupLabel
           ref={forwardedRef}
-          className={classNames(styles.SectionLabelRow, className)}
+          className={classNames(styles.SectionLabel, className)}
           data-testid={SECTION_LABEL_TEST_ID}
-          {...rest}
-        >
-          {leadingContent != null && (
-            <div className={styles.SectionLabelLeadingContent}>
-              <SectionLabelSideContentElement content={leadingContent} />
-            </div>
-          )}
-
-          {typeof content === 'string' ? (
-            <Text
-              id={labelId}
-              as="h3"
-              className={styles.SectionHeading}
-              typo="13"
-              color="text-neutral-lighter"
-              bold
-              truncated
-            >
-              {content}
-            </Text>
-          ) : (
-            <div
-              id={labelId}
-              className={styles.SectionLabel}
-            >
-              {content}
-            </div>
-          )}
-
-          {help != null && (
-            <div className={styles.SectionHelp}>
-              <Help>{help}</Help>
-            </div>
-          )}
-
-          {trailingContent != null && (
-            <div className={styles.SectionLabelTrailingContent}>
+          content={content}
+          contentAs="h3"
+          contentId={labelId}
+          help={help}
+          trailingContent={
+            trailingContent != null ? (
               <SectionLabelSideContentElement content={trailingContent} />
-            </div>
-          )}
-        </div>
+            ) : undefined
+          }
+          variant={variant}
+          {...rest}
+        />
       </div>
     )
   }

--- a/packages/bezier-react/src/beta/Section/Section.types.ts
+++ b/packages/bezier-react/src/beta/Section/Section.types.ts
@@ -2,6 +2,7 @@ import type { MouseEventHandler, ReactNode } from 'react'
 
 import type { BezierIcon } from '@channel.io/bezier-icons'
 
+import type { BaseGroupLabelVariant } from '~/src/beta/BaseGroupLabel'
 import type {
   ActivatableProps,
   BezierComponentProps,
@@ -16,9 +17,12 @@ export type SectionItemSideContent = BezierIcon | ReactNode
 
 export type SectionLabelSideContent = BezierIcon | ReactNode
 
-interface SectionLabelOwnProps
-  extends ContentProps<ReactNode>,
-    LeadingTrailingContentProps<SectionLabelSideContent> {
+interface SectionLabelOwnProps extends ContentProps<ReactNode> {
+  /**
+   * Visual variant of the section label.
+   * @default 'neutral-dark'
+   */
+  variant?: BaseGroupLabelVariant
   /**
    * Primary visible content of the section label.
    */
@@ -27,6 +31,10 @@ interface SectionLabelOwnProps
    * Tooltip content rendered next to the section label.
    */
   help?: ReactNode
+  /**
+   * Content rendered at the end of the section label.
+   */
+  trailingContent?: SectionLabelSideContent
 }
 
 interface SectionItemContentProps extends ContentProps<ReactNode> {

--- a/packages/bezier-react/src/beta/Select/Select.test.tsx
+++ b/packages/bezier-react/src/beta/Select/Select.test.tsx
@@ -2,6 +2,7 @@ import { PeopleIcon } from '@channel.io/bezier-icons'
 import { waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import baseGroupLabelStyles from '~/src/beta/BaseGroupLabel/BaseGroupLabel.module.scss'
 import { render } from '~/src/utils/test'
 
 import { Select, SelectGroup, SelectOption, SelectTrigger } from './'
@@ -110,7 +111,10 @@ describe('Select', () => {
             label="Email"
           />
         </SelectGroup>
-        <SelectGroup label="Broadcast">
+        <SelectGroup
+          label="Broadcast"
+          variant="neutral-dark"
+        >
           <SelectOption
             value="sms"
             label="SMS"
@@ -120,6 +124,9 @@ describe('Select', () => {
     )
 
     expect(getByRole('group', { name: 'Messaging' })).toBeInTheDocument()
+    expect(getByRole('group', { name: 'Broadcast' }).firstChild).toHaveClass(
+      baseGroupLabelStyles['variant-neutral-dark']
+    )
     expect(getAllByRole('option')).toHaveLength(3)
 
     await user.keyboard('{ArrowDown}')


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: 해당 없음
  - macOS: 해당 없음

## Related Issue

close web-11930

## Summary

`Section`, `CollapsibleSection`, `DropdownMenu`, `Select`, `MultiSelect`에서 사용하던 그룹 라벨 UI를 내부 `BaseGroupLabel` 기반으로 통합했습니다.

## Details

- 내부 전용 `BaseGroupLabel`을 추가하고 `neutral-dark`, `neutral-light` variant를 지원했습니다.
- `SectionLabel`은 `BaseGroupLabel`을 사용하도록 변경하고 정책에 맞춰 `leadingContent`를 제거했습니다.
- `CollapsibleSectionTrigger`는 기본 group label variant를 `neutral-dark`로 명시하고, trigger 역할의 chevron이 사용자 `trailingContent`와 함께 공존하도록 분리했습니다.
- `DropdownMenuGroup`, `SelectGroup`, `MultiSelectGroup`에는 group label `variant` prop을 추가하고 기본값을 `neutral-light`로 유지했습니다.
- 중복되어 있던 overlay group label 스타일을 제거하고 공통 스타일을 사용하도록 정리했습니다.
- release note 반영을 위해 changeset을 추가했습니다.

### Breaking change? (Yes/No)

Yes

Beta `SectionLabel`의 `leadingContent` prop을 제거했습니다. 섹션 라벨의 leading 영역은 디자인 정책상 더 이상 지원하지 않으며, 후행 액션/표시는 `trailingContent`를 사용해야 합니다.

## References

- 검증
  - `PATH=/Users/timo/.nvm/versions/node/v22.12.0/bin:$PATH ../../node_modules/.bin/tsc --noEmit`
  - `PATH=/Users/timo/.nvm/versions/node/v22.12.0/bin:$PATH ../../node_modules/.bin/jest BaseGroupLabel Section CollapsibleSection DropdownMenu Select MultiSelect --runInBand`
  - `PATH=/Users/timo/.nvm/versions/node/v22.12.0/bin:$PATH ../../node_modules/.bin/eslint --cache .`
  - `PATH=/Users/timo/.nvm/versions/node/v22.12.0/bin:$PATH ../../node_modules/.bin/stylelint --cache '**/*.scss'`

`stylelint`는 기존 `src/components/*` deprecated token warning 28개만 출력했고, 에러는 없었습니다.
