### PR TITLE
feat(tokens): add beta token compatibility to v2

### DIFF
--- a/.changeset/warm-snippets-glow.md
+++ b/.changeset/warm-snippets-glow.md
@@ -1,0 +1,6 @@
+---
+"@channel.io/bezier-react": minor
+"@channel.io/bezier-tokens": minor
+---
+
+Add v3 beta tokens for v2 backward compatibility.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn install
 
       - name: TurboRepo Local Server
-        uses: felixmosh/turborepo-gh-artifacts@v2
+        uses: felixmosh/turborepo-gh-artifacts@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           server-token: ${{ env.TURBO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
-      - alpha
+      - v2
 
 jobs:
   release:
@@ -39,8 +38,3 @@ jobs:
           # https://github.com/changesets/action/issues/187
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Release VSCode extension
-        run: yarn workspace bezier-vscode publish
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "turbo run test",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "version-packages": "changeset version && yarn --mode=\"update-lockfile\"",
-    "release": "turbo run build --filter='@channel.io/*' && changeset publish",
+    "release": "turbo run build --filter='@channel.io/*' && changeset publish --tag v2",
     "update-snapshot": "yarn workspace @channel.io/bezier-react update-snapshot",
     "changeset": "changeset",
     "postinstall": "husky install",

--- a/packages/bezier-react/src/styles/_tokens.scss
+++ b/packages/bezier-react/src/styles/_tokens.scss
@@ -1,2 +1,3 @@
 @use '../../node_modules/@channel.io/bezier-tokens/dist/css/styles.css' as *;
 @use '../../node_modules/@channel.io/bezier-tokens/dist/alpha/css/styles.css' as *;
+@use '../../node_modules/@channel.io/bezier-tokens/dist/beta/css/styles.css' as *;

--- a/packages/bezier-tokens/package.json
+++ b/packages/bezier-tokens/package.json
@@ -31,13 +31,27 @@
         "default": "./dist/alpha/esm/index.mjs"
       }
     },
+    "./beta": {
+      "require": {
+        "types": "./dist/types/beta/cjs/index.d.ts",
+        "default": "./dist/beta/cjs/index.js"
+      },
+      "import": {
+        "types": "./dist/types/beta/esm/index.d.mts",
+        "default": "./dist/beta/esm/index.mjs"
+      }
+    },
     "./css/*": "./dist/css/*",
-    "./alpha/css/*": "./dist/alpha/css/*"
+    "./alpha/css/*": "./dist/alpha/css/*",
+    "./beta/css/*": "./dist/beta/css/*"
   },
   "typesVersions": {
     "*": {
       "alpha": [
         "./dist/types/alpha/cjs/index.d.ts"
+      ],
+      "beta": [
+        "./dist/types/beta/cjs/index.d.ts"
       ]
     }
   },

--- a/packages/bezier-tokens/scripts/build-tokens.ts
+++ b/packages/bezier-tokens/scripts/build-tokens.ts
@@ -10,6 +10,9 @@ import {
   alphaCustomCss,
   alphaCustomJsCjs,
   alphaCustomJsEsm,
+  betaCustomCss,
+  betaCustomJsCjs,
+  betaCustomJsEsm,
   customJsCjs,
   customJsEsm,
 } from './lib/format'
