### PR TITLE
feat(bezier-codemod): add beta component migration workflow

### DIFF
--- a/.changeset/web-11689-beta-migration.md
+++ b/.changeset/web-11689-beta-migration.md
@@ -1,0 +1,7 @@
+---
+"@channel.io/bezier-codemod": patch
+---
+
+Add the root and alpha component to beta migration transform, structured
+diagnostics, scoped JSON/Markdown dry-run reporting, and the installable
+`migrate-bezier-beta` agent skill with a pinned `npx` fallback.

--- a/packages/bezier-codemod/README.md
+++ b/packages/bezier-codemod/README.md
@@ -10,7 +10,59 @@ In your terminal, navigate into your project's folder, then run:
 npx @channel.io/bezier-codemod
 ```
 
+## Agent skill
+
+Install the published migration skill into the consumer repository:
+
+```bash
+npx @channel.io/bezier-codemod@<version> --install-skill
+```
+
+This creates `.agents/skills/migrate-bezier-beta` and records the exact codemod
+version that installed it. An agent can then be asked naturally, for example:
+
+```text
+$migrate-bezier-beta로 features/Document만 dry-run하고 변경점과 QA 주요 구간을 요약해줘
+```
+
+The skill searches for matching source paths, excludes generated copies,
+states the resolved scope, and invokes the codemod. It uses a matching local
+binary when available; otherwise it automatically executes the pinned package
+with `npx`. It never falls back to an unpinned latest version.
+
 ## Transformations
+
+### Root and alpha components to beta
+
+**`beta-component-migration`**
+
+Run the provenance-aware transform non-interactively and write diagnostics for
+agent-assisted cases:
+
+```bash
+npx @channel.io/bezier-codemod \
+  --transform beta-component-migration \
+  --scope src/features/Document \
+  --dry-run \
+  --report .bezier-beta-migration-report.json \
+  --summary .bezier-beta-migration-summary.md
+```
+
+`--scope` accepts one `.ts`/`.tsx` file or directory. A directory is converted
+to a TypeScript glob after the CLI verifies that it exists inside the current
+repository. Use `--files` for a reviewed explicit glob. Dry-run does not save
+source files and produces both machine-readable JSON and a Markdown summary
+with changed paths, automatic change types, diagnostic categories, and QA
+hotspots.
+
+The transform handles import aliases, literal prop mappings, typed props
+objects, native Form ownership, and the mechanical Tabs update. Structural
+migrations such as ListItem, Select, TextField, navigation, and collapsible
+sections are emitted as source-located diagnostics.
+
+The published package includes the `migrate-bezier-beta` agent skill. Invoke
+that single skill when the codemod and heuristic follow-up should run as one
+verified migration workflow.
 
 ### v3 beta token to stable token
 

--- a/packages/bezier-codemod/package.json
+++ b/packages/bezier-codemod/package.json
@@ -23,7 +23,8 @@
     "clean": "rm -rf dist node_modules .turbo .eslintcache .jestcache"
   },
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "dependencies": {
     "@inkjs/ui": "^2.0.0",

--- a/packages/bezier-codemod/skills/migrate-bezier-beta/SKILL.md
+++ b/packages/bezier-codemod/skills/migrate-bezier-beta/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: migrate-bezier-beta
+description: Migrate TypeScript and React repositories from @channel.io/bezier-react root or alpha component APIs to @channel.io/bezier-react/beta. Use when upgrading legacy Bezier components, resolving beta migration diagnostics, converting FormControl/TextField/ListItem/Select and other old interfaces, or validating that a repository no longer uses deprecated Bezier component exports.
+---
+
+# Migrate Bezier Beta
+
+Run the provenance-aware codemod, resolve its structured diagnostics with
+repository context, and verify the migrated application. Do not stop after the
+codemod when warnings or legacy imports remain.
+
+## Workflow
+
+1. Inspect `git status` and preserve all pre-existing changes.
+2. Resolve the user's natural-language scope to one concrete source file or
+   directory. Search repository-owned TypeScript paths with `rg --files` and
+   compare every matching suffix. Exclude dependencies, generated files,
+   `dist`, `build`, coverage, snapshots, and vendored code. Prefer a path under
+   the target application's `src` tree. If multiple owned source paths remain
+   plausible, ask the user instead of widening the scope.
+3. State the resolved path before execution. Locate this skill directory and
+   run a dry-run first:
+
+   ```bash
+   node <skill-directory>/scripts/run-codemod.mjs \
+     --scope apps/example/src/features/Document \
+     --dry-run \
+     --report /tmp/bezier-beta-migration-report.json \
+     --summary /tmp/bezier-beta-migration-summary.md
+   ```
+
+   `--scope` accepts a `.ts`/`.tsx` file or directory. The codemod validates
+   that it exists inside the repository, turns a directory into a
+   `**/*.{ts,tsx}` glob, excludes generated/build directories, and prints the
+   resolved glob plus matched file count before transformation. Use `--files`
+   only when the user explicitly supplies a reviewed glob.
+
+4. Read the Markdown summary and JSON report. Report the changed file count and
+   paths, automatic change types, diagnostic categories, and the highest-risk
+   QA hotspots. Add repository-specific QA flows when component structure or
+   product behavior makes a directory riskier than the numeric ranking alone.
+5. If any diagnostic is not a trivial local prop choice, read
+   [references/migration-guide.md](references/migration-guide.md) before editing
+   that case.
+6. Resolve diagnostics in source order. Inspect parent composition, state,
+   callbacks, accessibility, and nearby tests before choosing a heuristic
+   target. Never decide from the old component name alone.
+7. Run the codemod again with the same scope. Continue until a run is idempotent
+   and every report diagnostic is resolved or explicitly justified by a
+   root-only API with no beta replacement.
+8. Search imports from `@channel.io/bezier-react`. Confirm every remaining
+   named import is a non-deprecated provider, token, hook, or intentionally
+   retained primitive. Do not assume a green typecheck proves this.
+9. Run the repository formatter on touched files, then run typecheck and
+   focused tests. Fix narrowed token types, removed props, form ownership,
+   controlled state, keyboard behavior, and accessible names exposed by those
+   checks.
+10. Review the final diff for unrelated formatting. Keep reports outside the
+    repository or remove temporary reports unless the user asks to retain them.
+
+## Scope Interpretation
+
+- Treat phrases such as "features/Document only" as a path-search request, not
+  as a literal glob and not as permission to scan the whole repository.
+- Show all duplicate candidate roots considered and the one selected when the
+  repository is large or generated copies exist.
+- Never silently fall back from an empty or missing narrow scope to `src` or
+  the repository root.
+- Split very large migrations into user-requested paths so each batch has a
+  reviewable diff and focused QA surface.
+
+## Codemod Rules
+
+- Treat diagnostics as required work, not informational output.
+- Keep Bezier import provenance. Do not globally replace common literals or
+  prop names.
+- Preserve aliases unless normalization is necessary to resolve a collision.
+- Convert a native `<form>` that owns legacy fields to beta `<Form>`. Do not
+  create a new form or nest forms without proving submission ownership.
+- Prefer minimal, local edits for automatic cases. Use broader restructuring
+  only for intent-dependent components described in the migration guide.
+- Re-run typecheck after structure-heavy batches so one semantic decision is
+  tested at a time.
+
+## Missing Codemod Binary
+
+The runner uses `BEZIER_CODEMOD_BIN` when explicitly set, then a repository-local
+binary only when its package version matches this installed skill, then the CLI
+shipped beside the skill. If none is available, it automatically runs
+`npx --yes @channel.io/bezier-codemod@<pinned-version>`. The pin is written when
+the skill is installed. Never replace it with `latest` or another unreviewed
+version during a migration.
+
+## Completion Criteria
+
+Finish only when the codemod is idempotent, diagnostics are resolved, deprecated
+root/alpha component imports are gone or deliberately retained with evidence,
+and typecheck plus relevant tests pass. Report any retained primitive or
+unverified interaction explicitly.

--- a/packages/bezier-codemod/skills/migrate-bezier-beta/agents/openai.yaml
+++ b/packages/bezier-codemod/skills/migrate-bezier-beta/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Migrate Bezier Beta'
+  short_description: 'Run codemods and resolve Bezier beta migrations'
+  default_prompt: 'Use $migrate-bezier-beta to migrate this repository from legacy Bezier components to beta.'

--- a/packages/bezier-codemod/skills/migrate-bezier-beta/references/migration-guide.md
+++ b/packages/bezier-codemod/skills/migrate-bezier-beta/references/migration-guide.md
@@ -1,0 +1,168 @@
+# Bezier root/alpha to beta migration guide
+
+Use this reference after the codemod writes
+`.bezier-beta-migration-report.json`. The report location is authoritative;
+do not infer Bezier ownership from JSX tag text alone.
+
+## Diagnostic handling
+
+| Diagnostic                   | Required action                                                                                     |
+| ---------------------------- | --------------------------------------------------------------------------------------------------- |
+| `dynamic-prop-value`         | Trace the local value union. Map it only if every possible value belongs to the legacy Bezier prop. |
+| `prop-collision`             | Compare both values and keep one beta prop. Never pick by source order.                             |
+| `manual-component-migration` | Use the component decision sections below.                                                          |
+| `manual-prop-migration`      | Select the beta value from semantic/visual intent, then remove the legacy prop.                     |
+| `form-owner-review`          | Confirm submission ownership. Use beta `Form` for a native form; do not create nested forms.        |
+| `form-field-size-manual`     | Choose `m` or `l`; review legacy `xs`/`xl` visually.                                                |
+| `tabs-size-*`                | Keep one `s` or `m` size on the owning `Tabs`.                                                      |
+| `import-name-collision`      | Normalize the alias after checking all references.                                                  |
+| `transform-failed`           | Inspect the file before continuing; do not suppress the error.                                      |
+
+## List and item decisions
+
+Choose the parent semantics before renaming `ListItem`:
+
+- Action menu under an overlay or more button: use `DropdownMenuItem` inside
+  `DropdownMenu`. Rename `onClick` to `onSelect`, left/right content to
+  leading/trailing content, and use `DropdownMenuSeparator` for dividers.
+- Static settings or grouped content: use `SectionItem` inside `Section`.
+- Collapsible grouped content: use `CollapsibleSectionTrigger` and
+  `CollapsibleSectionItem`/`SectionItem` inside `CollapsibleSection`.
+- App navigation: use `NavigationItem` inside `NavigationList`; use `href` for
+  links and `onClick` for button actions.
+- Selectable option: use `SelectOption` or `MultiSelectOption`; do not preserve
+  generic click handling.
+- Freeform row: keep an app-owned layout. Do not force it into a semantic beta
+  component.
+
+For `SectionLabel`, move children to `content`, left/right content to
+leading/trailing content, and remove `open`. If `open` controlled disclosure,
+move it to `CollapsibleSection` and use `CollapsibleSectionTrigger`.
+
+## Form decisions
+
+- Convert `<form>` that contains migrated `FormControl` nodes directly to
+  `<Form>` and convert `FormControl` to `FormField`.
+- Keep native form props (`onSubmit`, `action`, `method`, `noValidate`) on
+  `Form`; it wraps a native form element.
+- Do not add a `Form` around a standalone `FormField` without confirming the
+  submission scope.
+- Keep `size="m"` or `size="l"`. Choose a new size for legacy `xs`/`xl`.
+- Use `FormErrorMessage` for error text. Do not automatically reinterpret
+  arbitrary conditional `FormHelperText` as an error.
+- Use `FormGroup` only when one label describes multiple controls.
+
+## Select and TextField decisions
+
+For legacy `Select`, rebuild the data model explicitly:
+
+```tsx
+<Select
+  value={value}
+  onValueChange={setValue}
+>
+  <SelectOption
+    value="open"
+    label="Open"
+  />
+  <SelectOption
+    value="closed"
+    label="Closed"
+  />
+</Select>
+```
+
+Use `SelectGroup` for grouped options. Rich `content` requires a plain `label`
+for trigger display, typeahead, and accessible naming. Use `MultiSelect` only
+when the old control actually allowed multiple selected values.
+
+For `TextField`:
+
+- Static `type="search"`: migrate to `Search` and preserve `allowClear`.
+- Other supported input types: migrate to `TextInput`.
+- Rename left/right content and wrapper opt-outs to leading/trailing names.
+- Review imperative refs; beta exposes the native-oriented `TextInputRef`, not
+  every legacy selection helper.
+- Dynamic `type` that can include search requires splitting render branches or
+  keeping an app wrapper that chooses `Search` vs `TextInput`.
+
+## Button decisions
+
+Mechanical names are:
+
+- `text` -> `label`
+- `leftContent` / `prefixContent` -> `leadingContent`
+- `rightContent` / `suffixContent` -> `trailingContent`
+- `href` requires `as="a"` unless a custom router component owns navigation
+
+Do not mechanically map the old visual props. Choose both beta dimensions:
+
+- `variant`: `filled`, `outlined`, or `ghost`
+- `semantic`: `primary`, `secondary`, or `destructive`
+
+Legacy red/destructive actions normally become `semantic="destructive"`, but
+the variant still depends on emphasis. Remove legacy `xl` only after choosing
+`l` or changing layout. For custom `as={RouterLink}`, verify disabled/loading
+navigation behavior in the wrapper.
+
+## Toggle and segmented controls
+
+- `SegmentedControl` supports `s` and `m`; legacy `xs -> s`, `l -> m`.
+- Text items use string children with optional `leadingContent` and
+  `trailingContent`.
+- Icon-only items use `icon` and require an `aria-label`.
+- Convert `AlphaToggleButtonGroup` to `SegmentedControl` only for single
+  selection. Beta SegmentedControl is not a replacement for a multi-select
+  toggle group.
+- Keep app-owned controls when independent pressed states are required.
+
+## Navigation and disclosure
+
+- Wrap `NavItem`/`NavGroup` migrations in `NavigationList`.
+- `NavigationItem` must have either `href` or `onClick`.
+- Map `NavGroup.name` to a visible `label`; map `open` to controlled open state
+  and `onClick` to `onOpenChange` after removing name-based callback coupling.
+- `OutlineItem` becomes `NavigationGroup` only when it represents navigation.
+  Use `CollapsibleSection` for grouped disclosure and keep a tree widget
+  app-owned when hierarchical keyboard behavior is required.
+
+## Feedback and display edge cases
+
+- `Banner variant="alt"`: choose a supported variant after visual review. Do
+  not preserve `iconColor`; beta owns icon color by variant.
+- `ProgressBar`: the codemod adds `width={36}` when legacy width was omitted.
+  Choose `default` or `overlaid` for old variants.
+- `Tag`: removed monochrome variants have no Badge-style neutral rename.
+- `Toast`: map semantic intent to `info`, `success`, or `error`; move z-index
+  to `ToastProvider`. Review old `offline`/`online` presets manually.
+- `Tooltip`/`Help`: remove body icons. Put essential icon meaning in the
+  trigger or textual title/description.
+- `Emoji.imageUrl`: use a supported emoji name or app-owned image.
+- `AlphaStatusBadge`: derive `online`, `offline`, `online-dnd`, or
+  `offline-dnd` from both legacy booleans. Preserve dynamic combinations with
+  an explicit expression.
+- `LegacyIcon`: first migrate icon names to `@channel.io/bezier-icons`, then
+  pass the icon source to beta `Icon`.
+
+## Layout primitives
+
+- `Center`: use a Box/HStack/VStack that preserves horizontal and vertical
+  alignment.
+- generic `Stack`: choose HStack or VStack from direction; move StackItem props
+  to children or Box.
+- `LegacySpacer`: prefer parent spacing; use Box only for intentional flexible
+  space.
+- `KeyValueItem`: use SettingsField only for setting rows. Use SectionItem or
+  app layout for general data rows and preserve independent action targets.
+
+## Verification
+
+After edits, rerun the codemod. Then:
+
+1. Resolve every remaining report entry in source.
+2. Search root Bezier imports and confirm every remaining symbol is deliberately
+   root-only and non-deprecated.
+3. Run typecheck; use errors to find narrowed tokens, removed props, and stale
+   type imports.
+4. Run focused tests for forms, selection, menus, navigation, and overlays.
+5. Verify keyboard behavior and accessible names for structural migrations.

--- a/packages/bezier-codemod/skills/migrate-bezier-beta/scripts/run-codemod.mjs
+++ b/packages/bezier-codemod/skills/migrate-bezier-beta/scripts/run-codemod.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const PACKAGE_NAME = '@channel.io/bezier-codemod'
+
+function readOption(args, name, fallback) {
+  const index = args.indexOf(name)
+  if (index === -1) {
+    return fallback
+  }
+  const value = args[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} requires a value`)
+  }
+  return value
+}
+
+function readJson(filePath) {
+  if (!existsSync(filePath)) {
+    return undefined
+  }
+  return JSON.parse(readFileSync(filePath, 'utf8'))
+}
+
+function compatiblePackage(filePath, version) {
+  const manifest = readJson(filePath)
+  return manifest?.name === PACKAGE_NAME && manifest.version === version
+}
+
+const args = process.argv.slice(2)
+const scope = readOption(args, '--scope')
+const files = readOption(args, '--files')
+if (Boolean(scope) === Boolean(files)) {
+  throw new Error('Pass exactly one of --scope or --files.')
+}
+
+const report = readOption(
+  args,
+  '--report',
+  '.bezier-beta-migration-report.json'
+)
+const summary = readOption(
+  args,
+  '--summary',
+  '.bezier-beta-migration-summary.md'
+)
+const hotspotDepth = readOption(args, '--hotspot-depth', '2')
+const dryRun = args.includes('--dry-run')
+const cwd = process.cwd()
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
+const skillRoot = path.resolve(scriptDirectory, '..')
+const packageRoot = path.resolve(skillRoot, '../..')
+const installedPin = readJson(path.join(skillRoot, 'codemod-version.json'))
+const packagedManifest = readJson(path.join(packageRoot, 'package.json'))
+const pin =
+  installedPin?.packageName === PACKAGE_NAME
+    ? installedPin
+    : packagedManifest?.name === PACKAGE_NAME && packagedManifest.version
+      ? { packageName: PACKAGE_NAME, version: packagedManifest.version }
+      : undefined
+
+if (!pin?.version) {
+  throw new Error(
+    'This skill has no codemod version pin. Reinstall it with npx @channel.io/bezier-codemod@<version> --install-skill.'
+  )
+}
+
+const explicitBinary = process.env.BEZIER_CODEMOD_BIN
+const localBinary = path.join(
+  cwd,
+  `node_modules/.bin/bezier-codemod${process.platform === 'win32' ? '.cmd' : ''}`
+)
+const localManifest = path.join(
+  cwd,
+  'node_modules/@channel.io/bezier-codemod/package.json'
+)
+const packagedCli = path.join(packageRoot, 'dist/cli.js')
+
+let command
+let commandArgs
+let source
+
+if (explicitBinary) {
+  if (!existsSync(explicitBinary)) {
+    throw new Error(`BEZIER_CODEMOD_BIN does not exist: ${explicitBinary}`)
+  }
+  command = explicitBinary
+  commandArgs = []
+  source = 'BEZIER_CODEMOD_BIN'
+} else if (
+  existsSync(localBinary) &&
+  compatiblePackage(localManifest, pin.version)
+) {
+  command = localBinary
+  commandArgs = []
+  source = `local ${PACKAGE_NAME}@${pin.version}`
+} else if (
+  existsSync(packagedCli) &&
+  packagedManifest?.name === PACKAGE_NAME &&
+  packagedManifest.version === pin.version
+) {
+  command = process.execPath
+  commandArgs = [packagedCli]
+  source = `packaged ${PACKAGE_NAME}@${pin.version}`
+} else {
+  command = process.platform === 'win32' ? 'npx.cmd' : 'npx'
+  commandArgs = ['--yes', `${PACKAGE_NAME}@${pin.version}`]
+  source = `npx ${PACKAGE_NAME}@${pin.version}`
+}
+
+commandArgs.push(
+  '--transform',
+  'beta-component-migration',
+  scope ? '--scope' : '--files',
+  scope ?? files,
+  '--report',
+  report,
+  '--summary',
+  summary,
+  '--hotspot-depth',
+  hotspotDepth
+)
+if (dryRun) {
+  commandArgs.push('--dry-run')
+}
+
+console.log(`Running ${source}.`)
+const result = spawnSync(command, commandArgs, {
+  cwd,
+  stdio: 'inherit',
+})
+
+if (result.error) {
+  throw result.error
+}
+process.exitCode = result.status ?? 1

--- a/packages/bezier-codemod/src/App.tsx
+++ b/packages/bezier-codemod/src/App.tsx
@@ -10,6 +10,7 @@ import {
 import { Box, Text, useApp } from 'ink'
 
 import project from './project.js'
+import betaComponentMigration from './transforms/beta-component-migration/transform.js'
 import iconNameToBezierIcon from './transforms/icon-name-to-bezier-icons/transform.js'
 import iconsToBezierIcons from './transforms/icons-to-bezier-icons/transform.js'
 import enumMemberToStringLiteral from './transforms/v2-enum-member-to-string-literal/transform.js'
@@ -62,6 +63,7 @@ enum Option {
   V2ImportFromBezierToStyledComponents = 'v2-import-from-bezier-to-styled-components',
 
   V3BetaTokenToStableToken = 'v3-beta-token-to-stable-token',
+  BetaComponentMigration = 'beta-component-migration',
   Exit = 'Exit',
 }
 
@@ -96,6 +98,7 @@ const transformMap = {
   [Option.V2TextComponentInterface]: textComponentInterface,
 
   [Option.V3BetaTokenToStableToken]: betaTokenToStableToken,
+  [Option.BetaComponentMigration]: betaComponentMigration,
 }
 
 const options = (Object.keys(transformMap) as Option[])

--- a/packages/bezier-codemod/src/cli.tsx
+++ b/packages/bezier-codemod/src/cli.tsx
@@ -4,11 +4,27 @@ import { render } from 'ink'
 import meow from 'meow'
 
 import App from './App.js'
+import { installMigrateBezierBetaSkill } from './install-skill.js'
+import { runBetaComponentMigration } from './transforms/beta-component-migration/runner.js'
 
-meow(
+const cli = meow(
   `
   Usage:
     $ npx @channel.io/bezier-codemod
+    $ npx @channel.io/bezier-codemod --install-skill
+    $ npx @channel.io/bezier-codemod --transform beta-component-migration --scope src/features/Document --dry-run
+
+  Options:
+    --install-skill  Install the migrate-bezier-beta skill in .agents/skills
+    --skill-path     Override the skill root or destination
+    --force          Replace an existing installed skill
+    --transform      Run a transform without the interactive UI
+    --scope          Source file or directory; directories become TypeScript globs
+    --files          Explicit source file path or glob
+    --dry-run        Produce diagnostics without saving source files
+    --report         Write a JSON migration report
+    --summary        Write a Markdown migration summary
+    --hotspot-depth  Directory depth used to group QA hotspots (default: 2)
 
   More info:
     https://github.com/channel-io/bezier-react
@@ -16,11 +32,82 @@ meow(
   {
     importMeta: import.meta,
     flags: {
-      name: {
+      installSkill: {
+        type: 'boolean',
+        default: false,
+      },
+      skillPath: {
         type: 'string',
+      },
+      force: {
+        type: 'boolean',
+        default: false,
+      },
+      transform: {
+        type: 'string',
+      },
+      scope: {
+        type: 'string',
+      },
+      files: {
+        type: 'string',
+      },
+      dryRun: {
+        type: 'boolean',
+        default: false,
+      },
+      report: {
+        type: 'string',
+      },
+      summary: {
+        type: 'string',
+      },
+      hotspotDepth: {
+        type: 'number',
+        default: 2,
       },
     },
   }
 )
 
-render(<App />)
+if (cli.flags.installSkill) {
+  const installed = await installMigrateBezierBetaSkill({
+    skillPath: cli.flags.skillPath,
+    force: cli.flags.force,
+  })
+  // eslint-disable-next-line no-console
+  console.log(
+    `Installed migrate-bezier-beta at ${installed.path} (pinned to ${installed.packageName}@${installed.version}).`
+  )
+} else if (cli.flags.transform) {
+  if (cli.flags.transform !== 'beta-component-migration') {
+    throw new Error(`Unknown non-interactive transform: ${cli.flags.transform}`)
+  }
+  const reportPath =
+    cli.flags.report ??
+    (cli.flags.dryRun ? '.bezier-beta-migration-report.json' : undefined)
+  const summaryPath =
+    cli.flags.summary ??
+    (cli.flags.dryRun ? '.bezier-beta-migration-summary.md' : undefined)
+  const report = await runBetaComponentMigration({
+    files: cli.flags.files,
+    scope: cli.flags.scope,
+    dryRun: cli.flags.dryRun,
+    reportPath,
+    summaryPath,
+    hotspotDepth: cli.flags.hotspotDepth,
+    onScopeResolved: (scope, fileCount) => {
+      // eslint-disable-next-line no-console
+      console.log(`Resolved scope: ${scope.glob} (${fileCount} files)`)
+    },
+  })
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({ ...report.summary, reportPath, summaryPath }, null, 2)
+  )
+  if (report.summary.errors > 0) {
+    process.exitCode = 1
+  }
+} else {
+  render(<App />)
+}

--- a/packages/bezier-codemod/src/install-skill.test.ts
+++ b/packages/bezier-codemod/src/install-skill.test.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { installMigrateBezierBetaSkill } from './install-skill.js'
+
+describe('migrate-bezier-beta skill installer', () => {
+  it('installs a version-pinned skill and uses that pin for npx fallback', async () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'bezier-beta-skill-')
+    )
+    const sourceDirectory = path.join(directory, 'src')
+    const binaryDirectory = path.join(directory, 'bin')
+    const capturedArgsPath = path.join(directory, 'npx-args.json')
+    fs.mkdirSync(sourceDirectory)
+    fs.mkdirSync(binaryDirectory)
+    const installed = await installMigrateBezierBetaSkill({ cwd: directory })
+    const pin = JSON.parse(
+      fs.readFileSync(path.join(installed.path, 'codemod-version.json'), 'utf8')
+    ) as { packageName: string; version: string }
+    const fakeNpxPath = path.join(binaryDirectory, 'npx')
+    fs.writeFileSync(
+      fakeNpxPath,
+      `#!/usr/bin/env node\nrequire('fs').writeFileSync(${JSON.stringify(
+        capturedArgsPath
+      )}, JSON.stringify(process.argv.slice(2)))\n`
+    )
+    fs.chmodSync(fakeNpxPath, 0o755)
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(installed.path, 'scripts', 'run-codemod.mjs'),
+        '--scope',
+        'src',
+        '--dry-run',
+      ],
+      {
+        cwd: directory,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${binaryDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
+        },
+      }
+    )
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(fs.readFileSync(capturedArgsPath, 'utf8'))).toEqual(
+      expect.arrayContaining([
+        '--yes',
+        `${pin.packageName}@${pin.version}`,
+        '--scope',
+        'src',
+        '--dry-run',
+      ])
+    )
+  })
+
+  it('requires force before replacing an installed skill', async () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'bezier-beta-skill-force-')
+    )
+    await installMigrateBezierBetaSkill({ cwd: directory })
+
+    await expect(
+      installMigrateBezierBetaSkill({ cwd: directory })
+    ).rejects.toThrow('Skill already exists')
+    await expect(
+      installMigrateBezierBetaSkill({ cwd: directory, force: true })
+    ).resolves.toEqual(expect.objectContaining({ version: expect.any(String) }))
+  })
+})

--- a/packages/bezier-codemod/src/install-skill.ts
+++ b/packages/bezier-codemod/src/install-skill.ts
@@ -1,0 +1,105 @@
+import fs from 'fs/promises'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const PACKAGE_NAME = '@channel.io/bezier-codemod'
+const SKILL_NAME = 'migrate-bezier-beta'
+
+export interface InstallSkillOptions {
+  cwd?: string
+  skillPath?: string
+  force?: boolean
+}
+
+export interface InstalledSkill {
+  path: string
+  packageName: string
+  version: string
+}
+
+function assertInsideCwd(targetPath: string, cwd: string) {
+  const relative = path.relative(cwd, targetPath)
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(
+      `Skill destination must stay inside the repository: ${targetPath}`
+    )
+  }
+}
+
+async function copyDirectory(source: string, destination: string) {
+  await fs.mkdir(destination, { recursive: true })
+  const entries = await fs.readdir(source, { withFileTypes: true })
+  await Promise.all(
+    entries.map(async (entry) => {
+      const sourcePath = path.join(source, entry.name)
+      const destinationPath = path.join(destination, entry.name)
+      if (entry.isDirectory()) {
+        await copyDirectory(sourcePath, destinationPath)
+        return
+      }
+      if (!entry.isFile()) {
+        throw new Error(`Unsupported skill entry: ${sourcePath}`)
+      }
+      await fs.copyFile(sourcePath, destinationPath)
+    })
+  )
+}
+
+export async function installMigrateBezierBetaSkill({
+  cwd = process.cwd(),
+  skillPath = '.agents/skills',
+  force = false,
+}: InstallSkillOptions = {}): Promise<InstalledSkill> {
+  const absoluteCwd = path.resolve(cwd)
+  const moduleDirectory = path.dirname(fileURLToPath(import.meta.url))
+  const packageRoot = path.resolve(moduleDirectory, '..')
+  const source = path.join(packageRoot, 'skills', SKILL_NAME)
+  const requestedDestination = path.resolve(absoluteCwd, skillPath)
+  const destination =
+    path.basename(requestedDestination) === SKILL_NAME
+      ? requestedDestination
+      : path.join(requestedDestination, SKILL_NAME)
+  assertInsideCwd(destination, absoluteCwd)
+
+  const packageJson = JSON.parse(
+    await fs.readFile(path.join(packageRoot, 'package.json'), 'utf8')
+  ) as { name?: string; version?: string }
+  if (packageJson.name !== PACKAGE_NAME || !packageJson.version) {
+    throw new Error('Could not determine the installed Bezier codemod version.')
+  }
+
+  try {
+    await fs.access(destination)
+    if (!force) {
+      throw new Error(
+        `Skill already exists at ${destination}. Pass --force to replace it.`
+      )
+    }
+    await fs.rm(destination, { recursive: true, force: true })
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      !('code' in error && error.code === 'ENOENT')
+    ) {
+      throw error
+    }
+  }
+
+  await fs.mkdir(path.dirname(destination), { recursive: true })
+  await copyDirectory(source, destination)
+  await fs.writeFile(
+    path.join(destination, 'codemod-version.json'),
+    `${JSON.stringify(
+      { packageName: PACKAGE_NAME, version: packageJson.version },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  )
+
+  return {
+    path: destination,
+    packageName: PACKAGE_NAME,
+    version: packageJson.version,
+  }
+}

--- a/packages/bezier-codemod/src/project.ts
+++ b/packages/bezier-codemod/src/project.ts
@@ -4,14 +4,17 @@ import { IndentationText, NewLineKind, Project, QuoteKind } from 'ts-morph'
  * By default, set to the value that most closely matches the setting used by Channel team.
  * @see https://ts-morph.com/manipulation/settings#manipulation-settings
  */
