### PR TITLE
fix: correct beta settings field spacing

### DIFF
--- a/.changeset/web-12590-settings-spacing-followup.md
+++ b/.changeset/web-12590-settings-spacing-followup.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Correct beta SettingsField spacing around field content and dividers.

--- a/packages/bezier-react/src/beta/Settings/Settings.module.scss
+++ b/packages/bezier-react/src/beta/Settings/Settings.module.scss
@@ -8,11 +8,16 @@
   width: 100%;
 }
 
+.SettingsFieldWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-bottom: 12px;
+}
+
 .SettingsField {
   box-sizing: border-box;
   width: 100%;
-  padding-top: 12px;
-  padding-bottom: 16px;
 }
 
 .LabelLeft {

--- a/packages/bezier-react/src/beta/Settings/Settings.stories.tsx
+++ b/packages/bezier-react/src/beta/Settings/Settings.stories.tsx
@@ -73,7 +73,7 @@ export const FieldSpacing: StoryObj<SettingsProps & SettingsFieldProps> = {
         </SettingsField>
         <SettingsField
           label="Label left with description"
-          description="Each field keeps its own vertical padding."
+          description="Content starts without additional top padding."
         >
           <Switch />
         </SettingsField>
@@ -88,7 +88,7 @@ export const FieldSpacing: StoryObj<SettingsProps & SettingsFieldProps> = {
         </SettingsField>
         <SettingsField
           label="Label top with description"
-          description="Dividers stay between the padded fields."
+          description="The divider follows the field spacing contract."
           labelPosition="top"
         >
           <TextInput defaultValue="Bezier" />

--- a/packages/bezier-react/src/beta/Settings/Settings.test.tsx
+++ b/packages/bezier-react/src/beta/Settings/Settings.test.tsx
@@ -1,13 +1,13 @@
-
 import { Switch } from '~/src/beta/Switch'
 import { render } from '~/src/utils/test'
 
 import { Settings, SettingsField } from './Settings'
 
+import styles from './Settings.module.scss'
 
 describe('Settings', () => {
-  it('renders dividers between fields by default', () => {
-    const { getAllByRole } = render(
+  it('groups each field with a following divider except for the last field', () => {
+    const { container, getAllByTestId, getByRole } = render(
       <Settings>
         <SettingsField label="Notifications">
           <Switch />
@@ -18,7 +18,17 @@ describe('Settings', () => {
       </Settings>
     )
 
-    expect(getAllByRole('separator')).toHaveLength(1)
+    const fields = getAllByTestId('bezier-beta-switch')
+    const divider = getByRole('separator')
+    const wrappers = container.querySelectorAll(
+      `.${styles.SettingsFieldWrapper}`
+    )
+
+    expect(wrappers).toHaveLength(2)
+    expect(wrappers[0]).toContainElement(fields[0])
+    expect(wrappers[0]).toContainElement(divider)
+    expect(wrappers[1]).toContainElement(fields[1])
+    expect(wrappers[1]).not.toContainElement(divider)
   })
 })
 

--- a/packages/bezier-react/src/beta/Settings/Settings.tsx
+++ b/packages/bezier-react/src/beta/Settings/Settings.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { Children, Fragment, forwardRef, isValidElement } from 'react'
+import { Children, forwardRef, isValidElement } from 'react'
 
 import classNames from 'classnames'
-
-
 
 import { Divider } from '~/src/beta/Divider'
 import { Help } from '~/src/beta/Help'
@@ -36,7 +34,9 @@ function SettingsFieldHelp({ help }: Pick<SettingsFieldProps, 'help'>) {
  */
 export const Settings = forwardRef<HTMLDivElement, SettingsProps>(
   function Settings({ children, className, ...rest }, forwardedRef) {
-    if (!children) {
+    const fields = Children.toArray(children)
+
+    if (fields.length === 0) {
       return null
     }
 
@@ -46,16 +46,20 @@ export const Settings = forwardRef<HTMLDivElement, SettingsProps>(
         className={classNames(styles.Settings, className)}
         {...rest}
       >
-        {Children.map(children, (child, index) => (
-          <Fragment key={index}>
-            {index > 0 && (
+        {fields.map((field, index) => (
+          <div
+            // eslint-disable-next-line react/no-array-index-key
+            key={index}
+            className={styles.SettingsFieldWrapper}
+          >
+            {field}
+            {index < fields.length - 1 && (
               <Divider
                 className={styles.SettingsDivider}
                 withoutSideIndent
               />
             )}
-            {child}
-          </Fragment>
+          </div>
         ))}
       </div>
     )


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)
  - Windows: Chrome, Edge, (Optional) Firefox
  - macOS: Chrome, Edge, Safari, (Optional) Firefox

## Related Issue

- [WEB-12590](https://linear.app/channel/issue/WEB-12590/bezier-sectionlabel%EC%9D%98-%EB%B9%84%EC%9D%98%EB%8F%84%EC%A0%81-%ED%95%98%EB%8B%A8-6px-%EA%B0%84%EA%B2%A9-%EC%A0%9C%EA%B1%B0-%EB%B0%8F-settings-%EA%B0%84%EA%B2%A9-%EC%88%98%EC%A0%95)
- Follow-up to #2895

## Summary

Beta `Settings`의 field spacing을 정정된 Figma 스펙에 맞췄습니다.

- `SettingsField` 자체의 상하 padding을 제거했습니다.
- 각 field content와 뒤따르는 divider 사이에 16px 간격을 적용했습니다.
- 각 field group 아래에 12px 여백을 적용하고 마지막 field에는 divider를 렌더링하지 않습니다.

## Details

#2895에서 `SettingsField`의 상단 12px / 하단 16px padding으로 반영했던 값은 앱에서 감싼 Box 영역까지 포함해 측정한 값이었습니다.

정정된 컴포넌트 정책은 field content의 상단 추가 여백 0px, field group의 하단 여백 12px, content와 divider 사이의 layout gap 16px입니다. 이를 표현하기 위해 각 field와 그 뒤의 divider를 하나의 wrapper로 묶었습니다. Divider는 앞 field의 spacing에 속하며 마지막 field에는 렌더링하지 않습니다. Divider 자체의 기본 6px parallel indent 정책은 변경하지 않았습니다.

`Section` 관련 수정은 최신 `v4`에 이미 반영되어 있어 이번 PR의 범위에서 제외했습니다. `FieldSpacing` Storybook 설명과 divider 배치 테스트를 함께 갱신하고 `@channel.io/bezier-react` patch changeset을 추가했습니다.

### Breaking change? (Yes/No)

No

## References

- [Correction thread](https://channel.works/root/threads/groups/CTBezier-Redesign-v3-244958/6a6ffac112fc123ff601/6a7c02a6148b8b3d045d)
- [Figma Settings](https://www.figma.com/design/Q4eonbJMKogZHuzUGxETuQ/Web-Components?node-id=5150-1298&m=dev)
- Previous PR: #2895
- Verification
  - Settings Jest suite: 2 tests
  - TypeScript package typecheck
  - Package-local ESLint
  - Stylelint
  - Storybook static build
  - `yarn changeset status`
  - `git diff --check`
