### PR TITLE
feat: support semantic beta item roots

### DIFF
--- a/.changeset/web-12068-dropdown-menu-item.md
+++ b/.changeset/web-12068-dropdown-menu-item.md
@@ -2,4 +2,4 @@
 '@channel.io/bezier-react': patch
 ---
 
-Support semantic beta item roots with stricter link typing. `BaseItem` can render anchors and buttons from its own props, `DropdownMenuItem` renders as an anchor when `href` is provided while staying role-based by default, and item-like components can opt into string content line clamping through `contentMaxLines`.
+Support semantic beta item roots with stricter link typing. `BaseItem` can render anchors and buttons from its own props, `DropdownMenuItem` renders as an anchor when `href` is provided while staying role-based by default, link branches allow anchor click interception with `href`, and item-like components can opt into string content line clamping through `contentMaxLines`.

--- a/.changeset/web-12068-dropdown-menu-item.md
+++ b/.changeset/web-12068-dropdown-menu-item.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Support semantic beta item roots with stricter link typing. `BaseItem` can render anchors and buttons from its own props, `DropdownMenuItem` renders as an anchor when `href` is provided while staying role-based by default, and item-like components can opt into string content line clamping through `contentMaxLines`.

--- a/packages/bezier-react/src/beta/BaseItem/BaseItem.module.scss
+++ b/packages/bezier-react/src/beta/BaseItem/BaseItem.module.scss
@@ -10,8 +10,8 @@
 .BaseItem {
   overflow: hidden;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
+  gap: 8px;
+  align-items: center;
 
   box-sizing: border-box;
   width: 100%;
@@ -38,7 +38,11 @@
     cursor: pointer;
   }
 
-  &:where(.active, [data-highlighted]) {
+  &:where(.active) {
+    background-color: var(--color-fill-neutral-light);
+  }
+
+  &:where([data-highlighted]) {
     background-color: var(--color-fill-neutral-lighter);
   }
 
@@ -59,11 +63,21 @@
     @include state.focus-ring($gap: 0);
   }
 
