### PR TITLE
feat: align beta button styles with latest design

### DIFF
--- a/.changeset/web-12475-button-styles.md
+++ b/.changeset/web-12475-button-styles.md
@@ -1,0 +1,9 @@
+---
+'@channel.io/bezier-react': minor
+---
+
+Align beta Button and IconButton with the latest design specification.
+
+- Add the `activate` semantic and `floating` variant.
+- Update component dimensions and icon sizes.
+- Refine secondary and destructive filled colors.

--- a/packages/bezier-react/src/beta/Button/Button.module.scss
+++ b/packages/bezier-react/src/beta/Button/Button.module.scss
@@ -35,6 +35,10 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
     height: 20px;
     padding: 2px 4px;
 
+    & .ButtonIcon {
+      @include dimension.square(14px);
+    }
+
     & .ButtonText {
       padding: 0 3px;
     }
@@ -44,6 +48,10 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
     min-width: 24px;
     height: 24px;
     padding: 3px 6px;
+
+    & .ButtonIcon {
+      @include dimension.square(16px);
+    }
 
     & .ButtonText {
       padding: 0 3px;
@@ -58,7 +66,7 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
     padding: 7px 10px;
 
     & .ButtonText {
-      padding: 0 4px;
+      padding: 0 3px;
     }
   }
 
@@ -66,8 +74,8 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
     --b-beta-button-content-gap: 2px;
 
     min-width: 44px;
-    height: 44px;
-    padding: 13px 12px;
+    height: 42px;
+    padding: 12px;
 
     & .ButtonText {
       padding: 0 4px;
@@ -80,14 +88,16 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
     --b-beta-button-background-color: var(--color-fill-neutral-heaviest);
 
     &#{$active-selector} {
-      --b-beta-button-background-color: var(--color-fill-neutral-heaviest-hovered);
+      --b-beta-button-background-color: var(
+        --color-fill-neutral-heaviest-hovered
+      );
     }
   }
 
   &:where(.variant-filled.semantic-secondary) {
     --b-beta-button-text-color: var(--color-text-neutral);
     --b-beta-button-icon-color: var(--color-icon-neutral-heavy);
-    --b-beta-button-background-color: var(--color-fill-neutral);
+    --b-beta-button-background-color: var(--color-fill-neutral-light);
 
     &#{$active-selector} {
       --b-beta-button-background-color: var(--color-fill-neutral-hovered);
@@ -95,13 +105,25 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
   }
 
   &:where(.variant-filled.semantic-destructive) {
-    --b-beta-button-text-color: var(--color-text-inverse);
-    --b-beta-button-icon-color: var(--color-icon-inverse-heavier);
+    --b-beta-button-text-color: var(--color-text-absolute-white);
+    --b-beta-button-icon-color: var(--color-icon-absolute-white);
     --b-beta-button-background-color: var(--color-fill-accent-red-heavier);
 
     &#{$active-selector} {
       --b-beta-button-background-color: var(
         --color-fill-accent-red-heavier-hovered
+      );
+    }
+  }
+
+  &:where(.variant-filled.semantic-activate) {
+    --b-beta-button-text-color: var(--color-text-absolute-white);
+    --b-beta-button-icon-color: var(--color-icon-absolute-white);
+    --b-beta-button-background-color: var(--color-fill-accent-green-heavier);
+
+    &#{$active-selector} {
+      --b-beta-button-background-color: var(
+        --color-fill-accent-green-heavier-hovered
       );
     }
   }
@@ -132,6 +154,11 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
     --b-beta-button-icon-color: var(--color-icon-accent-red);
   }
 
