### PR TITLE
fix: stabilize extracted CSS order across entry points

### DIFF
--- a/.changeset/stable-styles-build.md
+++ b/.changeset/stable-styles-build.md
@@ -1,5 +1,0 @@
----
-"@channel.io/bezier-react": patch
----
-
-Ensure extracted styles use a deterministic order across stable and beta entry points.

--- a/.changeset/stable-styles-build.md
+++ b/.changeset/stable-styles-build.md
@@ -1,0 +1,5 @@
+---
+"@channel.io/bezier-react": patch
+---
+
+Ensure extracted styles use a deterministic order across stable and beta entry points.

--- a/packages/bezier-react/rollup.config.mjs
+++ b/packages/bezier-react/rollup.config.mjs
@@ -24,6 +24,8 @@ const pkg = JSON.parse(
 
 const rootDir = fileURLToPath(new URL('.', import.meta.url))
 const styleSheetDir = 'styles.css'
+const buildEntryId = 'virtual:bezier-react-build-entry'
+const resolvedBuildEntryId = `\0${buildEntryId}`
 
 const extensions = [...DEFAULT_EXTENSIONS, '.ts', '.tsx']
 
@@ -54,9 +56,49 @@ function minifycss() {
   }
 }
 
+/**
+ * Create a single build-only entry so that styles from every public entry are
+ * ordered against the same module graph when they are extracted.
+ */
+function buildEntry() {
+  return {
+    name: 'build-entry',
+    resolveId(id) {
+      if (id === buildEntryId) {
+        return resolvedBuildEntryId
+      }
+
+      return null
+    },
+    load(id) {
+      if (id === resolvedBuildEntryId) {
+        return `
+          import * as stable from '~/src/index'
+          import * as beta from '~/src/beta/index'
+
+          export { beta, stable }
+        `
+      }
+
+      return null
+    },
+    generateBundle(options, bundle) {
+      Object.entries(bundle).forEach(([fileName, output]) => {
+        if (
+          output.type === 'chunk' &&
+          output.facadeModuleId === resolvedBuildEntryId
+        ) {
+          delete bundle[fileName]
+          delete bundle[`${fileName}.map`]
+        }
+      })
+    },
+  }
+}
+
 const generateConfig = ({ output = [], plugins = [] }) =>
   defineConfig({
-    input: ['src/index.ts', 'src/beta/index.ts'],
+    input: buildEntryId,
     output,
     plugins: [
       alias({
@@ -122,6 +164,7 @@ const generateConfig = ({ output = [], plugins = [] }) =>
       url(),
       visualizer({ filename: 'stats.html' }),
       minifycss(),
+      buildEntry(),
       ...plugins,
     ],
     onwarn(warning, warn) {


### PR DESCRIPTION
## Self Checklist

- [x] PR 제목과 커밋 메시지를 영어 Conventional Commits 형식으로 작성했습니다.
- [x] 별도 prerelease 배포가 필요하지 않은 빌드 수정이므로 changeset을 추가하지 않았습니다.
- [x] 별도 문서 변경이 필요하지 않음을 확인했습니다.
- [x] JS/types 빌드와 설정 파일 ESLint를 확인했습니다.
- [x] 브라우저별 확인이 필요하지 않은 빌드 산출물 변경임을 확인했습니다.

## Related Issue

- https://github.com/channel-io/bezier-react/pull/2888 에서 이 문제로 인해 코드를 수정한 바 있음

## Summary

stable 및 beta 엔트리의 스타일을 하나의 CSS 파일로 추출할 때 스타일 순서가 비결정적으로 바뀌는 문제를 수정합니다.

## Details

### 문제 발생 원인

v4에서 beta subpath를 제공하기 위해 Rollup input이 아래와 같이 두 개로 구성되어 있습니다.

```js
input: ['src/index.ts', 'src/beta/index.ts']
```

두 public entry가 서로 독립된 root이지만 `rollup-plugin-postcss`는 양쪽에서 수집한 CSS를 하나의 `styles.css`로 추출합니다. 이때 플러그인이 여러 entry 사이의 전체 순서를 하나의 import graph로 표현하지 못하므로, 다른 entry에서 수집된 CSS의 병합 순서가 Sass transform 완료 순서에 따라 달라질 수 있습니다.

그 결과 동일한 specificity를 가진 stable 스타일과 beta 스타일의 순서가 빌드마다 달라질 수 있고, 나중에 배치된 규칙이 앞의 규칙을 덮어쓰면서 실제 UI가 달라질 수 있었습니다.

### 구현 방식

두 public entry를 직접 Rollup input으로 사용하는 대신, 두 entry를 모두 import하는 build-only virtual entry 하나를 input으로 사용합니다.

virtual entry는 실제 파일로 만들지 않고 Rollup 플러그인의 `resolveId`/`load` 훅에서 다음 모듈과 동일한 내용을 메모리상으로 제공합니다.

```js
import * as stable from '~/src/index'
import * as beta from '~/src/beta/index'

export { beta, stable }
```

따라서 스타일 수집 관점의 module graph는 다음과 같이 하나의 root를 갖습니다.

```text
virtual:bezier-react-build-entry
├── src/index.ts
│   └── stable 컴포넌트와 CSS
└── src/beta/index.ts
    └── beta 컴포넌트와 CSS
```

두 entry를 namespace로 import한 뒤 다시 export하는 이유는 JS export graph가 tree-shaking으로 제거되지 않도록 유지하기 위해서입니다. 기존 설정의 `preserveModules: true`와 함께 사용되므로 `index.js`, `beta/index.js` 및 하위 모듈은 기존과 동일하게 개별 파일로 출력됩니다.

virtual entry 자체는 공개 API가 아니므로 빌드 과정에서 생성되는 facade chunk와 sourcemap만 `generateBundle` 훅에서 제거합니다. 이 과정은 해당 wrapper chunk만 제거하며, public entry와 컴포넌트 chunk 및 `styles.css`에는 영향을 주지 않습니다.

알려진 Modal 배치 문제는 `4.0.0-next.14`에서 이미 selector specificity 보강으로 해결됐습니다. 이번 변경은 향후 빌드의 CSS 순서를 결정적으로 만드는 빌드 재현성 수정이며, 이 PR만으로 별도 prerelease를 배포하지 않기 위해 changeset은 추가하지 않았습니다.

### 유지되는 계약

- root 및 beta public subpath
- 각 public entry의 export 목록
- 기존 `preserveModules` 기반 chunk 구조
- 단일 `styles.css` 배포 방식

### 검증

- 깨끗한 `dist`에서 6회 반복 빌드해 CJS/ESM CSS hash가 매번 동일함을 확인했습니다.
- 변경 전후 chunk 수가 모두 354개이며 추가되거나 누락된 chunk가 없음을 확인했습니다.
- root/beta export 목록이 변경 전과 동일함을 확인했습니다.
- build-only virtual entry의 facade chunk와 sourcemap이 최종 배포물에 남지 않음을 확인했습니다.
- package export가 가리키는 파일이 모두 존재함을 확인했습니다.

### Breaking change? (Yes/No)

No

## References

- [Channel thread](https://channel.works/root/threads/groups/Web-Bezier-124831/6a61b6a09b730473a518/6a61b6a09b730473a518)