@@ -21,6 +24,7 @@ const CustomTransforms = [...Object.values(CSSTransforms)]
 const BUILD_PATH = {
   BASE: 'dist',
   BASE_ALPHA: 'dist/alpha',
+  BASE_BETA: 'dist/beta',
   CJS: 'cjs',
   ESM: 'esm',
   CSS: 'css',
@@ -40,6 +44,14 @@ const AlphaTokenBuilder = CustomTransforms.reduce(
   .registerFormat(alphaCustomJsCjs)
   .registerFormat(alphaCustomJsEsm)
   .registerFormat(alphaCustomCss)
+
+const BetaTokenBuilder = CustomTransforms.reduce(
+  (builder, transform) => builder.registerTransform(transform),
+  StyleDictionary
+)
+  .registerFormat(betaCustomJsCjs)
+  .registerFormat(betaCustomJsEsm)
+  .registerFormat(betaCustomCss)
 
 function defineWebPlatform({
   options,
@@ -63,6 +75,11 @@ interface DefineConfigOptions {
    * TODO: Remove this option in the next major release.
    */
   useAlpha?: boolean
+  /**
+   * Whether to use the beta version of the custom formatter
+   * TODO: Remove this option in the next major release.
+   */
+  useBeta?: boolean
   source: string[]
   reference?: string[]
   basePath: string
@@ -74,6 +91,7 @@ interface DefineConfigOptions {
 
 function defineConfig({
   useAlpha = false,
+  useBeta = false,
   source,
   reference = [],
   basePath,
@@ -90,7 +108,11 @@ function defineConfig({
         files: [
           {
             destination: `${destination}.js`,
-            format: useAlpha ? alphaCustomJsCjs.name : customJsCjs.name,
+            format: useBeta
+              ? betaCustomJsCjs.name
+              : useAlpha
+                ? alphaCustomJsCjs.name
+                : customJsCjs.name,
             filter: ({ filePath }) =>
               source.some((src) => minimatch(filePath, src)),
           },
@@ -102,7 +124,11 @@ function defineConfig({
         files: [
           {
             destination: `${destination}.mjs`,
-            format: useAlpha ? alphaCustomJsEsm.name : customJsEsm.name,
+            format: useBeta
+              ? betaCustomJsEsm.name
+              : useAlpha
+                ? alphaCustomJsEsm.name
+                : customJsEsm.name,
             filter: ({ filePath }) =>
               source.some((src) => minimatch(filePath, src)),
           },
@@ -114,7 +140,11 @@ function defineConfig({
         files: [
           {
             destination: `${destination}.css`,
-            format: useAlpha ? alphaCustomCss.name : 'css/variables',
+            format: useBeta
+              ? betaCustomCss.name
+              : useAlpha
+                ? alphaCustomCss.name
+                : 'css/variables',
             filter: ({ filePath }) =>
               source.some((src) => minimatch(filePath, src)),
             options: {
@@ -198,6 +228,43 @@ async function main() {
         options: { cssSelector: '[data-bezier-theme="dark"]' },
       })
     ),
+    BetaTokenBuilder.extend(
+      defineConfig({
+        useBeta: true,
+        source: ['src/beta/global/*.json'],
+        basePath: BUILD_PATH.BASE_BETA,
+        destination: 'global',
+        options: { cssSelector: ':where(:root, :host)' },
+      })
+    ),
+    BetaTokenBuilder.extend(
+      defineConfig({
+        useBeta: true,
+        source: [
+          'src/beta/semantic/*.json',
+          'src/beta/semantic/light-theme/*.json',
+        ],
+        reference: ['src/beta/global/*.json'],
+        basePath: BUILD_PATH.BASE_BETA,
+        destination: 'lightTheme',
+        options: {
+          cssSelector: ':where(:root, :host), [data-bezier-theme="light"]',
+        },
+      })
+    ),
+    BetaTokenBuilder.extend(
+      defineConfig({
+        useBeta: true,
+        source: [
+          'src/beta/semantic/*.json',
+          'src/beta/semantic/dark-theme/*.json',
+        ],
+        reference: ['src/beta/global/*.json'],
+        basePath: BUILD_PATH.BASE_BETA,
+        destination: 'darkTheme',
+        options: { cssSelector: '[data-bezier-theme="dark"]' },
+      })
+    ),
   ].forEach((builder) => {
     builder.buildAllPlatforms()
   })
@@ -205,6 +272,7 @@ async function main() {
   for (const buildPath of [
     `${BUILD_PATH.BASE}/${BUILD_PATH.CSS}`,
     `${BUILD_PATH.BASE_ALPHA}/${BUILD_PATH.CSS}`,
+    `${BUILD_PATH.BASE_BETA}/${BUILD_PATH.CSS}`,
   ]) {
     await mergeCss(buildPath)
   }
@@ -212,8 +280,10 @@ async function main() {
   for (const options of [
     { buildPath: `${BUILD_PATH.BASE}/${BUILD_PATH.CJS}`, isCjs: true },
     { buildPath: `${BUILD_PATH.BASE_ALPHA}/${BUILD_PATH.CJS}`, isCjs: true },
+    { buildPath: `${BUILD_PATH.BASE_BETA}/${BUILD_PATH.CJS}`, isCjs: true },
     { buildPath: `${BUILD_PATH.BASE}/${BUILD_PATH.ESM}`, isCjs: false },
     { buildPath: `${BUILD_PATH.BASE_ALPHA}/${BUILD_PATH.ESM}`, isCjs: false },
+    { buildPath: `${BUILD_PATH.BASE_BETA}/${BUILD_PATH.ESM}`, isCjs: false },
   ]) {
     await buildJsIndex(options)
   }

--- a/packages/bezier-tokens/scripts/lib/format.ts
+++ b/packages/bezier-tokens/scripts/lib/format.ts
@@ -222,6 +222,147 @@ export const alphaCustomCss: CustomFormat = {
   },
 }
 
+/**
+ * A custom formatter for adding ref information to tokens for beta version.
+ * TODO: Remove this formatter in the next major release.
+ */
+export const betaCustomJsCjs: CustomFormat = {
+  name: 'beta/custom/js/cjs',
+  formatter({ dictionary, file }) {
+    const categorizedTokens = dictionary.allTokens.reduce(
+      (acc, token) => {
+        const fileNameWithoutExtension = token.filePath
+          .split('/')
+          .pop()!
+          .split('.')
+          .shift()!
+        acc[fileNameWithoutExtension] = acc[fileNameWithoutExtension] || []
+        acc[fileNameWithoutExtension].push(token)
+        return acc
+      },
+      {} as Record<string, typeof dictionary.allTokens>
+    )
+
+    return (
+      `${fileHeader({ file })}module.exports = Object.freeze({` +
+      `${Object.keys(categorizedTokens).map(
+        (category) =>
+          `\n  "${category}": Object.freeze({\n` +
+          `${processTokensWithHovered(categorizedTokens[category])
+            .map((token) => {
+              const ref = (() => {
+                if (!dictionary.usesReference(token.original.value)) {
+                  return null
+                }
+
+                let value = token.value as string | number | null
+
+                dictionary
+                  .getReferences(token.original.value)
+                  .forEach((ref) => {
+                    value = value
+                      ?.toString()
+                      .replace(ref.value, ref.name) as string
+                  })
+
+                return value
+              })()
+
+              const valueObject = ref
+                ? {
+                    value: token.value,
+                    ref,
+                  }
+                : { value: token.value }
+
+              return `    "${token.name}": Object.freeze(${JSON.stringify(valueObject)}),`
+            })
+            .join('\n')}\n  })`
+      )}\n` +
+      '})\n'
+    )
+  },
+}
+
+/**
+ * A custom formatter for adding ref information to tokens for beta version.
+ * TODO: Remove this formatter in the next major release.
+ */
+export const betaCustomJsEsm: CustomFormat = {
+  name: 'beta/custom/js/esm',
+  formatter({ dictionary, file }) {
+    const categorizedTokens = dictionary.allTokens.reduce(
+      (acc, token) => {
+        const fileNameWithoutExtension = token.filePath
+          .split('/')
+          .pop()!
+          .split('.')
+          .shift()!
+        acc[fileNameWithoutExtension] = acc[fileNameWithoutExtension] || []
+        acc[fileNameWithoutExtension].push(token)
+        return acc
+      },
+      {} as Record<string, typeof dictionary.allTokens>
+    )
+
+    return (
+      `${fileHeader({ file })}export default Object.freeze({` +
+      `${Object.keys(categorizedTokens).map(
+        (category) =>
+          `\n  "${category}": Object.freeze({\n` +
+          `${processTokensWithHovered(categorizedTokens[category])
+            .map((token) => {
+              const ref = (() => {
+                if (!dictionary.usesReference(token.original.value)) {
+                  return null
+                }
+
+                let value = token.value as string | number | null
+
+                dictionary
+                  .getReferences(token.original.value)
+                  .forEach((ref) => {
+                    value = value
+                      ?.toString()
+                      .replace(ref.value, ref.name) as string
+                  })
+
+                return value
+              })()
+
+              const valueObject = ref
+                ? {
+                    value: token.value,
+                    ref,
+                  }
+                : { value: token.value }
+
+              return `    "${token.name}": Object.freeze(${JSON.stringify(valueObject)}),`
+            })
+            .join('\n')}\n  })`
+      )}\n` +
+      '})\n'
+    )
+  },
+}
+
+export const betaCustomCss: CustomFormat = {
+  name: 'beta/custom/css',
+  formatter({ dictionary, options }) {
+    const propertyFormatter = createPropertyFormatter({
+      outputReferences: options.outputReferences,
+      dictionary,
+      format: 'css',
+    })
+
+    const formattedResult = processTokensWithHovered(dictionary.allTokens)
+      .map(propertyFormatter)
+      .join('\n')
+
+    return `${options.selector} {\n${formattedResult}\n}\n`
+  },
+}
+
 function getHoveredColorToken(token: TransformedToken): TransformedToken {
   const theme = token.filePath.includes('dark') ? 'dark' : 'light'
   return {

--- a/packages/bezier-tokens/scripts/lib/transform.ts
+++ b/packages/bezier-tokens/scripts/lib/transform.ts
@@ -1,6 +1,6 @@
 import type { Named, Transform } from 'style-dictionary'
 
-import { extractNumber, toCSSDimension } from './utils'
+import { extractNumber, toCSSDimension, toPx } from './utils'
 
 type CustomTransform = Named<Transform<unknown>>
 type Transforms = Record<string, CustomTransform>
@@ -9,8 +9,38 @@ export const CSSTransforms = {
   alphaNamespace: {
     name: 'custom/alpha/namespace',
     type: 'name',
-    matcher: (token) => token.filePath.startsWith('src/alpha'),
+    matcher: (token) => token.filePath.startsWith('src/alpha/'),
     transformer: ({ name }) => `alpha-${name}`,
+  },
+  removeNormalSuffix: {
+    name: 'custom/remove-normal-suffix',
+    type: 'name',
+    matcher: (token) => {
+      if (!token.filePath.startsWith('src/beta/')) {
+        return false
+      }
+      const path = token.path || []
+      const lastSegment = path[path.length - 1]
+      return lastSegment === 'normal' && path.length > 1
+    },
+    transformer: ({ name }) => name.replace(/-normal$/, ''),
+  },
+  dimensionPx: {
+    name: 'custom/css/dimension/beta-px',
+    type: 'value',
+    transitive: true,
+    matcher: (token) =>
+      token.type === 'dimension' && token.filePath.startsWith('src/beta/'),
+    transformer: ({ value }) => {
+      if (typeof value !== 'string') {
+        return value as string
+      }
+      const trimmed = value.trim()
+      if (/^-?(?:0|0\.0+)?$/.test(trimmed)) {
+        return '0'
+      }
+      return toPx(trimmed)
+    },
   },
   fontRem: {
     name: 'custom/css/font/rem',

--- a/packages/bezier-tokens/scripts/lib/utils.ts
+++ b/packages/bezier-tokens/scripts/lib/utils.ts
@@ -9,6 +9,15 @@ export const toCamelCase = (str: string) =>
 export const extractNumber = (str: string) =>
   str.match(/-?\d+(\.\d+)?/g)?.join('')
 
+export const toPx = (value: string) => {
+  const trimmed = value.trim()
+  if (!/^[+-]?\d+(\.\d+)?$/.test(trimmed)) {
+    return value
+  }
+  const numeric = extractNumber(trimmed)
+  return numeric ? `${numeric}px` : `${trimmed}px`
+}
+
 export const toCSSDimension = (value: string) =>
   /^0[a-zA-Z]+$/.test(value) ? 0 : value
 

--- a/packages/bezier-tokens/src/beta/global/color.json
+++ b/packages/bezier-tokens/src/beta/global/color.json
@@ -1,0 +1,968 @@
+{
+  "color": {
+    "blue": {
+      "100": {
+        "value": "#b2b7ffff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#8d93ffff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#8082ffff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#6157eaff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#5139d9ff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#4134bbff",
+        "type": "color"
+      },
+      "300-0": {
+        "value": "#6b6eff00",
+        "type": "color"
+      },
+      "300-10": {
+        "value": "#6b6eff1a",
+        "type": "color"
+      },
+      "300-18": {
+        "value": "#6b6eff2e",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#6b6eff4d",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#6b6eff73",
+        "type": "color"
+      },
+      "400-0": {
+        "value": "#6157ea00",
+        "type": "color"
+      },
+      "400-5": {
+        "value": "#6157ea0d",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#6157ea1a",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#6157ea33",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#6157ea4d",
+        "type": "color"
+      }
+    },
+    "cobalt": {
+      "100": {
+        "value": "#a1d5ffff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#8dcafcff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#5cadefff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#3292e3ff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#3176d1ff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#2b59b5ff",
+        "type": "color"
+      },
+      "300-0": {
+        "value": "#5cadef00",
+        "type": "color"
+      },
+      "300-10": {
+        "value": "#5cadef1a",
+        "type": "color"
+      },
+      "300-18": {
+        "value": "#5cadef2e",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#5cadef4d",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#5cadef73",
+        "type": "color"
+      },
+      "400-0": {
+        "value": "#3292e300",
+        "type": "color"
+      },
+      "400-5": {
+        "value": "#3292e30d",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#3292e31a",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#3292e333",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#3292e34d",
+        "type": "color"
+      }
+    },
+    "green": {
+      "100": {
+        "value": "#a4ecb3ff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#7cd985ff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#51c371ff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#20ab55ff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#358761ff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#327055ff",
+        "type": "color"
+      },
+      "300-0": {
+        "value": "#4bc16c00",
+        "type": "color"
+      },
+      "300-10": {
+        "value": "#4bc16c1a",
+        "type": "color"
+      },
+      "300-18": {
+        "value": "#4bc16c2e",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#4bc16c4d",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#4bc16c73",
+        "type": "color"
+      },
+      "400-0": {
+        "value": "#20ab5500",
+        "type": "color"
+      },
+      "400-5": {
+        "value": "#20ab550d",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#20ab551a",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#20ab5533",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#20ab554d",
+        "type": "color"
+      }
+    },
+    "red": {
+      "100": {
+        "value": "#ffb8b8ff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#ff8683ff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#f36868ff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#e1535dff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#bc3a42ff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#992c34ff",
+        "type": "color"
+      },
+      "300-0": {
+        "value": "#f2606000",
+        "type": "color"
+      },
+      "300-10": {
+        "value": "#f260601a",
+        "type": "color"
+      },
+      "300-18": {
+        "value": "#f260602e",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#f260604d",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#f2606073",
+        "type": "color"
+      },
+      "400-0": {
+        "value": "#e1535d00",
+        "type": "color"
+      },
+      "400-5": {
+        "value": "#e1535d0d",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#e1535d1a",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#e1535d33",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#e1535d4d",
+        "type": "color"
+      }
+    },
+    "orange": {
+      "100": {
+        "value": "#ffc38fff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#ffab70ff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#f79847ff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#e67f2bff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#c1630dff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#a1540cff",
+        "type": "color"
+      },
+      "300-0": {
+        "value": "#f7984700",
+        "type": "color"
+      },
+      "300-10": {
+        "value": "#f798471a",
+        "type": "color"
+      },
+      "300-18": {
+        "value": "#f798472e",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#f798474d",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#f7984773",
+        "type": "color"
+      },
+      "400-0": {
+        "value": "#e67f2b00",
+        "type": "color"
+      },
+      "400-5": {
+        "value": "#e67f2b0d",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#e67f2b1a",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#e67f2b33",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#e67f2b4d",
+        "type": "color"
+      }
+    },
+    "yellow": {
+      "100": {
+        "value": "#ffe38fff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#fed968ff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#f0be27ff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#edae0dff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#c38f00ff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#9e7504ff",
+        "type": "color"
+      },
+      "300-0": {
+        "value": "#f0be2700",
+        "type": "color"
+      },
+      "300-10": {
+        "value": "#f0be271a",
+        "type": "color"
+      },
+      "300-18": {
+        "value": "#f0be272e",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#f0be274d",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#f0be2773",
+        "type": "color"
+      },
+      "400-0": {
+        "value": "#edae0d00",
+        "type": "color"
+      },
+      "400-5": {
+        "value": "#edae0d0d",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#edae0d1a",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#edae0d33",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#edae0d4d",
+        "type": "color"
+      }
+    },
+    "olive": {
+      "100": {
+        "value": "#e7f17cff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#dbe56eff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#b7c427ff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#a9b110ff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#7b801cff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#65691cff",
+        "type": "color"
+      },
+      "300-0": {
+        "value": "#b7c42700",
+        "type": "color"
+      },
+      "300-10": {
+        "value": "#b7c4271a",
+        "type": "color"
+      },
+      "300-18": {
+        "value": "#b7c4272e",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#b7c4274d",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#b7c42773",
+        "type": "color"
+      },
+      "400-0": {
+        "value": "#a9b11000",
+        "type": "color"
+      },
+      "400-5": {
+        "value": "#a9b1100d",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#a9b1101a",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#a9b11033",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#a9b1104d",
+        "type": "color"
+      }
+    },
+    "teal": {
+      "100": {
+        "value": "#9beee6ff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#72e0d5ff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#40d3c5ff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#09b2acff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#068e95ff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#06687dff",
+        "type": "color"
+      },
+      "300-0": {
+        "value": "#40d3c500",
+        "type": "color"
+      },
+      "300-10": {
+        "value": "#40d3c51a",
+        "type": "color"
+      },
+      "300-18": {
+        "value": "#40d3c52e",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#40d3c54d",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#40d3c573",
+        "type": "color"
+      },
+      "400-0": {
+        "value": "#09b2ac00",
+        "type": "color"
+      },
+      "400-5": {
+        "value": "#09b2ac0d",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#09b2ac1a",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#09b2ac33",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#09b2ac4d",
+        "type": "color"
+      }
+    },
+    "navy": {
+      "100": {
+        "value": "#a5b2eeff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#8b99d9ff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#7e89cdff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#424fabff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#353888ff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#22245bff",
+        "type": "color"
+      },
+      "300-0": {
+        "value": "#6f7bc800",
+        "type": "color"
+      },
+      "300-10": {
+        "value": "#6f7bc81a",
+        "type": "color"
+      },
+      "300-18": {
+        "value": "#6f7bc82e",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#6f7bc84d",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#6f7bc873",
+        "type": "color"
+      },
+      "400-0": {
+        "value": "#424fab00",
+        "type": "color"
+      },
+      "400-5": {
+        "value": "#424fab0d",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#424fab1a",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#424fab33",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#424fab4d",
+        "type": "color"
+      }
+    },
+    "purple": {
+      "100": {
+        "value": "#d1b5ffff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#c19affff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#a970ffff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#8e57e7ff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#6735b6ff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#54278fff",
+        "type": "color"
+      },
+      "300-0": {
+        "value": "#a970ff00",
+        "type": "color"
+      },
+      "300-10": {
+        "value": "#a970ff1a",
+        "type": "color"
+      },
+      "300-18": {
+        "value": "#a970ff2e",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#a970ff4d",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#a970ff73",
+        "type": "color"
+      },
+      "400-0": {
+        "value": "#8e57e700",
+        "type": "color"
+      },
+      "400-5": {
+        "value": "#8e57e70d",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#8e57e71a",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#8e57e733",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#8e57e74d",
+        "type": "color"
+      }
+    },
+    "pink": {
+      "100": {
+        "value": "#ffafefff",
+        "type": "color"
+      },
+      "200": {
+        "value": "#f392e0ff",
+        "type": "color"
+      },
+      "300": {
+        "value": "#ec6fd3ff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#d64bb5ff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#b0369eff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#962c86ff",
+        "type": "color"
+      },
+      "300-0": {
+        "value": "#ec6fd300",
+        "type": "color"
+      },
+      "300-10": {
+        "value": "#ec6fd31a",
+        "type": "color"
+      },
+      "300-18": {
+        "value": "#ec6fd32e",
+        "type": "color"
+      },
+      "300-30": {
+        "value": "#ec6fd34d",
+        "type": "color"
+      },
+      "300-45": {
+        "value": "#ec6fd373",
+        "type": "color"
+      },
+      "400-0": {
+        "value": "#d64bb500",
+        "type": "color"
+      },
+      "400-5": {
+        "value": "#d64bb50d",
+        "type": "color"
+      },
+      "400-10": {
+        "value": "#d64bb51a",
+        "type": "color"
+      },
+      "400-20": {
+        "value": "#d64bb533",
+        "type": "color"
+      },
+      "400-30": {
+        "value": "#d64bb54d",
+        "type": "color"
+      }
+    },
+    "grey": {
+      "25": {
+        "value": "#fdfdffff",
+        "type": "color"
+      },
+      "50": {
+        "value": "#fbfbfbff",
+        "type": "color"
+      },
+      "50-80": {
+        "value": "#fbfbfbcc",
+        "type": "color"
+      },
+      "100": {
+        "value": "#f7f7f8ff",
+        "type": "color"
+      },
+      "100-80": {
+        "value": "#f7f7f8cc",
+        "type": "color"
+      },
+      "100-90": {
+        "value": "#f7f7f8e6",
+        "type": "color"
+      },
+      "200": {
+        "value": "#efeff0ff",
+        "type": "color"
+      },
+      "200-80": {
+        "value": "#efeff0cc",
+        "type": "color"
+      },
+      "200-90": {
+        "value": "#efeff0e6",
+        "type": "color"
+      },
+      "300": {
+        "value": "#e2e2e4ff",
+        "type": "color"
+      },
+      "400": {
+        "value": "#cfcfd1ff",
+        "type": "color"
+      },
+      "500": {
+        "value": "#a7a7aaff",
+        "type": "color"
+      },
+      "600": {
+        "value": "#79797eff",
+        "type": "color"
+      },
+      "650": {
+        "value": "#5a5a5fff",
+        "type": "color"
+      },
+      "700": {
+        "value": "#3b3b3fff",
+        "type": "color"
+      },
+      "700-80": {
+        "value": "#3b3b3fcc",
+        "type": "color"
+      },
+      "700-90": {
+        "value": "#3b3b3fe6",
+        "type": "color"
+      },
+      "750": {
+        "value": "#313135ff",
+        "type": "color"
+      },
+      "750-90": {
+        "value": "#313135e6",
+        "type": "color"
+      },
+      "800": {
+        "value": "#29292dff",
+        "type": "color"
+      },
+      "800-80": {
+        "value": "#29292dcc",
+        "type": "color"
+      },
+      "800-90": {
+        "value": "#29292de6",
+        "type": "color"
+      },
+      "850": {
+        "value": "#242426ff",
+        "type": "color"
+      },
+      "850-80": {
+        "value": "#242426cc",
+        "type": "color"
+      },
+      "850-90": {
+        "value": "#242426e6",
+        "type": "color"
+      },
+      "900": {
+        "value": "#1d1d20ff",
+        "type": "color"
+      },
+      "900-0": {
+        "value": "#24242800",
+        "type": "color"
+      },
+      "900-90": {
+        "value": "#1d1d2000",
+        "type": "color"
+      },
+      "950": {
+        "value": "#1a1a1cff",
+        "type": "color"
+      }
+    },
+    "white": {
+      "0": {
+        "value": "#fff0",
+        "type": "color"
+      },
+      "3": {
+        "value": "#ffffff08",
+        "type": "color"
+      },
+      "5": {
+        "value": "#ffffff0d",
+        "type": "color"
+      },
+      "8": {
+        "value": "#ffffff14",
+        "type": "color"
+      },
+      "12": {
+        "value": "#ffffff1f",
+        "type": "color"
+      },
+      "20": {
+        "value": "#fff3",
+        "type": "color"
+      },
+      "22": {
+        "value": "#ffffff38",
+        "type": "color"
+      },
+      "30": {
+        "value": "#ffffff4d",
+        "type": "color"
+      },
+      "40": {
+        "value": "#fff6",
+        "type": "color"
+      },
+      "50": {
+        "value": "#ffffff80",
+        "type": "color"
+      },
+      "60": {
+        "value": "#fff9",
+        "type": "color"
+      },
+      "80": {
+        "value": "#fffc",
+        "type": "color"
+      },
+      "90": {
+        "value": "#ffffffe6",
+        "type": "color"
+      },
+      "100": {
+        "value": "#ffff",
+        "type": "color"
+      }
+    },
+    "black": {
+      "0": {
+        "value": "#0000",
+        "type": "color"
+      },
+      "1": {
+        "value": "#00000003",
+        "type": "color"
+      },
+      "3": {
+        "value": "#00000008",
+        "type": "color"
+      },
+      "5": {
+        "value": "#0000000d",
+        "type": "color"
+      },
+      "8": {
+        "value": "#00000014",
+        "type": "color"
+      },
+      "15": {
+        "value": "#00000026",
+        "type": "color"
+      },
+      "20": {
+        "value": "#0003",
+        "type": "color"
+      },
+      "22": {
+        "value": "#00000038",
+        "type": "color"
+      },
+      "30": {
+        "value": "#0000004d",
+        "type": "color"
+      },
+      "40": {
+        "value": "#0006",
+        "type": "color"
+      },
+      "50": {
+        "value": "#00000080",
+        "type": "color"
+      },
+      "60": {
+        "value": "#0009",
+        "type": "color"
+      },
+      "70": {
+        "value": "#000000b3",
+        "type": "color"
+      },
+      "85": {
+        "value": "#000000d9",
+        "type": "color"
+      },
+      "100": {
+        "value": "#000f",
+        "type": "color"
+      }
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/global/dimension.json
+++ b/packages/bezier-tokens/src/beta/global/dimension.json
@@ -1,0 +1,160 @@
+{
+  "dimension": {
+    "1-m": {
+      "value": "-1",
+      "type": "dimension"
+    },
+    "1": {
+      "value": "1",
+      "type": "dimension"
+    },
+    "2": {
+      "value": "2",
+      "type": "dimension"
+    },
+    "3": {
+      "value": "3",
+      "type": "dimension"
+    },
+    "4": {
+      "value": "4",
+      "type": "dimension"
+    },
+    "6": {
+      "value": "6",
+      "type": "dimension"
+    },
+    "7": {
+      "value": "7",
+      "type": "dimension"
+    },
+    "8": {
+      "value": "8",
+      "type": "dimension"
+    },
+    "10": {
+      "value": "10",
+      "type": "dimension"
+    },
+    "12": {
+      "value": "12",
+      "type": "dimension"
+    },
+    "14": {
+      "value": "14",
+      "type": "dimension"
+    },
+    "16": {
+      "value": "16",
+      "type": "dimension"
+    },
+    "20": {
+      "value": "20",
+      "type": "dimension"
+    },
+    "22": {
+      "value": "22",
+      "type": "dimension"
+    },
+    "24": {
+      "value": "24",
+      "type": "dimension"
+    },
+    "28": {
+      "value": "28",
+      "type": "dimension"
+    },
+    "30": {
+      "value": "30",
+      "type": "dimension"
+    },
+    "32": {
+      "value": "32",
+      "type": "dimension"
+    },
+    "36": {
+      "value": "36",
+      "type": "dimension"
+    },
+    "40": {
+      "value": "40",
+      "type": "dimension"
+    },
+    "42": {
+      "value": "42",
+      "type": "dimension"
+    },
+    "44": {
+      "value": "44",
+      "type": "dimension"
+    },
+    "48": {
+      "value": "48",
+      "type": "dimension"
+    },
+    "54": {
+      "value": "54",
+      "type": "dimension"
+    },
+    "60": {
+      "value": "60",
+      "type": "dimension"
+    },
+    "72": {
+      "value": "72",
+      "type": "dimension"
+    },
+    "90": {
+      "value": "90",
+      "type": "dimension"
+    },
+    "120": {
+      "value": "120",
+      "type": "dimension"
+    },
+    "160": {
+      "value": "160",
+      "type": "dimension"
+    },
+    "200": {
+      "value": "200",
+      "type": "dimension"
+    },
+    "240": {
+      "value": "240",
+      "type": "dimension"
+    },
+    "320": {
+      "value": "320",
+      "type": "dimension"
+    },
+    "420": {
+      "value": "420",
+      "type": "dimension"
+    },
+    "540": {
+      "value": "540",
+      "type": "dimension"
+    },
+    "640": {
+      "value": "640",
+      "type": "dimension"
+    },
+    "720": {
+      "value": "720",
+      "type": "dimension"
+    },
+    "800": {
+      "value": "800",
+      "type": "dimension"
+    },
+    "900": {
+      "value": "900",
+      "type": "dimension"
+    },
+    "40-p": {
+      "value": "40%",
+      "type": "dimension"
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/global/layer.json
+++ b/packages/bezier-tokens/src/beta/global/layer.json
@@ -1,0 +1,38 @@
+{
+  "layer": {
+    "depth": {
+      "1-m": {
+        "value": "-1",
+        "type": "depth"
+      },
+      "0": {
+        "value": "0",
+        "type": "depth"
+      },
+      "1": {
+        "value": "1",
+        "type": "depth"
+      },
+      "1000": {
+        "value": "1000",
+        "type": "depth"
+      },
+      "1100": {
+        "value": "1100",
+        "type": "depth"
+      },
+      "1200": {
+        "value": "1200",
+        "type": "depth"
+      },
+      "1300": {
+        "value": "1300",
+        "type": "depth"
+      },
+      "2000": {
+        "value": "2000",
+        "type": "depth"
+      }
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/global/motion.json
+++ b/packages/bezier-tokens/src/beta/global/motion.json
@@ -1,0 +1,24 @@
+{
+  "motion": {
+    "duration": {
+      "150": {
+        "value": "150ms",
+        "type": "duration"
+      },
+      "300": {
+        "value": "300ms",
+        "type": "duration"
+      },
+      "450": {
+        "value": "450ms",
+        "type": "duration"
+      }
+    },
+    "timing-function": {
+      "easing": {
+        "value": [0.3, 0, 0, 1],
+        "type": "cubicBezier"
+      }
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/global/typography.json
+++ b/packages/bezier-tokens/src/beta/global/typography.json
@@ -1,0 +1,166 @@
+{
+  "typography": {
+    "font-family": {
+      "sans": {
+        "kr": {
+          "value": [
+            "Inter",
+            "NotoSansKR",
+            "Noto Sans KR",
+            "NotoSansJP",
+            "Noto Sans JP",
+            "-apple-system",
+            "BlinkMacSystemFont",
+            "Helvetica Neue",
+            "Segoe UI",
+            "Roboto",
+            "system-ui",
+            "sans-serif"
+          ],
+          "type": "fontFamily"
+        },
+        "jp": {
+          "value": [
+            "Inter",
+            "NotoSansJP",
+            "Noto Sans JP",
+            "NotoSansKR",
+            "Noto Sans KR",
+            "-apple-system",
+            "BlinkMacSystemFont",
+            "Helvetica Neue",
+            "Segoe UI",
+            "Roboto",
+            "system-ui",
+            "sans-serif"
+          ],
+          "type": "fontFamily"
+        }
+      },
+      "monospace": {
+        "value": [
+          "ui-monospace",
+          "Cascadia Code",
+          "Source Code Pro",
+          "Menlo",
+          "Consolas",
+          "DejaVu Sans Mono",
+          "monospace"
+        ],
+        "type": "fontFamily"
+      }
+    },
+    "font-size": {
+      "11": {
+        "value": "11",
+        "type": "dimension"
+      },
+      "12": {
+        "value": "12",
+        "type": "dimension"
+      },
+      "13": {
+        "value": "13",
+        "type": "dimension"
+      },
+      "14": {
+        "value": "14",
+        "type": "dimension"
+      },
+      "15": {
+        "value": "15",
+        "type": "dimension"
+      },
+      "16": {
+        "value": "16",
+        "type": "dimension"
+      },
+      "17": {
+        "value": "17",
+        "type": "dimension"
+      },
+      "18": {
+        "value": "18",
+        "type": "dimension"
+      },
+      "22": {
+        "value": "22",
+        "type": "dimension"
+      },
+      "24": {
+        "value": "24",
+        "type": "dimension"
+      },
+      "30": {
+        "value": "30",
+        "type": "dimension"
+      },
+      "36": {
+        "value": "36",
+        "type": "dimension"
+      }
+    },
+    "font-weight": {
+      "400": {
+        "value": "400",
+        "type": "fontWeight"
+      },
+      "700": {
+        "value": "700",
+        "type": "fontWeight"
+      }
+    },
+    "line-height": {
+      "16": {
+        "value": "16",
+        "type": "dimension"
+      },
+      "18": {
+        "value": "18",
+        "type": "dimension"
+      },
+      "20": {
+        "value": "20",
+        "type": "dimension"
+      },
+      "22": {
+        "value": "22",
+        "type": "dimension"
+      },
+      "24": {
+        "value": "24",
+        "type": "dimension"
+      },
+      "28": {
+        "value": "28",
+        "type": "dimension"
+      },
+      "32": {
+        "value": "32",
+        "type": "dimension"
+      },
+      "36": {
+        "value": "36",
+        "type": "dimension"
+      },
+      "44": {
+        "value": "44",
+        "type": "dimension"
+      }
+    },
+    "letter-spacing": {
+      "0": {
+        "value": "0",
+        "type": "dimension"
+      },
+      "0-1": {
+        "value": "-0.1",
+        "type": "dimension"
+      },
+      "0-4": {
+        "value": "-0.4",
+        "type": "dimension"
+      }
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/semantic/backdrop.json
+++ b/packages/bezier-tokens/src/beta/semantic/backdrop.json
@@ -1,0 +1,12 @@
+{
+  "backdrop": {
+    "large": {
+      "value": "{dimension.60}",
+      "type": "backdrop"
+    },
+    "small": {
+      "value": "{dimension.6}",
+      "type": "backdrop"
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/semantic/border.json
+++ b/packages/bezier-tokens/src/beta/semantic/border.json
@@ -1,0 +1,92 @@
+{
+  "border": {
+    "default": {
+      "value": {
+        "color": "{color.border.neutral.normal}",
+        "type": "dropShadow",
+        "offsetX": "0",
+        "offsetY": "0",
+        "blur": "0",
+        "spread": "{dimension.1}"
+      },
+      "type": "shadow"
+    },
+    "bottom": {
+      "value": {
+        "color": "{color.border.neutral.normal}",
+        "type": "dropShadow",
+        "offsetX": "0",
+        "offsetY": "{dimension.1-m}",
+        "blur": "0",
+        "spread": "0"
+      },
+      "type": "shadow"
+    },
+    "right": {
+      "value": {
+        "color": "{color.border.neutral.normal}",
+        "type": "dropShadow",
+        "offsetX": "{dimension.1-m}",
+        "offsetY": "0",
+        "blur": "0",
+        "spread": "0"
+      },
+      "type": "shadow"
+    },
+    "left": {
+      "value": {
+        "color": "{color.border.neutral.normal}",
+        "type": "dropShadow",
+        "offsetX": "{dimension.1}",
+        "offsetY": "0",
+        "blur": "0",
+        "spread": "0"
+      },
+      "type": "shadow"
+    },
+    "top": {
+      "value": {
+        "color": "{color.border.neutral.normal}",
+        "type": "dropShadow",
+        "offsetX": "0",
+        "offsetY": "{dimension.1}",
+        "blur": "0",
+        "spread": "0"
+      },
+      "type": "shadow"
+    },
+    "white-high": {
+      "value": {
+        "color": "{color.surface.high}",
+        "type": "dropShadow",
+        "offsetX": "0",
+        "offsetY": "0",
+        "blur": "0",
+        "spread": "{dimension.1}"
+      },
+      "type": "shadow"
+    },
+    "white-higher": {
+      "value": {
+        "color": "{color.surface.higher}",
+        "type": "dropShadow",
+        "offsetX": "0",
+        "offsetY": "0",
+        "blur": "0",
+        "spread": "{dimension.1}"
+      },
+      "type": "shadow"
+    },
+    "white-highest": {
+      "value": {
+        "color": "{color.surface.highest}",
+        "type": "dropShadow",
+        "offsetX": "0",
+        "offsetY": "0",
+        "blur": "0",
+        "spread": "{dimension.1}"
+      },
+      "type": "shadow"
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/semantic/dark-theme/color.json
+++ b/packages/bezier-tokens/src/beta/semantic/dark-theme/color.json
@@ -1,0 +1,773 @@
+{
+  "color": {
+    "text": {
+      "action": {
+        "value": "{color.blue.300}",
+        "type": "color"
+      },
+      "success": {
+        "value": "{color.green.300}",
+        "type": "color"
+      },
+      "highlight": {
+        "value": "{color.cobalt.300}",
+        "type": "color"
+      },
+      "warning": {
+        "value": "{color.orange.300}",
+        "type": "color"
+      },
+      "critical": {
+        "value": "{color.red.300}",
+        "type": "color"
+      },
+      "neutral": {
+        "heaviest": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{color.white.80}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.white.60}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.white.40}",
+          "type": "color"
+        }
+      },
+      "accent": {
+        "blue": {
+          "value": "{color.blue.300}",
+          "type": "color"
+        },
+        "cobalt": {
+          "value": "{color.cobalt.300}",
+          "type": "color"
+        },
+        "green": {
+          "value": "{color.green.300}",
+          "type": "color"
+        },
+        "red": {
+          "value": "{color.red.300}",
+          "type": "color"
+        },
+        "orange": {
+          "value": "{color.orange.300}",
+          "type": "color"
+        },
+        "yellow": {
+          "value": "{color.yellow.300}",
+          "type": "color"
+        },
+        "olive": {
+          "value": "{color.olive.300}",
+          "type": "color"
+        },
+        "teal": {
+          "value": "{color.teal.300}",
+          "type": "color"
+        },
+        "navy": {
+          "value": "{color.navy.300}",
+          "type": "color"
+        },
+        "purple": {
+          "value": "{color.purple.300}",
+          "type": "color"
+        },
+        "pink": {
+          "value": "{color.pink.300}",
+          "type": "color"
+        }
+      },
+      "absolute": {
+        "white": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
+        "black": {
+          "value": "{color.black.100}",
+          "type": "color"
+        }
+      },
+      "inverse": {
+        "value": "{color.black.85}",
+        "type": "color"
+      }
+    },
+    "icon": {
+      "action": {
+        "value": "{color.blue.300}",
+        "type": "color"
+      },
+      "success": {
+        "value": "{color.green.300}",
+        "type": "color"
+      },
+      "highlight": {
+        "value": "{color.cobalt.300}",
+        "type": "color"
+      },
+      "warning": {
+        "value": "{color.orange.300}",
+        "type": "color"
+      },
+      "critical": {
+        "value": "{color.red.300}",
+        "type": "color"
+      },
+      "neutral": {
+        "normal": {
+          "value": "{color.white.40}",
+          "type": "color"
+        },
+        "heavy": {
+          "value": "{color.white.60}",
+          "type": "color"
+        },
+        "heavier": {
+          "value": "{color.white.80}",
+          "type": "color"
+        }
+      },
+      "accent": {
+        "blue": {
+          "value": "{color.blue.300}",
+          "type": "color"
+        },
+        "cobalt": {
+          "value": "{color.cobalt.300}",
+          "type": "color"
+        },
+        "green": {
+          "value": "{color.green.300}",
+          "type": "color"
+        },
+        "red": {
+          "value": "{color.red.300}",
+          "type": "color"
+        },
+        "orange": {
+          "value": "{color.orange.300}",
+          "type": "color"
+        },
+        "yellow": {
+          "value": "{color.yellow.300}",
+          "type": "color"
+        },
+        "olive": {
+          "value": "{color.olive.300}",
+          "type": "color"
+        },
+        "teal": {
+          "value": "{color.teal.300}",
+          "type": "color"
+        },
+        "navy": {
+          "value": "{color.navy.300}",
+          "type": "color"
+        },
+        "purple": {
+          "value": "{color.purple.300}",
+          "type": "color"
+        },
+        "pink": {
+          "value": "{color.pink.300}",
+          "type": "color"
+        }
+      },
+      "absolute": {
+        "white": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
+        "black": {
+          "value": "{color.black.100}",
+          "type": "color"
+        }
+      },
+      "inverse": {
+        "heavier": { "value": "{color.black.85}", "type": "color" }
+      }
+    },
+    "fill": {
+      "neutral": {
+        "heaviest": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
+        "heavier": {
+          "value": "{color.white.40}",
+          "type": "color"
+        },
+        "heavy": {
+          "value": "{color.white.20}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.white.8}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.white.5}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{color.white.3}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.white.0}",
+          "type": "color"
+        }
+      },
+      "action": {
+        "normal": {
+          "value": "{color.blue.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.blue.300-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.blue.300-18}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.blue.300-0}",
+          "type": "color"
+        }
+      },
+      "success": {
+        "normal": {
+          "value": "{color.green.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.green.300-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.green.300-18}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.green.300-0}",
+          "type": "color"
+        }
+      },
+      "highlight": {
+        "normal": {
+          "value": "{color.cobalt.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.cobalt.300-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.cobalt.300-18}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.cobalt.300-0}",
+          "type": "color"
+        }
+      },
+      "warning": {
+        "normal": {
+          "value": "{color.orange.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.orange.300-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.orange.300-18}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.orange.300-0}",
+          "type": "color"
+        }
+      },
+      "critical": {
+        "normal": {
+          "value": "{color.red.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.red.300-30}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.red.300-18}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.red.300-0}",
+          "type": "color"
+        }
+      },
+      "grey": {
+        "light": {
+          "value": "{color.grey.900}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{color.grey.850}",
+          "type": "color"
+        },
+        "heavy": {
+          "value": "{color.grey.800}",
+          "type": "color"
+        },
+        "heavier": {
+          "value": "{color.grey.750}",
+          "type": "color"
+        }
+      },
+      "accent": {
+        "blue": {
+          "normal": {
+            "value": "{color.blue.300-18}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.blue.300-30}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.blue.300}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.blue.300-0}",
+            "type": "color"
+          }
+        },
+        "cobalt": {
+          "normal": {
+            "value": "{color.cobalt.300-18}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.cobalt.300-30}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.cobalt.300}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.cobalt.300-0}",
+            "type": "color"
+          }
+        },
+        "green": {
+          "normal": {
+            "value": "{color.green.300-18}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.green.300-30}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.green.300}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.green.300-0}",
+            "type": "color"
+          }
+        },
+        "red": {
+          "normal": {
+            "value": "{color.red.300-18}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.red.300-30}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.red.300}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.red.300-0}",
+            "type": "color"
+          }
+        },
+        "orange": {
+          "normal": {
+            "value": "{color.orange.300-18}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.orange.300-30}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.orange.300}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.orange.300-0}",
+            "type": "color"
+          }
+        },
+        "yellow": {
+          "normal": {
+            "value": "{color.yellow.300-18}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.yellow.300-30}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.yellow.300}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.yellow.300-0}",
+            "type": "color"
+          }
+        },
+        "olive": {
+          "normal": {
+            "value": "{color.olive.300-18}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.olive.300-30}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.olive.300}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.olive.300-0}",
+            "type": "color"
+          }
+        },
+        "teal": {
+          "normal": {
+            "value": "{color.teal.300-18}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.teal.300-30}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.teal.300}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.teal.300-0}",
+            "type": "color"
+          }
+        },
+        "navy": {
+          "normal": {
+            "value": "{color.navy.300-18}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.navy.300-30}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.navy.300}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.navy.300-0}",
+            "type": "color"
+          }
+        },
+        "purple": {
+          "normal": {
+            "value": "{color.purple.300-18}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.purple.300-30}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.purple.300}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.purple.300-0}",
+            "type": "color"
+          }
+        },
+        "pink": {
+          "normal": {
+            "value": "{color.pink.300-18}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.pink.300-30}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.pink.300}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.pink.300-0}",
+            "type": "color"
+          }
+        }
+      },
+      "absolute": {
+        "white": {
+          "normal": { "value": "{color.white.100}", "type": "color" },
+          "light": { "value": "{color.white.20}", "type": "color" },
+          "transparent": { "value": "{color.white.0}", "type": "color" }
+        },
+        "black": {
+          "normal": { "value": "{color.black.100}", "type": "color" },
+          "light": { "value": "{color.black.20}", "type": "color" },
+          "transparent": { "value": "{color.black.0}", "type": "color" }
+        }
+      },
+      "bright": {
+        "value": "{color.grey.650}",
+        "type": "color"
+      }
+    },
+    "border": {
+      "neutral": {
+        "normal": {
+          "value": "{color.white.12}",
+          "type": "color"
+        },
+        "heavy": {
+          "value": "{color.white.20}",
+          "type": "color"
+        },
+        "heavier": {
+          "value": "{color.white.40}",
+          "type": "color"
+        }
+      },
+      "detach": {
+        "normal": {
+          "value": "{color.grey.900}",
+          "type": "color"
+        },
+        "highest": {
+          "value": "{color.grey.750}",
+          "type": "color"
+        },
+        "higher": {
+          "value": "{color.grey.800}",
+          "type": "color"
+        },
+        "high": {
+          "value": "{color.grey.850}",
+          "type": "color"
+        },
+        "low": {
+          "value": "{color.grey.950}",
+          "type": "color"
+        }
+      },
+      "absolute": {
+        "white": {
+          "value": "{color.white.100}",
+          "type": "color"
+        }
+      }
+    },
+    "surface": {
+      "normal": {
+        "value": "{color.grey.900}",
+        "type": "color"
+      },
+      "highest": {
+        "value": "{color.grey.750}",
+        "type": "color"
+      },
+      "higher": {
+        "value": "{color.grey.800}",
+        "type": "color"
+      },
+      "high": {
+        "value": "{color.grey.850}",
+        "type": "color"
+      },
+      "low": {
+        "value": "{color.grey.950}",
+        "type": "color"
+      },
+      "glass": {
+        "normal": {
+          "value": "{color.grey.800-90}",
+          "type": "color"
+        },
+        "highest": {
+          "value": "{color.grey.750-90}",
+          "type": "color"
+        },
+        "higher": {
+          "value": "{color.grey.800-90}",
+          "type": "color"
+        },
+        "high": {
+          "value": "{color.grey.850-90}",
+          "type": "color"
+        }
+      }
+    },
+    "dim": {
+      "absolute": {
+        "black": {
+          "normal": {
+            "value": "{color.black.40}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.black.60}",
+            "type": "color"
+          }
+        },
+        "white": {
+          "normal": {
+            "value": "{color.white.40}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.white.60}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "gradient": {
+      "green": {
+        "normal": {
+          "value": "{color.green.400}",
+          "type": "color"
+        },
+        "heavy": {
+          "value": "{color.green.300}",
+          "type": "color"
+        }
+      }
+    },
+    "state": {
+      "default": {
+        "value": "{color.white.20}",
+        "type": "color"
+      },
+      "action": {
+        "normal": {
+          "value": "{color.blue.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.blue.300-45}",
+          "type": "color"
+        }
+      },
+      "warning": {
+        "normal": {
+          "value": "{color.orange.300}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.orange.300-30}",
+          "type": "color"
+        }
+      }
+    },
+    "elevation": {
+      "xlarge": {
+        "value": "{color.black.30}",
+        "type": "color"
+      },
+      "large": {
+        "value": "{color.black.22}",
+        "type": "color"
+      },
+      "medium": {
+        "value": "{color.black.15}",
+        "type": "color"
+      },
+      "small": {
+        "value": "{color.black.8}",
+        "type": "color"
+      },
+      "base": {
+        "value": "{color.black.5}",
+        "type": "color"
+      },
+      "base-inner": {
+        "value": "{color.white.12}",
+        "type": "color"
+      }
+    },
+    "chart": {
+      "theme": {
+        "default": {
+          "01": {
+            "value": "#7c72fd",
+            "type": "color"
+          },
+          "02": {
+            "value": "#81dfdd",
+            "type": "color"
+          },
+          "03": {
+            "value": "#fc9783",
+            "type": "color"
+          },
+          "04": {
+            "value": "#b1596a",
+            "type": "color"
+          },
+          "05": {
+            "value": "#fe71ba",
+            "type": "color"
+          },
+          "06": {
+            "value": "#c971ec",
+            "type": "color"
+          },
+          "07": {
+            "value": "#4a75e3",
+            "type": "color"
+          },
+          "08": {
+            "value": "#80b6fd",
+            "type": "color"
+          },
+          "09": {
+            "value": "#fb90f1",
+            "type": "color"
+          },
+          "10": {
+            "value": "#b4d6e5",
+            "type": "color"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/semantic/elevation.json
+++ b/packages/bezier-tokens/src/beta/semantic/elevation.json
@@ -1,0 +1,178 @@
+{
+  "elevation": {
+    "1": {
+      "value": [
+        {
+          "color": "{color.elevation.small}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "{dimension.1}",
+          "blur": "{dimension.2}",
+          "spread": "0"
+        },
+        {
+          "color": "{color.elevation.base}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "{dimension.1}"
+        },
+        {
+          "color": "{color.elevation.base-inner}",
+          "type": "innerShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "0"
+        }
+      ],
+      "type": "shadow"
+    },
+    "2": {
+      "value": [
+        {
+          "color": "{color.elevation.small}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "{dimension.2}",
+          "blur": "{dimension.6}",
+          "spread": "0"
+        },
+        {
+          "color": "{color.elevation.base}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "{dimension.1}"
+        },
+        {
+          "color": "{color.elevation.base-inner}",
+          "type": "innerShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "0"
+        }
+      ],
+      "type": "shadow"
+    },
+    "3": {
+      "value": [
+        {
+          "color": "{color.elevation.small}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "{dimension.4}",
+          "blur": "{dimension.12}",
+          "spread": "0"
+        },
+        {
+          "color": "{color.elevation.base}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "{dimension.1}"
+        },
+        {
+          "color": "{color.elevation.base-inner}",
+          "type": "innerShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "0"
+        }
+      ],
+      "type": "shadow"
+    },
+    "4": {
+      "value": [
+        {
+          "color": "{color.elevation.small}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "{dimension.4}",
+          "blur": "{dimension.24}",
+          "spread": "0"
+        },
+        {
+          "color": "{color.elevation.base}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "{dimension.1}"
+        },
+        {
+          "color": "{color.elevation.base-inner}",
+          "type": "innerShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "0"
+        }
+      ],
+      "type": "shadow"
+    },
+    "5": {
+      "value": [
+        {
+          "color": "{color.elevation.small}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "{dimension.6}",
+          "blur": "{dimension.40}",
+          "spread": "0"
+        },
+        {
+          "color": "{color.elevation.base}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "{dimension.1}"
+        },
+        {
+          "color": "{color.elevation.base-inner}",
+          "type": "innerShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "0"
+        }
+      ],
+      "type": "shadow"
+    },
+    "6": {
+      "value": [
+        {
+          "color": "{color.elevation.small}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "{dimension.12}",
+          "blur": "{dimension.60}",
+          "spread": "0"
+        },
+        {
+          "color": "{color.elevation.base}",
+          "type": "dropShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "{dimension.1}"
+        },
+        {
+          "color": "{color.elevation.base-inner}",
+          "type": "innerShadow",
+          "offsetX": "0",
+          "offsetY": "0",
+          "blur": "{dimension.2}",
+          "spread": "0"
+        }
+      ],
+      "type": "shadow"
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/semantic/layer.json
+++ b/packages/bezier-tokens/src/beta/semantic/layer.json
@@ -1,0 +1,38 @@
+{
+  "layer": {
+    "z-index": {
+      "base": {
+        "value": "{layer.depth.0}",
+        "type": "z-index"
+      },
+      "floating": {
+        "value": "{layer.depth.1}",
+        "type": "z-index"
+      },
+      "overlay": {
+        "value": "{layer.depth.1000}",
+        "type": "z-index"
+      },
+      "modal": {
+        "value": "{layer.depth.1100}",
+        "type": "z-index"
+      },
+      "toast": {
+        "value": "{layer.depth.1200}",
+        "type": "z-index"
+      },
+      "tooltip": {
+        "value": "{layer.depth.1300}",
+        "type": "z-index"
+      },
+      "hidden": {
+        "value": "{layer.depth.1-m}",
+        "type": "z-index"
+      },
+      "important": {
+        "value": "{layer.depth.2000}",
+        "type": "z-index"
+      }
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/semantic/light-theme/color.json
+++ b/packages/bezier-tokens/src/beta/semantic/light-theme/color.json
@@ -1,0 +1,773 @@
+{
+  "color": {
+    "text": {
+      "action": {
+        "value": "{color.blue.400}",
+        "type": "color"
+      },
+      "success": {
+        "value": "{color.green.400}",
+        "type": "color"
+      },
+      "highlight": {
+        "value": "{color.cobalt.400}",
+        "type": "color"
+      },
+      "warning": {
+        "value": "{color.orange.400}",
+        "type": "color"
+      },
+      "critical": {
+        "value": "{color.red.400}",
+        "type": "color"
+      },
+      "neutral": {
+        "heaviest": {
+          "value": "{color.black.100}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{color.black.85}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.black.60}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.black.40}",
+          "type": "color"
+        }
+      },
+      "accent": {
+        "blue": {
+          "value": "{color.blue.400}",
+          "type": "color"
+        },
+        "cobalt": {
+          "value": "{color.cobalt.400}",
+          "type": "color"
+        },
+        "green": {
+          "value": "{color.green.400}",
+          "type": "color"
+        },
+        "red": {
+          "value": "{color.red.400}",
+          "type": "color"
+        },
+        "orange": {
+          "value": "{color.orange.400}",
+          "type": "color"
+        },
+        "yellow": {
+          "value": "{color.yellow.400}",
+          "type": "color"
+        },
+        "olive": {
+          "value": "{color.olive.300}",
+          "type": "color"
+        },
+        "teal": {
+          "value": "{color.teal.400}",
+          "type": "color"
+        },
+        "navy": {
+          "value": "{color.navy.400}",
+          "type": "color"
+        },
+        "purple": {
+          "value": "{color.purple.400}",
+          "type": "color"
+        },
+        "pink": {
+          "value": "{color.pink.400}",
+          "type": "color"
+        }
+      },
+      "absolute": {
+        "white": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
+        "black": {
+          "value": "{color.black.100}",
+          "type": "color"
+        }
+      },
+      "inverse": {
+        "value": "{color.white.100}",
+        "type": "color"
+      }
+    },
+    "icon": {
+      "action": {
+        "value": "{color.blue.400}",
+        "type": "color"
+      },
+      "success": {
+        "value": "{color.green.400}",
+        "type": "color"
+      },
+      "highlight": {
+        "value": "{color.cobalt.400}",
+        "type": "color"
+      },
+      "warning": {
+        "value": "{color.orange.400}",
+        "type": "color"
+      },
+      "critical": {
+        "value": "{color.red.400}",
+        "type": "color"
+      },
+      "neutral": {
+        "normal": {
+          "value": "{color.black.40}",
+          "type": "color"
+        },
+        "heavy": {
+          "value": "{color.black.60}",
+          "type": "color"
+        },
+        "heavier": {
+          "value": "{color.black.85}",
+          "type": "color"
+        }
+      },
+      "accent": {
+        "blue": {
+          "value": "{color.blue.400}",
+          "type": "color"
+        },
+        "cobalt": {
+          "value": "{color.cobalt.400}",
+          "type": "color"
+        },
+        "green": {
+          "value": "{color.green.400}",
+          "type": "color"
+        },
+        "red": {
+          "value": "{color.red.400}",
+          "type": "color"
+        },
+        "orange": {
+          "value": "{color.orange.400}",
+          "type": "color"
+        },
+        "yellow": {
+          "value": "{color.yellow.400}",
+          "type": "color"
+        },
+        "olive": {
+          "value": "{color.olive.400}",
+          "type": "color"
+        },
+        "teal": {
+          "value": "{color.teal.400}",
+          "type": "color"
+        },
+        "navy": {
+          "value": "{color.navy.400}",
+          "type": "color"
+        },
+        "purple": {
+          "value": "{color.purple.400}",
+          "type": "color"
+        },
+        "pink": {
+          "value": "{color.pink.400}",
+          "type": "color"
+        }
+      },
+      "absolute": {
+        "white": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
+        "black": {
+          "value": "{color.black.100}",
+          "type": "color"
+        }
+      },
+      "inverse": {
+        "heavier": { "value": "{color.white.100}", "type": "color" }
+      }
+    },
+    "fill": {
+      "neutral": {
+        "heaviest": {
+          "value": "{color.black.85}",
+          "type": "color"
+        },
+        "heavier": {
+          "value": "{color.black.40}",
+          "type": "color"
+        },
+        "heavy": {
+          "value": "{color.black.15}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.black.5}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.black.3}",
+          "type": "color"
+        },
+        "lightest": {
+          "value": "{color.black.1}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.black.0}",
+          "type": "color"
+        }
+      },
+      "action": {
+        "normal": {
+          "value": "{color.blue.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.blue.400-20}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.blue.400-10}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.blue.400-0}",
+          "type": "color"
+        }
+      },
+      "success": {
+        "normal": {
+          "value": "{color.green.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.green.400-20}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.green.400-10}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.green.400-0}",
+          "type": "color"
+        }
+      },
+      "highlight": {
+        "normal": {
+          "value": "{color.cobalt.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.cobalt.400-20}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.cobalt.400-10}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.cobalt.400-0}",
+          "type": "color"
+        }
+      },
+      "warning": {
+        "normal": {
+          "value": "{color.orange.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.orange.400-20}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.orange.400-10}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.orange.400-0}",
+          "type": "color"
+        }
+      },
+      "critical": {
+        "normal": {
+          "value": "{color.red.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.red.400-20}",
+          "type": "color"
+        },
+        "lighter": {
+          "value": "{color.red.400-10}",
+          "type": "color"
+        },
+        "transparent": {
+          "value": "{color.red.400-0}",
+          "type": "color"
+        }
+      },
+      "grey": {
+        "light": {
+          "value": "{color.grey.25}",
+          "type": "color"
+        },
+        "normal": {
+          "value": "{color.grey.50}",
+          "type": "color"
+        },
+        "heavy": {
+          "value": "{color.grey.100}",
+          "type": "color"
+        },
+        "heavier": {
+          "value": "{color.grey.200}",
+          "type": "color"
+        }
+      },
+      "accent": {
+        "blue": {
+          "normal": {
+            "value": "{color.blue.400-10}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.blue.400-20}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.blue.400}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.blue.400-0}",
+            "type": "color"
+          }
+        },
+        "cobalt": {
+          "normal": {
+            "value": "{color.cobalt.400-10}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.cobalt.400-20}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.cobalt.400}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.cobalt.400-0}",
+            "type": "color"
+          }
+        },
+        "green": {
+          "normal": {
+            "value": "{color.green.400-10}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.green.400-20}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.green.400}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.green.400-0}",
+            "type": "color"
+          }
+        },
+        "red": {
+          "normal": {
+            "value": "{color.red.400-10}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.red.400-20}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.red.400}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.red.400-0}",
+            "type": "color"
+          }
+        },
+        "orange": {
+          "normal": {
+            "value": "{color.orange.400-10}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.orange.400-20}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.orange.400}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.orange.400-0}",
+            "type": "color"
+          }
+        },
+        "yellow": {
+          "normal": {
+            "value": "{color.yellow.400-10}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.yellow.400-20}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.yellow.400}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.yellow.400-0}",
+            "type": "color"
+          }
+        },
+        "olive": {
+          "normal": {
+            "value": "{color.olive.400-10}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.olive.400-20}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.olive.400}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.olive.400-0}",
+            "type": "color"
+          }
+        },
+        "teal": {
+          "normal": {
+            "value": "{color.teal.400-10}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.teal.400-20}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.teal.400}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.teal.400-0}",
+            "type": "color"
+          }
+        },
+        "navy": {
+          "normal": {
+            "value": "{color.navy.400-10}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.navy.400-20}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.navy.400}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.navy.400-0}",
+            "type": "color"
+          }
+        },
+        "purple": {
+          "normal": {
+            "value": "{color.purple.400-10}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.purple.400-20}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.purple.400}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.purple.400-0}",
+            "type": "color"
+          }
+        },
+        "pink": {
+          "normal": {
+            "value": "{color.pink.400-10}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.pink.400-20}",
+            "type": "color"
+          },
+          "heavier": {
+            "value": "{color.pink.400}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{color.pink.400-0}",
+            "type": "color"
+          }
+        }
+      },
+      "absolute": {
+        "white": {
+          "normal": { "value": "{color.white.100}", "type": "color" },
+          "light": { "value": "{color.white.20}", "type": "color" },
+          "transparent": { "value": "{color.white.0}", "type": "color" }
+        },
+        "black": {
+          "normal": { "value": "{color.black.100}", "type": "color" },
+          "light": { "value": "{color.black.20}", "type": "color" },
+          "transparent": { "value": "{color.black.0}", "type": "color" }
+        }
+      },
+      "bright": {
+        "value": "{color.grey.25}",
+        "type": "color"
+      }
+    },
+    "border": {
+      "neutral": {
+        "normal": {
+          "value": "{color.black.8}",
+          "type": "color"
+        },
+        "heavy": {
+          "value": "{color.black.15}",
+          "type": "color"
+        },
+        "heavier": {
+          "value": "{color.black.40}",
+          "type": "color"
+        }
+      },
+      "detach": {
+        "normal": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
+        "highest": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
+        "higher": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
+        "high": {
+          "value": "{color.white.100}",
+          "type": "color"
+        },
+        "low": {
+          "value": "{color.grey.50}",
+          "type": "color"
+        }
+      },
+      "absolute": {
+        "white": {
+          "value": "{color.white.100}",
+          "type": "color"
+        }
+      }
+    },
+    "surface": {
+      "normal": {
+        "value": "{color.white.100}",
+        "type": "color"
+      },
+      "highest": {
+        "value": "{color.white.100}",
+        "type": "color"
+      },
+      "higher": {
+        "value": "{color.white.100}",
+        "type": "color"
+      },
+      "high": {
+        "value": "{color.white.100}",
+        "type": "color"
+      },
+      "low": {
+        "value": "{color.grey.50}",
+        "type": "color"
+      },
+      "glass": {
+        "normal": {
+          "value": "{color.white.90}",
+          "type": "color"
+        },
+        "highest": {
+          "value": "{color.grey.200-90}",
+          "type": "color"
+        },
+        "higher": {
+          "value": "{color.grey.100-90}",
+          "type": "color"
+        },
+        "high": {
+          "value": "{color.white.90}",
+          "type": "color"
+        }
+      }
+    },
+    "dim": {
+      "absolute": {
+        "black": {
+          "normal": {
+            "value": "{color.black.40}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.black.60}",
+            "type": "color"
+          }
+        },
+        "white": {
+          "normal": {
+            "value": "{color.white.40}",
+            "type": "color"
+          },
+          "heavy": {
+            "value": "{color.white.60}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "gradient": {
+      "green": {
+        "normal": {
+          "value": "{color.green.400}",
+          "type": "color"
+        },
+        "heavy": {
+          "value": "{color.green.300}",
+          "type": "color"
+        }
+      }
+    },
+    "state": {
+      "default": {
+        "value": "{color.black.15}",
+        "type": "color"
+      },
+      "action": {
+        "normal": {
+          "value": "{color.blue.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.blue.400-30}",
+          "type": "color"
+        }
+      },
+      "warning": {
+        "normal": {
+          "value": "{color.orange.400}",
+          "type": "color"
+        },
+        "light": {
+          "value": "{color.orange.400-30}",
+          "type": "color"
+        }
+      }
+    },
+    "elevation": {
+      "xlarge": {
+        "value": "{color.black.30}",
+        "type": "color"
+      },
+      "large": {
+        "value": "{color.black.22}",
+        "type": "color"
+      },
+      "medium": {
+        "value": "{color.black.15}",
+        "type": "color"
+      },
+      "small": {
+        "value": "{color.black.8}",
+        "type": "color"
+      },
+      "base": {
+        "value": "{color.black.5}",
+        "type": "color"
+      },
+      "base-inner": {
+        "value": "{color.white.12}",
+        "type": "color"
+      }
+    },
+    "chart": {
+      "theme": {
+        "default": {
+          "01": {
+            "value": "#7c72fd",
+            "type": "color"
+          },
+          "02": {
+            "value": "#81dfdd",
+            "type": "color"
+          },
+          "03": {
+            "value": "#fc9783",
+            "type": "color"
+          },
+          "04": {
+            "value": "#b1596a",
+            "type": "color"
+          },
+          "05": {
+            "value": "#fe71ba",
+            "type": "color"
+          },
+          "06": {
+            "value": "#c971ec",
+            "type": "color"
+          },
+          "07": {
+            "value": "#4a75e3",
+            "type": "color"
+          },
+          "08": {
+            "value": "#80b6fd",
+            "type": "color"
+          },
+          "09": {
+            "value": "#fb90f1",
+            "type": "color"
+          },
+          "10": {
+            "value": "#b4d6e5",
+            "type": "color"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/semantic/motion.json
+++ b/packages/bezier-tokens/src/beta/semantic/motion.json
@@ -1,0 +1,27 @@
+{
+  "motion": {
+    "transition": {
+      "fast": {
+        "value": {
+          "duration": "{motion.duration.150}",
+          "timingFunction": "{motion.timing-function.easing}"
+        },
+        "type": "transition"
+      },
+      "default": {
+        "value": {
+          "duration": "{motion.duration.300}",
+          "timingFunction": "{motion.timing-function.easing}"
+        },
+        "type": "transition"
+      },
+      "slow": {
+        "value": {
+          "duration": "{motion.duration.450}",
+          "timingFunction": "{motion.timing-function.easing}"
+        },
+        "type": "transition"
+      }
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/semantic/opacity.json
+++ b/packages/bezier-tokens/src/beta/semantic/opacity.json
@@ -1,0 +1,8 @@
+{
+  "opacity": {
+    "disabled": {
+      "value": "{dimension.40-p}",
+      "type": "opacity"
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/semantic/radius.json
+++ b/packages/bezier-tokens/src/beta/semantic/radius.json
@@ -1,0 +1,52 @@
+{
+  "radius": {
+    "2": {
+      "value": "{dimension.2}",
+      "type": "radius"
+    },
+    "3": {
+      "value": "{dimension.3}",
+      "type": "radius"
+    },
+    "4": {
+      "value": "{dimension.4}",
+      "type": "radius"
+    },
+    "6": {
+      "value": "{dimension.6}",
+      "type": "radius"
+    },
+    "7": {
+      "value": "{dimension.7}",
+      "type": "radius"
+    },
+    "8": {
+      "value": "{dimension.8}",
+      "type": "radius"
+    },
+    "10": {
+      "value": "{dimension.10}",
+      "type": "radius"
+    },
+    "12": {
+      "value": "{dimension.12}",
+      "type": "radius"
+    },
+    "14": {
+      "value": "{dimension.14}",
+      "type": "radius"
+    },
+    "16": {
+      "value": "{dimension.16}",
+      "type": "radius"
+    },
+    "20": {
+      "value": "{dimension.20}",
+      "type": "radius"
+    },
+    "32": {
+      "value": "{dimension.32}",
+      "type": "radius"
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/semantic/state.json
+++ b/packages/bezier-tokens/src/beta/semantic/state.json
@@ -1,0 +1,128 @@
+{
+  "state": {
+    "error": {
+      "value": {
+        "color": "{color.state.warning.normal}",
+        "type": "dropShadow",
+        "offsetX": "0",
+        "offsetY": "0",
+        "blur": "0",
+        "spread": "{dimension.1}"
+      },
+      "type": "shadow"
+    },
+    "active": {
+      "value": {
+        "color": "{color.state.action.normal}",
+        "type": "dropShadow",
+        "offsetX": "0",
+        "offsetY": "0",
+        "blur": "0",
+        "spread": "{dimension.1}"
+      },
+      "type": "shadow"
+    },
+    "input": {
+      "default": {
+        "value": [
+          {
+            "color": "{color.elevation.base}",
+            "type": "dropShadow",
+            "offsetX": "0",
+            "offsetY": "{dimension.1}",
+            "blur": "{dimension.2}",
+            "spread": "0"
+          },
+          {
+            "color": "{color.state.default}",
+            "type": "innerShadow",
+            "offsetX": "0",
+            "offsetY": "0",
+            "blur": "0",
+            "spread": "{dimension.1}"
+          }
+        ],
+        "type": "shadow"
+      },
+      "hovered": {
+        "value": [
+          {
+            "color": "{color.elevation.base}",
+            "type": "dropShadow",
+            "offsetX": "0",
+            "offsetY": "{dimension.2}",
+            "blur": "{dimension.6}",
+            "spread": "0"
+          },
+          {
+            "color": "{color.state.action.normal}",
+            "type": "innerShadow",
+            "offsetX": "0",
+            "offsetY": "0",
+            "blur": "0",
+            "spread": "{dimension.1}"
+          }
+        ],
+        "type": "shadow"
+      },
+      "active": {
+        "value": [
+          {
+            "color": "{color.elevation.base}",
+            "type": "dropShadow",
+            "offsetX": "0",
+            "offsetY": "{dimension.2}",
+            "blur": "{dimension.6}",
+            "spread": "0"
+          },
+          {
+            "color": "{color.state.action.light}",
+            "type": "dropShadow",
+            "offsetX": "0",
+            "offsetY": "0",
+            "blur": "0",
+            "spread": "{dimension.3}"
+          },
+          {
+            "color": "{color.state.action.normal}",
+            "type": "innerShadow",
+            "offsetX": "0",
+            "offsetY": "0",
+            "blur": "0",
+            "spread": "{dimension.1}"
+          }
+        ],
+        "type": "shadow"
+      },
+      "error": {
+        "value": [
+          {
+            "color": "{color.elevation.base}",
+            "type": "dropShadow",
+            "offsetX": "0",
+            "offsetY": "{dimension.2}",
+            "blur": "{dimension.6}",
+            "spread": "0"
+          },
+          {
+            "color": "{color.state.warning.light}",
+            "type": "dropShadow",
+            "offsetX": "0",
+            "offsetY": "0",
+            "blur": "0",
+            "spread": "{dimension.3}"
+          },
+          {
+            "color": "{color.state.warning.normal}",
+            "type": "innerShadow",
+            "offsetX": "0",
+            "offsetY": "0",
+            "blur": "0",
+            "spread": "{dimension.1}"
+          }
+        ],
+        "type": "shadow"
+      }
+    }
+  }
+}

--- a/packages/bezier-tokens/src/beta/semantic/typography.json
+++ b/packages/bezier-tokens/src/beta/semantic/typography.json
@@ -1,0 +1,114 @@
+{
+  "typography": {
+    "heading": {
+      "font-family": {
+        "value": "{typography.font-family.sans.kr}"
+      },
+      "size": {
+        "xlarge": {
+          "value": "{typography.font-size.24}"
+        },
+        "large": {
+          "value": "{typography.font-size.22}"
+        },
+        "medium": {
+          "value": "{typography.font-size.18}"
+        },
+        "small": {
+          "value": "{typography.font-size.17}"
+        },
+        "xsmall": {
+          "value": "{typography.font-size.16}"
+        },
+        "2xsmall": {
+          "value": "{typography.font-size.15}"
+        }
+      },
+      "weight": {
+        "bold": { "value": "{typography.font-weight.700}" }
+      },
+      "letter-spacing": {
+        "normal": { "value": "{typography.letter-spacing.0}" },
+        "tight": { "value": "{typography.letter-spacing.0-1}" },
+        "tighter": { "value": "{typography.letter-spacing.0-4}" }
+      },
+      "line-height": {
+        "xlarge": { "value": "{typography.line-height.32}" },
+        "large": { "value": "{typography.line-height.28}" },
+        "medium": { "value": "{typography.line-height.24}" },
+        "small": { "value": "{typography.line-height.24}" },
+        "xsmall": { "value": "{typography.line-height.24}" },
+        "2xsmall": { "value": "{typography.line-height.20}" }
+      }
+    },
+    "text": {
+      "font-family": {
+        "value": "{typography.font-family.sans.kr}"
+      },
+      "size": {
+        "2xlarge": { "value": "{typography.font-size.17}" },
+        "xlarge": { "value": "{typography.font-size.16}" },
+        "large": { "value": "{typography.font-size.15}" },
+        "medium": { "value": "{typography.font-size.14}" },
+        "small": { "value": "{typography.font-size.13}" },
+        "xsmall": { "value": "{typography.font-size.12}" },
+        "2xsmall": { "value": "{typography.font-size.11}" }
+      },
+      "weight": {
+        "bold": { "value": "{typography.font-weight.700}" },
+        "regular": { "value": "{typography.font-weight.400}" }
+      },
+      "letter-spacing": {
+        "normal": { "value": "{typography.letter-spacing.0}" },
+        "tight": { "value": "{typography.letter-spacing.0-1}" }
+      },
+      "line-height": {
+        "2xlarge": { "value": "{typography.line-height.24}" },
+        "xlarge": { "value": "{typography.line-height.24}" },
+        "large": { "value": "{typography.line-height.20}" },
+        "medium": { "value": "{typography.line-height.18}" },
+        "small": { "value": "{typography.line-height.18}" },
+        "xsmall": { "value": "{typography.line-height.16}" },
+        "2xsmall": { "value": "{typography.line-height.16}" }
+      }
+    },
+    "display": {
+      "font-family": {
+        "value": "{typography.font-family.sans.kr}"
+      },
+      "size": {
+        "large": { "value": "{typography.font-size.36}" },
+        "medium": { "value": "{typography.font-size.30}" }
+      },
+      "weight": {
+        "bold": { "value": "{typography.font-weight.700}" }
+      },
+      "letter-spacing": {
+        "tighter": { "value": "{typography.letter-spacing.0-4}" }
+      },
+      "line-height": {
+        "large": { "value": "{typography.line-height.44}" },
+        "medium": { "value": "{typography.line-height.36}" }
+      }
+    },
+    "code": {
+      "font-family": {
+        "value": "{typography.font-family.monospace}"
+      },
+      "size": {
+        "medium": { "value": "{typography.font-size.14}" },
+        "small": { "value": "{typography.font-size.13}" }
+      },
+      "weight": {
+        "regular": { "value": "{typography.font-weight.400}" }
+      },
+      "letter-spacing": {
+        "normal": { "value": "{typography.letter-spacing.0}" }
+      },
+      "line-height": {
+        "medium": { "value": "{typography.line-height.18}" },
+        "small": { "value": "{typography.line-height.18}" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Self Checklist

- [x] PR 제목을 **영문**으로 작성하고 적절한 **라벨**을 추가했습니다.
- [ ] 커밋 메시지를 **영문**으로 작성하고 [**Conventional Commits 명세**](https://www.conventionalcommits.org/en/v1.0.0/)를 따랐습니다.
- [x] 릴리스가 필요한 변경에 대한 [**changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)을 추가했습니다.
- [x] 관련 문서를 작성하거나 수정했습니다. 이번 호환 릴리스에는 별도 문서 변경이 필요하지 않습니다.
- [x] 관련 테스트를 작성하거나 수정했습니다. 기존 빌드와 테스트 범위로 백포트 동작을 검증했습니다.
- [x] 여러 브라우저에서 변경을 확인했습니다. 이번 변경은 CSS 토큰 정의와 패키지 export를 복구하는 작업이므로 브라우저별 검증은 필요하지 않습니다.

## Related Issue

- [WEB-12102](https://linear.app/channel/issue/WEB-12102/bug-snippet-색상-토큰-근본-원인-수정-및-소비처-업데이트)
- 관련 원인 조사: [WEB-12094](https://linear.app/channel/issue/WEB-12094/bug-snippet-preview-색상-소실-원인-파악)

## Summary

React 16 소비처가 Bezier React v3 또는 v4로 올리지 않고도 최신 CSS 토큰 계약을 사용할 수 있도록 장기 유지용 `v2` 브랜치에 beta(v3) 디자인 토큰을 추가합니다.

기존 stable(v1)과 alpha(v2) 토큰 산출물은 유지하면서 안정 버전 `@channel.io/bezier-react@2.7.0`과 `@channel.io/bezier-tokens@0.3.0` 릴리스를 준비합니다.

## Details

- 최신 v1 호환 구현에서 사용하는 beta token source를 백포트했습니다.
- beta token의 CJS, ESM, type declaration, CSS 산출물을 생성합니다.
- `@channel.io/bezier-tokens/beta`와 `@channel.io/bezier-tokens/beta/css/*`를 export합니다.
- 기존 stable/alpha style과 함께 beta CSS를 `@channel.io/bezier-react/styles.css`에 번들링합니다.
- `@channel.io/bezier-react`와 `@channel.io/bezier-tokens`에 minor changeset을 추가했습니다.
- release workflow가 장기 유지용 `v2` 브랜치에서만 실행되도록 변경했습니다.
- 기존 npm `latest`와 `next` dist-tag를 유지하기 위해 `changeset publish --tag v2`로 배포합니다.
- v2 릴리스와 무관한 VSCode extension 배포를 release workflow에서 제외했습니다.
- CI artifact upload를 복구하기 위해 `felixmosh/turborepo-gh-artifacts`를 `main`과 동일한 v3로 올렸습니다.

검증 결과:

- Node.js 18.20.5 기준 immutable install과 전체 package build가 통과했습니다.
- token/React lint, typecheck, stylelint, Prettier가 통과했습니다.
- 71개 test suite, 568개 test, 39개 snapshot이 통과했습니다.
- 기존 v2 stable/alpha CJS, ESM, CSS 산출물이 byte 단위로 동일함을 확인했습니다.
- 최신 v1 호환 구현의 light/dark color token 각 172개와 값이 모두 일치합니다.
- Snippet에 필요한 CSS token 23개가 최종 Bezier stylesheet에 포함됨을 확인했습니다.
- GitHub CI와 Chromatic이 통과했습니다.

### Breaking change? (No)

하위 호환되는 v2 유지보수 릴리스입니다. 기존 React peer dependency, component API, stable token, alpha token은 변경하지 않습니다. beta token CSS와 package export만 추가합니다.

## References

- v1 beta token 호환 구현: [#2790](https://github.com/channel-io/bezier-react/pull/2790)
- v1 유지 브랜치 release workflow: [#2705](https://github.com/channel-io/bezier-react/pull/2705)
- Snippet 색상 소실 제보: [Team Chat thread](https://channel.works/root/threads/groups/Redesign-BugFeedback-562745/6a4c928c1b3f86dc326c/6a505da3e999bf0cb76a)