-const project = new Project({
-  manipulationSettings: {
-    indentationText: IndentationText.TwoSpaces,
-    newLineKind: NewLineKind.LineFeed,
-    quoteKind: QuoteKind.Single,
-    usePrefixAndSuffixTextForRename: true,
-    useTrailingCommas: false,
-  },
-})
+export const createProject = () =>
+  new Project({
+    manipulationSettings: {
+      indentationText: IndentationText.TwoSpaces,
+      newLineKind: NewLineKind.LineFeed,
+      quoteKind: QuoteKind.Single,
+      usePrefixAndSuffixTextForRename: true,
+      useTrailingCommas: false,
+    },
+  })
+
+const project = createProject()
 
 export default project

--- a/packages/bezier-codemod/src/transforms/beta-component-migration/runner.test.ts
+++ b/packages/bezier-codemod/src/transforms/beta-component-migration/runner.test.ts
@@ -1,0 +1,122 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { runBetaComponentMigration } from './runner.js'
+
+describe('beta component migration runner', () => {
+  it('supports dry runs and writes a structured report', async () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'bezier-beta-migration-')
+    )
+    const sourcePath = path.join(directory, 'example.tsx')
+    const reportPath = path.join(directory, 'report.json')
+    const summaryPath = path.join(directory, 'summary.md')
+    const input = `
+      import { Icon, ListItem } from '@channel.io/bezier-react'
+      export const Example = () => <ListItem content={<Icon size="m" />} />
+    `
+    fs.writeFileSync(sourcePath, input)
+
+    const report = await runBetaComponentMigration({
+      files: sourcePath,
+      dryRun: true,
+      reportPath,
+      summaryPath,
+    })
+
+    expect(fs.readFileSync(sourcePath, 'utf8')).toBe(input)
+    expect(report.summary).toEqual({
+      scannedFiles: 1,
+      changedFiles: 1,
+      changes: 2,
+      warnings: 1,
+      errors: 0,
+      filesWithDiagnostics: 1,
+    })
+    expect(report.changedFilePaths).toEqual([sourcePath])
+    expect(report.changesByCode).toEqual({
+      'import-moved': 1,
+      'literal-mapped': 1,
+    })
+    expect(report.diagnosticsByCode).toEqual({
+      'manual-component-migration': 1,
+    })
+    expect(report.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'manual-component-migration',
+        component: 'ListItem',
+        filePath: sourcePath,
+      }),
+    ])
+    expect(JSON.parse(fs.readFileSync(reportPath, 'utf8'))).toEqual(report)
+    expect(fs.readFileSync(summaryPath, 'utf8')).toContain(
+      '# Bezier Beta Migration Summary'
+    )
+    expect(fs.readFileSync(summaryPath, 'utf8')).toContain(sourcePath)
+  })
+
+  it('resolves a directory scope and excludes generated directories', async () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'bezier-beta-migration-scope-')
+    )
+    const sourceDirectory = path.join(directory, 'src', 'features', 'Document')
+    const generatedDirectory = path.join(sourceDirectory, 'dist')
+    fs.mkdirSync(generatedDirectory, { recursive: true })
+    fs.writeFileSync(
+      path.join(sourceDirectory, 'owned.tsx'),
+      "import { Badge } from '@channel.io/bezier-react'\nexport const badge = <Badge />\n"
+    )
+    fs.writeFileSync(
+      path.join(generatedDirectory, 'copy.tsx'),
+      "import { Badge } from '@channel.io/bezier-react'\nexport const badge = <Badge />\n"
+    )
+    const onScopeResolved = jest.fn()
+
+    const report = await runBetaComponentMigration({
+      cwd: directory,
+      scope: 'src/features/Document',
+      dryRun: true,
+      onScopeResolved,
+    })
+
+    expect(report.scope).toEqual({
+      input: 'src/features/Document',
+      kind: 'directory',
+      resolvedPath: 'src/features/Document',
+      glob: 'src/features/Document/**/*.{ts,tsx}',
+    })
+    expect(report.summary.scannedFiles).toBe(1)
+    expect(report.changedFilePaths).toEqual(['src/features/Document/owned.tsx'])
+    expect(onScopeResolved).toHaveBeenCalledWith(report.scope, 1)
+  })
+
+  it('rejects a natural scope outside the repository', async () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'bezier-beta-migration-outside-')
+    )
+
+    await expect(
+      runBetaComponentMigration({
+        cwd: directory,
+        scope: '..',
+        dryRun: true,
+      })
+    ).rejects.toThrow('--scope must stay inside the current repository')
+  })
+
+  it('rejects a natural scope inside generated output', async () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'bezier-beta-migration-generated-')
+    )
+    fs.mkdirSync(path.join(directory, 'dist'), { recursive: true })
+
+    await expect(
+      runBetaComponentMigration({
+        cwd: directory,
+        scope: 'dist',
+        dryRun: true,
+      })
+    ).rejects.toThrow('--scope points inside an excluded directory')
+  })
+})

