### PR TITLE
fix: align beta input spacing and collapsible section chevron

### DIFF
--- a/.changeset/web-input-section-layout.md
+++ b/.changeset/web-input-section-layout.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Align beta input/select spacing with the BaseInput spec and place the `CollapsibleSection` chevron next to the trigger label.

--- a/packages/bezier-react/src/beta/BaseSelect/BaseSelect.module.scss
+++ b/packages/bezier-react/src/beta/BaseSelect/BaseSelect.module.scss
@@ -13,7 +13,7 @@
   cursor: pointer;
 
   display: flex;
-  gap: 6px;
+  gap: 8px;
   align-items: center;
 
   box-sizing: border-box;

--- a/packages/bezier-react/src/beta/BaseTextInput/BaseTextInput.module.scss
+++ b/packages/bezier-react/src/beta/BaseTextInput/BaseTextInput.module.scss
@@ -9,6 +9,7 @@
 
   overflow: hidden;
   display: flex;
+  gap: 8px;
   align-items: center;
 
   box-sizing: border-box;
@@ -128,12 +129,5 @@
   display: flex;
   flex: 0 0 auto;
   align-items: center;
-}
-
-.LeadingSlot {
-  padding-right: 6px;
-}
-
-.TrailingSlot {
-  padding-right: 2px;
+  justify-content: center;
 }

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.module.scss
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.module.scss
@@ -6,10 +6,39 @@
   }
 }
 
