### PR TITLE
fix: stabilize Modal close button positioning

### DIFF
--- a/.changeset/fix-modal-close-position.md
+++ b/.changeset/fix-modal-close-position.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Ensure stable and beta `Modal` close buttons remain positioned correctly regardless of extracted CSS rule order.

--- a/packages/bezier-react/src/beta/Modal/Modal.module.scss
+++ b/packages/bezier-react/src/beta/Modal/Modal.module.scss
@@ -76,6 +76,13 @@ $close-icon-button-margin: -6;
   flex-direction: column;
   width: 100%;
   height: 100%;
+
+  // NOTE: Keep modal placement more specific than the base button positioning rule.
+  > .CloseIconButton {
+    position: absolute;
+    top: #{$modal-padding + $close-icon-button-margin}px;
+    right: #{$modal-padding + $close-icon-button-margin}px;
+  }
 }
 
 .ModalHeader {
@@ -135,12 +142,6 @@ $close-icon-button-margin: -6;
 
 .Description {
   margin: 0;
-}
-
-.CloseIconButton {
-  position: absolute;
-  top: #{$modal-padding + $close-icon-button-margin}px;
-  right: #{$modal-padding + $close-icon-button-margin}px;
 }
 
 .CloseIconButtonSpacer {

--- a/packages/bezier-react/src/components/Modal/Modal.module.scss
+++ b/packages/bezier-react/src/components/Modal/Modal.module.scss
@@ -112,6 +112,13 @@ $close-icon-button-margin-y: -6;
   flex-direction: column;
   width: 100%;
   height: 100%;
+
+  // NOTE: Keep modal placement more specific than the base button positioning rule.
+  > .CloseIconButton {
+    position: absolute;
+    top: #{$modal-padding + $close-icon-button-margin-y}px;
+    right: #{$modal-padding + $close-icon-button-margin-x}px;
+  }
 }
 
 .TitleContainer {
@@ -130,12 +137,6 @@ $close-icon-button-margin-y: -6;
 
 .Title {
   width: 100%;
-}
-
-.CloseIconButton {
-  position: absolute;
-  top: #{$modal-padding + $close-icon-button-margin-y}px;
-  right: #{$modal-padding + $close-icon-button-margin-x}px;
 }
 
 .CloseIconButtonSpacer {


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or did not have to)
- [x] I wrote or updated **documentation** related to the changes. (or did not have to)
- [x] I wrote or updated **tests** related to the changes. (or did not have to)
- [ ] I tested the changes in various browsers. (or did not have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

- [Web-Bezier 팀챗 스레드](https://channel.works/root/threads/groups/Web-Bezier-124831/6a61b6a09b730473a518/6a61b6a09b730473a518)

## Summary

`Modal` 닫기 버튼의 위치 지정 규칙이 CSS 출력 순서와 무관하게 적용되도록 selector specificity를 높였습니다.

## Details

- `4.0.0-next.13`의 Rollup 산출물에서 beta `Modal.CloseIconButton` 규칙이 `IconButton`의 기본 `position: relative` 규칙보다 먼저 배치됐습니다.
- 두 규칙의 specificity가 같아 뒤쪽의 `position: relative`가 이기면서 닫기 버튼이 모달 우상단을 벗어났습니다.
- stable/beta Modal 모두 `.ModalSection > .CloseIconButton` 형태로 범위를 좁혀 specificity를 `0,2,0`으로 높였습니다. 따라서 추출 CSS 순서가 바뀌어도 `position: absolute`가 유지됩니다.
- `@channel.io/bezier-react` patch changeset을 추가했습니다. 현재 prerelease 흐름에서는 `4.0.0-next.14`에 포함됩니다.
- `rollup-plugin-postcss`의 multi-entry CSS 결합 순서 문제 자체는 이번 PR에서 변경하지 않고 별도로 조사합니다.

검증:

- stable/beta Modal 테스트 55개 통과
- Stylelint 오류 없음 (기존 deprecated token 경고 1건)
- Rollup 패키지 빌드 성공
- 생성 CSS에서 stable/beta selector specificity 보강 확인
- 수정 산출물 tgz 생성 완료, `ch-desk-web` 소비자 검증 예정

### Breaking change? (Yes/No)

No

## References

- Storybook/Chromatic은 소스 SCSS를 Webpack으로 컴파일하므로 Rollup이 추출한 배포용 `dist/styles.css` 순서 문제를 재현하지 않습니다.