--- a/packages/bezier-codemod/src/transforms/beta-component-migration/runner.ts
+++ b/packages/bezier-codemod/src/transforms/beta-component-migration/runner.ts
@@ -1,0 +1,537 @@
+import fs from 'fs/promises'
+import path from 'path'
+
+import { createProject } from '../../project.js'
+
+import transform from './transform.js'
+import { type MigrationChange, type MigrationDiagnostic } from './types.js'
+
+const GLOB_CHARACTERS = '*?{}[]!'
+const EXCLUDED_DIRECTORY_NAMES = new Set([
+  '.next',
+  '__generated__',
+  'build',
+  'coverage',
+  'dist',
+  'generated',
+  'node_modules',
+  'storybook-static',
+  'vendor',
+])
+
+export interface MigrationScope {
+  input: string
+  kind: 'directory' | 'file' | 'glob'
+  resolvedPath: string
+  glob: string
+}
+
+export interface MigrationQaHotspot {
+  path: string
+  changedFiles: number
+  diagnosticFiles: number
+  diagnostics: number
+  risks: Record<string, number>
+}
+
+export interface RunBetaComponentMigrationOptions {
+  files?: string
+  scope?: string
+  dryRun?: boolean
+  reportPath?: string
+  summaryPath?: string
+  cwd?: string
+  hotspotDepth?: number
+  onScopeResolved?: (scope: MigrationScope, fileCount: number) => void
+}
+
+export interface BetaComponentMigrationReport {
+  version: 2
+  transform: 'beta-component-migration'
+  dryRun: boolean
+  cwd: string
+  scope: MigrationScope
+  summary: {
+    scannedFiles: number
+    changedFiles: number
+    changes: number
+    warnings: number
+    errors: number
+    filesWithDiagnostics: number
+  }
+  changedFilePaths: string[]
+  changes: MigrationChange[]
+  changesByCode: Record<string, number>
+  diagnostics: MigrationDiagnostic[]
+  diagnosticsByCode: Record<string, number>
+  diagnosticsByComponent: Record<string, number>
+  qaHotspots: MigrationQaHotspot[]
+}
+
+interface ResolvedMigrationInput {
+  scope: MigrationScope
+  scopeRoot: string
+  filePattern: string
+}
+
+function containsGlob(value: string) {
+  return [...value].some((character) => GLOB_CHARACTERS.includes(character))
+}
+
+function toPosixPath(value: string) {
+  return value.split(path.sep).join('/')
+}
+
+function relativePath(filePath: string, cwd: string) {
+  const relative = path.relative(cwd, filePath)
+  return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+    ? toPosixPath(relative)
+    : toPosixPath(filePath)
+}
+
+function globRoot(pattern: string, cwd: string) {
+  const absolutePattern = path.resolve(cwd, pattern)
+  const firstGlobIndex = [...absolutePattern].findIndex((character) =>
+    GLOB_CHARACTERS.includes(character)
+  )
+  if (firstGlobIndex === -1) {
+    return path.dirname(absolutePattern)
+  }
+  const staticPrefix = absolutePattern.slice(0, firstGlobIndex)
+  return staticPrefix.endsWith(path.sep)
+    ? staticPrefix.slice(0, -1)
+    : path.dirname(staticPrefix)
+}
+
+function assertInsideCwd(filePath: string, cwd: string) {
+  const relative = path.relative(cwd, filePath)
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(
+      `--scope must stay inside the current repository: ${filePath}`
+    )
+  }
+}
+
+async function resolveMigrationInput(
+  files: string | undefined,
+  scope: string | undefined,
+  cwd: string
+): Promise<ResolvedMigrationInput> {
+  if (Boolean(files) === Boolean(scope)) {
+    throw new Error('Pass exactly one of --scope or --files.')
+  }
+
+  if (scope) {
+    const realCwd = await fs.realpath(cwd)
+    const requestedPath = path.resolve(realCwd, scope)
+    let resolvedPath: string
+    try {
+      resolvedPath = await fs.realpath(requestedPath)
+    } catch {
+      throw new Error(`--scope does not exist: ${scope}`)
+    }
+    assertInsideCwd(resolvedPath, realCwd)
+    const stat = await fs.stat(resolvedPath)
+    if (!stat.isDirectory() && !stat.isFile()) {
+      throw new Error(`--scope must be a source file or directory: ${scope}`)
+    }
+    if (stat.isFile() && !/\.tsx?$/.test(resolvedPath)) {
+      throw new Error(`--scope file must use a .ts or .tsx extension: ${scope}`)
+    }
+    const scopeSegments = path.relative(realCwd, resolvedPath).split(path.sep)
+    if (
+      scopeSegments.some((segment) => EXCLUDED_DIRECTORY_NAMES.has(segment))
+    ) {
+      throw new Error(`--scope points inside an excluded directory: ${scope}`)
+    }
+
+    const filePattern = stat.isDirectory()
+      ? `${toPosixPath(resolvedPath)}/**/*.{ts,tsx}`
+      : toPosixPath(resolvedPath)
+    return {
+      scope: {
+        input: scope,
+        kind: stat.isDirectory() ? 'directory' : 'file',
+        resolvedPath: relativePath(resolvedPath, realCwd),
+        glob: relativePath(filePattern, realCwd),
+      },
+      scopeRoot: stat.isDirectory() ? resolvedPath : path.dirname(resolvedPath),
+      filePattern,
+    }
+  }
+
+  const inputPattern = files as string
+  const filePattern = toPosixPath(path.resolve(cwd, inputPattern))
+  const scopeRoot = globRoot(filePattern, cwd)
+  return {
+    scope: {
+      input: inputPattern,
+      kind: containsGlob(inputPattern) ? 'glob' : 'file',
+      resolvedPath: relativePath(
+        containsGlob(inputPattern) ? scopeRoot : filePattern,
+        cwd
+      ),
+      glob: inputPattern,
+    },
+    scopeRoot,
+    filePattern,
+  }
+}
+
+function isExcludedSourceFile(filePath: string, scopeRoot: string) {
+  const relative = path.relative(scopeRoot, filePath)
+  return relative
+    .split(path.sep)
+    .slice(0, -1)
+    .some((segment) => EXCLUDED_DIRECTORY_NAMES.has(segment))
+}
+
+async function findSourceFiles(directory: string): Promise<string[]> {
+  const entries = await fs.readdir(directory, { withFileTypes: true })
+  const nestedFiles = await Promise.all(
+    entries
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .map(async (entry) => {
+        const entryPath = path.join(directory, entry.name)
+        if (entry.isDirectory()) {
+          return EXCLUDED_DIRECTORY_NAMES.has(entry.name)
+            ? []
+            : findSourceFiles(entryPath)
+        }
+        return entry.isFile() && /\.tsx?$/.test(entry.name) ? [entryPath] : []
+      })
+  )
+  return nestedFiles.flat()
+}
+
+async function addSourceFiles(
+  project: ReturnType<typeof createProject>,
+  input: ResolvedMigrationInput
+) {
+  let sourceFiles
+  if (input.scope.kind === 'directory') {
+    const filePaths = await findSourceFiles(input.scopeRoot)
+    sourceFiles = filePaths.map((filePath) =>
+      project.addSourceFileAtPath(filePath)
+    )
+  } else if (containsGlob(input.filePattern)) {
+    const projectPattern = path.isAbsolute(input.filePattern)
+      ? path.relative(process.cwd(), input.filePattern)
+      : input.filePattern
+    sourceFiles = project.addSourceFilesAtPaths(projectPattern)
+  } else {
+    sourceFiles = [project.addSourceFileAtPath(input.filePattern)]
+  }
+  return sourceFiles
+    .filter(
+      (sourceFile) =>
+        !isExcludedSourceFile(sourceFile.getFilePath(), input.scopeRoot)
+    )
+    .sort((left, right) =>
+      left.getFilePath().localeCompare(right.getFilePath())
+    )
+}
+
+function countBy<T>(items: T[], getKey: (item: T) => string) {
+  const counts = new Map<string, number>()
+  items.forEach((item) => {
+    const key = getKey(item)
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  })
+  return Object.fromEntries(
+    [...counts.entries()].sort(([left], [right]) => left.localeCompare(right))
+  )
+}
+
+function hotspotPath(filePath: string, scopeRoot: string, depth: number) {
+  const relative = path.relative(scopeRoot, filePath)
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    return toPosixPath(path.dirname(filePath))
+  }
+  const directories = relative.split(path.sep).slice(0, -1)
+  return directories.length === 0
+    ? '.'
+    : toPosixPath(directories.slice(0, depth).join(path.sep))
+}
+
+function createQaHotspots(
+  changedFilePaths: string[],
+  diagnostics: MigrationDiagnostic[],
+  scopeRoot: string,
+  depth: number
+) {
+  const entries = new Map<
+    string,
+    {
+      changedFiles: Set<string>
+      diagnosticFiles: Set<string>
+      diagnostics: number
+      risks: Map<string, number>
+    }
+  >()
+  const entryFor = (filePath: string) => {
+    const key = hotspotPath(filePath, scopeRoot, depth)
+    const entry = entries.get(key) ?? {
+      changedFiles: new Set<string>(),
+      diagnosticFiles: new Set<string>(),
+      diagnostics: 0,
+      risks: new Map<string, number>(),
+    }
+    entries.set(key, entry)
+    return entry
+  }
+
+  changedFilePaths.forEach((filePath) =>
+    entryFor(filePath).changedFiles.add(filePath)
+  )
+  diagnostics.forEach((diagnostic) => {
+    const entry = entryFor(diagnostic.filePath)
+    entry.diagnosticFiles.add(diagnostic.filePath)
+    entry.diagnostics += 1
+    entry.risks.set(
+      diagnostic.code,
+      (entry.risks.get(diagnostic.code) ?? 0) + 1
+    )
+  })
+
+  return [...entries.entries()]
+    .map(([entryPath, entry]) => ({
+      path: entryPath,
+      changedFiles: entry.changedFiles.size,
+      diagnosticFiles: entry.diagnosticFiles.size,
+      diagnostics: entry.diagnostics,
+      risks: Object.fromEntries(
+        [...entry.risks.entries()].sort(([, left], [, right]) => right - left)
+      ),
+    }))
+    .sort(
+      (left, right) =>
+        right.diagnostics - left.diagnostics ||
+        right.diagnosticFiles - left.diagnosticFiles ||
+        right.changedFiles - left.changedFiles ||
+        left.path.localeCompare(right.path)
+    )
+}
+
+function normalizeLocations<T extends { filePath: string }>(
+  items: T[],
+  cwd: string
+) {
+  return items.map((item) => ({
+    ...item,
+    filePath: relativePath(item.filePath, cwd),
+  }))
+}
+
+function markdownTable(headers: string[], rows: string[][]) {
+  if (rows.length === 0) {
+    return '_None_'
+  }
+  const escape = (value: string) => value.replaceAll('|', '\\|')
+  return [
+    `| ${headers.map(escape).join(' | ')} |`,
+    `| ${headers.map(() => '---').join(' | ')} |`,
+    ...rows.map((row) => `| ${row.map(escape).join(' | ')} |`),
+  ].join('\n')
+}
+
+export function renderBetaComponentMigrationMarkdown(
+  report: BetaComponentMigrationReport
+) {
+  const mode = report.dryRun ? 'Dry run' : 'Write'
+  const hotspotRows = report.qaHotspots.slice(0, 20).map((hotspot) => [
+    `\`${hotspot.path}\``,
+    String(hotspot.changedFiles),
+    String(hotspot.diagnosticFiles),
+    String(hotspot.diagnostics),
+    Object.entries(hotspot.risks)
+      .slice(0, 3)
+      .map(([code, count]) => `${code} (${count})`)
+      .join(', ') || '-',
+  ])
+  const lines = [
+    '# Bezier Beta Migration Summary',
+    '',
+    `- Mode: ${mode}`,
+    `- Scope: \`${report.scope.resolvedPath}\``,
+    `- Resolved glob: \`${report.scope.glob}\``,
+    '',
+    '## Summary',
+    '',
+    markdownTable(
+      [
+        'Scanned',
+        'Changed',
+        'Changes',
+        'Warnings',
+        'Errors',
+        'Diagnostic files',
+      ],
+      [
+        [
+          String(report.summary.scannedFiles),
+          String(report.summary.changedFiles),
+          String(report.summary.changes),
+          String(report.summary.warnings),
+          String(report.summary.errors),
+          String(report.summary.filesWithDiagnostics),
+        ],
+      ]
+    ),
+    '',
+    '## Automatic Changes',
+    '',
+    markdownTable(
+      ['Change type', 'Count'],
+      Object.entries(report.changesByCode)
+        .sort(([, left], [, right]) => right - left)
+        .map(([code, count]) => [`\`${code}\``, String(count)])
+    ),
+    '',
+    '## Diagnostic Categories',
+    '',
+    markdownTable(
+      ['Diagnostic', 'Count'],
+      Object.entries(report.diagnosticsByCode)
+        .sort(([, left], [, right]) => right - left)
+        .map(([code, count]) => [`\`${code}\``, String(count)])
+    ),
+    '',
+    '## QA Hotspots',
+    '',
+    markdownTable(
+      [
+        'Path',
+        'Changed files',
+        'Diagnostic files',
+        'Diagnostics',
+        'Main risks',
+      ],
+      hotspotRows
+    ),
+    '',
+    '## Changed Files',
+    '',
+    report.changedFilePaths.length > 0
+      ? report.changedFilePaths
+          .map((filePath) => `- \`${filePath}\``)
+          .join('\n')
+      : '_None_',
+    '',
+  ]
+  return `${lines.join('\n')}\n`
+}
+
+export async function runBetaComponentMigration({
+  files,
+  scope,
+  dryRun = false,
+  reportPath,
+  summaryPath,
+  cwd = process.cwd(),
+  hotspotDepth = 2,
+  onScopeResolved,
+}: RunBetaComponentMigrationOptions) {
+  if (!Number.isInteger(hotspotDepth) || hotspotDepth < 1) {
+    throw new Error('hotspotDepth must be a positive integer.')
+  }
+
+  const absoluteCwd = await fs.realpath(path.resolve(cwd))
+  const input = await resolveMigrationInput(files, scope, absoluteCwd)
+  const project = createProject()
+  const sourceFiles = await addSourceFiles(project, input)
+  onScopeResolved?.(input.scope, sourceFiles.length)
+
+  const diagnostics: MigrationDiagnostic[] = []
+  const changes: MigrationChange[] = []
+  const changedFilePaths: string[] = []
+
+  for (const sourceFile of sourceFiles) {
+    const before = sourceFile.getFullText()
+    try {
+      const result = transform(sourceFile)
+      diagnostics.push(...result.diagnostics)
+      changes.push(...result.changes)
+      if (sourceFile.getFullText() !== before) {
+        changedFilePaths.push(sourceFile.getFilePath())
+        if (!dryRun) {
+          await sourceFile.save()
+        }
+      }
+    } catch (error) {
+      diagnostics.push({
+        code: 'transform-failed',
+        severity: 'error',
+        filePath: sourceFile.getFilePath(),
+        line: 1,
+        column: 1,
+        message: error instanceof Error ? error.message : String(error),
+        suggestion: 'Inspect this file manually and rerun the migration.',
+      })
+    }
+  }
+
+  const normalizedChanges = normalizeLocations(changes, absoluteCwd)
+  const normalizedDiagnostics = normalizeLocations(diagnostics, absoluteCwd)
+  const normalizedChangedFilePaths = changedFilePaths.map((filePath) =>
+    relativePath(filePath, absoluteCwd)
+  )
+  const filesWithDiagnostics = new Set(
+    normalizedDiagnostics.map(({ filePath }) => filePath)
+  ).size
+  const report: BetaComponentMigrationReport = {
+    version: 2,
+    transform: 'beta-component-migration',
+    dryRun,
+    cwd: toPosixPath(absoluteCwd),
+    scope: input.scope,
+    summary: {
+      scannedFiles: sourceFiles.length,
+      changedFiles: normalizedChangedFilePaths.length,
+      changes: normalizedChanges.length,
+      warnings: normalizedDiagnostics.filter(
+        ({ severity }) => severity === 'warning'
+      ).length,
+      errors: normalizedDiagnostics.filter(
+        ({ severity }) => severity === 'error'
+      ).length,
+      filesWithDiagnostics,
+    },
+    changedFilePaths: normalizedChangedFilePaths,
+    changes: normalizedChanges,
+    changesByCode: countBy(normalizedChanges, ({ code }) => code),
+    diagnostics: normalizedDiagnostics,
+    diagnosticsByCode: countBy(normalizedDiagnostics, ({ code }) => code),
+    diagnosticsByComponent: countBy(
+      normalizedDiagnostics,
+      ({ component }) => component ?? '(unscoped)'
+    ),
+    qaHotspots: createQaHotspots(
+      changedFilePaths,
+      diagnostics,
+      input.scopeRoot,
+      hotspotDepth
+    ),
+  }
+
+  if (reportPath) {
+    const absoluteReportPath = path.resolve(absoluteCwd, reportPath)
+    await fs.mkdir(path.dirname(absoluteReportPath), { recursive: true })
+    await fs.writeFile(
+      absoluteReportPath,
+      `${JSON.stringify(report, null, 2)}\n`,
+      'utf8'
+    )
+  }
+  if (summaryPath) {
+    const absoluteSummaryPath = path.resolve(absoluteCwd, summaryPath)
+    await fs.mkdir(path.dirname(absoluteSummaryPath), { recursive: true })
+    await fs.writeFile(
+      absoluteSummaryPath,
+      renderBetaComponentMigrationMarkdown(report),
+      'utf8'
+    )
+  }
+
+  return report
+}

