### PR TITLE
fix(release): publish v2 token compatibility from bezier-react only

### DIFF
--- a/.changeset/warm-snippets-glow.md
+++ b/.changeset/warm-snippets-glow.md
@@ -1,6 +1,5 @@
 ---
 "@channel.io/bezier-react": minor
-"@channel.io/bezier-tokens": minor
 ---
 
 Add v3 beta tokens for v2 backward compatibility.


### PR DESCRIPTION
## Self Checklist

- [x] PR 제목을 **영문**으로 작성하고 적절한 **라벨**을 추가했습니다.
- [x] 커밋 메시지를 **영문**으로 작성하고 [**Conventional Commits 명세**](https://www.conventionalcommits.org/en/v1.0.0/)를 따랐습니다.
- [x] 릴리스가 필요한 변경에 대한 [**changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)을 수정했습니다.
- [x] 관련 문서를 작성하거나 수정했습니다. 이번 변경은 v2 release metadata 보정이므로 별도 문서 변경이 필요하지 않습니다.
- [x] 관련 테스트를 작성하거나 수정했습니다. 기존 token/React 빌드 및 전체 lint, typecheck, test로 검증했습니다.
- [x] 여러 브라우저에서 변경을 확인했습니다. 구현과 CSS 산출물은 #2881에서 변경되지 않으므로 추가 브라우저 검증이 필요하지 않습니다.

## Related Issue

- [WEB-12102](https://linear.app/channel/issue/WEB-12102/bug-snippet-%EC%83%89%EC%83%81-%ED%86%A0%ED%81%B0-%EA%B7%BC%EB%B3%B8-%EC%9B%90%EC%9D%B8-%EC%88%98%EC%A0%95-%EB%B0%8F-%EC%86%8C%EB%B9%84%EC%B2%98-%EC%97%85%EB%8D%B0%EC%9D%B4%ED%8A%B8)
- 선행 구현: #2881
- 현재 release PR: #2882

## Summary

#2881에서 추가한 v2 beta(v3) token source/build/export 구조는 그대로 유지하고, 실제 공개 릴리스 대상만 `@channel.io/bezier-react@2.7.0`으로 제한합니다.

`@channel.io/bezier-tokens`는 beta token 구현을 소유하지만 패키지 버전은 `0.2.13`으로 유지하며 이번에 별도로 배포하지 않습니다.

## Details

- 기존 changeset에서 `@channel.io/bezier-tokens` minor 항목을 제거했습니다.
- `bezier-tokens`의 beta source/build/export와 React의 beta CSS import는 #2881 구현을 그대로 사용합니다.
- release build에서 token workspace를 먼저 빌드하고 React `styles.css`에 beta CSS를 번들링하므로, token package를 별도로 배포하지 않아도 React 배포 산출물에는 beta token CSS가 포함됩니다.
- PR의 실제 코드 diff는 없으며 기존 changeset 한 줄만 변경합니다.
- Changesets version 단계에서 private Figma plugin의 버전과 React 의존성은 함께 갱신되지만, `private: true` package는 npm publish 대상에서 제외됩니다.

격리 복제본에서 `version-packages`를 실행한 결과:

- `@channel.io/bezier-react`: `2.6.2 -> 2.7.0`
- `@channel.io/bezier-tokens`: `0.2.13` 유지
- `@channel.io/stylelint-bezier`: `0.2.7` 유지
- private Figma plugin: `0.6.19 -> 0.6.20`, npm publish 제외
- private VSCode package: `0.3.0` 유지

검증 결과:

- token package build와 React build가 통과했습니다.
- 전체 lint, typecheck, test가 통과했습니다. React 기준 71개 suite, 568개 test, 39개 snapshot입니다.
- React CJS/ESM `styles.css`가 #2881 검증 산출물과 같은 크기와 SHA-256을 유지합니다.
- Changeset status의 유일한 공개 release는 `@channel.io/bezier-react@2.7.0`입니다.

### Breaking change? (No)

구현과 공개 API는 #2881에서 변경되지 않습니다. 이번 PR은 공개 release package를 React 하나로 제한하는 metadata 보정입니다.

## References

- v2 beta token 구현: #2881
- 수정 대상 release PR: #2882