+  &:where(.variant-outlined.semantic-activate) {
+    --b-beta-button-text-color: var(--color-text-accent-green);
+    --b-beta-button-icon-color: var(--color-icon-accent-green);
+  }
+
   &:where(.variant-ghost) {
     --b-beta-button-background-color: var(--color-fill-neutral-transparent);
 
@@ -155,6 +182,40 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
   &:where(.variant-ghost.semantic-destructive) {
     --b-beta-button-text-color: var(--color-text-accent-red);
     --b-beta-button-icon-color: var(--color-icon-accent-red);
+  }
+
+  &:where(.variant-ghost.semantic-activate) {
+    --b-beta-button-text-color: var(--color-text-accent-green);
+    --b-beta-button-icon-color: var(--color-icon-accent-green);
+  }
+
+  &:where(.variant-floating) {
+    --b-beta-button-background-color: var(--color-fill-bright);
+    --b-beta-button-box-shadow: var(--elevation-2);
+
+    &#{$active-selector} {
+      --b-beta-button-box-shadow: var(--elevation-3);
+    }
+  }
+
+  &:where(.variant-floating.semantic-primary) {
+    --b-beta-button-text-color: var(--color-text-neutral-light);
+    --b-beta-button-icon-color: var(--color-icon-neutral-heavy);
+  }
+
+  &:where(.variant-floating.semantic-secondary) {
+    --b-beta-button-text-color: var(--color-text-neutral-lighter);
+    --b-beta-button-icon-color: var(--color-icon-neutral);
+  }
+
+  &:where(.variant-floating.semantic-destructive) {
+    --b-beta-button-text-color: var(--color-text-accent-red);
+    --b-beta-button-icon-color: var(--color-icon-accent-red);
+  }
+
+  &:where(.variant-floating.semantic-activate) {
+    --b-beta-button-text-color: var(--color-text-accent-green);
+    --b-beta-button-icon-color: var(--color-icon-accent-green);
   }
 
   &:where(.loading) {
@@ -181,7 +242,7 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
 }
 
 .ButtonIcon {
-  @include dimension.square(16px);
+  @include dimension.square(18px);
 
   flex: 0 0 auto;
   color: var(--b-beta-button-icon-color);

--- a/packages/bezier-react/src/beta/Button/Button.stories.tsx
+++ b/packages/bezier-react/src/beta/Button/Button.stories.tsx
@@ -7,7 +7,21 @@ import { VStack } from '~/src/beta/VStack'
 import { Button } from './Button'
 import { type ButtonProps } from './Button.types'
 
+const BUTTON_VARIANTS = ['filled', 'outlined', 'ghost', 'floating'] as const
 
+const BUTTON_SEMANTICS = [
+  'primary',
+  'secondary',
+  'destructive',
+  'activate',
+] as const
+
+const BUTTON_STATES = [
+  { label: 'Default' },
+  { label: 'Active', active: true },
+  { label: 'Disabled', disabled: true },
+  { label: 'Loading', loading: true },
+] as const
 
 const meta: Meta<typeof Button> = {
   title: 'Beta components/Button',
@@ -17,13 +31,13 @@ const meta: Meta<typeof Button> = {
       control: {
         type: 'radio',
       },
-      options: ['filled', 'outlined', 'ghost'],
+      options: BUTTON_VARIANTS,
     },
     semantic: {
       control: {
         type: 'radio',
       },
-      options: ['primary', 'secondary', 'destructive'],
+      options: BUTTON_SEMANTICS,
     },
     size: {
       control: {
@@ -57,23 +71,21 @@ export const Primary: StoryObj<ButtonProps> = {
 export const Variants: StoryObj<ButtonProps> = {
   render: (args: ButtonProps) => (
     <VStack spacing={16}>
-      {(['filled', 'outlined', 'ghost'] as const).map((variant) => (
+      {BUTTON_VARIANTS.map((variant) => (
         <HStack
           key={variant}
           spacing={8}
         >
-          {(['primary', 'secondary', 'destructive'] as const).map(
-            (semantic) => (
-              <Button
-                key={semantic}
-                {...args}
-                variant={variant}
-                semantic={semantic}
-                leadingContent={PlusIcon}
-                trailingContent={ArrowRightIcon}
-              />
-            )
-          )}
+          {BUTTON_SEMANTICS.map((semantic) => (
+            <Button
+              key={semantic}
+              {...args}
+              variant={variant}
+              semantic={semantic}
+              leadingContent={PlusIcon}
+              trailingContent={ArrowRightIcon}
+            />
+          ))}
         </HStack>
       ))}
     </VStack>
@@ -99,6 +111,31 @@ export const Variants: StoryObj<ButtonProps> = {
       },
     },
   },
+}
+
+export const States: StoryObj<ButtonProps> = {
+  render: () => (
+    <VStack spacing={16}>
+      {(['filled', 'floating'] as const).map((variant) => (
+        <HStack
+          key={variant}
+          spacing={8}
+          align="center"
+        >
+          {BUTTON_STATES.map(({ label, ...stateProps }) => (
+            <Button
+              key={label}
+              label={label}
+              variant={variant}
+              semantic="activate"
+              leadingContent={PlusIcon}
+              {...stateProps}
+            />
+          ))}
+        </HStack>
+      ))}
+    </VStack>
+  ),
 }
 
 export const Sizes: StoryObj<ButtonProps> = {

--- a/packages/bezier-react/src/beta/Button/Button.test.tsx
+++ b/packages/bezier-react/src/beta/Button/Button.test.tsx
@@ -13,6 +13,21 @@ describe('Button', () => {
     expect(getByRole('button', { name: 'Button' })).toBeInTheDocument()
   })
 
+  it('should support activate floating style', () => {
+    const { getByRole } = render(
+      <Button
+        label="Activate"
+        variant="floating"
+        semantic="activate"
+      />
+    )
+
+    expect(getByRole('button', { name: 'Activate' })).toHaveClass(
+      'variant-floating',
+      'semantic-activate'
+    )
+  })
+
   it('should have type="button" by default', () => {
     const { getByRole } = render(<Button label="Button" />)
 

--- a/packages/bezier-react/src/beta/Button/Button.types.ts
+++ b/packages/bezier-react/src/beta/Button/Button.types.ts
@@ -12,9 +12,13 @@ import {
   type SizeProps,
 } from '~/src/types/props'
 
-export type ButtonVariant = 'filled' | 'outlined' | 'ghost'
+export type ButtonVariant = 'filled' | 'outlined' | 'ghost' | 'floating'
 
-export type ButtonSemantic = 'primary' | 'secondary' | 'destructive'
+export type ButtonSemantic =
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'activate'
 
 export type ButtonSize = 'xs' | 's' | 'm' | 'l'
 
@@ -51,10 +55,7 @@ interface ButtonOwnProps
 }
 
 interface ButtonButtonProps
-  extends Omit<
-    BaseButtonButtonProps,
-    keyof ButtonOwnProps | 'color' | 'type'
-  > {
+  extends Omit<BaseButtonButtonProps, keyof ButtonOwnProps | 'color' | 'type'> {
   as?: 'button'
   /**
    * `type` attribute of typical HTML button.
@@ -67,10 +68,7 @@ interface ButtonButtonProps
 }
 
 interface ButtonAnchorProps
-  extends Omit<
-    BaseButtonAnchorProps,
-    keyof ButtonOwnProps | 'color'
-  > {}
+  extends Omit<BaseButtonAnchorProps, keyof ButtonOwnProps | 'color'> {}
 
 interface ButtonCustomElementProps
   extends Omit<

--- a/packages/bezier-react/src/beta/IconButton/IconButton.module.scss
+++ b/packages/bezier-react/src/beta/IconButton/IconButton.module.scss
@@ -29,10 +29,10 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
   &:where(.size-xs) {
     @include dimension.square(20px);
 
-    padding: 2px;
+    padding: 3px;
 
     & .IconButtonIcon {
-      @include dimension.square(16px);
+      @include dimension.square(14px);
     }
   }
 
@@ -49,20 +49,20 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
   &:where(.size-m) {
     @include dimension.square(32px);
 
-    padding: 6px;
+    padding: 7px;
 
     & .IconButtonIcon {
-      @include dimension.square(20px);
+      @include dimension.square(18px);
     }
   }
 
   &:where(.size-l) {
-    @include dimension.square(44px);
+    @include dimension.square(42px);
 
     padding: 12px;
 
     & .IconButtonIcon {
-      @include dimension.square(20px);
+      @include dimension.square(18px);
     }
   }
 
@@ -79,7 +79,7 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
 
   &:where(.variant-filled.semantic-secondary) {
     --b-beta-icon-button-icon-color: var(--color-icon-neutral-heavy);
-    --b-beta-icon-button-background-color: var(--color-fill-neutral);
+    --b-beta-icon-button-background-color: var(--color-fill-neutral-light);
 
     &#{$active-selector} {
       --b-beta-icon-button-background-color: var(--color-fill-neutral-hovered);
@@ -87,7 +87,7 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
   }
 
   &:where(.variant-filled.semantic-destructive) {
-    --b-beta-icon-button-icon-color: var(--color-icon-inverse-heavier);
+    --b-beta-icon-button-icon-color: var(--color-icon-absolute-white);
     --b-beta-icon-button-background-color: var(--color-fill-accent-red-heavier);
 
     &#{$active-selector} {
@@ -97,8 +97,23 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
     }
   }
 
+  &:where(.variant-filled.semantic-activate) {
+    --b-beta-icon-button-icon-color: var(--color-icon-absolute-white);
+    --b-beta-icon-button-background-color: var(
+      --color-fill-accent-green-heavier
+    );
+
+    &#{$active-selector} {
+      --b-beta-icon-button-background-color: var(
+        --color-fill-accent-green-heavier-hovered
+      );
+    }
+  }
+
   &:where(.variant-outlined) {
-    --b-beta-icon-button-background-color: var(--color-fill-neutral-transparent);
+    --b-beta-icon-button-background-color: var(
+      --color-fill-neutral-transparent
+    );
     --b-beta-icon-button-box-shadow: inset 0 0 0 1px var(--color-border-neutral);
 
     &#{$active-selector} {
@@ -120,8 +135,14 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
     --b-beta-icon-button-icon-color: var(--color-icon-accent-red);
   }
 
+  &:where(.variant-outlined.semantic-activate) {
+    --b-beta-icon-button-icon-color: var(--color-icon-accent-green);
+  }
+
   &:where(.variant-ghost) {
-    --b-beta-icon-button-background-color: var(--color-fill-neutral-transparent);
+    --b-beta-icon-button-background-color: var(
+      --color-fill-neutral-transparent
+    );
 
     &#{$active-selector} {
       --b-beta-icon-button-background-color: var(
@@ -140,6 +161,35 @@ $active-selector: ':where(.active, :hover):where(:not(:disabled, [aria-disabled=
 
   &:where(.variant-ghost.semantic-destructive) {
     --b-beta-icon-button-icon-color: var(--color-icon-accent-red);
+  }
+
+  &:where(.variant-ghost.semantic-activate) {
+    --b-beta-icon-button-icon-color: var(--color-icon-accent-green);
+  }
+
+  &:where(.variant-floating) {
+    --b-beta-icon-button-background-color: var(--color-fill-bright);
+    --b-beta-icon-button-box-shadow: var(--elevation-2);
+
+    &#{$active-selector} {
+      --b-beta-icon-button-box-shadow: var(--elevation-3);
+    }
+  }
+
+  &:where(.variant-floating.semantic-primary) {
+    --b-beta-icon-button-icon-color: var(--color-icon-neutral-heavy);
+  }
+
+  &:where(.variant-floating.semantic-secondary) {
+    --b-beta-icon-button-icon-color: var(--color-icon-neutral);
+  }
+
+  &:where(.variant-floating.semantic-destructive) {
+    --b-beta-icon-button-icon-color: var(--color-icon-accent-red);
+  }
+
+  &:where(.variant-floating.semantic-activate) {
+    --b-beta-icon-button-icon-color: var(--color-icon-accent-green);
   }
 
   &:where(.loading) {

--- a/packages/bezier-react/src/beta/IconButton/IconButton.stories.tsx
+++ b/packages/bezier-react/src/beta/IconButton/IconButton.stories.tsx
@@ -7,7 +7,26 @@ import { VStack } from '~/src/beta/VStack'
 import { IconButton } from './IconButton'
 import { type IconButtonProps } from './IconButton.types'
 
+const ICON_BUTTON_VARIANTS = [
+  'filled',
+  'outlined',
+  'ghost',
+  'floating',
+] as const
 
+const ICON_BUTTON_SEMANTICS = [
+  'primary',
+  'secondary',
+  'destructive',
+  'activate',
+] as const
+
+const ICON_BUTTON_STATES = [
+  { label: 'Default' },
+  { label: 'Active', active: true },
+  { label: 'Disabled', disabled: true },
+  { label: 'Loading', loading: true },
+] as const
 
 const meta: Meta<typeof IconButton> = {
   title: 'Beta components/IconButton',
@@ -17,13 +36,13 @@ const meta: Meta<typeof IconButton> = {
       control: {
         type: 'radio',
       },
-      options: ['filled', 'outlined', 'ghost'],
+      options: ICON_BUTTON_VARIANTS,
     },
     semantic: {
       control: {
         type: 'radio',
       },
-      options: ['primary', 'secondary', 'destructive'],
+      options: ICON_BUTTON_SEMANTICS,
     },
     size: {
       control: {
@@ -58,23 +77,21 @@ export const Primary: StoryObj<IconButtonProps> = {
 export const Variants: StoryObj<IconButtonProps> = {
   render: (args: IconButtonProps) => (
     <VStack spacing={16}>
-      {(['filled', 'outlined', 'ghost'] as const).map((variant) => (
+      {ICON_BUTTON_VARIANTS.map((variant) => (
         <HStack
           key={variant}
           spacing={8}
         >
-          {(['primary', 'secondary', 'destructive'] as const).map(
-            (semantic) => (
-              <IconButton
-                key={semantic}
-                {...args}
-                variant={variant}
-                semantic={semantic}
-                content={PlusIcon}
-                aria-label={`${semantic} ${variant}`}
-              />
-            )
-          )}
+          {ICON_BUTTON_SEMANTICS.map((semantic) => (
+            <IconButton
+              key={semantic}
+              {...args}
+              variant={variant}
+              semantic={semantic}
+              content={PlusIcon}
+              aria-label={`${semantic} ${variant}`}
+            />
+          ))}
         </HStack>
       ))}
     </VStack>
@@ -104,6 +121,31 @@ export const Variants: StoryObj<IconButtonProps> = {
       },
     },
   },
+}
+
+export const States: StoryObj<IconButtonProps> = {
+  render: () => (
+    <VStack spacing={16}>
+      {(['filled', 'floating'] as const).map((variant) => (
+        <HStack
+          key={variant}
+          spacing={8}
+          align="center"
+        >
+          {ICON_BUTTON_STATES.map(({ label, ...stateProps }) => (
+            <IconButton
+              key={label}
+              content={PlusIcon}
+              variant={variant}
+              semantic="activate"
+              aria-label={`${label} ${variant}`}
+              {...stateProps}
+            />
+          ))}
+        </HStack>
+      ))}
+    </VStack>
+  ),
 }
 
 export const Sizes: StoryObj<IconButtonProps> = {

--- a/packages/bezier-react/src/beta/IconButton/IconButton.test.tsx
+++ b/packages/bezier-react/src/beta/IconButton/IconButton.test.tsx
@@ -18,6 +18,22 @@ describe('IconButton', () => {
     expect(getByRole('button', { name: 'Add' })).toBeInTheDocument()
   })
 
+  it('should support activate floating style', () => {
+    const { getByRole } = render(
+      <IconButton
+        content={PlusIcon}
+        variant="floating"
+        semantic="activate"
+        aria-label="Activate"
+      />
+    )
+
+    expect(getByRole('button', { name: 'Activate' })).toHaveClass(
+      'variant-floating',
+      'semantic-activate'
+    )
+  })
+
   it('should have type="button" by default', () => {
     const { getByRole } = render(
       <IconButton


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [x] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

- [WEB-12475](https://linear.app/channel/issue/WEB-12475/bezier-button-iconbutton-%EC%83%89%EC%83%81-%EC%B6%94%EA%B0%80-%EB%B0%8F-%EC%88%98%EC%A0%95)

## Summary

Align beta `Button` and `IconButton` with the latest Figma specification.

## Details

- Add the `floating` variant and `activate` semantic to the public API.
- Update component dimensions, padding, and icon sizes.
- Apply the revised filled, floating, destructive, and activate colors for light and dark themes.
- Extend Storybook coverage for all variant/semantic combinations and activate states.
- Add unit coverage and a minor changeset for the new public API.
- Verify with Jest, TypeScript, ESLint, Stylelint, a Storybook production build, and local visual inspection.

### Breaking change? (Yes/No)

No.

## References

- [Button and IconButton change overview](https://www.figma.com/design/Q4eonbJMKogZHuzUGxETuQ/Web-Components?node-id=9569-713&t=bbGTt79yGtsaSdbI-1)