--- a/packages/bezier-codemod/src/transforms/beta-component-migration/transform.test.ts
+++ b/packages/bezier-codemod/src/transforms/beta-component-migration/transform.test.ts
@@ -1,0 +1,245 @@
+import project from '../../project.js'
+
+import transform from './transform.js'
+
+function migrate(source: string) {
+  const sourceFile = project.createSourceFile(
+    'beta-migration-test.tsx',
+    source,
+    {
+      overwrite: true,
+    }
+  )
+  const result = transform(sourceFile)
+  return {
+    code: sourceFile.getFullText(),
+    changes: result.changes,
+    diagnostics: result.diagnostics,
+  }
+}
+
+describe('beta component migration', () => {
+  it('transforms component-scoped literal props and preserves unrelated components', () => {
+    const { code, diagnostics } = migrate(`
+      import {
+        Avatar,
+        Badge as BezierBadge,
+        Banner,
+        Button,
+        Icon,
+        Spinner,
+        Status,
+      } from '@channel.io/bezier-react'
+      import { Icon as OtherIcon } from './icons'
+
+      export const Example = ({ compact }) => (
+        <>
+          <BezierBadge variant="monochrome-light" />
+          <Icon size={compact ? 'xs' : 'm'} />
+          <Spinner size="xl" />
+          <Avatar name="A" status="online-crescent" />
+          <Status type="offline-crescent" />
+          <Banner icon={null} />
+          <Button text="Save" leftContent={Icon} />
+          <OtherIcon size="m" />
+        </>
+      )
+    `)
+
+    expect(code).toContain("from '@channel.io/bezier-react/beta'")
+    expect(code).toContain('<BezierBadge variant="neutral-light" />')
+    expect(code).toContain("<Icon size={compact ? '16' : '24'} />")
+    expect(code).toContain('<Spinner size="48" />')
+    expect(code).toContain('status="online-dnd"')
+    expect(code).toContain('type="offline-dnd"')
+    expect(code).toContain('<Banner leadingIcon={null} />')
+    expect(code).toContain('<Button label="Save" leadingContent={Icon} />')
+    expect(code).toContain('<OtherIcon size="m" />')
+    expect(diagnostics).toHaveLength(0)
+  })
+
+  it('converts a native form owner and FormControl together', () => {
+    const { code, diagnostics } = migrate(`
+      import { FormControl, FormLabel, TextArea } from '@channel.io/bezier-react'
+
+      export const Example = () => (
+        <form onSubmit={() => undefined}>
+          <FormControl size="m">
+            <FormLabel>Email</FormLabel>
+            <TextArea />
+          </FormControl>
+        </form>
+      )
+    `)
+
+    expect(code).toContain('Form, FormField')
+    expect(code).toContain('<Form onSubmit={() => undefined}>')
+    expect(code).toContain('<FormField size="m">')
+    expect(code).toContain('</FormField>')
+    expect(code).toContain('</Form>')
+    expect(diagnostics).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'form-owner-review' }),
+      ])
+    )
+  })
+
+  it('reports a standalone FormControl instead of inventing form ownership', () => {
+    const { code, diagnostics } = migrate(`
+      import { FormControl } from '@channel.io/bezier-react'
+      export const Field = () => <FormControl size="xl" />
+    `)
+
+    expect(code).toContain('FormField')
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'form-field-size-manual' }),
+        expect.objectContaining({ code: 'form-owner-review' }),
+      ])
+    )
+  })
+
+  it('removes TabItems and moves a supported TabList size to Tabs', () => {
+    const { code, diagnostics } = migrate(`
+      import { Tabs, TabList, TabItems, TabItem } from '@channel.io/bezier-react'
+      export const Example = () => (
+        <Tabs defaultValue="all">
+          <TabList size="s">
+            <TabItems>
+              <TabItem value="all">All</TabItem>
+            </TabItems>
+          </TabList>
+        </Tabs>
+      )
+    `)
+
+    expect(code).toContain('<Tabs defaultValue="all" size="s">')
+    expect(code).toContain('<TabList>')
+    expect(code).not.toContain('TabItems')
+    expect(diagnostics).toHaveLength(0)
+  })
+
+  it('leaves intent-dependent components on the root import and reports them', () => {
+    const { code, diagnostics } = migrate(`
+      import { ListItem, Badge } from '@channel.io/bezier-react'
+      export const Example = () => <ListItem content={<Badge>New</Badge>} />
+    `)
+
+    expect(code).toContain(
+      "import { ListItem } from '@channel.io/bezier-react'"
+    )
+    expect(code).toContain(
+      "import { Badge } from '@channel.io/bezier-react/beta'"
+    )
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'manual-component-migration',
+        component: 'ListItem',
+      }),
+    ])
+  })
+
+  it('reports dynamic values and does not rewrite unrelated literals', () => {
+    const { code, diagnostics } = migrate(`
+      import { Icon } from '@channel.io/bezier-react'
+      const size = 'm'
+      const domain = { size: 'm' }
+      export const Example = () => <Icon size={size} />
+    `)
+
+    expect(code).toContain('<Icon size={size} />')
+    expect(code).toContain("const domain = { size: 'm' }")
+    expect(diagnostics).toEqual([
+      expect.objectContaining({ code: 'dynamic-prop-value' }),
+    ])
+  })
+
+  it('transforms typed props objects and Storybook args only with proven context', () => {
+    const { code, diagnostics } = migrate(`
+      import { Badge, type IconProps, Spinner } from '@channel.io/bezier-react'
+      import type { StoryObj } from '@storybook/react'
+
+      const iconProps: IconProps = { size: 'l' }
+      const story = { args: { variant: 'monochrome-dark' } }
+      const badgeStory: StoryObj<typeof Badge> = { variant: 'monochrome-light' }
+      const spinnerStory = { size: 'm' } satisfies StoryObj<typeof Spinner>
+    `)
+
+    expect(code).toContain("const iconProps: IconProps = { size: '36' }")
+    expect(code).toContain(
+      "const story = { args: { variant: 'monochrome-dark' } }"
+    )
+    expect(code).toContain(
+      "const badgeStory: StoryObj<typeof Badge> = { variant: 'neutral-light' }"
+    )
+    expect(code).toContain(
+      "const spinnerStory = { size: '20' } satisfies StoryObj<typeof Spinner>"
+    )
+    expect(diagnostics).toHaveLength(0)
+  })
+
+  it('moves a standalone type-only import without creating an empty import', () => {
+    const { code, diagnostics } = migrate(`
+      import type { OverlayProps } from '@channel.io/bezier-react'
+      export type Props = Pick<OverlayProps, 'position'>
+    `)
+
+    expect(code).toContain(
+      "import type { OverlayProps } from '@channel.io/bezier-react/beta'"
+    )
+    expect(code).not.toContain("from '@channel.io/bezier-react'")
+    expect(diagnostics).toHaveLength(0)
+  })
+
+  it('is idempotent for fully automatic migrations', () => {
+    const first = migrate(`
+      import { Badge, Icon } from '@channel.io/bezier-react'
+      export const Example = () => <Badge variant="monochrome-dark" icon={<Icon size="m" />} />
+    `)
+    const sourceFile = project.createSourceFile(
+      'beta-migration-idempotence-test.tsx',
+      first.code,
+      { overwrite: true }
+    )
+
+    const second = transform(sourceFile)
+
+    expect(sourceFile.getFullText()).toBe(first.code)
+    expect(first.diagnostics).toHaveLength(0)
+    expect(second.changes).toHaveLength(0)
+    expect(second.diagnostics).toHaveLength(0)
+  })
+
+  it('composes the legacy enum transform before beta value mappings', () => {
+    const { code, diagnostics } = migrate(`
+      import { Icon, IconSize, Status, StatusType } from '@channel.io/bezier-react'
+      export const Example = () => (
+        <>
+          <Icon size={IconSize.Normal} />
+          <Status type={StatusType.OnlineCrescent} />
+        </>
+      )
+    `)
+
+    expect(code).toContain("<Icon size='24' />")
+    expect(code).toContain("<Status type='online-dnd' />")
+    expect(code).not.toContain('IconSize')
+    expect(code).not.toContain('StatusType')
+    expect(diagnostics).toHaveLength(0)
+  })
+
+  it('preserves the legacy ProgressBar default width', () => {
+    const { code, changes } = migrate(`
+      import { ProgressBar } from '@channel.io/bezier-react'
+      export const Example = () => <ProgressBar value={0.5} />
+    `)
+
+    expect(code).toContain('<ProgressBar value={0.5} width={36} />')
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'default-preserved' }),
+        expect.objectContaining({ code: 'import-moved' }),
+      ])
+    )
+  })
+})

