### PR TITLE
fix: use touchable-hover for ListItem and beta BaseItem hover

### DIFF
--- a/.changeset/touchable-hover-list-base-item.md
+++ b/.changeset/touchable-hover-list-base-item.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Gate `ListItem` and beta `BaseItem` hover styles behind `touchable-hover` so touch devices no longer keep a lingering hover background and instead show press (`:active`) feedback.

--- a/packages/bezier-react/src/beta/BaseItem/BaseItem.module.scss
+++ b/packages/bezier-react/src/beta/BaseItem/BaseItem.module.scss
@@ -1,3 +1,4 @@
+@use '../../styles/mixins/interaction';
 @use '../../styles/mixins/state';
 
 .Icon {
@@ -64,7 +65,7 @@
   }
 
   &:where(.interactive:not(.disabled, .active, [data-highlighted], :disabled)) {
-    &:hover {
+    @include interaction.touchable-hover {
       background-color: var(--color-fill-neutral-lighter);
     }
   }

--- a/packages/bezier-react/src/components/ListItem/ListItem.module.scss
+++ b/packages/bezier-react/src/components/ListItem/ListItem.module.scss
@@ -1,3 +1,5 @@
+@use '../../styles/mixins/interaction';
+
 .ListItemLeftIcon {
   transition: color var(--motion-transition-default);
 }
@@ -53,11 +55,11 @@
   }
 
   &:where(.clickable:not(.disabled, .active)) {
-    &:where(.focused, :focus-visible) {
+    @include interaction.touchable-hover {
       background-color: var(--color-fill-neutral-light);
     }
 
-    &:where(:hover) {
+    &:where(.focused, :focus-visible) {
       background-color: var(--color-fill-neutral-light);
     }
   }


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)

## Related Issue

<!-- internal tracking -->

## Summary

`ListItem` and beta `BaseItem` kept their hover background on touch devices after a tap or scroll, because a bare `:hover` rule also matches on touch. This gates the hover style behind the existing `touchable-hover` mixin so it responds to pointer capability.

## Details

- Both components styled their hover background with a bare `:hover` selector.
- They now use `@include interaction.touchable-hover`, which applies the style to `:hover` under `@media (hover: hover)` and to `:active` under `@media (hover: none)`.
- Hover-capable devices are unchanged. On touch devices the background no longer lingers after the pointer leaves, and appears only while the item is pressed (`:active`).
- Consistent with how `Checkbox`, `CheckableAvatar`, and `RadioGroup` already use the mixin.

### Breaking change? (Yes/No)

No.

## References

- `touchable-hover` mixin in `styles/mixins/_interaction.scss`