-.TriggerTrailingContent {
+.TriggerContent {
+  overflow: hidden;
   display: inline-flex;
+  flex: 0 1 auto;
   gap: 8px;
   align-items: center;
+
+  min-width: 0;
+}
+
+.TriggerMainContent {
+  overflow: hidden;
+
+  min-width: 0;
+
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 18px;
+  color: inherit;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.TriggerHelp,
+.TriggerContentSuffix,
+.TriggerTrailingContent {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+}
+
+.TriggerTrailingContent {
+  gap: 8px;
   min-width: 0;
 }
 

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.stories.tsx
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.stories.tsx
@@ -1,10 +1,7 @@
 import { useState } from 'react'
 
-import {
-  ChevronSmallRightIcon,
-} from '@channel.io/bezier-icons'
+import { ChevronSmallRightIcon, PlusIcon } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
-
 
 import { Box } from '~/src/beta/Box'
 import { Text } from '~/src/beta/Text'
@@ -14,7 +11,6 @@ import {
   CollapsibleSectionItem,
   CollapsibleSectionTrigger,
 } from './CollapsibleSection'
-
 
 const meta: Meta<typeof CollapsibleSection> = {
   title: 'Beta components/CollapsibleSection',
@@ -80,7 +76,7 @@ export const RichLabel: Story = {
         <CollapsibleSectionTrigger
           help="Help text"
           content="Trigger"
-          trailingContent={ChevronSmallRightIcon}
+          trailingContent={PlusIcon}
         />
         <CollapsibleSectionItem
           content="Profile"

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.test.tsx
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.test.tsx
@@ -11,6 +11,8 @@ import {
   CollapsibleSectionTrigger,
 } from './CollapsibleSection'
 
+import styles from './CollapsibleSection.module.scss'
+
 
 describe('CollapsibleSection', () => {
   it('renders a labelled collapsible section', async () => {
@@ -132,6 +134,11 @@ describe('CollapsibleSection', () => {
       'true'
     )
     expect(getByText('Optional')).toBeInTheDocument()
-    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+    expect(getByText('Optional')).toHaveClass(styles.TriggerTrailingContent)
+
+    const chevron = container.querySelector('svg')
+
+    expect(chevron).toHaveAttribute('aria-hidden', 'true')
+    expect(chevron?.parentElement).toHaveClass(styles.TriggerContentSuffix)
   })
 })

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.tsx
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.tsx
@@ -17,6 +17,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '~/src/beta/Collapsible'
+import { Help } from '~/src/beta/Help'
 import { Section, SectionItem, SectionLabel } from '~/src/beta/Section'
 import type { SectionLabelSideContent } from '~/src/beta/Section/Section.types'
 
@@ -158,21 +159,31 @@ export function CollapsibleSectionTrigger({
             aria-disabled={ariaDisabled}
             data-state={dataState}
             data-active={dataActive}
-            content={content}
-            help={help}
+            content={
+              <span className={styles.TriggerContent}>
+                <span className={styles.TriggerMainContent}>{content}</span>
+                {help != null && (
+                  <span className={styles.TriggerHelp}>
+                    <Help>{help}</Help>
+                  </span>
+                )}
+                <span className={styles.TriggerContentSuffix}>
+                  <ChevronIcon
+                    className={styles.TriggerChevron}
+                    aria-hidden
+                  />
+                </span>
+              </span>
+            }
             variant={variant}
             trailingContent={
-              <span className={styles.TriggerTrailingContent}>
-                {trailingContent != null && (
+              trailingContent != null ? (
+                <span className={styles.TriggerTrailingContent}>
                   <CollapsibleSectionTriggerTrailingContentElement
                     content={trailingContent}
                   />
-                )}
-                <ChevronIcon
-                  className={styles.TriggerChevron}
-                  aria-hidden
-                />
-              </span>
+                </span>
+              ) : undefined
             }
             role="button"
             tabIndex={disabled ? -1 : 0}

--- a/packages/bezier-react/src/beta/Search/Search.module.scss
+++ b/packages/bezier-react/src/beta/Search/Search.module.scss
@@ -1,8 +1,6 @@
 .Search {
   --b-beta-text-input-background-color: var(--color-fill-grey);
   --b-beta-text-input-radius: var(--radius-12);
-
-  gap: 6px;
 }
 
 .SearchIcon {
@@ -18,8 +16,8 @@
   align-items: center;
   justify-content: center;
 
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
 
   color: var(--color-icon-neutral);
 


### PR DESCRIPTION
## Self Checklist

- [x] PR 제목을 **영어**로 작성했고, 적절한 **label**은 필요 시 추가할 예정입니다.
- [x] 커밋 메시지를 **영어**와 [**Conventional Commits 명세**](https://www.conventionalcommits.org/en/v1.0.0/)에 맞춰 작성했습니다.
- [x] 릴리즈가 필요한 변경에 대한 **changeset**을 추가했습니다.
- [x] 문서 변경은 필요하지 않습니다.
- [x] 관련 테스트를 추가/수정했습니다.
- [ ] 브라우저별 수동 테스트는 아직 진행하지 않았습니다.
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

close WEB-12011 WEB-12001

## Summary

`CollapsibleSection` trigger의 chevron을 라벨 바로 옆에 배치하고, beta input/select 계열의 gap을 Figma BaseInput 스펙에 맞춰 정리했습니다.

## Details

- `CollapsibleSectionTrigger`에서 chevron을 사용자 `trailingContent`와 분리했습니다.
- chevron은 trigger label/help 바로 뒤에 렌더링되고, 사용자 `trailingContent`는 기존처럼 우측 trailing 영역에 남습니다.
- `BaseTextInput`의 leading/trailing slot 간격을 개별 padding이 아니라 root `gap: 8px` 기준으로 정리했습니다.
- `Search`의 별도 `gap: 6px` override를 제거하고 clear button 크기를 Figma slot 크기에 맞춰 조정했습니다.
- `BaseSelect` trigger gap을 `8px`로 조정했습니다.
- patch changeset을 추가했습니다.

### Breaking change? (Yes/No)

No

## References

- Figma BaseInput: https://www.figma.com/design/Q4eonbJMKogZHuzUGxETuQ/Web-Components?node-id=8204-32&m=dev

검증:

- `yarn exec jest --config packages/bezier-react/jest.config.js packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.test.tsx packages/bezier-react/src/beta/Search/Search.test.tsx packages/bezier-react/src/beta/Select/Select.test.tsx packages/bezier-react/src/beta/MultiSelect/MultiSelect.test.tsx --runInBand`
- `yarn exec tsc --noEmit -p packages/bezier-react/tsconfig.json`
- `yarn exec stylelint packages/bezier-react/src/beta/BaseTextInput/BaseTextInput.module.scss packages/bezier-react/src/beta/Search/Search.module.scss packages/bezier-react/src/beta/BaseSelect/BaseSelect.module.scss packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.module.scss`
- `../../node_modules/.bin/eslint src/beta/BaseTextInput/BaseTextInput.tsx src/beta/BaseTextInput/BaseTextInput.types.ts src/beta/Search/Search.tsx src/beta/Search/Search.types.ts src/beta/CollapsibleSection/CollapsibleSection.tsx src/beta/CollapsibleSection/CollapsibleSection.test.tsx`