--- a/packages/bezier-codemod/src/transforms/beta-component-migration/transform.ts
+++ b/packages/bezier-codemod/src/transforms/beta-component-migration/transform.ts
@@ -1,0 +1,1723 @@
+import {
+  type ImportDeclaration,
+  type ImportSpecifier,
+  type JsxAttribute,
+  type JsxElement,
+  type JsxOpeningElement,
+  type JsxSelfClosingElement,
+  Node,
+  type ObjectLiteralExpression,
+  type SourceFile,
+  SyntaxKind,
+} from 'ts-morph'
+
+import enumMemberToStringLiteral from '../v2-enum-member-to-string-literal/transform.js'
+
+import {
+  type BetaComponentMigrationResult,
+  type MigrationChange,
+  type MigrationDiagnostic,
+} from './types.js'
+
+const ROOT_MODULE = '@channel.io/bezier-react'
+const BETA_MODULE = '@channel.io/bezier-react/beta'
+
+type JsxOpeningLike = JsxOpeningElement | JsxSelfClosingElement
+
+interface ImportedBinding {
+  exportedName: string
+  localName: string
+  declaration: ImportDeclaration
+  specifier: ImportSpecifier
+}
+
+export const COMPONENT_EXPORT_MAP: Record<string, string> = {
+  AlphaAvatar: 'Avatar',
+  AlphaAvatarGroup: 'AvatarGroup',
+  AlphaButton: 'Button',
+  AlphaFloatingButton: 'Button',
+  AlphaFloatingIconButton: 'IconButton',
+  AlphaIconButton: 'IconButton',
+  AlphaLoader: 'Spinner',
+  Avatar: 'Avatar',
+  AvatarGroup: 'AvatarGroup',
+  Badge: 'Badge',
+  Banner: 'Banner',
+  Box: 'Box',
+  Button: 'Button',
+  ButtonGroup: 'ButtonGroup',
+  Checkbox: 'Checkbox',
+  ConfirmModal: 'ConfirmModal',
+  ConfirmModalBody: 'ConfirmModalBody',
+  ConfirmModalClose: 'ConfirmModalClose',
+  ConfirmModalContent: 'ConfirmModalContent',
+  ConfirmModalFooter: 'ConfirmModalFooter',
+  ConfirmModalHeader: 'ConfirmModalHeader',
+  ConfirmModalTrigger: 'ConfirmModalTrigger',
+  Divider: 'Divider',
+  Emoji: 'Emoji',
+  FormControl: 'FormField',
+  FormErrorMessage: 'FormErrorMessage',
+  FormGroup: 'FormGroup',
+  FormHelperText: 'FormHelperText',
+  FormLabel: 'FormLabel',
+  Help: 'Help',
+  HStack: 'HStack',
+  Icon: 'Icon',
+  Modal: 'Modal',
+  ModalBody: 'ModalBody',
+  ModalClose: 'ModalClose',
+  ModalContent: 'ModalContent',
+  ModalFooter: 'ModalFooter',
+  ModalHeader: 'ModalHeader',
+  ModalTrigger: 'ModalTrigger',
+  Overlay: 'Overlay',
+  ProgressBar: 'ProgressBar',
+  Radio: 'Radio',
+  RadioGroup: 'RadioGroup',
+  SectionLabel: 'SectionLabel',
+  SegmentedControl: 'SegmentedControl',
+  SegmentedControlItem: 'SegmentedControlItem',
+  SegmentedControlTabContent: 'SegmentedControlTabContent',
+  SegmentedControlTabList: 'SegmentedControlTabList',
+  Select: 'Select',
+  Slider: 'Slider',
+  SmoothCornersBox: 'SmoothCornersBox',
+  Spinner: 'Spinner',
+  Status: 'Status',
+  Switch: 'Switch',
+  TabAction: 'TabAction',
+  TabActions: 'TabActions',
+  TabContent: 'TabContent',
+  TabItem: 'TabItem',
+  TabList: 'TabList',
+  Tabs: 'Tabs',
+  Tag: 'Tag',
+  Text: 'Text',
+  TextArea: 'TextArea',
+  ToastProvider: 'ToastProvider',
+  Tooltip: 'Tooltip',
+  VStack: 'VStack',
+  useAvatarRadiusToken: 'useAvatarRadiusToken',
+  useFormControlContext: 'useFormFieldContext',
+  useFormFieldProps: 'useFormFieldProps',
+  useModalContainerContext: 'useModalContainerContext',
+  useToast: 'useToast',
+}
+
+const TYPE_EXPORT_MAP: Record<string, string> = {
+  AlphaAvatarGroupProps: 'AvatarGroupProps',
+  AlphaAvatarProps: 'AvatarProps',
+  AlphaAvatarSize: 'AvatarSize',
+  AlphaButtonProps: 'ButtonProps',
+  AlphaButtonSize: 'ButtonSize',
+  AlphaFloatingButtonProps: 'ButtonProps',
+  AlphaFloatingButtonSize: 'ButtonSize',
+  AlphaFloatingIconButtonProps: 'IconButtonProps',
+  AlphaIconButtonProps: 'IconButtonProps',
+  AlphaLoaderProps: 'SpinnerProps',
+  AvatarGroupEllipsisType: 'AvatarGroupEllipsisType',
+  AvatarGroupProps: 'AvatarGroupProps',
+  AvatarProps: 'AvatarProps',
+  AvatarSize: 'AvatarSize',
+  BadgeProps: 'BadgeProps',
+  BadgeSize: 'BadgeSize',
+  BadgeVariant: 'BadgeVariant',
+  BannerProps: 'BannerProps',
+  BannerVariant: 'BannerVariant',
+  BoxProps: 'BoxProps',
+  ButtonGroupProps: 'ButtonGroupProps',
+  ButtonProps: 'ButtonProps',
+  ButtonSize: 'ButtonSize',
+  CheckboxProps: 'CheckboxProps',
+  CheckedState: 'CheckedState',
+  ConfirmModalBodyProps: 'ConfirmModalBodyProps',
+  ConfirmModalCloseProps: 'ConfirmModalCloseProps',
+  ConfirmModalContentProps: 'ConfirmModalContentProps',
+  ConfirmModalFooterProps: 'ConfirmModalFooterProps',
+  ConfirmModalHeaderProps: 'ConfirmModalHeaderProps',
+  ConfirmModalProps: 'ConfirmModalProps',
+  ConfirmModalTriggerProps: 'ConfirmModalTriggerProps',
+  DividerProps: 'DividerProps',
+  EmojiProps: 'EmojiProps',
+  EmojiSize: 'EmojiSize',
+  FormControlAriaProps: 'FormFieldAriaProps',
+  FormControlContextValue: 'FormFieldContextValue',
+  FormControlProps: 'FormFieldProps',
+  FormErrorMessageProps: 'FormErrorMessageProps',
+  FormFieldProps: 'FormFieldProps',
+  FormFieldSize: 'FormFieldSize',
+  FormGroupProps: 'FormGroupProps',
+  FormHelperTextProps: 'FormHelperTextProps',
+  FormLabelProps: 'FormLabelProps',
+  HelpProps: 'HelpProps',
+  HStackProps: 'HStackProps',
+  IconProps: 'IconProps',
+  IconSize: 'IconSize',
+  ModalBodyProps: 'ModalBodyProps',
+  ModalCloseProps: 'ModalCloseProps',
+  ModalContentProps: 'ModalContentProps',
+  ModalFooterProps: 'ModalFooterProps',
+  ModalHeaderProps: 'ModalHeaderProps',
+  ModalProps: 'ModalProps',
+  ModalTitleSize: 'ModalTitleSize',
+  ModalTriggerProps: 'ModalTriggerProps',
+  OverlayPosition: 'OverlayPosition',
+  OverlayProps: 'OverlayProps',
+  ProgressBarProps: 'ProgressBarProps',
+  ProgressBarSize: 'ProgressBarSize',
+  ProgressBarVariant: 'ProgressBarVariant',
+  RadioGroupProps: 'RadioGroupProps',
+  RadioProps: 'RadioProps',
+  SectionLabelProps: 'SectionLabelProps',
+  SegmentedControlItemProps: 'SegmentedControlItemProps',
+  SegmentedControlProps: 'SegmentedControlProps',
+  SegmentedControlSize: 'SegmentedControlSize',
+  SegmentedControlTabContentProps: 'SegmentedControlTabContentProps',
+  SegmentedControlTabListProps: 'SegmentedControlTabListProps',
+  SelectProps: 'SelectProps',
+  SliderProps: 'SliderProps',
+  SmoothCornersBoxProps: 'SmoothCornersBoxProps',
+  SpinnerProps: 'SpinnerProps',
+  SpinnerSize: 'SpinnerSize',
+  StatusProps: 'StatusProps',
+  StatusSize: 'StatusSize',
+  StatusType: 'StatusType',
+  SwitchProps: 'SwitchProps',
+  TabActionProps: 'TabActionProps',
+  TabContentProps: 'TabContentProps',
+  TabItemProps: 'TabItemProps',
+  TabListProps: 'TabListProps',
+  TabSize: 'TabSize',
+  TabsProps: 'TabsProps',
+  TagProps: 'TagProps',
+  TagSize: 'TagSize',
+  TagVariant: 'TagVariant',
+  TextAreaHeight: 'TextAreaHeight',
+  TextAreaProps: 'TextAreaProps',
+  TextProps: 'TextProps',
+  ToastContent: 'ToastContent',
+  ToastId: 'ToastId',
+  ToastOptions: 'ToastOptions',
+  ToastPlacement: 'ToastPlacement',
+  ToastPreset: 'ToastPreset',
+  ToastProps: 'ToastProps',
+  ToastProviderProps: 'ToastProviderProps',
+  ToastType: 'ToastType',
+  TooltipPosition: 'TooltipPosition',
+  TooltipProps: 'TooltipProps',
+  VStackProps: 'VStackProps',
+}
+
+const EXPORT_MAP = { ...COMPONENT_EXPORT_MAP, ...TYPE_EXPORT_MAP }
+
+export const MANUAL_EXPORTS: Record<string, string> = {
+  AlphaButtonColor:
+    'Choose beta Button semantic and variant from intent; the legacy color is not a beta color prop.',
+  AlphaButtonVariant:
+    'Choose beta Button variant and semantic; alpha primary/secondary/tertiary are not direct beta values.',
+  AlphaDialogPrimitive:
+    'Keep AlphaDialogPrimitive on the root entrypoint until a beta DialogPrimitive is exported.',
+  AlphaStatusBadge:
+    'Choose a beta Status type from online/doNotDisturb state; the boolean pair has no direct prop rename.',
+  AlphaFloatingButtonColor:
+    'Choose beta Button semantic and variant from intent; the legacy color is not a beta color prop.',
+  AlphaFloatingButtonVariant:
+    'Choose beta Button variant and semantic; the floating variant has no direct beta value.',
+  AlphaToggleButton:
+    'Migrate the toggle intent to SegmentedControl or an app-owned pressed button.',
+  AlphaToggleButtonGroup:
+    'Choose SegmentedControl for single selection or an app-owned multi-toggle control.',
+  AlphaToggleEmojiButtonGroup:
+    'Rebuild with SegmentedControl or an app-owned emoji selector.',
+  AlphaTooltipPrimitive:
+    'Use Tooltip for standard help text or keep a low-level primitive until the trigger/content behavior is reviewed.',
+  AutoFocus:
+    'Use the target control autoFocus prop or an explicit focus effect.',
+  ButtonColorVariant:
+    'Choose beta Button semantic; legacy color variants are not exposed by beta Button.',
+  ButtonStyleVariant:
+    'Choose beta Button variant from filled, outlined, or ghost.',
+  Center:
+    'Replace Center with Box, HStack, or VStack and preserve both-axis alignment.',
+  CheckableAvatar:
+    'Compose beta Avatar with Checkbox or another explicit selection control.',
+  CheckboxSize:
+    'Remove the size prop and verify the fixed 18px beta Checkbox treatment.',
+  KeyValueItem:
+    'Choose SettingsField for a setting row or SectionItem for a general key/value row.',
+  KeyValueMultiLineItem:
+    'Choose SettingsField or app-owned layout after reviewing actions and click targets.',
+  LegacyIcon:
+    'Replace legacy icon names with @channel.io/bezier-icons sources before using beta Icon.',
+  LegacyHStack: 'Replace with beta HStack and review item/spacer behavior.',
+  LegacyStack: 'Replace with HStack or VStack and review item/spacer behavior.',
+  LegacyStackItem:
+    'Move item layout props to the HStack/VStack child or a Box.',
+  LegacySpacer: 'Use layout spacing or an explicit Box.',
+  LegacyTooltip: 'Migrate trigger and content behavior to beta Tooltip.',
+  LegacyVStack: 'Replace with beta VStack and review item/spacer behavior.',
+  ListItem:
+    'Choose SectionItem, DropdownMenuItem, NavigationItem, or a select option from usage intent.',
+  NavGroup:
+    'Migrate to NavigationGroup inside NavigationList and convert callbacks to open state.',
+  NavItem:
+    'Migrate to NavigationItem inside NavigationList and choose href or onClick semantics.',
+  OutlineItem:
+    'Choose CollapsibleSection, NavigationGroup, or app-owned tree behavior.',
+  SectionLabel:
+    'Move SectionLabel into Section or CollapsibleSection and convert children to content.',
+  Select:
+    'Rebuild options and trigger with beta Select/SelectOption composition.',
+  Stack: 'Replace with HStack or VStack according to direction.',
+  StackItem: 'Move item layout props to the HStack/VStack child or a Box.',
+  SwitchSize:
+    'Remove the size prop and verify the fixed beta Switch treatment.',
+  TextField:
+    'Use Search for type="search"; otherwise use TextInput and rename side-content props.',
+  ToggleButtonGroup:
+    'Choose SegmentedControl for single selection or an app-owned multi-toggle control.',
+  ToastAppearance:
+    'Map appearance intent to the beta info, success, or error preset.',
+}
+
+const ICON_SIZE_MAP: Record<string, string> = {
+  xxxs: '10',
+  xxs: '12',
+  xs: '16',
+  s: '20',
+  m: '24',
+  l: '36',
+  xl: '44',
+}
+
+const SPINNER_SIZE_MAP: Record<string, string> = {
+  xs: '12',
+  s: '16',
+  m: '20',
+  l: '24',
+  xl: '48',
+}
+
+const STATUS_MAP: Record<string, string> = {
+  'online-crescent': 'online-dnd',
+  'offline-crescent': 'offline-dnd',
+}
+
+const BADGE_VARIANT_MAP: Record<string, string> = {
+  'monochrome-light': 'neutral-light',
+  'monochrome-dark': 'neutral-dark',
+}
+
+const SEGMENTED_CONTROL_SIZE_MAP: Record<string, string> = {
+  xs: 's',
+  s: 's',
+  m: 'm',
+  l: 'm',
+}
+
+function getBindings(sourceFile: SourceFile) {
+  return sourceFile
+    .getImportDeclarations()
+    .filter((declaration) =>
+      [ROOT_MODULE, BETA_MODULE].includes(declaration.getModuleSpecifierValue())
+    )
+    .flatMap((declaration) =>
+      declaration.getNamedImports().map((specifier) => ({
+        exportedName: specifier.getName(),
+        localName: specifier.getAliasNode()?.getText() ?? specifier.getName(),
+        declaration,
+        specifier,
+      }))
+    )
+}
+
+function isTypeOnlyBinding(binding: ImportedBinding) {
+  return binding.declaration.isTypeOnly() || binding.specifier.isTypeOnly()
+}
+
+function localNamesFor(bindings: ImportedBinding[], exportedNames: string[]) {
+  return bindings
+    .filter((binding) => exportedNames.includes(binding.exportedName))
+    .map((binding) => binding.localName)
+}
+
+function localNamesForModule(
+  bindings: ImportedBinding[],
+  exportedNames: string[],
+  moduleSpecifier: string
+) {
+  return bindings
+    .filter(
+      (binding) =>
+        binding.declaration.getModuleSpecifierValue() === moduleSpecifier &&
+        exportedNames.includes(binding.exportedName)
+    )
+    .map((binding) => binding.localName)
+}
+
+function getJsxOpenings(sourceFile: SourceFile, localNames: string[]) {
+  return (
+    [SyntaxKind.JsxOpeningElement, SyntaxKind.JsxSelfClosingElement] as const
+  )
+    .flatMap((kind) => sourceFile.getDescendantsOfKind(kind))
+    .filter((node) => localNames.includes(node.getTagNameNode().getText()))
+}
+
+function getAttribute(node: JsxOpeningLike, name: string) {
+  return node
+    .getAttributes()
+    .find(
+      (attribute): attribute is JsxAttribute =>
+        Node.isJsxAttribute(attribute) &&
+        attribute.getNameNode().getText() === name
+    )
+}
+
+function getStringAttributeInitializer(attribute: JsxAttribute) {
+  const initializer = attribute.getInitializer()
+  return initializer && Node.isStringLiteral(initializer)
+    ? initializer
+    : undefined
+}
+
+function createDiagnostic(
+  sourceFile: SourceFile,
+  node: Node,
+  diagnostic: Omit<
+    MigrationDiagnostic,
+    'filePath' | 'line' | 'column' | 'severity'
+  > & { severity?: MigrationDiagnostic['severity'] }
+) {
+  const { line, column } = sourceFile.getLineAndColumnAtPos(node.getStart())
+  return {
+    severity: 'warning' as const,
+    filePath: sourceFile.getFilePath(),
+    line,
+    column,
+    ...diagnostic,
+  }
+}
+
+function createChange(
+  sourceFile: SourceFile,
+  node: Node,
+  change: Omit<MigrationChange, 'filePath' | 'line' | 'column'>
+) {
+  const { line, column } = sourceFile.getLineAndColumnAtPos(node.getStart())
+  return {
+    filePath: sourceFile.getFilePath(),
+    line,
+    column,
+    ...change,
+  }
+}
+
+function renameAttribute(
+  sourceFile: SourceFile,
+  node: JsxOpeningLike,
+  from: string,
+  to: string,
+  component: string,
+  diagnostics: MigrationDiagnostic[],
+  changes: MigrationChange[]
+) {
+  const attribute = getAttribute(node, from)
+  if (!attribute) {
+    return
+  }
+  if (getAttribute(node, to)) {
+    diagnostics.push(
+      createDiagnostic(sourceFile, attribute, {
+        code: 'prop-collision',
+        component,
+        message: `${component} has both ${from} and ${to}; the codemod left both unchanged.`,
+        suggestion: `Choose the intended ${to} value and remove ${from}.`,
+      })
+    )
+    return
+  }
+  changes.push(
+    createChange(sourceFile, attribute, {
+      code: 'prop-renamed',
+      component,
+      message: `Renamed ${component}.${from} to ${to}.`,
+    })
+  )
+  attribute.getNameNode().replaceWithText(to)
+}
+
+function mapExpressionLiteral(
+  node: Node,
+  valueMap: Record<string, string>
+): boolean {
+  if (
+    Node.isStringLiteral(node) ||
+    Node.isNoSubstitutionTemplateLiteral(node)
+  ) {
+    const mapped = valueMap[node.getLiteralValue()]
+    if (mapped) {
+      node.setLiteralValue(mapped)
+      return true
+    }
+    return false
+  }
+  if (Node.isConditionalExpression(node)) {
+    const whenTrueChanged = mapExpressionLiteral(node.getWhenTrue(), valueMap)
+    const whenFalseChanged = mapExpressionLiteral(node.getWhenFalse(), valueMap)
+    return whenTrueChanged || whenFalseChanged
+  }
+  if (Node.isParenthesizedExpression(node)) {
+    return mapExpressionLiteral(node.getExpression(), valueMap)
+  }
+  return false
+}
+
+function isLiteralOnlyExpression(node: Node): boolean {
+  if (
+    Node.isStringLiteral(node) ||
+    Node.isNoSubstitutionTemplateLiteral(node)
+  ) {
+    return true
+  }
+  if (Node.isConditionalExpression(node)) {
+    return (
+      isLiteralOnlyExpression(node.getWhenTrue()) &&
+      isLiteralOnlyExpression(node.getWhenFalse())
+    )
+  }
+  if (Node.isParenthesizedExpression(node)) {
+    return isLiteralOnlyExpression(node.getExpression())
+  }
+  return false
+}
+
+function mapAttributeValue(
+  attribute: JsxAttribute,
+  valueMap: Record<string, string>
+) {
+  const initializer = attribute.getInitializer()
+  if (!initializer) {
+    return false
+  }
+  if (Node.isStringLiteral(initializer)) {
+    const mapped = valueMap[initializer.getLiteralValue()]
+    if (mapped) {
+      initializer.setLiteralValue(mapped)
+      return true
+    }
+    return false
+  }
+  if (Node.isJsxExpression(initializer)) {
+    const expression = initializer.getExpression()
+    return expression ? mapExpressionLiteral(expression, valueMap) : false
+  }
+  return false
+}
+
+function transformMappedAttribute(
+  sourceFile: SourceFile,
+  nodes: JsxOpeningLike[],
+  prop: string,
+  valueMap: Record<string, string>,
+  component: string,
+  diagnostics: MigrationDiagnostic[],
+  changes: MigrationChange[]
+) {
+  nodes.forEach((node) => {
+    const attribute = getAttribute(node, prop)
+    if (!attribute) {
+      return
+    }
+    if (mapAttributeValue(attribute, valueMap)) {
+      changes.push(
+        createChange(sourceFile, attribute, {
+          code: 'literal-mapped',
+          component,
+          message: `Mapped legacy ${component}.${prop} literals to beta values.`,
+        })
+      )
+      return
+    }
+    const initializer = attribute.getInitializer()
+    if (
+      initializer &&
+      (Node.isStringLiteral(initializer) ||
+        (Node.isJsxExpression(initializer) &&
+          initializer.getExpression() &&
+          isLiteralOnlyExpression(initializer.getExpressionOrThrow())))
+    ) {
+      return
+    }
+    diagnostics.push(
+      createDiagnostic(sourceFile, attribute, {
+        code: 'dynamic-prop-value',
+        component,
+        message: `${component}.${prop} could not be proven to use only legacy literal values.`,
+        suggestion: `Map the value to the beta ${component}.${prop} union.`,
+      })
+    )
+  })
+}
+
+function reportAttribute(
+  sourceFile: SourceFile,
+  nodes: JsxOpeningLike[],
+  prop: string,
+  component: string,
+  message: string,
+  suggestion: string,
+  diagnostics: MigrationDiagnostic[]
+) {
+  nodes.forEach((node) => {
+    const attribute = getAttribute(node, prop)
+    if (attribute) {
+      diagnostics.push(
+        createDiagnostic(sourceFile, attribute, {
+          code: 'manual-prop-migration',
+          component,
+          message,
+          suggestion,
+        })
+      )
+    }
+  })
+}
+
+function reportMappedAttributeRemainder(
+  sourceFile: SourceFile,
+  nodes: JsxOpeningLike[],
+  prop: string,
+  values: string[],
+  component: string,
+  message: string,
+  suggestion: string,
+  diagnostics: MigrationDiagnostic[]
+) {
+  nodes.forEach((node) => {
+    const attribute = getAttribute(node, prop)
+    if (!attribute) {
+      return
+    }
+    const literal = getStringAttributeInitializer(attribute)
+    if (literal && !values.includes(literal.getLiteralValue())) {
+      return
+    }
+    diagnostics.push(
+      createDiagnostic(sourceFile, attribute, {
+        code: 'manual-prop-migration',
+        component,
+        message,
+        suggestion,
+      })
+    )
+  })
+}
+
+function getObjectTypeContext(node: Node) {
+  let current = node
+  while (current.getParent()) {
+    const parent = current.getParentOrThrow()
+    if (
+      Node.isParenthesizedExpression(parent) ||
+      Node.isAsExpression(parent) ||
+      Node.isSatisfiesExpression(parent)
+    ) {
+      if (Node.isAsExpression(parent) || Node.isSatisfiesExpression(parent)) {
+        return parent.getTypeNode()?.getText()
+      }
+      current = parent
+      continue
+    }
+    if (
+      Node.isVariableDeclaration(parent) &&
+      parent.getInitializer() === current
+    ) {
+      return parent.getTypeNode()?.getText()
+    }
+    return undefined
+  }
+  return undefined
+}
+
+function getTypedObjectLiterals(
+  sourceFile: SourceFile,
+  bindings: ImportedBinding[],
+  exportedTypeNames: string[],
+  exportedComponentNames: string[] = []
+) {
+  const contextNames = [
+    ...localNamesFor(bindings, exportedTypeNames),
+    ...localNamesFor(bindings, exportedComponentNames),
+  ]
+  if (contextNames.length === 0) {
+    return []
+  }
+  return sourceFile
+    .getDescendantsOfKind(SyntaxKind.ObjectLiteralExpression)
+    .filter((object) => {
+      const context = getObjectTypeContext(object)
+      return Boolean(
+        context &&
+          contextNames.some((name) => new RegExp(`\\b${name}\\b`).test(context))
+      )
+    })
+}
+
+function getObjectProperty(object: ObjectLiteralExpression, name: string) {
+  return object
+    .getProperties()
+    .find(
+      (property) =>
+        (Node.isPropertyAssignment(property) ||
+          Node.isShorthandPropertyAssignment(property)) &&
+        property.getName() === name
+    )
+}
+
+function renameObjectProperty(
+  sourceFile: SourceFile,
+  object: ObjectLiteralExpression,
+  from: string,
+  to: string,
+  component: string,
+  diagnostics: MigrationDiagnostic[],
+  changes: MigrationChange[]
+) {
+  const property = getObjectProperty(object, from)
+  if (!property) {
+    return
+  }
+  if (getObjectProperty(object, to)) {
+    diagnostics.push(
+      createDiagnostic(sourceFile, property, {
+        code: 'prop-collision',
+        component,
+        message: `${component} props contain both ${from} and ${to}; the codemod left both unchanged.`,
+        suggestion: `Choose the intended ${to} value and remove ${from}.`,
+      })
+    )
+    return
+  }
+  changes.push(
+    createChange(sourceFile, property, {
+      code: 'prop-renamed',
+      component,
+      message: `Renamed ${component}.${from} to ${to} in a typed props object.`,
+    })
+  )
+  if (Node.isPropertyAssignment(property)) {
+    property.getNameNode().replaceWithText(to)
+  } else if (Node.isShorthandPropertyAssignment(property)) {
+    property.replaceWithText(`${to}: ${from}`)
+  }
+}
+
+function mapObjectProperty(
+  sourceFile: SourceFile,
+  object: ObjectLiteralExpression,
+  prop: string,
+  valueMap: Record<string, string>,
+  component: string,
+  diagnostics: MigrationDiagnostic[],
+  changes: MigrationChange[]
+) {
+  const property = getObjectProperty(object, prop)
+  if (!property) {
+    return
+  }
+  if (!Node.isPropertyAssignment(property)) {
+    diagnostics.push(
+      createDiagnostic(sourceFile, property, {
+        code: 'dynamic-prop-value',
+        component,
+        message: `${component}.${prop} shorthand could not be proven to use only legacy literal values.`,
+        suggestion: `Map the value to the beta ${component}.${prop} union.`,
+      })
+    )
+    return
+  }
+  const initializer = property.getInitializer()
+  if (!initializer) {
+    return
+  }
+  if (mapExpressionLiteral(initializer, valueMap)) {
+    changes.push(
+      createChange(sourceFile, property, {
+        code: 'literal-mapped',
+        component,
+        message: `Mapped legacy ${component}.${prop} literals to beta values in a typed props object.`,
+      })
+    )
+  } else if (!isLiteralOnlyExpression(initializer)) {
+    diagnostics.push(
+      createDiagnostic(sourceFile, property, {
+        code: 'dynamic-prop-value',
+        component,
+        message: `${component}.${prop} could not be proven to use only legacy literal values.`,
+        suggestion: `Map the value to the beta ${component}.${prop} union.`,
+      })
+    )
+  }
+}
+
+function transformTypedObjects(
+  sourceFile: SourceFile,
+  bindings: ImportedBinding[],
+  diagnostics: MigrationDiagnostic[],
+  changes: MigrationChange[]
+) {
+  getTypedObjectLiterals(
+    sourceFile,
+    bindings,
+    ['BadgeProps'],
+    ['Badge']
+  ).forEach((object) =>
+    mapObjectProperty(
+      sourceFile,
+      object,
+      'variant',
+      BADGE_VARIANT_MAP,
+      'Badge',
+      diagnostics,
+      changes
+    )
+  )
+  getTypedObjectLiterals(sourceFile, bindings, ['IconProps'], ['Icon']).forEach(
+    (object) =>
+      mapObjectProperty(
+        sourceFile,
+        object,
+        'size',
+        ICON_SIZE_MAP,
+        'Icon',
+        diagnostics,
+        changes
+      )
+  )
+  getTypedObjectLiterals(
+    sourceFile,
+    bindings,
+    ['SpinnerProps'],
+    ['Spinner']
+  ).forEach((object) =>
+    mapObjectProperty(
+      sourceFile,
+      object,
+      'size',
+      SPINNER_SIZE_MAP,
+      'Spinner',
+      diagnostics,
+      changes
+    )
+  )
+  getTypedObjectLiterals(
+    sourceFile,
+    bindings,
+    ['AvatarProps'],
+    ['Avatar', 'AlphaAvatar']
+  ).forEach((object) =>
+    mapObjectProperty(
+      sourceFile,
+      object,
+      'status',
+      STATUS_MAP,
+      'Avatar',
+      diagnostics,
+      changes
+    )
+  )
+  getTypedObjectLiterals(
+    sourceFile,
+    bindings,
+    ['StatusProps'],
+    ['Status']
+  ).forEach((object) =>
+    mapObjectProperty(
+      sourceFile,
+      object,
+      'type',
+      STATUS_MAP,
+      'Status',
+      diagnostics,
+      changes
+    )
+  )
+  getTypedObjectLiterals(
+    sourceFile,
+    bindings,
+    ['BannerProps'],
+    ['Banner']
+  ).forEach((object) =>
+    renameObjectProperty(
+      sourceFile,
+      object,
+      'icon',
+      'leadingIcon',
+      'Banner',
+      diagnostics,
+      changes
+    )
+  )
+  getTypedObjectLiterals(
+    sourceFile,
+    bindings,
+    ['ButtonProps', 'AlphaButtonProps'],
+    ['Button', 'AlphaButton', 'AlphaFloatingButton']
+  ).forEach((object) => {
+    renameObjectProperty(
+      sourceFile,
+      object,
+      'text',
+      'label',
+      'Button',
+      diagnostics,
+      changes
+    )
+    renameObjectProperty(
+      sourceFile,
+      object,
+      'leftContent',
+      'leadingContent',
+      'Button',
+      diagnostics,
+      changes
+    )
+    renameObjectProperty(
+      sourceFile,
+      object,
+      'rightContent',
+      'trailingContent',
+      'Button',
+      diagnostics,
+      changes
+    )
+    renameObjectProperty(
+      sourceFile,
+      object,
+      'prefixContent',
+      'leadingContent',
+      'Button',
+      diagnostics,
+      changes
+    )
+    renameObjectProperty(
+      sourceFile,
+      object,
+      'suffixContent',
+      'trailingContent',
+      'Button',
+      diagnostics,
+      changes
+    )
+  })
+  getTypedObjectLiterals(
+    sourceFile,
+    bindings,
+    ['SegmentedControlProps'],
+    ['SegmentedControl']
+  ).forEach((object) =>
+    mapObjectProperty(
+      sourceFile,
+      object,
+      'size',
+      SEGMENTED_CONTROL_SIZE_MAP,
+      'SegmentedControl',
+      diagnostics,
+      changes
+    )
+  )
+}
+
+function transformTabs(
+  sourceFile: SourceFile,
+  bindings: ImportedBinding[],
+  diagnostics: MigrationDiagnostic[],
+  changes: MigrationChange[]
+) {
+  const tabsNames = localNamesFor(bindings, ['Tabs'])
+  const tabListNames = localNamesFor(bindings, ['TabList'])
+  const tabItemsBindings = bindings.filter(
+    (binding) => binding.exportedName === 'TabItems'
+  )
+  const tabItemsNames = tabItemsBindings.map((binding) => binding.localName)
+
+  sourceFile
+    .getDescendantsOfKind(SyntaxKind.JsxElement)
+    .filter((element) =>
+      tabItemsNames.includes(
+        element.getOpeningElement().getTagNameNode().getText()
+      )
+    )
+    .forEach((element) => {
+      changes.push(
+        createChange(sourceFile, element, {
+          code: 'tabs-updated',
+          component: 'Tabs',
+          message: 'Removed a legacy TabItems wrapper.',
+        })
+      )
+      element.replaceWithText(
+        element
+          .getJsxChildren()
+          .map((child) => child.getText())
+          .join('')
+      )
+    })
+
+  getJsxOpenings(sourceFile, tabListNames).forEach((tabList) => {
+    const size = getAttribute(tabList, 'size')
+    if (!size) {
+      return
+    }
+    const literal = getStringAttributeInitializer(size)
+    if (!literal || !['s', 'm'].includes(literal.getLiteralValue())) {
+      diagnostics.push(
+        createDiagnostic(sourceFile, size, {
+          code: 'tabs-size-manual',
+          component: 'Tabs',
+          message: 'TabList size is dynamic or unsupported by beta Tabs.',
+          suggestion:
+            'Move an s or m size to the nearest Tabs; review legacy l manually.',
+        })
+      )
+      return
+    }
+    const owner = tabList
+      .getAncestors()
+      .filter(Node.isJsxElement)
+      .find((ancestor) =>
+        tabsNames.includes(
+          ancestor.getOpeningElement().getTagNameNode().getText()
+        )
+      )
+    if (!owner) {
+      diagnostics.push(
+        createDiagnostic(sourceFile, size, {
+          code: 'tabs-owner-not-found',
+          component: 'Tabs',
+          message:
+            'The codemod could not find the Tabs that owns this TabList.',
+          suggestion: 'Move size to the correct Tabs root.',
+        })
+      )
+      return
+    }
+    const ownerOpening = owner.getOpeningElement()
+    const ownerSize = getAttribute(ownerOpening, 'size')
+    if (ownerSize) {
+      if (ownerSize.getText() === size.getText()) {
+        changes.push(
+          createChange(sourceFile, size, {
+            code: 'tabs-updated',
+            component: 'Tabs',
+            message: 'Removed a duplicate TabList size already owned by Tabs.',
+          })
+        )
+        size.remove()
+      } else {
+        diagnostics.push(
+          createDiagnostic(sourceFile, size, {
+            code: 'tabs-size-conflict',
+            component: 'Tabs',
+            message: 'Tabs and TabList have conflicting size props.',
+            suggestion: 'Keep one beta-supported size on Tabs.',
+          })
+        )
+      }
+      return
+    }
+    changes.push(
+      createChange(sourceFile, size, {
+        code: 'tabs-updated',
+        component: 'Tabs',
+        message: 'Moved TabList size to its Tabs owner.',
+      })
+    )
+    ownerOpening.addAttribute({ name: 'size', initializer: literal.getText() })
+    size.remove()
+  })
+
+  tabItemsBindings.forEach((binding) => {
+    const remaining = sourceFile
+      .getDescendantsOfKind(SyntaxKind.Identifier)
+      .filter((identifier) => identifier.getText() === binding.localName)
+    if (remaining.length === 1) {
+      binding.specifier.remove()
+    } else {
+      diagnostics.push(
+        createDiagnostic(sourceFile, binding.specifier, {
+          code: 'tab-items-manual',
+          component: 'Tabs',
+          message:
+            'TabItems still has a non-JSX reference and cannot move to beta.',
+          suggestion:
+            'Inline the intended TabItem children and remove the TabItems reference.',
+        })
+      )
+    }
+  })
+}
+
+function ensureBetaImport(sourceFile: SourceFile, exportedName: string) {
+  const existing = getBindings(sourceFile).find(
+    (binding) =>
+      binding.declaration.getModuleSpecifierValue() === BETA_MODULE &&
+      binding.exportedName === exportedName
+  )
+  if (existing) {
+    return existing.localName
+  }
+  const occupiedNames = new Set(
+    sourceFile
+      .getImportDeclarations()
+      .flatMap((declaration) => [
+        ...declaration
+          .getNamedImports()
+          .map(
+            (specifier) =>
+              specifier.getAliasNode()?.getText() ?? specifier.getName()
+          ),
+        declaration.getDefaultImport()?.getText(),
+        declaration.getNamespaceImport()?.getText(),
+      ])
+      .filter((name): name is string => Boolean(name))
+  )
+  const localName = occupiedNames.has(exportedName)
+    ? `Bezier${exportedName}`
+    : exportedName
+  const declaration =
+    sourceFile
+      .getImportDeclarations()
+      .find((item) => item.getModuleSpecifierValue() === BETA_MODULE) ??
+    sourceFile.addImportDeclaration({ moduleSpecifier: BETA_MODULE })
+  declaration.addNamedImport({
+    name: exportedName,
+    alias: localName === exportedName ? undefined : localName,
+  })
+  return localName
+}
+
+function transformForm(
+  sourceFile: SourceFile,
+  bindings: ImportedBinding[],
+  diagnostics: MigrationDiagnostic[],
+  changes: MigrationChange[]
+) {
+  const fieldNames = localNamesFor(bindings, ['FormControl'])
+  if (fieldNames.length === 0) {
+    return
+  }
+  const fields = getJsxOpenings(sourceFile, fieldNames)
+  const nativeForms = new Set<JsxElement>()
+  fields.forEach((field) => {
+    const size = getAttribute(field, 'size')
+    const literal = size ? getStringAttributeInitializer(size) : undefined
+    if (size && (!literal || !['m', 'l'].includes(literal.getLiteralValue()))) {
+      diagnostics.push(
+        createDiagnostic(sourceFile, size, {
+          code: 'form-field-size-manual',
+          component: 'FormField',
+          message: 'Legacy FormControl size is not proven to be m or l.',
+          suggestion: 'Choose beta FormField size m or l.',
+        })
+      )
+    }
+
+    const nativeForm = field
+      .getAncestors()
+      .filter(Node.isJsxElement)
+      .find(
+        (ancestor) =>
+          ancestor.getOpeningElement().getTagNameNode().getText() === 'form'
+      )
+    if (!nativeForm) {
+      diagnostics.push(
+        createDiagnostic(sourceFile, field, {
+          code: 'form-owner-review',
+          component: 'FormField',
+          message:
+            'FormControl has no native form ancestor to convert automatically.',
+          suggestion:
+            'Place FormField under beta Form or confirm that an app-owned form supplies submission scope.',
+        })
+      )
+      return
+    }
+    nativeForms.add(nativeForm)
+  })
+
+  if (nativeForms.size > 0) {
+    const formName = ensureBetaImport(sourceFile, 'Form')
+    nativeForms.forEach((nativeForm) => {
+      changes.push(
+        createChange(sourceFile, nativeForm, {
+          code: 'form-converted',
+          component: 'Form',
+          message: 'Converted a native form owner to beta Form.',
+        })
+      )
+      nativeForm.getOpeningElement().getTagNameNode().replaceWithText(formName)
+      nativeForm.getClosingElement()?.getTagNameNode().replaceWithText(formName)
+    })
+  }
+}
+
+function transformButtons(
+  sourceFile: SourceFile,
+  bindings: ImportedBinding[],
+  diagnostics: MigrationDiagnostic[],
+  changes: MigrationChange[]
+) {
+  const buttonNames = localNamesFor(bindings, [
+    'Button',
+    'AlphaButton',
+    'AlphaFloatingButton',
+  ])
+  const iconButtonNames = localNamesFor(bindings, [
+    'AlphaIconButton',
+    'AlphaFloatingIconButton',
+  ])
+  const buttons = getJsxOpenings(sourceFile, buttonNames)
+  const legacyButtons = getJsxOpenings(
+    sourceFile,
+    localNamesForModule(
+      bindings,
+      ['Button', 'AlphaButton', 'AlphaFloatingButton'],
+      ROOT_MODULE
+    )
+  )
+  buttons.forEach((button) => {
+    renameAttribute(
+      sourceFile,
+      button,
+      'text',
+      'label',
+      'Button',
+      diagnostics,
+      changes
+    )
+    renameAttribute(
+      sourceFile,
+      button,
+      'leftContent',
+      'leadingContent',
+      'Button',
+      diagnostics,
+      changes
+    )
+    renameAttribute(
+      sourceFile,
+      button,
+      'rightContent',
+      'trailingContent',
+      'Button',
+      diagnostics,
+      changes
+    )
+    renameAttribute(
+      sourceFile,
+      button,
+      'prefixContent',
+      'leadingContent',
+      'Button',
+      diagnostics,
+      changes
+    )
+    renameAttribute(
+      sourceFile,
+      button,
+      'suffixContent',
+      'trailingContent',
+      'Button',
+      diagnostics,
+      changes
+    )
+    if (getAttribute(button, 'href') && !getAttribute(button, 'as')) {
+      changes.push(
+        createChange(sourceFile, button, {
+          code: 'anchor-normalized',
+          component: 'Button',
+          message: 'Added as="a" to a Button with href.',
+        })
+      )
+      button.addAttribute({ name: 'as', initializer: '"a"' })
+    }
+  })
+  ;[...buttons, ...getJsxOpenings(sourceFile, iconButtonNames)].forEach(
+    (button) => {
+      const as = getAttribute(button, 'as')
+      const type = getAttribute(button, 'type')
+      if (
+        as &&
+        type &&
+        getStringAttributeInitializer(as)?.getLiteralValue() === 'a'
+      ) {
+        changes.push(
+          createChange(sourceFile, type, {
+            code: 'anchor-normalized',
+            component: 'Button',
+            message: 'Removed button-only type from an anchor Button.',
+          })
+        )
+        type.remove()
+        diagnostics.push(
+          createDiagnostic(sourceFile, as, {
+            code: 'anchor-button-type-removed',
+            component: 'Button',
+            message: 'Removed button-only type from an anchor action.',
+            suggestion: 'Verify link navigation and disabled/loading behavior.',
+          })
+        )
+      }
+    }
+  )
+  ;['styleVariant', 'colorVariant', 'color', 'variant'].forEach((prop) =>
+    reportAttribute(
+      sourceFile,
+      legacyButtons,
+      prop,
+      'Button',
+      `Legacy Button.${prop} does not have a one-to-one beta visual mapping.`,
+      'Choose beta variant (filled/outlined/ghost) and semantic (primary/secondary/destructive) from intent.',
+      diagnostics
+    )
+  )
+  reportMappedAttributeRemainder(
+    sourceFile,
+    getJsxOpenings(
+      sourceFile,
+      localNamesForModule(
+        bindings,
+        [
+          'Button',
+          'AlphaButton',
+          'AlphaFloatingButton',
+          'AlphaIconButton',
+          'AlphaFloatingIconButton',
+        ],
+        ROOT_MODULE
+      )
+    ),
+    'size',
+    ['xl'],
+    'Button',
+    'Legacy Button size is dynamic or uses the removed xl value.',
+    'Use xs, s, m, or l and visually verify the result.',
+    diagnostics
+  )
+}
+
+function reportKnownIncompatibilities(
+  sourceFile: SourceFile,
+  bindings: ImportedBinding[],
+  diagnostics: MigrationDiagnostic[]
+) {
+  const report = (
+    exportedNames: string[],
+    prop: string,
+    component: string,
+    message: string,
+    suggestion: string
+  ) =>
+    reportAttribute(
+      sourceFile,
+      getJsxOpenings(sourceFile, localNamesFor(bindings, exportedNames)),
+      prop,
+      component,
+      message,
+      suggestion,
+      diagnostics
+    )
+
+  const reportValues = (
+    exportedNames: string[],
+    prop: string,
+    values: string[],
+    component: string,
+    message: string,
+    suggestion: string,
+    rootOnly = false
+  ) =>
+    reportMappedAttributeRemainder(
+      sourceFile,
+      getJsxOpenings(
+        sourceFile,
+        rootOnly
+          ? localNamesForModule(bindings, exportedNames, ROOT_MODULE)
+          : localNamesFor(bindings, exportedNames)
+      ),
+      prop,
+      values,
+      component,
+      message,
+      suggestion,
+      diagnostics
+    )
+
+  reportValues(
+    ['Banner'],
+    'variant',
+    ['alt'],
+    'Banner',
+    'Banner variant is dynamic or uses removed alt.',
+    'Choose default, blue, cobalt, green, orange, or red; review alt visually.'
+  )
+  report(
+    ['Banner'],
+    'iconColor',
+    'Banner',
+    'beta Banner owns leading icon color through its variant.',
+    'Remove iconColor and verify the selected Banner variant.'
+  )
+  report(
+    ['Tooltip', 'Help'],
+    'icon',
+    'Tooltip',
+    'beta Tooltip and Help do not render an icon inside the tooltip.',
+    'Move essential meaning to the trigger or textual title/description, then remove icon.'
+  )
+  report(
+    ['Emoji'],
+    'imageUrl',
+    'Emoji',
+    'beta Emoji removes imageUrl.',
+    'Use a supported emoji name or an app-owned image.'
+  )
+  report(
+    ['Checkbox'],
+    'size',
+    'Checkbox',
+    'beta Checkbox removes the size prop.',
+    'Remove size and verify the fixed beta control size.'
+  )
+  report(
+    ['Switch'],
+    'size',
+    'Switch',
+    'beta Switch removes the size prop.',
+    'Remove size and verify the fixed beta control size.'
+  )
+  ;['size', 'variant', 'color'].forEach((prop) =>
+    report(
+      ['AlphaLoader'],
+      prop,
+      'Spinner',
+      `AlphaLoader.${prop} has no exact beta Spinner mapping.`,
+      'Choose a beta source size and semantic color after visual review; legacy s is near 30 and m is near 48.'
+    )
+  )
+  reportValues(
+    ['ProgressBar'],
+    'variant',
+    ['green', 'green-alt', 'monochrome'],
+    'ProgressBar',
+    'ProgressBar variants changed from green/green-alt/monochrome to default/overlaid.',
+    'Choose default or overlaid from the visual context.',
+    true
+  )
+  reportValues(
+    ['Tag'],
+    'variant',
+    ['monochrome-light', 'monochrome-dark'],
+    'Tag',
+    'beta Tag removes monochrome-light and monochrome-dark.',
+    'Choose an available semantic color variant.',
+    true
+  )
+  report(
+    ['Toast'],
+    'appearance',
+    'Toast',
+    'beta Toast removes appearance and uses preset.',
+    'Map the semantic intent to info, success, or error preset.'
+  )
+  report(
+    ['Toast'],
+    'zIndex',
+    'Toast',
+    'beta Toast moves zIndex ownership to ToastProvider.',
+    'Move a non-default stacking decision to ToastProvider.'
+  )
+  reportValues(
+    ['AlphaAvatar'],
+    'size',
+    ['16'],
+    'Avatar',
+    'beta Avatar removes size 16.',
+    'Choose size 20 or an app-owned compact avatar treatment.',
+    true
+  )
+}
+
+function addManualImportDiagnostics(
+  sourceFile: SourceFile,
+  bindings: ImportedBinding[],
+  diagnostics: MigrationDiagnostic[]
+) {
+  bindings
+    .filter(
+      (binding) => binding.declaration.getModuleSpecifierValue() === ROOT_MODULE
+    )
+    .forEach((binding) => {
+      const baseName = Object.keys(MANUAL_EXPORTS)
+        .sort((left, right) => right.length - left.length)
+        .find((name) => binding.exportedName.startsWith(name))
+      if (!baseName) {
+        return
+      }
+      diagnostics.push(
+        createDiagnostic(sourceFile, binding.specifier, {
+          code: 'manual-component-migration',
+          component: baseName,
+          message: `${binding.exportedName} requires usage-intent review during beta migration.`,
+          suggestion: MANUAL_EXPORTS[baseName],
+        })
+      )
+    })
+}
+
+function preserveProgressBarWidth(
+  sourceFile: SourceFile,
+  bindings: ImportedBinding[],
+  changes: MigrationChange[]
+) {
+  getJsxOpenings(
+    sourceFile,
+    localNamesForModule(bindings, ['ProgressBar'], ROOT_MODULE)
+  ).forEach((progressBar) => {
+    if (!getAttribute(progressBar, 'width')) {
+      changes.push(
+        createChange(sourceFile, progressBar, {
+          code: 'default-preserved',
+          component: 'ProgressBar',
+          message: 'Added width={36} to preserve the legacy default width.',
+        })
+      )
+      progressBar.addAttribute({ name: 'width', initializer: '{36}' })
+    }
+  })
+}
+
+function moveImportsToBeta(
+  sourceFile: SourceFile,
+  diagnostics: MigrationDiagnostic[],
+  changes: MigrationChange[]
+) {
+  const rootBindings = getBindings(sourceFile).filter(
+    (binding) => binding.declaration.getModuleSpecifierValue() === ROOT_MODULE
+  )
+
+  rootBindings.forEach((binding) => {
+    const target = EXPORT_MAP[binding.exportedName]
+    if (!target) {
+      return
+    }
+    const oldLocalName = binding.localName
+    const existingTarget = getBindings(sourceFile).find(
+      (candidate) =>
+        candidate.declaration.getModuleSpecifierValue() === BETA_MODULE &&
+        candidate.exportedName === target &&
+        (isTypeOnlyBinding(binding) || !isTypeOnlyBinding(candidate))
+    )
+    let localName = binding.specifier.getAliasNode()?.getText() ?? target
+
+    if (existingTarget) {
+      localName = existingTarget.localName
+    } else {
+      const occupiedByOtherImport = sourceFile
+        .getImportDeclarations()
+        .flatMap((declaration) => declaration.getNamedImports())
+        .some(
+          (specifier) =>
+            specifier !== binding.specifier &&
+            (specifier.getAliasNode()?.getText() ?? specifier.getName()) ===
+              localName
+        )
+      if (occupiedByOtherImport) {
+        localName = oldLocalName
+        diagnostics.push(
+          createDiagnostic(sourceFile, binding.specifier, {
+            code: 'import-name-collision',
+            component: target,
+            message: `Could not rename ${oldLocalName} to ${target} because that local name is occupied.`,
+            suggestion: `The beta ${target} import keeps the local alias ${oldLocalName}; normalize it manually if desired.`,
+          })
+        )
+      }
+    }
+
+    const bindingNode =
+      binding.specifier.getAliasNode() ?? binding.specifier.getNameNode()
+    if (oldLocalName !== localName && Node.isIdentifier(bindingNode)) {
+      bindingNode.rename(localName)
+    }
+
+    if (!existingTarget) {
+      const namedImport = {
+        name: target,
+        alias: localName === target ? undefined : localName,
+        isTypeOnly:
+          !binding.declaration.isTypeOnly() && binding.specifier.isTypeOnly(),
+      }
+      const betaDeclaration = sourceFile
+        .getImportDeclarations()
+        .find(
+          (declaration) =>
+            declaration.getModuleSpecifierValue() === BETA_MODULE &&
+            declaration.isTypeOnly() === binding.declaration.isTypeOnly()
+        )
+      if (betaDeclaration) {
+        betaDeclaration.addNamedImport(namedImport)
+      } else {
+        sourceFile.addImportDeclaration({
+          isTypeOnly: binding.declaration.isTypeOnly(),
+          moduleSpecifier: BETA_MODULE,
+          namedImports: [namedImport],
+        })
+      }
+    }
+    changes.push(
+      createChange(sourceFile, binding.specifier, {
+        code: 'import-moved',
+        component: target,
+        message: `Moved ${binding.exportedName} from the root entrypoint to beta ${target}.`,
+      })
+    )
+    binding.specifier.remove()
+  })
+
+  sourceFile
+    .getImportDeclarations()
+    .filter(
+      (declaration) =>
+        declaration.getModuleSpecifierValue() === ROOT_MODULE &&
+        declaration.getNamedImports().length === 0 &&
+        !declaration.getDefaultImport() &&
+        !declaration.getNamespaceImport()
+    )
+    .forEach((declaration) => declaration.remove())
+}
+
+const transform = (sourceFile: SourceFile): BetaComponentMigrationResult => {
+  const changes: MigrationChange[] = []
+  const diagnostics: MigrationDiagnostic[] = []
+  const beforeEnumTransform = sourceFile.getFullText()
+  enumMemberToStringLiteral(sourceFile)
+  if (sourceFile.getFullText() !== beforeEnumTransform) {
+    changes.push(
+      createChange(sourceFile, sourceFile, {
+        code: 'legacy-enum-converted',
+        message: 'Converted legacy Bezier enum members to string literals.',
+      })
+    )
+  }
+  const bindings = getBindings(sourceFile)
+
+  transformMappedAttribute(
+    sourceFile,
+    getJsxOpenings(sourceFile, localNamesFor(bindings, ['Badge'])),
+    'variant',
+    BADGE_VARIANT_MAP,
+    'Badge',
+    diagnostics,
+    changes
+  )
+  transformMappedAttribute(
+    sourceFile,
+    getJsxOpenings(sourceFile, localNamesFor(bindings, ['Icon'])),
+    'size',
+    ICON_SIZE_MAP,
+    'Icon',
+    diagnostics,
+    changes
+  )
+  transformMappedAttribute(
+    sourceFile,
+    getJsxOpenings(sourceFile, localNamesFor(bindings, ['Spinner'])),
+    'size',
+    SPINNER_SIZE_MAP,
+    'Spinner',
+    diagnostics,
+    changes
+  )
+  transformMappedAttribute(
+    sourceFile,
+    getJsxOpenings(
+      sourceFile,
+      localNamesFor(bindings, ['Avatar', 'AlphaAvatar'])
+    ),
+    'status',
+    STATUS_MAP,
+    'Avatar',
+    diagnostics,
+    changes
+  )
+  transformMappedAttribute(
+    sourceFile,
+    getJsxOpenings(sourceFile, localNamesFor(bindings, ['Status'])),
+    'type',
+    STATUS_MAP,
+    'Status',
+    diagnostics,
+    changes
+  )
+  transformMappedAttribute(
+    sourceFile,
+    getJsxOpenings(sourceFile, localNamesFor(bindings, ['SegmentedControl'])),
+    'size',
+    SEGMENTED_CONTROL_SIZE_MAP,
+    'SegmentedControl',
+    diagnostics,
+    changes
+  )
+
+  getJsxOpenings(sourceFile, localNamesFor(bindings, ['Banner'])).forEach(
+    (banner) =>
+      renameAttribute(
+        sourceFile,
+        banner,
+        'icon',
+        'leadingIcon',
+        'Banner',
+        diagnostics,
+        changes
+      )
+  )
+  getJsxOpenings(
+    sourceFile,
+    localNamesFor(bindings, ['SegmentedControlItem'])
+  ).forEach((item) => {
+    renameAttribute(
+      sourceFile,
+      item,
+      'leftContent',
+      'leadingContent',
+      'SegmentedControlItem',
+      diagnostics,
+      changes
+    )
+    renameAttribute(
+      sourceFile,
+      item,
+      'rightContent',
+      'trailingContent',
+      'SegmentedControlItem',
+      diagnostics,
+      changes
+    )
+  })
+
+  transformButtons(sourceFile, bindings, diagnostics, changes)
+  transformTabs(sourceFile, bindings, diagnostics, changes)
+  transformForm(sourceFile, bindings, diagnostics, changes)
+  transformTypedObjects(sourceFile, bindings, diagnostics, changes)
+  preserveProgressBarWidth(sourceFile, bindings, changes)
+  reportKnownIncompatibilities(sourceFile, bindings, diagnostics)
+  addManualImportDiagnostics(sourceFile, bindings, diagnostics)
+  moveImportsToBeta(sourceFile, diagnostics, changes)
+
+  return { changes, diagnostics }
+}
+
+export default transform