-  &:where(.interactive:not(.disabled, .active, [data-highlighted])) {
+  &:where(.interactive:not(.disabled, .active, [data-highlighted], :disabled)) {
     &:hover {
       background-color: var(--color-fill-neutral-lighter);
     }
   }
+}
+
+.ContentWrapper {
+  overflow: hidden;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  justify-content: center;
+
+  min-width: 0;
 }
 
 .Content {
@@ -74,6 +88,10 @@
 
   width: 100%;
   min-width: 0;
+
+  &:where(.single-line) {
+    align-items: center;
+  }
 }
 
 .LeadingContent {
@@ -97,9 +115,18 @@
 }
 
 .MainContent {
+  overflow: hidden;
   display: flex;
+  flex: 1 1 auto;
   align-items: center;
+
+  width: 100%;
   min-width: 0;
+
+  > * {
+    min-width: 0;
+    max-width: 100%;
+  }
 }
 
 .Description {

--- a/packages/bezier-react/src/beta/BaseItem/BaseItem.test.tsx
+++ b/packages/bezier-react/src/beta/BaseItem/BaseItem.test.tsx
@@ -1,11 +1,10 @@
 import { PlusIcon } from '@channel.io/bezier-icons'
 
-
+import baseItemStyles from '~/src/beta/BaseItem/BaseItem.module.scss'
 import textStyles from '~/src/beta/Text/Text.module.scss'
 import { render } from '~/src/utils/test'
 
 import { BaseItem } from './BaseItem'
-
 
 describe('BaseItem', () => {
   it('renders string content, description, and BezierIcon side content', () => {
@@ -22,14 +21,120 @@ describe('BaseItem', () => {
     expect(getByText('Content')).toBeInTheDocument()
     expect(getByText('Description')).toBeInTheDocument()
     expect(getByText('⌘K')).toBeInTheDocument()
-    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+    expect(container.querySelector('svg')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
+  })
+
+  it('renders trailing content as a root-level sibling of the content wrapper', () => {
+    const { getByText } = render(
+      <BaseItem
+        description="Description"
+        trailingContent="⌘K"
+      >
+        Content
+      </BaseItem>
+    )
+
+    const trailingContent = getByText('⌘K').closest(
+      `.${baseItemStyles.TrailingContent}`
+    )
+
+    expect(trailingContent?.parentElement).toHaveClass(baseItemStyles.BaseItem)
+    expect(trailingContent?.closest(`.${baseItemStyles.Content}`)).toBeNull()
+  })
+
+  it('renders an anchor root when href is provided', () => {
+    const { getByRole } = render(
+      <BaseItem href="/settings">
+        Settings
+      </BaseItem>
+    )
+
+    const item = getByRole('link', { name: 'Settings' })
+
+    expect(item.tagName).toBe('A')
+    expect(item).toHaveAttribute('href', '/settings')
+  })
+
+  it('renders a button root when onClick is provided', () => {
+    const { getByRole } = render(
+      <BaseItem onClick={jest.fn()}>Settings</BaseItem>
+    )
+
+    const item = getByRole('button', { name: 'Settings' })
+
+    expect(item.tagName).toBe('BUTTON')
+    expect(item).toHaveAttribute('type', 'button')
+  })
+
+  it('keeps an explicit div root even when onClick is provided', () => {
+    const { getByText } = render(
+      <BaseItem
+        as="div"
+        role="menuitem"
+        onClick={jest.fn()}
+      >
+        Settings
+      </BaseItem>
+    )
+
+    const item = getByText('Settings').closest('[role="menuitem"]')
+
+    expect(item?.tagName).toBe('DIV')
+  })
+
+  it('centers content row for single-line items', () => {
+    const { getByText } = render(<BaseItem>Content</BaseItem>)
+
+    expect(
+      getByText('Content').closest(`.${baseItemStyles.Content}`)
+    ).toHaveClass(baseItemStyles['single-line'])
+  })
+
+  it('keeps content row top-aligned for items with description', () => {
+    const { getByText } = render(
+      <BaseItem description="Description">Content</BaseItem>
+    )
+
+    expect(
+      getByText('Content').closest(`.${baseItemStyles.Content}`)
+    ).not.toHaveClass(baseItemStyles['single-line'])
+  })
+
+  it('does not truncate string content by default', () => {
+    const { getByText } = render(<BaseItem>Long content</BaseItem>)
+
+    expect(getByText('Long content')).not.toHaveClass(textStyles.truncated)
+    expect(getByText('Long content')).not.toHaveClass(
+      textStyles['multi-line-truncated']
+    )
+  })
+
+  it('truncates string content when contentMaxLines is provided', () => {
+    const { getByText, rerender } = render(
+      <BaseItem contentMaxLines={1}>
+        Single line content
+      </BaseItem>
+    )
+
+    expect(getByText('Single line content')).toHaveClass(textStyles.truncated)
+
+    rerender(
+      <BaseItem contentMaxLines={2}>
+        Multi line content
+      </BaseItem>
+    )
+
+    expect(getByText('Multi line content')).toHaveClass(
+      textStyles['multi-line-truncated']
+    )
   })
 
   it('does not truncate string description', () => {
     const { getByText } = render(
-      <BaseItem description="Long description">
-        Content
-      </BaseItem>
+      <BaseItem description="Long description">Content</BaseItem>
     )
 
     expect(getByText('Long description')).not.toHaveClass(
@@ -41,6 +146,7 @@ describe('BaseItem', () => {
     const { getByText } = render(
       <BaseItem
         role="button"
+        interactive
         active
         disabled
         size="m"

--- a/packages/bezier-react/src/beta/BaseItem/BaseItem.tsx
+++ b/packages/bezier-react/src/beta/BaseItem/BaseItem.tsx
@@ -3,21 +3,26 @@
 import { forwardRef } from 'react'
 import * as React from 'react'
 
-import { isBezierIcon } from '@channel.io/bezier-icons'
+import { type BezierIcon, isBezierIcon } from '@channel.io/bezier-icons'
 import classNames from 'classnames'
-
 
 import { Text } from '~/src/beta/Text'
 
-import type { BaseItemProps, BaseItemSideContent } from './BaseItem.types'
+import type { BaseItemComponent, BaseItemProps } from './BaseItem.types'
 
 import styles from './BaseItem.module.scss'
 
+type BaseItemRootProps = React.HTMLAttributes<HTMLElement> &
+  React.RefAttributes<HTMLElement> & {
+    disabled?: boolean
+    href?: string
+    type?: string
+  }
 
 function BaseItemSideContentElement({
   content,
 }: {
-  content?: BaseItemSideContent
+  content?: BezierIcon | React.ReactNode
 }) {
   if (isBezierIcon(content)) {
     const SourceElement = content
@@ -33,46 +38,69 @@ function BaseItemSideContentElement({
   return content
 }
 
-export const BaseItem = forwardRef<HTMLDivElement, BaseItemProps>(
-  function BaseItem(
-    {
-      className,
-      children,
-      description,
-      leadingContent,
-      trailingContent,
-      size = 'm',
-      variant = 'neutral',
-      active = false,
-      disabled = false,
-      ...rest
-    },
-    forwardedRef
-  ) {
-    const hasLeadingContent = leadingContent != null
-    const interactive =
-      rest.role === 'menuitem' ||
-      rest.role === 'option' ||
-      rest.role === 'button' ||
-      rest.onClick != null
+function getTextTruncated(maxLines: BaseItemProps['contentMaxLines']) {
+  if (maxLines == null) {
+    return undefined
+  }
 
-    return (
-      <div
-        ref={forwardedRef}
-        className={classNames(
-          styles.BaseItem,
-          styles[`size-${size}`],
-          styles[variant],
-          active && styles.active,
-          disabled && styles.disabled,
-          interactive && styles.interactive,
-          className
-        )}
-        aria-disabled={disabled || undefined}
-        {...rest}
-      >
-        <div className={styles.Content}>
-          {hasLeadingContent && (
+  return maxLines <= 1 ? true : maxLines
+}
+
+const BaseItemImpl = forwardRef<HTMLElement, BaseItemProps>(function BaseItem(
+  {
+    as,
+    className,
+    children,
+    description,
+    contentMaxLines,
+    leadingContent,
+    trailingContent,
+    size = 'm',
+    variant = 'neutral',
+    active = false,
+    disabled = false,
+    interactive = false,
+    'aria-disabled': ariaDisabled,
+    ...rest
+  },
+  forwardedRef
+) {
+  const isSingleLine = description == null
+  const contentTruncated = getTextTruncated(contentMaxLines)
+  const rootElement =
+    as ??
+    ('href' in rest && rest.href != null
+      ? 'a'
+      : 'onClick' in rest && rest.onClick != null
+        ? 'button'
+        : 'div')
+  const Component = rootElement as React.ElementType<BaseItemRootProps>
+  const rootProps = {
+    ref: forwardedRef as React.Ref<HTMLElement>,
+    className: classNames(
+      styles.BaseItem,
+      styles[`size-${size}`],
+      styles[variant],
+      active && styles.active,
+      disabled && styles.disabled,
+      interactive && styles.interactive,
+      className
+    ),
+    'aria-disabled': disabled || ariaDisabled || undefined,
+    ...(rootElement === 'button' && { disabled, type: 'button' }),
+    ...rest,
+  } as BaseItemRootProps
+
+  return (
+    <Component {...rootProps}>
+      <div className={styles.ContentWrapper}>
+        <div
+          className={classNames(
+            styles.Content,
+            isSingleLine && styles['single-line']
+          )}
+        >
+          {leadingContent != null && (
             <div className={styles.LeadingContent}>
               <BaseItemSideContentElement content={leadingContent} />
             </div>
@@ -84,7 +112,7 @@ export const BaseItem = forwardRef<HTMLDivElement, BaseItemProps>(
                 <Text
                   typo="14"
                   fontWeight="500"
-                  truncated
+                  truncated={contentTruncated}
                 >
                   {children}
                 </Text>
@@ -93,19 +121,13 @@ export const BaseItem = forwardRef<HTMLDivElement, BaseItemProps>(
               )}
             </div>
           </div>
-
-          {trailingContent != null && (
-            <div className={styles.TrailingContent}>
-              <BaseItemSideContentElement content={trailingContent} />
-            </div>
-          )}
         </div>
 
         {description != null && (
           <div
             className={classNames(
               styles.Description,
-              hasLeadingContent && styles['has-leading-content']
+              leadingContent != null && styles['has-leading-content']
             )}
           >
             {typeof description === 'string' ? (
@@ -121,6 +143,14 @@ export const BaseItem = forwardRef<HTMLDivElement, BaseItemProps>(
           </div>
         )}
       </div>
-    )
-  }
-)
+
+      {trailingContent != null && (
+        <div className={styles.TrailingContent}>
+          <BaseItemSideContentElement content={trailingContent} />
+        </div>
+      )}
+    </Component>
+  )
+})
+
+export const BaseItem = BaseItemImpl as BaseItemComponent

--- a/packages/bezier-react/src/beta/BaseItem/BaseItem.types.ts
+++ b/packages/bezier-react/src/beta/BaseItem/BaseItem.types.ts
@@ -1,13 +1,20 @@
-import type { ReactNode } from 'react'
+import type {
+  MouseEventHandler,
+  ReactElement,
+  ReactNode,
+  RefAttributes,
+} from 'react'
 
 import type { BezierIcon } from '@channel.io/bezier-icons'
 
+import type { TextProps } from '~/src/beta/Text'
 import type {
   ActivatableProps,
   BezierComponentProps,
   ChildrenProps,
   DisableProps,
   LeadingTrailingContentProps,
+  LinkProps,
   SizeProps,
   VariantProps,
 } from '~/src/types/props'
@@ -16,28 +23,86 @@ export type BaseItemSize = 'm'
 
 export type BaseItemVariant = 'neutral' | 'destructive'
 
-export type BaseItemSideContent = BezierIcon | ReactNode
-
 /**
  * Visual foundation for row-like components.
  *
- * `BaseItem` does not provide menu, option, or button semantics by itself.
- * Purpose-built components such as `DropdownMenuItem` should own roles,
- * keyboard interaction, and selection behavior.
+ * `BaseItem` can render a semantic root through `as`, but it does not provide
+ * menu, option, or button behavior by itself. Purpose-built components such as
+ * `DropdownMenuItem` should own roles, keyboard interaction, and selection
+ * behavior.
  */
 interface BaseItemOwnProps
-  extends LeadingTrailingContentProps<BaseItemSideContent> {
-  /**
-   * Additional content below the main content.
-   */
-  description?: ReactNode
-}
-
-export interface BaseItemProps
-  extends BezierComponentProps<'div'>,
-    ChildrenProps,
+  extends ChildrenProps,
     DisableProps,
     ActivatableProps,
     SizeProps<BaseItemSize>,
     VariantProps<BaseItemVariant>,
-    BaseItemOwnProps {}
+    LeadingTrailingContentProps<BezierIcon | ReactNode> {
+  /**
+   * Additional content below the main content.
+   */
+  description?: ReactNode
+  /**
+   * Maximum number of lines for string children.
+   *
+   * When omitted, `BaseItem` does not apply text truncation. Components using
+   * `BaseItem` should own their own text overflow policy.
+   */
+  contentMaxLines?: Extract<TextProps['truncated'], number>
+  /**
+   * Whether to apply interactive row surface styles such as cursor and hover.
+   * Behavior such as click handling and keyboard interaction should be owned by
+   * the purpose-built component using `BaseItem`.
+   * @default false
+   */
+  interactive?: boolean
+}
+
+type BaseItemOmitKeys = keyof BaseItemOwnProps | 'as'
+
+type BaseItemDefaultDivProps = BaseItemOwnProps &
+  Omit<BezierComponentProps<'div'>, BaseItemOmitKeys | 'onClick'> & {
+    as?: undefined
+    href?: never
+    onClick?: never
+    type?: never
+  }
+
+type BaseItemExplicitDivProps = BaseItemOwnProps &
+  Omit<BezierComponentProps<'div'>, BaseItemOmitKeys> & {
+    as?: 'div'
+    href?: never
+    type?: never
+  }
+
+export type BaseItemDivProps =
+  | BaseItemDefaultDivProps
+  | BaseItemExplicitDivProps
+
+export type BaseItemButtonProps = BaseItemOwnProps &
+  Omit<BezierComponentProps<'button'>, BaseItemOmitKeys | 'onClick'> & {
+    as?: 'button'
+    href?: never
+    onClick: MouseEventHandler<HTMLButtonElement>
+  }
+
+export type BaseItemAnchorProps = BaseItemOwnProps &
+  Omit<BezierComponentProps<'a'>, BaseItemOmitKeys> & {
+    as?: 'a'
+    type?: never
+  } & Required<LinkProps>
+
+export type BaseItemProps =
+  | BaseItemDivProps
+  | BaseItemButtonProps
+  | BaseItemAnchorProps
+
+export type BaseItemComponent = {
+  (
+    props: BaseItemAnchorProps & RefAttributes<HTMLAnchorElement>
+  ): ReactElement | null
+  (
+    props: BaseItemButtonProps & RefAttributes<HTMLButtonElement>
+  ): ReactElement | null
+  (props: BaseItemDivProps & RefAttributes<HTMLDivElement>): ReactElement | null
+}

--- a/packages/bezier-react/src/beta/BaseSelect/BaseSelect.tsx
+++ b/packages/bezier-react/src/beta/BaseSelect/BaseSelect.tsx
@@ -17,9 +17,6 @@ import * as React from 'react'
 import { CheckIcon } from '@channel.io/bezier-icons'
 import classNames from 'classnames'
 
-
-
-
 import { BaseGroupLabel } from '~/src/beta/BaseGroupLabel'
 import { BaseItem } from '~/src/beta/BaseItem/BaseItem'
 import { useFormFieldProps } from '~/src/beta/Form'
@@ -43,9 +40,6 @@ import type {
 } from './BaseSelect.types'
 
 import styles from './BaseSelect.module.scss'
-
-
-
 
 type SelectValue = BaseSelectValue
 type SelectProps<Value extends SelectValue = SelectValue> =
@@ -577,6 +571,7 @@ function BaseSelectOptionElement<Value extends SelectValue>({
       aria-disabled={disabled || undefined}
       data-b-select-option="true"
       disabled={disabled}
+      interactive
       description={description}
       leadingContent={leadingContent}
       trailingContent={optionTrailingContent}

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import type { CSSProperties, ReactNode } from 'react'
+import type { CSSProperties, MouseEvent, ReactNode } from 'react'
 
 import {
   ArchiveIcon,
@@ -90,46 +90,49 @@ function ControlledMenu({
 }
 
 export const WithTrigger: Story = {
-  render: () => (
-    <DropdownMenu>
-      <DropdownMenuTrigger>
-        <IconButton
-          aria-label="More"
-          content={PlusIcon}
-          variant="outlined"
-          semantic="secondary"
-        />
-      </DropdownMenuTrigger>
+  render: () => {
+    const handleDocumentationClick = (event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault()
+      window.history.pushState({}, '', '#dropdown-menu-documentation')
+    }
 
-      <DropdownMenuItem
-        content="Edit"
-        leadingContent={EditIcon}
-        onSelect={() => {}}
-      />
-      <DropdownMenuItem
-        content="Archive"
-        leadingContent={ArchiveIcon}
-        onSelect={() => {}}
-      />
-      <DropdownMenuItem
-        content="Open documentation in new page"
-        leadingContent={ArrowRightUpSmallIcon}
-        href="https://github.com/channel-io/bezier-react"
-        target="_blank"
-        rel="noreferrer"
-        onClick={(event) => {
-          event.preventDefault()
-        }}
-      />
-      <DropdownMenuSeparator />
-      <DropdownMenuItem
-        content="Delete"
-        variant="destructive"
-        leadingContent={TrashIcon}
-        onSelect={() => {}}
-      />
-    </DropdownMenu>
-  ),
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger>
+          <IconButton
+            aria-label="More"
+            content={PlusIcon}
+            variant="outlined"
+            semantic="secondary"
+          />
+        </DropdownMenuTrigger>
+
+        <DropdownMenuItem
+          content="Edit"
+          leadingContent={EditIcon}
+          onSelect={() => {}}
+        />
+        <DropdownMenuItem
+          content="Archive"
+          leadingContent={ArchiveIcon}
+          onSelect={() => {}}
+        />
+        <DropdownMenuItem
+          content="Open documentation route"
+          leadingContent={ArrowRightUpSmallIcon}
+          href="#dropdown-menu-documentation"
+          onClick={handleDocumentationClick}
+        />
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          content="Delete"
+          variant="destructive"
+          leadingContent={TrashIcon}
+          onSelect={() => {}}
+        />
+      </DropdownMenu>
+    )
+  },
 }
 
 export const ItemContent: Story = {

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import type { CSSProperties, ReactNode } from 'react'
 
 import {
   ArchiveIcon,
+  ArrowRightUpSmallIcon,
   CheckIcon,
   EditIcon,
   PlusIcon,
@@ -10,7 +11,6 @@ import {
   TrashIcon,
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
-
 
 import { Button } from '~/src/beta/Button'
 import { IconButton } from '~/src/beta/IconButton'
@@ -26,7 +26,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from './DropdownMenu'
-
 
 const meta: Meta<typeof DropdownMenu> = {
   title: 'Beta components/DropdownMenu',
@@ -50,11 +49,13 @@ export default meta
 
 type Story = StoryObj<typeof DropdownMenu>
 
-function DropdownMenuExample({
+function ControlledMenu({
   children,
+  label = 'Open menu',
   maxHeight,
 }: {
   children: ReactNode
+  label?: string
   maxHeight?: CSSProperties['maxHeight']
 }) {
   const [show, setShow] = useState(false)
@@ -67,7 +68,7 @@ function DropdownMenuExample({
     <>
       <Button
         ref={setTargetRef}
-        label="Open menu"
+        label={label}
         variant="outlined"
         semantic="secondary"
         leadingContent={PlusIcon}
@@ -85,93 +86,6 @@ function DropdownMenuExample({
         {children}
       </DropdownMenu>
     </>
-  )
-}
-
-function ControlledWithExternalTriggerExample() {
-  const [show, setShow] = useState(false)
-  const triggerRef = useRef<HTMLButtonElement>(null)
-
-  return (
-    <>
-      <Button
-        ref={triggerRef}
-        label="Open menu"
-        variant="outlined"
-        semantic="secondary"
-        active={show}
-        aria-haspopup="menu"
-        aria-expanded={show}
-        onClick={() => setShow((prev) => !prev)}
-      />
-      <DropdownMenu
-        show={show}
-        target={triggerRef.current}
-        onHide={() => setShow(false)}
-      >
-        <DropdownMenuItem
-          content="Rename"
-          leadingContent={EditIcon}
-        />
-        <DropdownMenuItem
-          content="Archive"
-          leadingContent={ArchiveIcon}
-        />
-      </DropdownMenu>
-    </>
-  )
-}
-
-function ControlledWithContainerTargetExample() {
-  const [show, setShow] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
-  const triggerRef = useRef<HTMLButtonElement>(null)
-
-  return (
-    <div
-      ref={containerRef}
-      style={{
-        position: 'relative',
-        overflow: 'auto',
-        width: 360,
-        height: 260,
-        padding: 24,
-        border: '1px solid #d9d9d9',
-        borderRadius: 12,
-      }}
-    >
-      <div style={{ height: 64 }} />
-      <Button
-        ref={triggerRef}
-        label="Open in container"
-        variant="outlined"
-        semantic="secondary"
-        active={show}
-        aria-haspopup="menu"
-        aria-expanded={show}
-        onClick={() => setShow((prev) => !prev)}
-      />
-      <DropdownMenu
-        show={show}
-        target={triggerRef.current}
-        container={containerRef.current}
-        onHide={() => setShow(false)}
-      >
-        <DropdownMenuItem
-          content="Rename"
-          leadingContent={EditIcon}
-        />
-        <DropdownMenuItem
-          content="Archive"
-          leadingContent={ArchiveIcon}
-        />
-        <DropdownMenuItem
-          content="Delete"
-          variant="destructive"
-          leadingContent={TrashIcon}
-        />
-      </DropdownMenu>
-    </div>
   )
 }
 
@@ -197,6 +111,13 @@ export const WithTrigger: Story = {
         leadingContent={ArchiveIcon}
         onSelect={() => {}}
       />
+      <DropdownMenuItem
+        content="Open documentation in new page"
+        leadingContent={ArrowRightUpSmallIcon}
+        href="https://github.com/channel-io/bezier-react"
+        target="_blank"
+        rel="noreferrer"
+      />
       <DropdownMenuSeparator />
       <DropdownMenuItem
         content="Delete"
@@ -208,17 +129,9 @@ export const WithTrigger: Story = {
   ),
 }
 
-export const ControlledWithExternalTrigger: Story = {
-  render: () => <ControlledWithExternalTriggerExample />,
-}
-
-export const ControlledWithContainerTarget: Story = {
-  render: () => <ControlledWithContainerTargetExample />,
-}
-
-export const RichContent: Story = {
+export const ItemContent: Story = {
   render: () => (
-    <DropdownMenuExample>
+    <ControlledMenu>
       <DropdownMenuItem
         content={
           <Text typo="14">
@@ -243,50 +156,34 @@ export const RichContent: Story = {
           </Text>
         }
       />
-    </DropdownMenuExample>
+      <DropdownMenuItem
+        content="Archive"
+        leadingContent={ArchiveIcon}
+        disabled
+      />
+    </ControlledMenu>
   ),
 }
 
-export const WithSubmenu: Story = {
+export const GroupsAndSubmenus: Story = {
   render: () => (
-    <DropdownMenuExample>
-      <DropdownMenuItem
-        content="Edit"
-        leadingContent={EditIcon}
-      />
-      <DropdownMenuSub>
-        <DropdownMenuSubTrigger
-          content="Move to"
-          leadingContent={SendForwardIcon}
-        />
-        <DropdownMenuSubContent>
-          <DropdownMenuItem content="Inbox" />
-          <DropdownMenuItem content="Archive" />
-          <DropdownMenuItem content="Trash" />
-        </DropdownMenuSubContent>
-      </DropdownMenuSub>
-      <DropdownMenuSeparator />
-      <DropdownMenuItem
-        content="Delete"
-        variant="destructive"
-        leadingContent={TrashIcon}
-      />
-    </DropdownMenuExample>
-  ),
-}
-
-export const Grouped: Story = {
-  render: () => (
-    <DropdownMenuExample>
+    <ControlledMenu>
       <DropdownMenuGroup label="File">
         <DropdownMenuItem
           content="Edit"
           leadingContent={EditIcon}
         />
-        <DropdownMenuItem
-          content="Archive"
-          leadingContent={ArchiveIcon}
-        />
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger
+            content="Move to"
+            leadingContent={SendForwardIcon}
+          />
+          <DropdownMenuSubContent>
+            <DropdownMenuItem content="Inbox" />
+            <DropdownMenuItem content="Archive" />
+            <DropdownMenuItem content="Trash" />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
       </DropdownMenuGroup>
       <DropdownMenuSeparator />
       <DropdownMenuGroup label="Danger zone">
@@ -296,41 +193,39 @@ export const Grouped: Story = {
           leadingContent={TrashIcon}
         />
       </DropdownMenuGroup>
-    </DropdownMenuExample>
+    </ControlledMenu>
   ),
 }
 
-export const DisabledAndDestructive: Story = {
+export const ControlledTarget: Story = {
   render: () => (
-    <DropdownMenuExample>
+    <ControlledMenu label="Open controlled menu">
       <DropdownMenuItem
-        content="Edit"
+        content="Rename"
         leadingContent={EditIcon}
       />
       <DropdownMenuItem
         content="Archive"
         leadingContent={ArchiveIcon}
-        disabled
       />
-      <DropdownMenuSeparator />
       <DropdownMenuItem
         content="Delete"
         variant="destructive"
         leadingContent={TrashIcon}
       />
-    </DropdownMenuExample>
+    </ControlledMenu>
   ),
 }
 
 export const Scrollable: Story = {
   render: () => (
-    <DropdownMenuExample maxHeight={180}>
+    <ControlledMenu maxHeight={180}>
       {Array.from({ length: 12 }, (_, index) => (
         <DropdownMenuItem
           key={index}
           content={`Menu item ${index + 1}`}
         />
       ))}
-    </DropdownMenuExample>
+    </ControlledMenu>
   ),
 }

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import type { CSSProperties, MouseEvent, ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 
 import {
   ArchiveIcon,
@@ -90,49 +90,42 @@ function ControlledMenu({
 }
 
 export const WithTrigger: Story = {
-  render: () => {
-    const handleDocumentationClick = (event: MouseEvent<HTMLAnchorElement>) => {
-      event.preventDefault()
-      window.history.pushState({}, '', '#dropdown-menu-documentation')
-    }
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger>
+        <IconButton
+          aria-label="More"
+          content={PlusIcon}
+          variant="outlined"
+          semantic="secondary"
+        />
+      </DropdownMenuTrigger>
 
-    return (
-      <DropdownMenu>
-        <DropdownMenuTrigger>
-          <IconButton
-            aria-label="More"
-            content={PlusIcon}
-            variant="outlined"
-            semantic="secondary"
-          />
-        </DropdownMenuTrigger>
-
-        <DropdownMenuItem
-          content="Edit"
-          leadingContent={EditIcon}
-          onSelect={() => {}}
-        />
-        <DropdownMenuItem
-          content="Archive"
-          leadingContent={ArchiveIcon}
-          onSelect={() => {}}
-        />
-        <DropdownMenuItem
-          content="Open documentation route"
-          leadingContent={ArrowRightUpSmallIcon}
-          href="#dropdown-menu-documentation"
-          onClick={handleDocumentationClick}
-        />
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          content="Delete"
-          variant="destructive"
-          leadingContent={TrashIcon}
-          onSelect={() => {}}
-        />
-      </DropdownMenu>
-    )
-  },
+      <DropdownMenuItem
+        content="Edit"
+        leadingContent={EditIcon}
+        onSelect={() => {}}
+      />
+      <DropdownMenuItem
+        content="Archive"
+        leadingContent={ArchiveIcon}
+        onSelect={() => {}}
+      />
+      <DropdownMenuItem
+        content="Go to README"
+        leadingContent={ArrowRightUpSmallIcon}
+        href="?path=/docs/readme--docs"
+        target="_top"
+      />
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        content="Delete"
+        variant="destructive"
+        leadingContent={TrashIcon}
+        onSelect={() => {}}
+      />
+    </DropdownMenu>
+  ),
 }
 
 export const ItemContent: Story = {

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useState } from 'react'
-import type { CSSProperties, ReactNode } from 'react'
+import type { CSSProperties, MouseEvent, ReactNode } from 'react'
 
 import {
   ArchiveIcon,
-  ArrowRightUpSmallIcon,
+  ArrowRightUpIcon,
   CheckIcon,
   EditIcon,
   PlusIcon,
@@ -49,6 +49,8 @@ export default meta
 
 type Story = StoryObj<typeof DropdownMenu>
 
+const README_STORY_PATH = '?path=/docs/readme--docs'
+
 function ControlledMenu({
   children,
   label = 'Open menu',
@@ -90,42 +92,59 @@ function ControlledMenu({
 }
 
 export const WithTrigger: Story = {
-  render: () => (
-    <DropdownMenu>
-      <DropdownMenuTrigger>
-        <IconButton
-          aria-label="More"
-          content={PlusIcon}
-          variant="outlined"
-          semantic="secondary"
-        />
-      </DropdownMenuTrigger>
+  render: () => {
+    const handleHistoryClick = (event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault()
 
-      <DropdownMenuItem
-        content="Edit"
-        leadingContent={EditIcon}
-        onSelect={() => {}}
-      />
-      <DropdownMenuItem
-        content="Archive"
-        leadingContent={ArchiveIcon}
-        onSelect={() => {}}
-      />
-      <DropdownMenuItem
-        content="Go to README"
-        leadingContent={ArrowRightUpSmallIcon}
-        href="?path=/docs/readme--docs"
-        target="_top"
-      />
-      <DropdownMenuSeparator />
-      <DropdownMenuItem
-        content="Delete"
-        variant="destructive"
-        leadingContent={TrashIcon}
-        onSelect={() => {}}
-      />
-    </DropdownMenu>
-  ),
+      const targetWindow = window.top ?? window
+
+      targetWindow.history.pushState({}, '', README_STORY_PATH)
+      targetWindow.dispatchEvent(new PopStateEvent('popstate'))
+    }
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger>
+          <IconButton
+            aria-label="More"
+            content={PlusIcon}
+            variant="outlined"
+            semantic="secondary"
+          />
+        </DropdownMenuTrigger>
+
+        <DropdownMenuItem
+          content="Edit"
+          leadingContent={EditIcon}
+          onSelect={() => {}}
+        />
+        <DropdownMenuItem
+          content="Archive"
+          leadingContent={ArchiveIcon}
+          onSelect={() => {}}
+        />
+        <DropdownMenuItem
+          content="Go to README by href"
+          leadingContent={ArrowRightUpIcon}
+          href={README_STORY_PATH}
+          target="_top"
+        />
+        <DropdownMenuItem
+          content="Go to README with onClick"
+          leadingContent={ArrowRightUpIcon}
+          href={README_STORY_PATH}
+          onClick={handleHistoryClick}
+        />
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          content="Delete"
+          variant="destructive"
+          leadingContent={TrashIcon}
+          onSelect={() => {}}
+        />
+      </DropdownMenu>
+    )
+  },
 }
 
 export const ItemContent: Story = {

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
@@ -117,6 +117,9 @@ export const WithTrigger: Story = {
         href="https://github.com/channel-io/bezier-react"
         target="_blank"
         rel="noreferrer"
+        onClick={(event) => {
+          event.preventDefault()
+        }}
       />
       <DropdownMenuSeparator />
       <DropdownMenuItem

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
@@ -2,7 +2,13 @@ import { Fragment, useState } from 'react'
 import type { MouseEvent, ReactElement } from 'react'
 
 import { PlusIcon, TrashIcon } from '@channel.io/bezier-icons'
-import { act, fireEvent, waitFor, within } from '@testing-library/react'
+import {
+  act,
+  createEvent,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import baseGroupLabelStyles from '~/src/beta/BaseGroupLabel/BaseGroupLabel.module.scss'
@@ -80,15 +86,21 @@ describe('DropdownMenu', () => {
     )
 
     await user.click(getByRole('button', { name: 'More' }))
+    const trigger = getByRole('button', { name: 'More' })
+    const item = getByRole('menuitem', { name: 'Edit' })
+
     await waitFor(() => {
-      expect(getByRole('menuitem', { name: 'Edit' })).toHaveFocus()
+      expect(item).toHaveFocus()
     })
-    await user.tab()
+
+    const event = createEvent.keyDown(item, { key: 'Tab' })
+    fireEvent(item, event)
 
     await waitFor(() => {
       expect(queryByRole('menu')).not.toBeInTheDocument()
     })
-    expect(getByRole('button', { name: 'Next' })).toHaveFocus()
+    expect(event.defaultPrevented).toBe(false)
+    expect(trigger).not.toHaveFocus()
   })
 
   it('does not render DropdownMenuTrigger inside the menu content', async () => {

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
@@ -5,7 +5,6 @@ import { PlusIcon, TrashIcon } from '@channel.io/bezier-icons'
 import { act, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-
 import baseGroupLabelStyles from '~/src/beta/BaseGroupLabel/BaseGroupLabel.module.scss'
 import { Button } from '~/src/beta/Button'
 import { IconButton } from '~/src/beta/IconButton'
@@ -22,7 +21,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from './DropdownMenu'
-
 
 describe('DropdownMenu', () => {
   it('opens with DropdownMenuTrigger and selects an item', async () => {
@@ -57,7 +55,9 @@ describe('DropdownMenu', () => {
     await user.click(getByRole('menuitem', { name: 'Edit' }))
 
     expect(onSelect).toHaveBeenCalledTimes(1)
-    expect(queryByRole('menu')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(queryByRole('menu')).not.toBeInTheDocument()
+    })
   })
 
   it('does not render DropdownMenuTrigger inside the menu content', async () => {
@@ -80,6 +80,38 @@ describe('DropdownMenu', () => {
     expect(
       within(getByRole('menu')).queryByRole('button', { name: 'More' })
     ).not.toBeInTheDocument()
+  })
+
+  it('renders a div menu item by default', () => {
+    const { getByRole } = render(
+      <DropdownMenu defaultShow>
+        <DropdownMenuItem content="Open" />
+      </DropdownMenu>
+    )
+
+    const item = getByRole('menuitem', { name: 'Open' })
+
+    expect(item.tagName).toBe('DIV')
+  })
+
+  it('renders an anchor menu item when href is provided', () => {
+    const { getByRole } = render(
+      <DropdownMenu defaultShow>
+        <DropdownMenuItem
+          content="Billing"
+          href="/billing"
+          target="_blank"
+          rel="noreferrer"
+        />
+      </DropdownMenu>
+    )
+
+    const item = getByRole('menuitem', { name: 'Billing' })
+
+    expect(item.tagName).toBe('A')
+    expect(item).toHaveAttribute('href', '/billing')
+    expect(item).toHaveAttribute('target', '_blank')
+    expect(item).toHaveAttribute('rel', 'noreferrer')
   })
 
   it('uses its root element as the default overlay container with DropdownMenuTrigger', async () => {
@@ -296,7 +328,9 @@ describe('DropdownMenu', () => {
     await user.keyboard('{Enter}')
 
     expect(onSelect).toHaveBeenCalledTimes(1)
-    expect(queryByRole('menu')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(queryByRole('menu')).not.toBeInTheDocument()
+    })
   })
 
   it('selects the focused item with Space', async () => {
@@ -485,9 +519,7 @@ describe('DropdownMenu', () => {
     fireEvent.pointerLeave(trigger, { relatedTarget: document.body })
 
     await waitFor(() => {
-      expect(
-        queryByRole('menuitem', { name: 'Inbox' })
-      ).not.toBeInTheDocument()
+      expect(queryByRole('menuitem', { name: 'Inbox' })).not.toBeInTheDocument()
     })
   })
 
@@ -549,9 +581,7 @@ describe('DropdownMenu', () => {
     fireEvent.keyDown(getAllByTestId(OVERLAY_TEST_ID)[1], { key: 'ArrowLeft' })
 
     await waitFor(() => {
-      expect(
-        queryByRole('menuitem', { name: 'Inbox' })
-      ).not.toBeInTheDocument()
+      expect(queryByRole('menuitem', { name: 'Inbox' })).not.toBeInTheDocument()
     })
     expect(trigger).toHaveFocus()
   })

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
@@ -60,6 +60,37 @@ describe('DropdownMenu', () => {
     })
   })
 
+  it('closes the menu with Tab without restoring focus to the trigger', async () => {
+    const user = userEvent.setup()
+
+    const { getByRole, queryByRole } = render(
+      <>
+        <DropdownMenu>
+          <DropdownMenuTrigger>
+            <Button
+              label="More"
+              variant="outlined"
+              semantic="secondary"
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuItem content="Edit" />
+        </DropdownMenu>
+        <button type="button">Next</button>
+      </>
+    )
+
+    await user.click(getByRole('button', { name: 'More' }))
+    await waitFor(() => {
+      expect(getByRole('menuitem', { name: 'Edit' })).toHaveFocus()
+    })
+    await user.tab()
+
+    await waitFor(() => {
+      expect(queryByRole('menu')).not.toBeInTheDocument()
+    })
+    expect(getByRole('button', { name: 'Next' })).toHaveFocus()
+  })
+
   it('does not render DropdownMenuTrigger inside the menu content', async () => {
     const user = userEvent.setup()
 

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useState } from 'react'
-import type { ReactElement } from 'react'
+import type { MouseEvent, ReactElement } from 'react'
 
 import { PlusIcon, TrashIcon } from '@channel.io/bezier-icons'
 import { act, fireEvent, waitFor, within } from '@testing-library/react'
@@ -112,6 +112,30 @@ describe('DropdownMenu', () => {
     expect(item).toHaveAttribute('href', '/billing')
     expect(item).toHaveAttribute('target', '_blank')
     expect(item).toHaveAttribute('rel', 'noreferrer')
+  })
+
+  it('closes an anchor menu item after an intercepted click', async () => {
+    const user = userEvent.setup()
+    const onClick = jest.fn((event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault()
+    })
+
+    const { getByRole, queryByRole } = render(
+      <DropdownMenu defaultShow>
+        <DropdownMenuItem
+          content="Billing"
+          href="/billing"
+          onClick={onClick}
+        />
+      </DropdownMenu>
+    )
+
+    await user.click(getByRole('menuitem', { name: 'Billing' }))
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(queryByRole('menu')).not.toBeInTheDocument()
+    })
   })
 
   it('uses its root element as the default overlay container with DropdownMenuTrigger', async () => {

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.test.tsx
@@ -138,6 +138,80 @@ describe('DropdownMenu', () => {
     })
   })
 
+  it('does not call anchor click handlers on disabled menu items', () => {
+    const onClick = jest.fn()
+
+    const { getByRole } = render(
+      <DropdownMenu defaultShow>
+        <DropdownMenuItem
+          content="Billing"
+          href="/billing"
+          disabled
+          onClick={onClick}
+        />
+      </DropdownMenu>
+    )
+
+    fireEvent.click(getByRole('menuitem', { name: 'Billing' }))
+
+    expect(onClick).not.toHaveBeenCalled()
+    expect(getByRole('menu')).toBeInTheDocument()
+  })
+
+  it('activates an anchor menu item with Space', async () => {
+    const user = userEvent.setup()
+    const onClick = jest.fn((event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault()
+    })
+    const onKeyDown = jest.fn()
+
+    const { getByRole, queryByRole } = render(
+      <DropdownMenu defaultShow>
+        <DropdownMenuItem
+          content="Billing"
+          href="/billing"
+          onClick={onClick}
+          onKeyDown={onKeyDown}
+        />
+      </DropdownMenu>
+    )
+
+    act(() => {
+      getByRole('menuitem', { name: 'Billing' }).focus()
+    })
+    await user.keyboard('[Space]')
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1)
+    expect(onClick).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(queryByRole('menu')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not activate an anchor menu item when Space keydown is prevented', async () => {
+    const user = userEvent.setup()
+    const onClick = jest.fn()
+
+    const { getByRole } = render(
+      <DropdownMenu defaultShow>
+        <DropdownMenuItem
+          content="Billing"
+          href="/billing"
+          onClick={onClick}
+          onKeyDown={(event) => event.preventDefault()}
+        />
+      </DropdownMenu>
+    )
+
+    act(() => {
+      getByRole('menuitem', { name: 'Billing' }).focus()
+    })
+    await user.keyboard('[Space]')
+
+    expect(onClick).not.toHaveBeenCalled()
+    expect(getByRole('menu')).toBeInTheDocument()
+  })
+
   it('uses its root element as the default overlay container with DropdownMenuTrigger', async () => {
     const user = userEvent.setup()
 
@@ -412,6 +486,33 @@ describe('DropdownMenu', () => {
 
     await user.click(getByRole('menuitem', { name: 'Open' }))
 
+    expect(getByRole('menu')).toBeInTheDocument()
+  })
+
+  it('does not select an item when its click event is already prevented', () => {
+    const onSelect = jest.fn()
+
+    const { getByRole } = render(
+      <DropdownMenu defaultShow>
+        <DropdownMenuItem
+          content="Open"
+          onSelect={onSelect}
+        />
+      </DropdownMenu>
+    )
+
+    const item = getByRole('menuitem', { name: 'Open' })
+
+    item.addEventListener(
+      'click',
+      (event) => {
+        event.preventDefault()
+      },
+      { capture: true }
+    )
+    fireEvent.click(item)
+
+    expect(onSelect).not.toHaveBeenCalled()
     expect(getByRole('menu')).toBeInTheDocument()
   })
 

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
@@ -505,12 +505,14 @@ export const DropdownMenuItem = forwardRef<HTMLElement, DropdownMenuItemProps>(
     }
 
     if (isLink) {
+      const { onClick, ...anchorRest } = rest
+
       return (
         <BaseItem
           as="a"
           ref={forwardedRef as React.Ref<HTMLAnchorElement>}
           {...commonProps}
-          {...rest}
+          {...anchorRest}
           draggable={false}
           onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
             if (disabled) {
@@ -519,10 +521,7 @@ export const DropdownMenuItem = forwardRef<HTMLElement, DropdownMenuItemProps>(
               return
             }
 
-            if (event.defaultPrevented) {
-              return
-            }
-
+            onClick?.(event)
             close()
           }}
           onKeyDown={(event: React.KeyboardEvent<HTMLAnchorElement>) => {

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
@@ -45,19 +45,10 @@ import styles from './DropdownMenu.module.scss'
 
 const MENU_ITEM_SELECTOR =
   '[data-b-dropdown-menu-item="true"]:not([aria-disabled="true"])'
-const TABBABLE_SELECTOR = [
-  'a[href]',
-  'button:not([disabled])',
-  'input:not([disabled])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  '[tabindex]:not([tabindex="-1"])',
-].join(',')
 
 type DropdownMenuContextValue = {
   open: boolean
   menuId: string
-  focusReferenceElement: HTMLElement | null
   overlayContainer: HTMLElement | null
   close: (options?: { restoreFocus?: boolean }) => void
 }
@@ -66,7 +57,6 @@ const [DropdownMenuContextProvider, useDropdownMenuContext] =
   createContext<DropdownMenuContextValue>({
     open: false,
     menuId: '',
-    focusReferenceElement: null,
     overlayContainer: null,
     close: () => {},
   })
@@ -149,12 +139,6 @@ function isSidePosition(position: NonNullable<DropdownMenuProps['position']>) {
   return position.startsWith('left') || position.startsWith('right')
 }
 
-function isElementTarget(
-  target: DropdownMenuProps['target'] | null | undefined
-): target is HTMLElement {
-  return (target as { nodeType?: number } | null | undefined)?.nodeType === 1
-}
-
 function getOverlayMargins({
   position,
   offset,
@@ -173,32 +157,6 @@ function getFocusableItems(container: HTMLElement | null) {
   }
 
   return Array.from(container.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR))
-}
-
-function getTabbableElements(document: Document) {
-  return Array.from(
-    document.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR)
-  ).filter(
-    (element) =>
-      element.tabIndex >= 0 &&
-      element.getAttribute('aria-hidden') !== 'true' &&
-      element.getAttribute('aria-disabled') !== 'true'
-  )
-}
-
-function focusAdjacentTabbableElement(
-  referenceElement: HTMLElement | null,
-  reverse: boolean
-) {
-  if (!referenceElement) {
-    return
-  }
-
-  const tabbableElements = getTabbableElements(referenceElement.ownerDocument)
-  const currentIndex = tabbableElements.indexOf(referenceElement)
-  const nextIndex = reverse ? currentIndex - 1 : currentIndex + 1
-
-  tabbableElements[nextIndex]?.focus()
 }
 
 function focusItem(container: HTMLElement | null, index: number) {
@@ -234,7 +192,7 @@ function DropdownMenuContent({
   autoFocusOnOpen?: boolean
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>
 }) {
-  const { open, menuId, focusReferenceElement, close } = useDropdownMenuContext()
+  const { open, menuId, close } = useDropdownMenuContext()
   const { window } = useWindow()
   const contentRef = useRef<HTMLDivElement>(null)
 
@@ -269,14 +227,12 @@ function DropdownMenuContent({
           break
         }
         case 'Tab': {
-          event.preventDefault()
-          focusAdjacentTabbableElement(focusReferenceElement, event.shiftKey)
           close({ restoreFocus: false })
           break
         }
       }
     },
-    [close, focusReferenceElement, onKeyDown]
+    [close, onKeyDown]
   )
 
   useEffect(() => {
@@ -331,8 +287,6 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
     const controlled = !isNil(show)
     const open = controlled ? Boolean(show) : uncontrolledOpen
     const overlayTarget = target ?? triggerElement
-    const focusReferenceElement =
-      triggerElement ?? (isElementTarget(overlayTarget) ? overlayTarget : null)
     const { trigger, items } = splitDropdownMenuChildren(children)
     const hasInternalTrigger = isValidElement(trigger)
     const overlayContainer =
@@ -364,11 +318,10 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
       (): DropdownMenuContextValue => ({
         open,
         menuId,
-        focusReferenceElement,
         overlayContainer,
         close,
       }),
-      [close, focusReferenceElement, menuId, open, overlayContainer]
+      [close, menuId, open, overlayContainer]
     )
 
     const overlayMargins = getOverlayMargins({ position, offset })

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
@@ -18,9 +18,6 @@ import * as React from 'react'
 import { ChevronSmallRightIcon } from '@channel.io/bezier-icons'
 import classNames from 'classnames'
 
-
-
-
 import { BaseGroupLabel } from '~/src/beta/BaseGroupLabel'
 import { BaseItem } from '~/src/beta/BaseItem/BaseItem'
 import { Divider } from '~/src/beta/Divider'
@@ -45,9 +42,6 @@ import type {
 } from './DropdownMenu.types'
 
 import styles from './DropdownMenu.module.scss'
-
-
-
 
 const MENU_ITEM_SELECTOR =
   '[data-b-dropdown-menu-item="true"]:not([aria-disabled="true"])'
@@ -438,83 +432,148 @@ export function DropdownMenuTrigger({
   } as Partial<typeof children.props>)
 }
 
-export const DropdownMenuItem = forwardRef<
-  HTMLDivElement,
-  DropdownMenuItemProps
->(function DropdownMenuItem(
-  {
-    className,
-    content,
-    disabled = false,
-    variant = 'neutral',
-    description,
-    leadingContent,
-    trailingContent,
-    closeOnSelect = true,
-    onSelect,
-    onKeyDown,
-    ...rest
-  },
-  forwardedRef
-) {
-  const { close } = useDropdownMenuContext()
+export const DropdownMenuItem = forwardRef<HTMLElement, DropdownMenuItemProps>(
+  function DropdownMenuItem(
+    {
+      className,
+      content,
+      disabled = false,
+      variant = 'neutral',
+      description,
+      leadingContent,
+      trailingContent,
+      closeOnSelect = true,
+      onSelect,
+      onKeyDown,
+      ...rest
+    },
+    forwardedRef
+  ) {
+    const { close } = useDropdownMenuContext()
+    const isLink = 'href' in rest && rest.href != null
+    const handleKeyDownProp = onKeyDown as
+      | React.KeyboardEventHandler<HTMLElement>
+      | undefined
 
-  const handleSelect = useCallback(
-    (
-      event:
-        | React.MouseEvent<HTMLDivElement>
-        | React.KeyboardEvent<HTMLDivElement>
-    ) => {
-      if (disabled) {
-        return
-      }
+    const handleSelect = useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        if (disabled) {
+          return false
+        }
 
-      onSelect?.(event)
+        onSelect?.(event)
 
-      if (!('defaultPrevented' in event) || !event.defaultPrevented) {
+        if ('defaultPrevented' in event && event.defaultPrevented) {
+          return false
+        }
+
         if (closeOnSelect) {
           close()
         }
-      }
-    },
-    [close, closeOnSelect, disabled, onSelect]
-  )
 
-  return (
-    <BaseItem
-      ref={forwardedRef}
-      className={className}
-      role="menuitem"
-      tabIndex={disabled ? undefined : -1}
-      aria-disabled={disabled || undefined}
-      data-b-dropdown-menu-item="true"
-      disabled={disabled}
-      variant={variant}
-      description={description}
-      leadingContent={leadingContent}
-      trailingContent={trailingContent}
-      {...rest}
-      onClick={(event) => {
-        if (!event.defaultPrevented) {
-          handleSelect(event)
-        }
-      }}
-      onKeyDown={(event) => {
-        onKeyDown?.(event)
-        if (event.defaultPrevented) {
-          return
-        }
+        return true
+      },
+      [close, closeOnSelect, disabled, onSelect]
+    )
 
-        if (event.key === 'Enter' || event.key === ' ') {
+    const commonProps = {
+      className,
+      role: 'menuitem',
+      tabIndex: -1,
+      'aria-disabled': disabled || undefined,
+      'data-b-dropdown-menu-item': 'true',
+      disabled,
+      interactive: true,
+      variant,
+      description,
+      leadingContent,
+      trailingContent,
+      children: content,
+    } satisfies {
+      className?: string
+      role: 'menuitem'
+      tabIndex: number
+      'aria-disabled'?: boolean
+      'data-b-dropdown-menu-item': string
+      disabled: boolean
+      interactive: boolean
+      variant: DropdownMenuItemProps['variant']
+      description: DropdownMenuItemProps['description']
+      leadingContent: DropdownMenuItemProps['leadingContent']
+      trailingContent: DropdownMenuItemProps['trailingContent']
+      children: DropdownMenuItemProps['content']
+    }
+
+    if (isLink) {
+      return (
+        <BaseItem
+          as="a"
+          ref={forwardedRef as React.Ref<HTMLAnchorElement>}
+          {...commonProps}
+          {...rest}
+          draggable={false}
+          onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
+            if (disabled) {
+              event.preventDefault()
+              event.stopPropagation()
+              return
+            }
+
+            if (event.defaultPrevented) {
+              return
+            }
+
+            close()
+          }}
+          onKeyDown={(event: React.KeyboardEvent<HTMLAnchorElement>) => {
+            handleKeyDownProp?.(event)
+            if (event.defaultPrevented) {
+              return
+            }
+
+            if (event.key === ' ') {
+              event.preventDefault()
+              event.currentTarget.click()
+            }
+          }}
+        />
+      )
+    }
+
+    return (
+      <BaseItem
+        as="div"
+        ref={forwardedRef as React.Ref<HTMLDivElement>}
+        {...commonProps}
+        {...rest}
+        onClick={(event: React.MouseEvent<HTMLDivElement>) => {
+          if (disabled) {
+            event.preventDefault()
+            event.stopPropagation()
+            return
+          }
+
+          if (event.defaultPrevented) {
+            return
+          }
+
           handleSelect(event)
-          event.preventDefault()
-        }
-      }}
-    >
-      {content}
-    </BaseItem>
-  )
-})
+        }}
+        onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+          handleKeyDownProp?.(event)
+          if (event.defaultPrevented) {
+            return
+          }
+
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            event.currentTarget.click()
+          }
+        }}
+      />
+    )
+  }
+)
 
 export const DropdownMenuGroup = forwardRef<
   HTMLDivElement,

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
@@ -457,10 +457,6 @@ export const DropdownMenuItem = forwardRef<HTMLElement, DropdownMenuItemProps>(
 
     const handleSelect = useCallback(
       (event: React.MouseEvent<HTMLDivElement>) => {
-        if (disabled) {
-          return false
-        }
-
         onSelect?.(event)
 
         if ('defaultPrevented' in event && event.defaultPrevented) {
@@ -473,7 +469,7 @@ export const DropdownMenuItem = forwardRef<HTMLElement, DropdownMenuItemProps>(
 
         return true
       },
-      [close, closeOnSelect, disabled, onSelect]
+      [close, closeOnSelect, onSelect]
     )
 
     const commonProps = {

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.tsx
@@ -45,18 +45,28 @@ import styles from './DropdownMenu.module.scss'
 
 const MENU_ITEM_SELECTOR =
   '[data-b-dropdown-menu-item="true"]:not([aria-disabled="true"])'
+const TABBABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
 
 type DropdownMenuContextValue = {
   open: boolean
   menuId: string
+  focusReferenceElement: HTMLElement | null
   overlayContainer: HTMLElement | null
-  close: () => void
+  close: (options?: { restoreFocus?: boolean }) => void
 }
 
 const [DropdownMenuContextProvider, useDropdownMenuContext] =
   createContext<DropdownMenuContextValue>({
     open: false,
     menuId: '',
+    focusReferenceElement: null,
     overlayContainer: null,
     close: () => {},
   })
@@ -139,6 +149,12 @@ function isSidePosition(position: NonNullable<DropdownMenuProps['position']>) {
   return position.startsWith('left') || position.startsWith('right')
 }
 
+function isElementTarget(
+  target: DropdownMenuProps['target'] | null | undefined
+): target is HTMLElement {
+  return (target as { nodeType?: number } | null | undefined)?.nodeType === 1
+}
+
 function getOverlayMargins({
   position,
   offset,
@@ -157,6 +173,32 @@ function getFocusableItems(container: HTMLElement | null) {
   }
 
   return Array.from(container.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR))
+}
+
+function getTabbableElements(document: Document) {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR)
+  ).filter(
+    (element) =>
+      element.tabIndex >= 0 &&
+      element.getAttribute('aria-hidden') !== 'true' &&
+      element.getAttribute('aria-disabled') !== 'true'
+  )
+}
+
+function focusAdjacentTabbableElement(
+  referenceElement: HTMLElement | null,
+  reverse: boolean
+) {
+  if (!referenceElement) {
+    return
+  }
+
+  const tabbableElements = getTabbableElements(referenceElement.ownerDocument)
+  const currentIndex = tabbableElements.indexOf(referenceElement)
+  const nextIndex = reverse ? currentIndex - 1 : currentIndex + 1
+
+  tabbableElements[nextIndex]?.focus()
 }
 
 function focusItem(container: HTMLElement | null, index: number) {
@@ -185,14 +227,14 @@ function moveFocus(container: HTMLElement | null, delta: number) {
 
 function DropdownMenuContent({
   children,
-  autoFocusOnMount = false,
+  autoFocusOnOpen = false,
   onKeyDown,
 }: {
   children: React.ReactNode
-  autoFocusOnMount?: boolean
+  autoFocusOnOpen?: boolean
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>
 }) {
-  const { menuId } = useDropdownMenuContext()
+  const { open, menuId, focusReferenceElement, close } = useDropdownMenuContext()
   const { window } = useWindow()
   const contentRef = useRef<HTMLDivElement>(null)
 
@@ -226,18 +268,24 @@ function DropdownMenuContent({
           items[items.length - 1]?.focus()
           break
         }
+        case 'Tab': {
+          event.preventDefault()
+          focusAdjacentTabbableElement(focusReferenceElement, event.shiftKey)
+          close({ restoreFocus: false })
+          break
+        }
       }
     },
-    [onKeyDown]
+    [close, focusReferenceElement, onKeyDown]
   )
 
   useEffect(() => {
-    if (autoFocusOnMount) {
+    if (autoFocusOnOpen && open) {
       window.requestAnimationFrame(() => {
         focusItem(contentRef.current, 0)
       })
     }
-  }, [autoFocusOnMount, window])
+  }, [autoFocusOnOpen, open, window])
 
   return (
     <div
@@ -283,6 +331,8 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
     const controlled = !isNil(show)
     const open = controlled ? Boolean(show) : uncontrolledOpen
     const overlayTarget = target ?? triggerElement
+    const focusReferenceElement =
+      triggerElement ?? (isElementTarget(overlayTarget) ? overlayTarget : null)
     const { trigger, items } = splitDropdownMenuChildren(children)
     const hasInternalTrigger = isValidElement(trigger)
     const overlayContainer =
@@ -303,19 +353,22 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
       [controlled, onHide, onShow]
     )
 
-    const close = useCallback(() => {
+    const close = useCallback((options?: { restoreFocus?: boolean }) => {
       setOpen(false)
-      triggerElement?.focus()
+      if (options?.restoreFocus !== false) {
+        triggerElement?.focus()
+      }
     }, [setOpen, triggerElement])
 
     const contextValue = useMemo(
       (): DropdownMenuContextValue => ({
         open,
         menuId,
+        focusReferenceElement,
         overlayContainer,
         close,
       }),
-      [close, menuId, open, overlayContainer]
+      [close, focusReferenceElement, menuId, open, overlayContainer]
     )
 
     const overlayMargins = getOverlayMargins({ position, offset })
@@ -350,7 +403,7 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
         onHide={close}
         {...rest}
       >
-        <DropdownMenuContent autoFocusOnMount>{items}</DropdownMenuContent>
+        <DropdownMenuContent autoFocusOnOpen>{items}</DropdownMenuContent>
       </Overlay>
     )
 
@@ -848,7 +901,7 @@ export const DropdownMenuSubContent = forwardRef<
       {...rest}
     >
       <DropdownMenuContextProvider value={rootContext}>
-        <DropdownMenuContent autoFocusOnMount={focusOnOpen}>
+        <DropdownMenuContent autoFocusOnOpen={focusOnOpen}>
           {children}
         </DropdownMenuContent>
       </DropdownMenuContextProvider>

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.types.ts
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.types.ts
@@ -167,7 +167,7 @@ type DropdownMenuItemActionProps = Omit<
 
 type DropdownMenuItemAnchorProps = Omit<
   BezierComponentProps<'a'>,
-  DropdownMenuItemBaseOmitKeys
+  Exclude<DropdownMenuItemBaseOmitKeys, 'onClick'>
 > & {
   closeOnSelect?: never
   onSelect?: never

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.types.ts
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.types.ts
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react'
+import type { MouseEvent, ReactElement, ReactNode } from 'react'
 
 import type { BezierIcon } from '@channel.io/bezier-icons'
 
@@ -11,6 +11,7 @@ import type {
   ContentProps,
   DisableProps,
   LeadingTrailingContentProps,
+  LinkProps,
   VariantProps,
 } from '~/src/types/props'
 
@@ -76,9 +77,7 @@ interface DropdownMenuOwnProps {
   onHide?: () => void
 }
 
-type DropdownMenuItemSelectEvent =
-  | React.MouseEvent<HTMLDivElement>
-  | React.KeyboardEvent<HTMLDivElement>
+type DropdownMenuItemSelectEvent = MouseEvent<HTMLDivElement>
 
 interface DropdownMenuSubContentOwnProps {
   /**
@@ -127,13 +126,16 @@ interface DropdownMenuItemContentProps extends ContentProps<ReactNode> {
   content?: ReactNode
 }
 
-interface DropdownMenuItemOwnProps
+interface DropdownMenuItemBaseOwnProps
   extends VariantProps<DropdownMenuItemVariant>,
     LeadingTrailingContentProps<DropdownMenuItemSideContent> {
   /**
    * Content below the main content.
    */
   description?: ReactNode
+}
+
+interface DropdownMenuItemActionOwnProps extends DropdownMenuItemBaseOwnProps {
   /**
    * Whether selecting the item closes the menu.
    * @default true
@@ -147,6 +149,29 @@ interface DropdownMenuItemOwnProps
    */
   onSelect?: (event: DropdownMenuItemSelectEvent) => void
 }
+
+type DropdownMenuItemBaseOmitKeys =
+  | keyof DropdownMenuItemActionOwnProps
+  | keyof DropdownMenuItemContentProps
+  | keyof DisableProps
+  | 'children'
+  | 'onClick'
+  | 'type'
+
+type DropdownMenuItemActionProps = Omit<
+  BezierComponentProps<'div'>,
+  DropdownMenuItemBaseOmitKeys
+> & {
+  href?: never
+}
+
+type DropdownMenuItemAnchorProps = Omit<
+  BezierComponentProps<'a'>,
+  DropdownMenuItemBaseOmitKeys
+> & {
+  closeOnSelect?: never
+  onSelect?: never
+} & Required<LinkProps>
 
 /**
  * Root action menu surface.
@@ -181,17 +206,12 @@ export interface DropdownMenuTriggerProps extends ChildrenProps<ReactElement> {}
  * `DropdownMenuSubTrigger`. Arbitrary children can be rendered inside
  * `DropdownMenu`, but they are not treated as menu items.
  */
-export interface DropdownMenuItemProps
-  extends Omit<
-      BezierComponentProps<'div'>,
-      | keyof DropdownMenuItemOwnProps
-      | keyof DropdownMenuItemContentProps
-      | 'children'
-      | 'onClick'
-    >,
-    DropdownMenuItemContentProps,
-    DisableProps,
-    DropdownMenuItemOwnProps {}
+export type DropdownMenuItemProps = DropdownMenuItemContentProps &
+  DisableProps &
+  (
+    | (DropdownMenuItemActionOwnProps & DropdownMenuItemActionProps)
+    | (DropdownMenuItemBaseOwnProps & DropdownMenuItemAnchorProps)
+  )
 
 export interface DropdownMenuGroupProps
   extends Omit<BezierComponentProps<'div'>, 'children'>,
@@ -228,11 +248,13 @@ export interface DropdownMenuSubProps extends ChildrenProps {}
  * This is not an action item, so use `DropdownMenuItem` when you need
  * `onSelect` handling.
  */
-export interface DropdownMenuSubTriggerProps
-  extends Omit<
-    DropdownMenuItemProps,
-    'trailingContent' | 'closeOnSelect' | 'onSelect'
-  > {}
+export type DropdownMenuSubTriggerProps = Omit<
+  DropdownMenuItemContentProps &
+    DisableProps &
+    DropdownMenuItemActionOwnProps &
+    DropdownMenuItemActionProps,
+  'trailingContent' | 'closeOnSelect' | 'onSelect'
+>
 
 /**
  * Floating content boundary for nested submenu items.

--- a/packages/bezier-react/src/beta/NavigationList/NavigationList.module.scss
+++ b/packages/bezier-react/src/beta/NavigationList/NavigationList.module.scss
@@ -89,51 +89,6 @@
   }
 }
 
-.NavigationItem {
-  display: block;
-
-  box-sizing: border-box;
-  width: 100%;
-  padding: 0;
-
-  color: inherit;
-  text-align: inherit;
-  text-decoration: none;
-
-  background-color: transparent;
-  border: 0;
-  border-radius: var(--radius-8);
-  outline: none;
-
-  &:where(:focus-visible) {
-    @include state.focus-ring($gap: 0);
-  }
-
-  &:where(.interactive) {
-    cursor: pointer;
-  }
-
-  &:where(.disabled) {
-    cursor: not-allowed;
-  }
-
-  &:where(.interactive:not(.disabled, .active):hover) {
-    :where(.NavigationItemBase) {
-      background-color: var(--color-fill-neutral-lighter);
-    }
-  }
-
-  &:where(.active) {
-    :where(.NavigationItemBase) {
-      background-color: var(--color-fill-neutral-light);
-    }
-  }
-}
-
-.NavigationItemBase {
-  pointer-events: none;
-}
-
 .NavigationGroupTrigger {
   @include navigation-row-surface;
 

--- a/packages/bezier-react/src/beta/NavigationList/NavigationList.test.tsx
+++ b/packages/bezier-react/src/beta/NavigationList/NavigationList.test.tsx
@@ -1,6 +1,7 @@
 import { SettingsIcon } from '@channel.io/bezier-icons'
 import userEvent from '@testing-library/user-event'
 
+import textStyles from '~/src/beta/Text/Text.module.scss'
 import { render } from '~/src/utils/test'
 
 import {
@@ -50,6 +51,22 @@ describe('NavigationList', () => {
     await user.click(getByRole('button', { name: 'Open modal' }))
 
     expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps long item content single-line truncated', () => {
+    const longContent =
+      'Channel profile with a very long navigation item label that should be truncated'
+
+    const { getByText } = render(
+      <NavigationList>
+        <NavigationItem
+          href="/settings/profile"
+          content={longContent}
+        />
+      </NavigationList>
+    )
+
+    expect(getByText(longContent)).toHaveClass(textStyles.truncated)
   })
 
   it('toggles group content from the parent trigger', async () => {

--- a/packages/bezier-react/src/beta/NavigationList/NavigationList.test.tsx
+++ b/packages/bezier-react/src/beta/NavigationList/NavigationList.test.tsx
@@ -1,3 +1,5 @@
+import type { MouseEvent } from 'react'
+
 import { SettingsIcon } from '@channel.io/bezier-icons'
 import userEvent from '@testing-library/user-event'
 
@@ -33,6 +35,27 @@ describe('NavigationList', () => {
     expect(getByTestId(NAVIGATION_ITEM_TEST_ID)).toBe(item)
     expect(item).toHaveAttribute('href', '/settings/profile')
     expect(item).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('calls anchor item onClick when href is provided', async () => {
+    const user = userEvent.setup()
+    const onClick = jest.fn((event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault()
+    })
+
+    const { getByRole } = render(
+      <NavigationList>
+        <NavigationItem
+          href="/settings/profile"
+          content="Profile"
+          onClick={onClick}
+        />
+      </NavigationList>
+    )
+
+    await user.click(getByRole('link', { name: 'Profile' }))
+
+    expect(onClick).toHaveBeenCalledTimes(1)
   })
 
   it('renders button items when onClick is provided', async () => {
@@ -185,6 +208,7 @@ describe('NavigationList', () => {
           href="/settings/profile"
           content="Profile"
           disabled
+          onClick={onClick}
         />
       </div>
     )

--- a/packages/bezier-react/src/beta/NavigationList/NavigationList.tsx
+++ b/packages/bezier-react/src/beta/NavigationList/NavigationList.tsx
@@ -97,7 +97,6 @@ export const NavigationItem = forwardRef<HTMLElement, NavigationItemProps>(
       ...rest
     } = props
     const isLink = 'href' in rest && rest.href != null
-    const Component = (isLink ? 'a' : 'button') as React.ElementType
 
     const handleDisabledLinkClick = (
       event: React.MouseEvent<HTMLAnchorElement>
@@ -108,39 +107,53 @@ export const NavigationItem = forwardRef<HTMLElement, NavigationItemProps>(
       }
     }
 
-    return (
-      <Component
-        ref={forwardedRef}
-        className={classNames(
-          styles.NavigationItem,
-          active && styles.active,
-          disabled && styles.disabled,
-          styles.interactive,
-          className
-        )}
-        style={style}
-        data-testid={NAVIGATION_ITEM_TEST_ID}
-        aria-disabled={disabled || undefined}
-        {...rest}
-        {...(isLink && {
-          draggable: false,
-          tabIndex: disabled ? -1 : rest.tabIndex,
-          onClick: handleDisabledLinkClick,
-        })}
-        {...(!isLink && {
-          type: rest.type ?? 'button',
-          disabled,
-        })}
-      >
+    if (isLink) {
+      const { href, ...anchorRest } = rest
+
+      return (
         <BaseItem
-          className={styles.NavigationItemBase}
+          as="a"
+          ref={forwardedRef as React.Ref<HTMLAnchorElement>}
+          className={className}
+          style={style}
+          data-testid={NAVIGATION_ITEM_TEST_ID}
+          aria-disabled={disabled || undefined}
+          href={href}
+          draggable={false}
+          active={active}
+          interactive
+          contentMaxLines={1}
           leadingContent={leadingContent}
           trailingContent={trailingContent}
           disabled={disabled}
+          {...anchorRest}
+          tabIndex={disabled ? -1 : anchorRest.tabIndex}
+          onClick={handleDisabledLinkClick}
         >
           {content}
         </BaseItem>
-      </Component>
+      )
+    }
+
+    return (
+      <BaseItem
+        as="button"
+        ref={forwardedRef as React.Ref<HTMLButtonElement>}
+        className={className}
+        style={style}
+        data-testid={NAVIGATION_ITEM_TEST_ID}
+        aria-disabled={disabled || undefined}
+        type={rest.type ?? 'button'}
+        active={active}
+        interactive
+        contentMaxLines={1}
+        leadingContent={leadingContent}
+        trailingContent={trailingContent}
+        disabled={disabled}
+        {...rest}
+      >
+        {content}
+      </BaseItem>
     )
   }
 )

--- a/packages/bezier-react/src/beta/NavigationList/NavigationList.tsx
+++ b/packages/bezier-react/src/beta/NavigationList/NavigationList.tsx
@@ -98,17 +98,8 @@ export const NavigationItem = forwardRef<HTMLElement, NavigationItemProps>(
     } = props
     const isLink = 'href' in rest && rest.href != null
 
-    const handleDisabledLinkClick = (
-      event: React.MouseEvent<HTMLAnchorElement>
-    ) => {
-      if (disabled) {
-        event.preventDefault()
-        event.stopPropagation()
-      }
-    }
-
     if (isLink) {
-      const { href, ...anchorRest } = rest
+      const { href, onClick, ...anchorRest } = rest
 
       return (
         <BaseItem
@@ -128,7 +119,15 @@ export const NavigationItem = forwardRef<HTMLElement, NavigationItemProps>(
           disabled={disabled}
           {...anchorRest}
           tabIndex={disabled ? -1 : anchorRest.tabIndex}
-          onClick={handleDisabledLinkClick}
+          onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
+            if (disabled) {
+              event.preventDefault()
+              event.stopPropagation()
+              return
+            }
+
+            onClick?.(event)
+          }}
         >
           {content}
         </BaseItem>

--- a/packages/bezier-react/src/beta/NavigationList/NavigationList.types.ts
+++ b/packages/bezier-react/src/beta/NavigationList/NavigationList.types.ts
@@ -8,6 +8,7 @@ import type {
   ChildrenProps,
   ContentProps,
   DisableProps,
+  LinkProps,
 } from '~/src/types/props'
 
 interface NavigationContentProps extends ContentProps<ReactNode> {
@@ -49,11 +50,10 @@ interface NavigationGroupOwnProps extends DisableProps {
 type NavigationItemBaseProps =
   | (Omit<
       BezierComponentProps<'a'>,
-      keyof NavigationItemOwnProps | 'children' | 'onClick'
+      keyof NavigationItemOwnProps | 'children' | 'onClick' | 'type'
     > & {
-      href: string
       onClick?: never
-    })
+    } & Required<LinkProps>)
   | (Omit<
       BezierComponentProps<'button'>,
       keyof NavigationItemOwnProps | 'children'

--- a/packages/bezier-react/src/beta/NavigationList/NavigationList.types.ts
+++ b/packages/bezier-react/src/beta/NavigationList/NavigationList.types.ts
@@ -50,10 +50,9 @@ interface NavigationGroupOwnProps extends DisableProps {
 type NavigationItemBaseProps =
   | (Omit<
       BezierComponentProps<'a'>,
-      keyof NavigationItemOwnProps | 'children' | 'onClick' | 'type'
-    > & {
-      onClick?: never
-    } & Required<LinkProps>)
+      keyof NavigationItemOwnProps | 'children' | 'type'
+    > &
+      Required<LinkProps>)
   | (Omit<
       BezierComponentProps<'button'>,
       keyof NavigationItemOwnProps | 'children'

--- a/packages/bezier-react/src/beta/Section/Section.module.scss
+++ b/packages/bezier-react/src/beta/Section/Section.module.scss
@@ -43,55 +43,9 @@
 }
 
 .SectionItem {
-  display: block;
-
-  box-sizing: border-box;
-  width: 100%;
-  padding: 0;
-
-  font: inherit;
-  color: inherit;
-  text-align: inherit;
-  text-decoration: none;
-
-  background-color: transparent;
-  border: 0;
-  border-radius: var(--radius-8);
-  outline: none;
-
-  transition:
-    background-color var(--motion-transition-fast),
-    color var(--motion-transition-fast);
-
-  &:where(.interactive) {
-    cursor: pointer;
-  }
-
-  &:where(.disabled) {
-    cursor: not-allowed;
-  }
-
-  &:where(:focus-visible) {
-    @include state.focus-ring($gap: 0);
-  }
-
-  &:where(.interactive:not(.disabled, .active):hover) {
-    :where(.SectionItemBase) {
-      background-color: var(--color-fill-neutral-lighter);
-    }
-  }
-
   &:where(.active) {
-    :where(.SectionItemBase) {
-      background-color: var(--color-fill-neutral-light);
-    }
-
-    :where(.SectionItemBase svg) {
+    :where(svg) {
       color: var(--color-icon-neutral-heavier);
     }
   }
-}
-
-.SectionItemBase {
-  pointer-events: none;
 }

--- a/packages/bezier-react/src/beta/Section/Section.test.tsx
+++ b/packages/bezier-react/src/beta/Section/Section.test.tsx
@@ -1,3 +1,5 @@
+import type { MouseEvent } from 'react'
+
 import { CheckIcon } from '@channel.io/bezier-icons'
 import { waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -114,6 +116,25 @@ describe('Section', () => {
     )
   })
 
+  it('calls anchor item onClick when href is provided', async () => {
+    const user = userEvent.setup()
+    const onClick = jest.fn((event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault()
+    })
+
+    const { getByRole } = render(
+      <SectionItem
+        content="Billing"
+        href="/billing"
+        onClick={onClick}
+      />
+    )
+
+    await user.click(getByRole('link', { name: 'Billing' }))
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
   it('renders a non-interactive item by default', () => {
     const { getByTestId, queryByRole } = render(
       <SectionItem content="Read only" />
@@ -165,6 +186,7 @@ describe('Section', () => {
           content="Billing"
           disabled
           href="/billing"
+          onClick={onClick}
         />
       </div>
     )

--- a/packages/bezier-react/src/beta/Section/Section.tsx
+++ b/packages/bezier-react/src/beta/Section/Section.tsx
@@ -84,15 +84,6 @@ export const SectionItem = forwardRef<HTMLElement, SectionItemProps>(
     const isLink = 'href' in rest && rest.href != null
     const isButton = 'onClick' in rest && rest.onClick != null
 
-    const handleDisabledLinkClick = (
-      event: React.MouseEvent<HTMLAnchorElement>
-    ) => {
-      if (disabled) {
-        event.preventDefault()
-        event.stopPropagation()
-      }
-    }
-
     const itemClassName = classNames(
       styles.SectionItem,
       active && styles.active,
@@ -108,10 +99,10 @@ export const SectionItem = forwardRef<HTMLElement, SectionItemProps>(
         </Text>
       ) : (
         description
-      )
+    )
 
     if (isLink) {
-      const { href, ...anchorRest } = rest
+      const { href, onClick, ...anchorRest } = rest
 
       return (
         <BaseItem
@@ -130,7 +121,15 @@ export const SectionItem = forwardRef<HTMLElement, SectionItemProps>(
           description={itemDescription}
           {...anchorRest}
           tabIndex={disabled ? -1 : anchorRest.tabIndex}
-          onClick={handleDisabledLinkClick}
+          onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
+            if (disabled) {
+              event.preventDefault()
+              event.stopPropagation()
+              return
+            }
+
+            onClick?.(event)
+          }}
         >
           {content}
         </BaseItem>

--- a/packages/bezier-react/src/beta/Section/Section.tsx
+++ b/packages/bezier-react/src/beta/Section/Section.tsx
@@ -83,10 +83,6 @@ export const SectionItem = forwardRef<HTMLElement, SectionItemProps>(
     } = props
     const isLink = 'href' in rest && rest.href != null
     const isButton = 'onClick' in rest && rest.onClick != null
-    const isInteractive = isLink || isButton
-    const Component = (
-      isLink ? 'a' : isButton ? 'button' : 'div'
-    ) as React.ElementType
 
     const handleDisabledLinkClick = (
       event: React.MouseEvent<HTMLAnchorElement>
@@ -97,48 +93,88 @@ export const SectionItem = forwardRef<HTMLElement, SectionItemProps>(
       }
     }
 
-    return (
-      <Component
-        ref={forwardedRef as React.Ref<HTMLElement>}
-        className={classNames(
-          styles.SectionItem,
-          active && styles.active,
-          disabled && styles.disabled,
-          isInteractive && styles.interactive,
-          className
-        )}
-        data-testid={SECTION_ITEM_TEST_ID}
-        aria-disabled={disabled || undefined}
-        {...(isButton && { type: rest.type ?? 'button' })}
-        {...rest}
-        {...(isLink && {
-          draggable: false,
-          tabIndex: disabled ? -1 : rest.tabIndex,
-          onClick: handleDisabledLinkClick,
-        })}
-        {...(isButton && { disabled })}
-      >
+    const itemClassName = classNames(
+      styles.SectionItem,
+      active && styles.active,
+      className
+    )
+    const itemDescription =
+      typeof description === 'string' ? (
+        <Text
+          typo="12"
+          color="text-neutral-lighter"
+        >
+          {renderTextWithNewLine(description)}
+        </Text>
+      ) : (
+        description
+      )
+
+    if (isLink) {
+      const { href, ...anchorRest } = rest
+
+      return (
         <BaseItem
-          className={styles.SectionItemBase}
+          as="a"
+          ref={forwardedRef as React.Ref<HTMLAnchorElement>}
+          className={itemClassName}
+          data-testid={SECTION_ITEM_TEST_ID}
+          aria-disabled={disabled || undefined}
+          href={href}
+          draggable={false}
+          active={active}
+          disabled={disabled}
+          interactive
           leadingContent={leadingContent}
           trailingContent={trailingContent}
-          description={
-            typeof description === 'string' ? (
-              <Text
-                typo="12"
-                color="text-neutral-lighter"
-              >
-                {renderTextWithNewLine(description)}
-              </Text>
-            ) : (
-              description
-            )
-          }
-          disabled={disabled}
+          description={itemDescription}
+          {...anchorRest}
+          tabIndex={disabled ? -1 : anchorRest.tabIndex}
+          onClick={handleDisabledLinkClick}
         >
           {content}
         </BaseItem>
-      </Component>
+      )
+    }
+
+    if (isButton) {
+      return (
+        <BaseItem
+          as="button"
+          ref={forwardedRef as React.Ref<HTMLButtonElement>}
+          className={itemClassName}
+          data-testid={SECTION_ITEM_TEST_ID}
+          aria-disabled={disabled || undefined}
+          type={rest.type ?? 'button'}
+          active={active}
+          disabled={disabled}
+          interactive
+          leadingContent={leadingContent}
+          trailingContent={trailingContent}
+          description={itemDescription}
+          {...rest}
+        >
+          {content}
+        </BaseItem>
+      )
+    }
+
+    return (
+      <BaseItem
+        as="div"
+        ref={forwardedRef as React.Ref<HTMLDivElement>}
+        className={itemClassName}
+        data-testid={SECTION_ITEM_TEST_ID}
+        aria-disabled={disabled || undefined}
+        active={active}
+        disabled={disabled}
+        leadingContent={leadingContent}
+        trailingContent={trailingContent}
+        description={itemDescription}
+        {...rest}
+      >
+        {content}
+      </BaseItem>
     )
   }
 )

--- a/packages/bezier-react/src/beta/Section/Section.types.ts
+++ b/packages/bezier-react/src/beta/Section/Section.types.ts
@@ -10,6 +10,7 @@ import type {
   ContentProps,
   DisableProps,
   LeadingTrailingContentProps,
+  LinkProps,
   MarginProps,
 } from '~/src/types/props'
 
@@ -88,11 +89,10 @@ type SectionItemBaseProps =
     })
   | (Omit<
       BezierComponentProps<'a'>,
-      keyof SectionItemOwnProps | 'children' | 'onClick'
+      keyof SectionItemOwnProps | 'children' | 'onClick' | 'type'
     > & {
-      href: string
       onClick?: never
-    })
+    } & Required<LinkProps>)
 
 /**
  * General row inside `Section`.

--- a/packages/bezier-react/src/beta/Section/Section.types.ts
+++ b/packages/bezier-react/src/beta/Section/Section.types.ts
@@ -89,10 +89,9 @@ type SectionItemBaseProps =
     })
   | (Omit<
       BezierComponentProps<'a'>,
-      keyof SectionItemOwnProps | 'children' | 'onClick' | 'type'
-    > & {
-      onClick?: never
-    } & Required<LinkProps>)
+      keyof SectionItemOwnProps | 'children' | 'type'
+    > &
+      Required<LinkProps>)
 
 /**
  * General row inside `Section`.


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

WEB-12068

## Summary

`BaseItem`을 기반으로 사용하는 beta item 계열 컴포넌트의 root element와 link 타입을 정리했습니다.

`DropdownMenuItem`은 기본적으로 기존 menu primitive 관례에 맞게 `div + role="menuitem"`을 유지하고, `href`가 전달된 경우에만 anchor로 렌더링합니다.

## Details

- `BaseItem`이 `href`, `onClick`, `as`에 따라 anchor/button/div root를 타입 안전하게 렌더링할 수 있도록 정리했습니다.
- `BaseItem`의 interactive surface style을 명시 prop으로 제공하고, hover/active 스타일을 공통화했습니다.
- `BaseItem`은 기본 ellipsis 정책을 갖지 않도록 하고, 필요한 사용처가 `contentMaxLines`로 명시할 수 있게 했습니다.
- `NavigationItem`은 기존 정책대로 긴 label을 1줄 ellipsis 처리하도록 `contentMaxLines={1}`을 명시했습니다.
- `DropdownMenuItem`은 `href`가 있을 때 anchor props를 받고, action item에서는 `onSelect`만 받을 수 있도록 타입을 분기했습니다.
- `SectionItem`, `NavigationItem`, `BaseItem`, `DropdownMenuItem`의 anchor branch에 공통 `LinkProps`를 적용했습니다.
- DropdownMenu stories를 정리하고 새 페이지를 여는 anchor item 예시를 추가했습니다.
- 관련 회귀 테스트를 추가했습니다.

검증:

- `tsc --noEmit -p packages/bezier-react/tsconfig.json`
- `jest src/beta/BaseItem/BaseItem.test.tsx src/beta/NavigationList/NavigationList.test.tsx src/beta/DropdownMenu/DropdownMenu.test.tsx src/beta/BaseSelect/BaseSelect.test.tsx src/beta/Select/Select.test.tsx src/beta/MultiSelect/MultiSelect.test.tsx --runInBand`
- targeted `eslint`
- targeted `stylelint`
- `git diff --check`

### Breaking change? (Yes/No)

No

## References

- `DropdownMenuItem` 기본 root는 기존처럼 role 기반 menu item으로 유지합니다.
- `href`가 있는 `DropdownMenuItem`은 새 anchor branch로 처리되며 `onSelect`를 받지 않습니다.
