### PR TITLE
fix: align beta section and settings spacing

### DIFF
--- a/.changeset/web-12590-section-settings-spacing.md
+++ b/.changeset/web-12590-section-settings-spacing.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Remove the unintended spacing below beta SectionLabel and align beta SettingsField vertical padding with the design specification.

--- a/packages/bezier-react/src/beta/Section/Section.module.scss
+++ b/packages/bezier-react/src/beta/Section/Section.module.scss
@@ -9,7 +9,6 @@
 
 .SectionHeader {
   min-width: 0;
-  margin-bottom: 6px;
 }
 
 .SectionLabel {

--- a/packages/bezier-react/src/beta/Settings/Settings.module.scss
+++ b/packages/bezier-react/src/beta/Settings/Settings.module.scss
@@ -11,8 +11,8 @@
 .SettingsField {
   box-sizing: border-box;
   width: 100%;
-  padding-top: 4px;
-  padding-bottom: 8px;
+  padding-top: 12px;
+  padding-bottom: 16px;
 }
 
 .LabelLeft {

--- a/packages/bezier-react/src/beta/Settings/Settings.stories.tsx
+++ b/packages/bezier-react/src/beta/Settings/Settings.stories.tsx
@@ -2,11 +2,10 @@ import { type Meta, type StoryObj } from '@storybook/react'
 
 import { Switch } from '~/src/beta/Switch'
 import { TextInput } from '~/src/beta/TextInput'
+import { VStack } from '~/src/beta/VStack'
 
 import { Settings, SettingsField } from './Settings'
 import type { SettingsFieldProps, SettingsProps } from './Settings.types'
-
-
 
 const SETTINGS_WIDTH = 360
 
@@ -61,4 +60,40 @@ export const Primary: StoryObj<SettingsProps & SettingsFieldProps> = {
   args: {
     labelPosition: 'left',
   },
+}
+
+export const FieldSpacing: StoryObj<SettingsProps & SettingsFieldProps> = {
+  tags: ['!autodocs'],
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <VStack spacing={24}>
+      <Settings style={{ width: SETTINGS_WIDTH }}>
+        <SettingsField label="Label left">
+          <Switch defaultChecked />
+        </SettingsField>
+        <SettingsField
+          label="Label left with description"
+          description="Each field keeps its own vertical padding."
+        >
+          <Switch />
+        </SettingsField>
+      </Settings>
+
+      <Settings style={{ width: SETTINGS_WIDTH }}>
+        <SettingsField
+          label="Label top"
+          labelPosition="top"
+        >
+          <TextInput defaultValue="Channel" />
+        </SettingsField>
+        <SettingsField
+          label="Label top with description"
+          description="Dividers stay between the padded fields."
+          labelPosition="top"
+        >
+          <TextInput defaultValue="Bezier" />
+        </SettingsField>
+      </Settings>
+    </VStack>
+  ),
 }


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

- [WEB-12590](https://linear.app/channel/issue/WEB-12590/bezier-sectionlabel%EC%9D%98-%EB%B9%84%EC%9D%98%EB%8F%84%EC%A0%81-%ED%95%98%EB%8B%A8-6px-%EA%B0%84%EA%B2%A9-%EC%A0%9C%EA%B1%B0-%EB%B0%8F-settings-%EA%B0%84%EA%B2%A9-%EC%88%98%EC%A0%95)

## Summary

Beta `Section`과 `Settings`의 간격을 최신 Figma 스펙에 맞췄습니다.

- `SectionLabel` 아래에 기본 적용되던 6px 간격을 제거했습니다.
- `SettingsField`의 상하 padding을 각각 12px, 16px로 조정했습니다.
- Settings의 label position과 divider 배치를 함께 확인할 수 있는 Storybook 스토리를 추가했습니다.

## Details

`SectionHeader`의 `margin-bottom: 6px`은 Figma의 `Section`과 `CollapsibleSection` 어느 쪽에도 존재하지 않는 간격이었습니다. `CollapsibleSection`도 내부적으로 `Section`과 `SectionLabel`을 조합하므로 공통 규칙을 제거해 두 컴포넌트를 함께 수정했습니다.

`SettingsField`는 기존 `padding-top: 4px`, `padding-bottom: 8px`에서 Figma 기준인 12px, 16px로 변경했습니다. `FieldSpacing` 스토리에는 `labelPosition="left"`와 `labelPosition="top"` 조합을 모두 포함했습니다.

릴리즈 반영을 위해 `@channel.io/bezier-react` patch changeset을 추가했습니다.

### Breaking change? (Yes/No)

No

## References

- [Figma CollapsibleSection](https://www.figma.com/design/Q4eonbJMKogZHuzUGxETuQ/Web-Components?node-id=2662-14252&m=dev)
- [Figma Internal/SectionLabel](https://www.figma.com/design/Q4eonbJMKogZHuzUGxETuQ/Web-Components?node-id=403-17&m=dev)
- 검증
  - 관련 Jest 3 suites / 19 tests
  - `yarn exec tsc --noEmit -p packages/bezier-react/tsconfig.json`
  - package-local ESLint
  - 변경 SCSS Stylelint
  - Storybook static build
  - `yarn changeset status`