--- a/packages/bezier-codemod/src/transforms/beta-component-migration/types.ts
+++ b/packages/bezier-codemod/src/transforms/beta-component-migration/types.ts
@@ -1,0 +1,36 @@
+export type MigrationDiagnosticSeverity = 'warning' | 'error'
+
+export interface MigrationDiagnostic {
+  code: string
+  severity: MigrationDiagnosticSeverity
+  filePath: string
+  line: number
+  column: number
+  component?: string
+  message: string
+  suggestion?: string
+}
+
+export type MigrationChangeCode =
+  | 'anchor-normalized'
+  | 'default-preserved'
+  | 'form-converted'
+  | 'import-moved'
+  | 'legacy-enum-converted'
+  | 'literal-mapped'
+  | 'prop-renamed'
+  | 'tabs-updated'
+
+export interface MigrationChange {
+  code: MigrationChangeCode
+  filePath: string
+  line: number
+  column: number
+  component?: string
+  message: string
+}
+
+export interface BetaComponentMigrationResult {
+  changes: MigrationChange[]
+  diagnostics: MigrationDiagnostic[]
+}


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - 브라우저에서 실행되는 기능이 아닌 CLI/codemod 변경이므로 브라우저 테스트는 해당하지 않습니다.

## Related Issue

- WEB-11689

