### PR TITLE
fix(release): use a valid dist-tag for v2 releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "turbo run test",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "version-packages": "changeset version && yarn --mode=\"update-lockfile\"",
-    "release": "turbo run build --filter='@channel.io/*' && changeset publish --tag v2",
+    "release": "turbo run build --filter='@channel.io/*' && changeset publish --tag legacy-v2",
     "update-snapshot": "yarn workspace @channel.io/bezier-react update-snapshot",
     "changeset": "changeset",
     "postinstall": "husky install",


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)

## Related Issue

- [WEB-12102](https://linear.app/channel/issue/WEB-12102)

## Summary

v2 release에서 사용하는 npm dist-tag를 `v2`에서 `legacy-v2`로 변경합니다.

## Details

`changeset publish --tag v2` 실행 시 npm이 `v2`를 유효한 SemVer range로 해석하여 `Tag name must not be a valid SemVer range` 오류로 배포가 실패했습니다.

SemVer range로 해석되지 않는 `legacy-v2`를 사용해 `@channel.io/bezier-react@2.7.0`을 별도 유지보수 태그로 게시합니다. 기존 `latest=3.6.6`과 `next=4.0.0-next.12` dist-tag는 변경하지 않습니다.

이미 release PR에서 2.7.0 versioning이 완료되었으므로 별도 changeset은 추가하지 않습니다.

### Breaking change? (Yes/No)

No

## References

- 실패한 workflow: https://github.com/channel-io/bezier-react/actions/runs/29086130211