## Summary

기존 `@channel.io/bezier-react` root 및 alpha 컴포넌트 사용처를 beta 컴포넌트로 마이그레이션하기 위한 codemod와 에이전트 스킬을 추가합니다.

기계적으로 결정 가능한 변경은 codemod가 수행하고, 컴포넌트 사용 의도를 확인해야 하는 변경은 소스 위치가 포함된 diagnostic으로 남겨 에이전트가 주변 문맥과 테스트를 확인한 뒤 처리하도록 구성했습니다.

## Details

### Beta component migration codemod

- import provenance와 alias를 보존하면서 root/alpha export를 beta entrypoint로 이동합니다.
- enum 및 literal value, prop rename, typed props object, `Form`/`FormField`, `Tabs`, `Button`, `ProgressBar`의 결정 가능한 변경을 처리합니다.
- `ListItem`, `Select`, `TextField`, navigation, disclosure 등 사용 의도에 따라 결과가 달라지는 항목은 diagnostic으로 보고합니다.
- 각 자동 변경을 구조화된 change event로 기록합니다.

### 범위 지정 및 dry-run 보고서

- `--scope`로 파일 또는 디렉터리 단위의 작업 범위를 지정할 수 있습니다.
- 디렉터리는 `**/*.{ts,tsx}` 범위로 해석하며 `dist`, `build`, generated output, dependency 경로를 제외합니다.
- 실행 전에 확정된 glob과 파일 수를 출력하고, dry-run에서는 소스 파일을 저장하지 않습니다.
- JSON 및 Markdown 보고서에 변경 파일 목록, 변경 유형, diagnostic 분류, QA hotspot을 기록합니다.

### Agent skill

- 배포 패키지에 `migrate-bezier-beta` 스킬과 migration reference를 포함합니다.
- `npx @channel.io/bezier-codemod@<version> --install-skill`로 소비자 저장소의 `.agents/skills`에 설치합니다.
- 설치 시 codemod 버전을 함께 기록합니다. 동일 버전의 로컬 binary가 없으면 해당 고정 버전을 `npx`로 실행하며 `latest`로 fallback하지 않습니다.

### 검증

- Jest 12 suites / 58 tests
- TypeScript typecheck
- ESLint
- package build
- `npm pack --dry-run`으로 배포 패키지의 skill/reference 포함 여부 확인
- `ch-desk-web/apps/ch-desk-web/src/features/Document` dry-run
  - 1,413 files scanned
  - 360 changed candidates
  - 1,339 automatic changes
  - 633 warnings / 0 errors
  - dry-run 후 `ch-desk-web` worktree가 변경되지 않음을 확인

### Breaking change? (No)

기존 interactive codemod 실행 방식을 유지하면서 transform, report, skill install 옵션을 추가합니다.

## References

- `packages/bezier-codemod/skills/migrate-bezier-beta/SKILL.md`
- `packages/bezier-codemod/skills/migrate-bezier-beta/references/migration-guide.md`
