### PR TITLE
feat: generate source-derived package manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Check generated manifests
+        run: yarn manifest:check
+
       - name: Lint
         run: yarn lint
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "configs/*"
   ],
   "scripts": {
-    "build": "turbo run build",
+    "build": "turbo run build && yarn manifest:generate",
     "dev": "turbo run dev --filter=@channel.io/bezier-react",
     "lint": "turbo run lint && syncpack lint",
     "format": "prettier . --write",
@@ -15,7 +15,7 @@
     "test": "turbo run test",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "version-packages": "changeset version && yarn --mode=\"update-lockfile\"",
-    "release": "turbo run build --filter='@channel.io/*' && changeset publish",
+    "release": "turbo run build --filter='@channel.io/*' && yarn manifest:generate && changeset publish",
     "manifest:generate": "node scripts/manifests/generate.mjs",
     "manifest:check": "node scripts/manifests/generate.mjs --check && node --test scripts/manifests/generate.test.mjs",
     "changeset": "changeset",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "version-packages": "changeset version && yarn --mode=\"update-lockfile\"",
     "release": "turbo run build --filter='@channel.io/*' && changeset publish",
+    "manifest:generate": "node scripts/manifests/generate.mjs",
+    "manifest:check": "node scripts/manifests/generate.mjs --check && node --test scripts/manifests/generate.test.mjs",
     "changeset": "changeset",
     "postinstall": "husky install",
     "knip": "knip --config knip.json --workspace packages/bezier-react --cache"

--- a/packages/bezier-icons/package.json
+++ b/packages/bezier-icons/package.json
@@ -16,6 +16,7 @@
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },
+    "./manifest.json": "./dist/manifest.json",
     "./*.svg": "./dist/svg/*.svg"
   },
   "files": [
@@ -25,7 +26,7 @@
     "*.svg"
   ],
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && node ../../scripts/manifests/generate.mjs --package icons",
     "dev": "rollup -c -w",
     "lint": "TIMING=1 eslint --cache .",
     "typecheck": "tsc --noEmit",

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -24,7 +24,8 @@
     "./styles.css": {
       "require": "./dist/cjs/styles.css",
       "import": "./dist/esm/styles.css"
-    }
+    },
+    "./manifest.json": "./dist/manifest.json"
   },
   "sideEffects": [
     "**/*.css",
@@ -38,6 +39,7 @@
   "scripts": {
     "build": "run-p 'build:*'",
     "build:js": "rollup -c",
+    "build:manifest": "node ../../scripts/manifests/generate.mjs --package react",
     "build:types": "tspc -p ./tsconfig.build.json",
     "dev": "yarn storybook",
     "lint": "run-p 'lint:*'",

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.stories.tsx
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.stories.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { ChevronSmallRightIcon, PlusIcon } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Box } from '~/src/beta/Box'
 import { Text } from '~/src/beta/Text'
 
@@ -15,6 +16,16 @@ import {
 const meta: Meta<typeof CollapsibleSection> = {
   title: 'Beta components/CollapsibleSection',
   component: CollapsibleSection,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'CollapsibleSection',
+      parts: {
+        CollapsibleSectionTrigger: { requiresAncestor: ['CollapsibleSection'] },
+        CollapsibleSectionItem: { requiresAncestor: ['CollapsibleSection'] },
+      },
+      independent: {},
+    }),
+  },
 }
 
 export default meta

--- a/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.stories.tsx
+++ b/packages/bezier-react/src/beta/CollapsibleSection/CollapsibleSection.stories.tsx
@@ -3,9 +3,9 @@ import { useState } from 'react'
 import { ChevronSmallRightIcon, PlusIcon } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Box } from '~/src/beta/Box'
 import { Text } from '~/src/beta/Text'
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import {
   CollapsibleSection,

--- a/packages/bezier-react/src/beta/ConfirmModal/ConfirmModal.stories.tsx
+++ b/packages/bezier-react/src/beta/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { Button } from '~/src/beta/Button'
 import { ButtonGroup } from '~/src/beta/ButtonGroup'
@@ -19,6 +20,20 @@ import {
 const meta: Meta<typeof ConfirmModal> = {
   title: 'Beta components/ConfirmModal',
   component: ConfirmModal,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'ConfirmModal',
+      parts: {
+        ConfirmModalTrigger: { requiresAncestor: ['ConfirmModal'] },
+        ConfirmModalContent: { requiresAncestor: ['ConfirmModal'] },
+        ConfirmModalHeader: { requiresAncestor: ['ConfirmModal', 'ConfirmModalContent'] },
+        ConfirmModalBody: { requiresAncestor: ['ConfirmModal', 'ConfirmModalContent'] },
+        ConfirmModalFooter: { requiresAncestor: ['ConfirmModal', 'ConfirmModalContent'] },
+        ConfirmModalClose: { requiresAncestor: ['ConfirmModal'] },
+      },
+      independent: {},
+    }),
+  },
 }
 
 export default meta

--- a/packages/bezier-react/src/beta/ConfirmModal/ConfirmModal.stories.tsx
+++ b/packages/bezier-react/src/beta/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,10 +1,10 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 
-import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { Button } from '~/src/beta/Button'
 import { ButtonGroup } from '~/src/beta/ButtonGroup'
 import { Text } from '~/src/beta/Text'
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import {
   ConfirmModal,

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
@@ -12,6 +12,7 @@ import {
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Button } from '~/src/beta/Button'
 import { IconButton } from '~/src/beta/IconButton'
 import { Text } from '~/src/beta/Text'
@@ -38,6 +39,19 @@ const meta: Meta<typeof DropdownMenu> = {
     ),
   ],
   parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'DropdownMenu',
+      parts: {
+        DropdownMenuTrigger: { requiresAncestor: ['DropdownMenu'] },
+        DropdownMenuGroup: { requiresAncestor: ['DropdownMenu'] },
+        DropdownMenuItem: { requiresAncestor: ['DropdownMenu'] },
+        DropdownMenuSeparator: { requiresAncestor: ['DropdownMenu'] },
+        DropdownMenuSub: { requiresAncestor: ['DropdownMenu'] },
+        DropdownMenuSubTrigger: { requiresAncestor: ['DropdownMenu', 'DropdownMenuSub'] },
+        DropdownMenuSubContent: { requiresAncestor: ['DropdownMenu', 'DropdownMenuSub'] },
+      },
+      independent: {},
+    }),
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/Q4eonbJMKogZHuzUGxETuQ/%F0%9F%9A%A7-Web-Components?node-id=3624-271&m=dev',

--- a/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/bezier-react/src/beta/DropdownMenu/DropdownMenu.stories.tsx
@@ -12,10 +12,10 @@ import {
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Button } from '~/src/beta/Button'
 import { IconButton } from '~/src/beta/IconButton'
 import { Text } from '~/src/beta/Text'
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import {
   DropdownMenu,

--- a/packages/bezier-react/src/beta/Form/Form.stories.tsx
+++ b/packages/bezier-react/src/beta/Form/Form.stories.tsx
@@ -1,6 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 
-import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 
 import { Checkbox } from '~/src/beta/Checkbox'
@@ -8,6 +7,7 @@ import { HStack } from '~/src/beta/HStack'
 import { TextArea } from '~/src/beta/TextArea'
 import { TextInput } from '~/src/beta/TextInput'
 import { VStack } from '~/src/beta/VStack'
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import type { FormFieldProps, FormProps } from './Form.types'
 

--- a/packages/bezier-react/src/beta/Form/Form.stories.tsx
+++ b/packages/bezier-react/src/beta/Form/Form.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 
 import { Checkbox } from '~/src/beta/Checkbox'
@@ -26,6 +27,19 @@ const FIELD_WIDTH = 360
 const meta: Meta<FormProps & FormFieldProps> = {
   title: 'Beta components/Form',
   component: Form,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'Form',
+      parts: {
+        FormField: { requiresAncestor: ['Form'] },
+        FormLabel: { requiresAncestor: ['Form', 'FormField'] },
+        FormHelperText: { requiresAncestor: ['Form', 'FormField'] },
+        FormErrorMessage: { requiresAncestor: ['Form', 'FormField'] },
+        FormGroup: { requiresAncestor: ['Form'] },
+      },
+      independent: {},
+    }),
+  },
   argTypes: {
     labelPosition: {
       control: {

--- a/packages/bezier-react/src/beta/Modal/Modal.stories.tsx
+++ b/packages/bezier-react/src/beta/Modal/Modal.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { Button } from '~/src/beta/Button'
 import { ButtonGroup } from '~/src/beta/ButtonGroup'
@@ -19,6 +20,20 @@ import {
 const meta: Meta<typeof Modal> = {
   title: 'Beta components/Modal',
   component: Modal,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'Modal',
+      parts: {
+        ModalTrigger: { requiresAncestor: ['Modal'] },
+        ModalContent: { requiresAncestor: ['Modal'] },
+        ModalHeader: { requiresAncestor: ['Modal', 'ModalContent'] },
+        ModalBody: { requiresAncestor: ['Modal', 'ModalContent'] },
+        ModalFooter: { requiresAncestor: ['Modal', 'ModalContent'] },
+        ModalClose: { requiresAncestor: ['Modal'] },
+      },
+      independent: {},
+    }),
+  },
 }
 
 export default meta

--- a/packages/bezier-react/src/beta/Modal/Modal.stories.tsx
+++ b/packages/bezier-react/src/beta/Modal/Modal.stories.tsx
@@ -1,10 +1,10 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 
-import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { Button } from '~/src/beta/Button'
 import { ButtonGroup } from '~/src/beta/ButtonGroup'
 import { Text } from '~/src/beta/Text'
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import {
   Modal,

--- a/packages/bezier-react/src/beta/MultiSelect/MultiSelect.stories.tsx
+++ b/packages/bezier-react/src/beta/MultiSelect/MultiSelect.stories.tsx
@@ -7,9 +7,9 @@ import {
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { Button } from '~/src/beta/Button'
 import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
-import { Button } from '~/src/beta/Button'
 
 import {
   MultiSelect,

--- a/packages/bezier-react/src/beta/MultiSelect/MultiSelect.stories.tsx
+++ b/packages/bezier-react/src/beta/MultiSelect/MultiSelect.stories.tsx
@@ -7,6 +7,7 @@ import {
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { Button } from '~/src/beta/Button'
 
@@ -22,6 +23,17 @@ import type { MultiSelectProps } from './'
 const meta: Meta<typeof MultiSelect> = {
   title: 'Beta components/MultiSelect',
   component: MultiSelect,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'MultiSelect',
+      parts: {
+        MultiSelectTrigger: { requiresAncestor: ['MultiSelect'] },
+        MultiSelectGroup: { requiresAncestor: ['MultiSelect'] },
+        MultiSelectOption: { requiresAncestor: ['MultiSelect'] },
+      },
+      independent: {},
+    }),
+  },
   decorators: [
     (Story) => (
       <div style={{ minHeight: 320 }}>

--- a/packages/bezier-react/src/beta/NavigationList/NavigationList.stories.tsx
+++ b/packages/bezier-react/src/beta/NavigationList/NavigationList.stories.tsx
@@ -7,6 +7,7 @@ import {
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Badge } from '~/src/beta/Badge'
 import { Icon } from '~/src/beta/Icon'
 
@@ -15,6 +16,16 @@ import { NavigationGroup, NavigationItem, NavigationList } from '.'
 const meta: Meta<typeof NavigationList> = {
   title: 'Beta components/NavigationList',
   component: NavigationList,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'NavigationList',
+      parts: {
+        NavigationGroup: { requiresAncestor: ['NavigationList'] },
+        NavigationItem: { requiresAncestor: ['NavigationList'] },
+      },
+      independent: {},
+    }),
+  },
 }
 
 export default meta

--- a/packages/bezier-react/src/beta/NavigationList/NavigationList.stories.tsx
+++ b/packages/bezier-react/src/beta/NavigationList/NavigationList.stories.tsx
@@ -7,9 +7,9 @@ import {
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Badge } from '~/src/beta/Badge'
 import { Icon } from '~/src/beta/Icon'
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { NavigationGroup, NavigationItem, NavigationList } from '.'
 

--- a/packages/bezier-react/src/beta/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/bezier-react/src/beta/RadioGroup/RadioGroup.stories.tsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react'
 
 import { type Meta, type StoryFn, type StoryObj } from '@storybook/react'
 
+import { FormField, FormLabel } from '~/src/beta/Form'
 import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
-import { FormField, FormLabel } from '~/src/beta/Form'
 
 import { Radio, RadioGroup } from './RadioGroup'
 import { type RadioGroupProps } from './RadioGroup.types'

--- a/packages/bezier-react/src/beta/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/bezier-react/src/beta/RadioGroup/RadioGroup.stories.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { type Meta, type StoryFn, type StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { FormField, FormLabel } from '~/src/beta/Form'
 
@@ -18,6 +19,13 @@ enum Theme {
 const meta: Meta<typeof RadioGroup> = {
   title: 'Beta components/RadioGroup',
   component: RadioGroup,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'RadioGroup',
+      parts: { Radio: { requiresAncestor: ['RadioGroup'] } },
+      independent: {},
+    }),
+  },
   argTypes: {
     direction: {
       control: {

--- a/packages/bezier-react/src/beta/Section/Section.stories.tsx
+++ b/packages/bezier-react/src/beta/Section/Section.stories.tsx
@@ -9,10 +9,10 @@ import {
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { Box } from '~/src/beta/Box'
 import { Text } from '~/src/beta/Text'
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { noop } from '~/src/utils/function'
 
 import { Section, SectionItem, SectionLabel } from './Section'

--- a/packages/bezier-react/src/beta/Section/Section.stories.tsx
+++ b/packages/bezier-react/src/beta/Section/Section.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { Box } from '~/src/beta/Box'
 import { Text } from '~/src/beta/Text'
@@ -20,6 +21,16 @@ import { Section, SectionItem, SectionLabel } from './Section'
 const meta: Meta<typeof Section> = {
   title: 'Beta components/Section',
   component: Section,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'Section',
+      parts: {
+        SectionLabel: { requiresAncestor: ['Section'] },
+        SectionItem: { requiresAncestor: ['Section'] },
+      },
+      independent: {},
+    }),
+  },
 }
 
 export default meta

--- a/packages/bezier-react/src/beta/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/bezier-react/src/beta/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,9 +1,9 @@
 import { ArrowRightIcon, PlusIcon, SquaresIcon } from '@channel.io/bezier-icons'
 import { type Meta, type StoryObj } from '@storybook/react'
 
+import { VStack } from '~/src/beta/VStack'
 import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
-import { VStack } from '~/src/beta/VStack'
 
 import {
   SegmentedControl,

--- a/packages/bezier-react/src/beta/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/bezier-react/src/beta/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,6 +1,7 @@
 import { ArrowRightIcon, PlusIcon, SquaresIcon } from '@channel.io/bezier-icons'
 import { type Meta, type StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { VStack } from '~/src/beta/VStack'
 
@@ -19,6 +20,17 @@ import {
 const meta: Meta<typeof SegmentedControl> = {
   title: 'Beta components/SegmentedControl',
   component: SegmentedControl,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'SegmentedControl',
+      parts: {
+        SegmentedControlTabList: { requiresAncestor: ['SegmentedControl'] },
+        SegmentedControlItem: { requiresAncestor: ['SegmentedControl', 'SegmentedControlTabList'] },
+        SegmentedControlTabContent: { requiresAncestor: ['SegmentedControl'] },
+      },
+      independent: {},
+    }),
+  },
   argTypes: {
     size: {
       control: {

--- a/packages/bezier-react/src/beta/Select/Select.stories.tsx
+++ b/packages/bezier-react/src/beta/Select/Select.stories.tsx
@@ -8,9 +8,9 @@ import {
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Avatar } from '~/src/beta/Avatar'
 import { Button } from '~/src/beta/Button'
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { Select, SelectGroup, SelectOption, SelectTrigger } from './'
 import type { SelectProps } from './'

--- a/packages/bezier-react/src/beta/Select/Select.stories.tsx
+++ b/packages/bezier-react/src/beta/Select/Select.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from '@channel.io/bezier-icons'
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Avatar } from '~/src/beta/Avatar'
 import { Button } from '~/src/beta/Button'
 
@@ -19,6 +20,17 @@ import type { SelectProps } from './'
 const meta: Meta<typeof Select> = {
   title: 'Beta components/Select',
   component: Select,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'Select',
+      parts: {
+        SelectTrigger: { requiresAncestor: ['Select'] },
+        SelectGroup: { requiresAncestor: ['Select'] },
+        SelectOption: { requiresAncestor: ['Select'] },
+      },
+      independent: {},
+    }),
+  },
   decorators: [
     (Story) => (
       <div style={{ minHeight: 320 }}>

--- a/packages/bezier-react/src/beta/Settings/Settings.stories.tsx
+++ b/packages/bezier-react/src/beta/Settings/Settings.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Switch } from '~/src/beta/Switch'
 import { TextInput } from '~/src/beta/TextInput'
 import { VStack } from '~/src/beta/VStack'
@@ -12,6 +13,13 @@ const SETTINGS_WIDTH = 360
 const meta: Meta<SettingsProps & SettingsFieldProps> = {
   title: 'Beta components/Settings',
   component: Settings,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'Settings',
+      parts: { SettingsField: { requiresAncestor: ['Settings'] } },
+      independent: {},
+    }),
+  },
   argTypes: {
     labelPosition: {
       control: {

--- a/packages/bezier-react/src/beta/Settings/Settings.stories.tsx
+++ b/packages/bezier-react/src/beta/Settings/Settings.stories.tsx
@@ -1,9 +1,9 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 
-import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Switch } from '~/src/beta/Switch'
 import { TextInput } from '~/src/beta/TextInput'
 import { VStack } from '~/src/beta/VStack'
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { Settings, SettingsField } from './Settings'
 import type { SettingsFieldProps, SettingsProps } from './Settings.types'

--- a/packages/bezier-react/src/beta/Tabs/Tabs.stories.tsx
+++ b/packages/bezier-react/src/beta/Tabs/Tabs.stories.tsx
@@ -1,6 +1,7 @@
 import { ArrowRightIcon, OpenInNewIcon, PlusIcon } from '@channel.io/bezier-icons'
 import { type Meta, type StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { Button } from '~/src/beta/Button'
 import { IconButton } from '~/src/beta/IconButton'
@@ -39,6 +40,23 @@ function getActionButtonSize(size?: TabSize) {
 const meta: Meta<typeof Tabs> = {
   title: 'Beta components/Tabs',
   component: Tabs,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'compound', root: 'Tabs',
+      parts: {
+        TabList: { requiresAncestor: ['Tabs'] },
+        TabItem: { requiresAncestor: ['Tabs', 'TabList'] },
+        TabActions: { requiresAncestor: ['Tabs', 'TabList'] },
+        TabAction: { requiresAncestor: ['Tabs', 'TabActions'] },
+        TabContent: { requiresAncestor: ['Tabs'] },
+      },
+      independent: {},
+      usage: {
+        when: ['Switching between peer views'],
+        avoid: ['Sequential multi-step flows'],
+      },
+    }),
+  },
   argTypes: {
     size: {
       control: {

--- a/packages/bezier-react/src/beta/Tabs/Tabs.stories.tsx
+++ b/packages/bezier-react/src/beta/Tabs/Tabs.stories.tsx
@@ -1,11 +1,11 @@
 import { ArrowRightIcon, OpenInNewIcon, PlusIcon } from '@channel.io/bezier-icons'
 import { type Meta, type StoryObj } from '@storybook/react'
 
-import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { Button } from '~/src/beta/Button'
 import { IconButton } from '~/src/beta/IconButton'
 import { VStack } from '~/src/beta/VStack'
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { TabActions, TabContent, TabItem, TabList, Tabs } from './Tabs'
 import { type TabSize, type TabsProps } from './Tabs.types'

--- a/packages/bezier-react/src/beta/Toast/Toast.stories.tsx
+++ b/packages/bezier-react/src/beta/Toast/Toast.stories.tsx
@@ -1,6 +1,7 @@
 import { CheckIcon } from '@channel.io/bezier-icons'
 import { type Meta, type StoryFn, type StoryObj } from '@storybook/react'
 
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Button } from '~/src/beta/Button'
 import { HStack } from '~/src/beta/HStack'
 
@@ -16,6 +17,13 @@ import {
 const meta: Meta<ToastProps> = {
   title: 'Beta components/Toast',
   component: ToastProvider,
+  parameters: {
+    bezier: defineBezierMetadata({
+      model: 'independent', root: 'ToastProvider',
+      parts: {},
+      independent: { Toast: {} },
+    }),
+  },
   argTypes: {
     autoDismiss: {
       control: 'boolean',

--- a/packages/bezier-react/src/beta/Toast/Toast.stories.tsx
+++ b/packages/bezier-react/src/beta/Toast/Toast.stories.tsx
@@ -1,9 +1,9 @@
 import { CheckIcon } from '@channel.io/bezier-icons'
 import { type Meta, type StoryFn, type StoryObj } from '@storybook/react'
 
-import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 import { Button } from '~/src/beta/Button'
 import { HStack } from '~/src/beta/HStack'
+import { defineBezierMetadata } from '~/src/storybook/defineBezierMetadata'
 
 import { ToastProvider, useToast } from './Toast'
 import {

--- a/packages/bezier-react/src/storybook/defineBezierMetadata.test.ts
+++ b/packages/bezier-react/src/storybook/defineBezierMetadata.test.ts
@@ -1,0 +1,16 @@
+import { defineBezierMetadata } from './defineBezierMetadata'
+
+describe('defineBezierMetadata', () => {
+  it('returns the metadata object unchanged', () => {
+    const metadata = {
+      model: 'compound',
+      root: 'Tabs',
+      parts: {
+        TabList: { requiresAncestor: ['Tabs'] },
+      },
+      independent: {},
+    } as const
+
+    expect(defineBezierMetadata(metadata)).toBe(metadata)
+  })
+})

--- a/packages/bezier-react/src/storybook/defineBezierMetadata.ts
+++ b/packages/bezier-react/src/storybook/defineBezierMetadata.ts
@@ -1,0 +1,26 @@
+export interface BezierMemberMetadata {
+  requiresAncestor?: readonly string[]
+}
+
+export interface BezierUsageMetadata {
+  when?: readonly string[]
+  avoid?: readonly string[]
+}
+
+export interface BezierMetadata {
+  model: 'compound' | 'independent'
+  root: string
+  parts: Readonly<Record<string, BezierMemberMetadata>>
+  independent: Readonly<Record<string, Record<string, never>>>
+  usage?: BezierUsageMetadata
+}
+
+/**
+ * Adds statically extractable semantic relationships to a Storybook family.
+ * Source exports and Props remain the API source of truth.
+ */
+export function defineBezierMetadata<const Metadata extends BezierMetadata>(
+  metadata: Metadata
+): Metadata {
+  return metadata
+}

--- a/packages/bezier-tokens/package.json
+++ b/packages/bezier-tokens/package.json
@@ -22,6 +22,7 @@
       },
       "sass": "./dist/scss/index.scss"
     },
+    "./manifest.json": "./dist/manifest.json",
     "./css/*": "./dist/css/*",
     "./scss/*": "./dist/scss/*"
   },
@@ -33,9 +34,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "run-s clean:build validate:tokens build:tokens build:types",
+    "build": "run-s clean:build validate:tokens build:tokens build:types build:manifest",
     "build:tokens": "ts-node scripts/build-tokens.ts",
     "build:types": "tsc -p tsconfig.build.json",
+    "build:manifest": "node ../../scripts/manifests/generate.mjs --package tokens",
     "validate:tokens": "ts-node scripts/validate-token-references.ts",
     "lint": "TIMING=1 eslint --cache .",
     "typecheck": "tsc --noEmit",

--- a/scripts/manifests/generate.mjs
+++ b/scripts/manifests/generate.mjs
@@ -1,0 +1,507 @@
+import { execFileSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import ts from 'typescript'
+
+export const SCHEMA_VERSION = '1.0.0'
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const repository = 'https://github.com/channel-io/bezier-react'
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function packageInfo(packageDir) {
+  const { name, version } = readJson(join(packageDir, 'package.json'))
+  return { name, version }
+}
+
+function sourceInfo(entrypoint) {
+  return {
+    repository,
+    commit: execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: rootDir,
+      encoding: 'utf8',
+    }).trim(),
+    entrypoint,
+  }
+}
+
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`
+}
+
+function writeOrCheck(outputPath, manifest, check) {
+  const next = stableJson(manifest)
+  if (check) {
+    if (!existsSync(outputPath)) {
+      throw new Error(
+        `Missing generated manifest: ${relative(rootDir, outputPath)}`
+      )
+    }
+    if (readFileSync(outputPath, 'utf8') !== next) {
+      throw new Error(
+        `Stale generated manifest: ${relative(rootDir, outputPath)}. Run yarn manifest:generate.`
+      )
+    }
+    return
+  }
+  mkdirSync(dirname(outputPath), { recursive: true })
+  writeFileSync(outputPath, next)
+}
+
+function exportedNames(checker, sourceFile) {
+  const symbol = checker.getSymbolAtLocation(sourceFile)
+  if (!symbol) return []
+  return checker
+    .getExportsOfModule(symbol)
+    .map((entry) => entry.getName())
+    .sort((a, b) => a.localeCompare(b))
+}
+
+function aliasedSymbol(checker, symbol) {
+  return symbol.flags & ts.SymbolFlags.Alias
+    ? checker.getAliasedSymbol(symbol)
+    : symbol
+}
+
+function jsDoc(checker, symbol) {
+  return ts.displayPartsToString(symbol.getDocumentationComment(checker)).trim()
+}
+
+function jsDocTags(symbol) {
+  return Object.fromEntries(
+    symbol.getJsDocTags().map(({ name, text }) => [
+      name,
+      text
+        ?.map((part) => part.text)
+        .join('')
+        .trim() ?? '',
+    ])
+  )
+}
+
+function literalValues(type) {
+  const members = (type.isUnion() ? type.types : [type]).filter(
+    (member) => !(member.flags & ts.TypeFlags.Undefined)
+  )
+  const values = members.flatMap((member) => {
+    if (member.isStringLiteral() || member.isNumberLiteral()) {
+      return [member.value]
+    }
+    if (member.flags & ts.TypeFlags.BooleanLiteral) {
+      return [member.intrinsicName === 'true']
+    }
+    return []
+  })
+  return values.length === members.length ? values : []
+}
+
+function propsFor(checker, symbol) {
+  const target = aliasedSymbol(checker, symbol)
+  const type = checker.getDeclaredTypeOfSymbol(target)
+  return checker
+    .getPropertiesOfType(type)
+    .filter((property) =>
+      property.declarations?.some(
+        (declaration) =>
+          !declaration.getSourceFile().fileName.includes('/node_modules/')
+      )
+    )
+    .map((property) => {
+      const declaration =
+        property.valueDeclaration ?? property.declarations?.[0]
+      const propertyType = declaration
+        ? checker.getTypeOfSymbolAtLocation(property, declaration)
+        : checker.getDeclaredTypeOfSymbol(property)
+      const tags = jsDocTags(property)
+      return {
+        name: property.getName(),
+        required: !(property.flags & ts.SymbolFlags.Optional),
+        type: checker.typeToString(
+          propertyType,
+          declaration,
+          ts.TypeFormatFlags.NoTruncation |
+            ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope
+        ),
+        literalValues: literalValues(propertyType),
+        default: tags.default || null,
+        deprecated: Object.hasOwn(tags, 'deprecated'),
+        description: jsDoc(checker, property) || null,
+      }
+    })
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function isComponentSymbol(checker, name, symbol) {
+  if (!/^[A-Z]/.test(name)) return false
+  const target = aliasedSymbol(checker, symbol)
+  if (!(target.flags & ts.SymbolFlags.Value)) return false
+  const declaration = target.valueDeclaration ?? target.declarations?.[0]
+  if (!declaration) return false
+  const type = checker.getTypeOfSymbolAtLocation(target, declaration)
+  return checker.getSignaturesOfType(type, ts.SignatureKind.Call).length > 0
+}
+
+function evaluateLiteral(node) {
+  if (ts.isStringLiteralLike(node)) return node.text
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return true
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return false
+  if (ts.isArrayLiteralExpression(node))
+    return node.elements.map(evaluateLiteral)
+  if (ts.isObjectLiteralExpression(node)) {
+    return Object.fromEntries(
+      node.properties.map((property) => {
+        if (!ts.isPropertyAssignment(property)) {
+          throw new Error('Bezier metadata only supports property assignments')
+        }
+        const name = property.name.getText().replace(/^['"]|['"]$/g, '')
+        return [name, evaluateLiteral(property.initializer)]
+      })
+    )
+  }
+  throw new Error(`Unsupported Bezier metadata expression: ${node.getText()}`)
+}
+
+function readStoryMetadata(storyPath) {
+  if (!existsSync(storyPath)) return null
+  const source = ts.createSourceFile(
+    storyPath,
+    readFileSync(storyPath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  )
+  let metadata = null
+  function visit(node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'defineBezierMetadata'
+    ) {
+      if (metadata)
+        throw new Error(`Multiple Bezier metadata blocks: ${storyPath}`)
+      metadata = evaluateLiteral(node.arguments[0])
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(source)
+  return metadata
+}
+
+function findCycle(metadata) {
+  const graph = new Map(
+    Object.entries(metadata.parts ?? {}).map(([name, value]) => [
+      name,
+      value.requiresAncestor ?? [],
+    ])
+  )
+  const active = new Set()
+  const visited = new Set()
+  function visit(name) {
+    if (active.has(name)) return true
+    if (visited.has(name)) return false
+    active.add(name)
+    for (const ancestor of graph.get(name) ?? []) {
+      if (visit(ancestor)) return true
+    }
+    active.delete(name)
+    visited.add(name)
+    return false
+  }
+  return [...graph.keys()].some(visit)
+}
+
+export function validateFamilyMetadata(
+  family,
+  members,
+  metadata,
+  hasStory = true
+) {
+  if (members.length === 1 && !metadata) {
+    return {
+      model: 'unknown',
+      root: members[0],
+      parts: {},
+      independent: {},
+      usage: null,
+    }
+  }
+  if (!hasStory) {
+    throw new Error(
+      `${family}: multi-component family requires a Story and parameters.bezier`
+    )
+  }
+  if (!metadata) {
+    throw new Error(
+      `${family}: multi-component family is missing parameters.bezier`
+    )
+  }
+  const classified = [
+    metadata.root,
+    ...Object.keys(metadata.parts ?? {}),
+    ...Object.keys(metadata.independent ?? {}),
+  ]
+  const missing = members.filter((member) => !classified.includes(member))
+  const unknown = classified.filter((member) => !members.includes(member))
+  const duplicates = classified.filter(
+    (member, index) => classified.indexOf(member) !== index
+  )
+  if (missing.length)
+    throw new Error(
+      `${family}: unclassified public member(s): ${missing.join(', ')}`
+    )
+  if (unknown.length)
+    throw new Error(`${family}: stale/unknown member(s): ${unknown.join(', ')}`)
+  if (duplicates.length)
+    throw new Error(
+      `${family}: duplicate member classification: ${duplicates.join(', ')}`
+    )
+  for (const [member, value] of Object.entries(metadata.parts ?? {})) {
+    for (const ancestor of value.requiresAncestor ?? []) {
+      if (!members.includes(ancestor)) {
+        throw new Error(`${family}.${member}: unknown ancestor ${ancestor}`)
+      }
+    }
+  }
+  if (findCycle(metadata)) throw new Error(`${family}: ancestor cycle detected`)
+  return { ...metadata, usage: metadata.usage ?? null }
+}
+
+export function generateReactManifest() {
+  const packageDir = join(rootDir, 'packages/bezier-react')
+  const betaDir = join(packageDir, 'src/beta')
+  const configPath = join(packageDir, 'tsconfig.json')
+  const config = ts.readConfigFile(configPath, ts.sys.readFile)
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    packageDir
+  )
+  const program = ts.createProgram(parsed.fileNames, parsed.options)
+  const checker = program.getTypeChecker()
+  const rootIndex = program.getSourceFile(join(betaDir, 'index.ts'))
+  const familyNames = rootIndex.statements
+    .filter(ts.isExportDeclaration)
+    .map((statement) => statement.moduleSpecifier?.text)
+    .filter((path) => path?.startsWith('./'))
+    .map((path) => path.slice(2))
+    .sort((a, b) => a.localeCompare(b))
+  const components = []
+  const exports = []
+  const types = []
+  for (const family of familyNames) {
+    const familyIndex = program.getSourceFile(join(betaDir, family, 'index.ts'))
+    const names = exportedNames(checker, familyIndex)
+    const propsNames = new Set(names.filter((name) => name.endsWith('Props')))
+    const moduleSymbol = checker.getSymbolAtLocation(familyIndex)
+    const symbols = new Map(
+      checker
+        .getExportsOfModule(moduleSymbol)
+        .map((symbol) => [symbol.getName(), symbol])
+    )
+    const members = names
+      .filter(
+        (name) =>
+          propsNames.has(`${name}Props`) ||
+          isComponentSymbol(checker, name, symbols.get(name))
+      )
+      .sort((a, b) => a.localeCompare(b))
+    const storyPath = join(betaDir, family, `${family}.stories.tsx`)
+    const semantics = validateFamilyMetadata(
+      family,
+      members,
+      readStoryMetadata(storyPath),
+      existsSync(storyPath)
+    )
+    for (const name of names) {
+      const target = aliasedSymbol(checker, symbols.get(name))
+      const tags = jsDocTags(target)
+      exports.push({
+        name,
+        family,
+        exportPath: './beta',
+        kind: members.includes(name)
+          ? 'component'
+          : target.flags & ts.SymbolFlags.Value
+            ? 'runtime'
+            : 'type',
+        deprecated: Object.hasOwn(tags, 'deprecated'),
+        description: jsDoc(checker, target) || null,
+      })
+    }
+    for (const name of members) {
+      const symbol = symbols.get(name)
+      const target = aliasedSymbol(checker, symbol)
+      const tags = jsDocTags(target)
+      const propsSymbol = symbols.get(`${name}Props`)
+      components.push({
+        name,
+        family,
+        exportPath: './beta',
+        propsType: propsSymbol ? `${name}Props` : null,
+        deprecated: Object.hasOwn(tags, 'deprecated'),
+        description: jsDoc(checker, target) || null,
+        props: propsSymbol ? propsFor(checker, propsSymbol) : [],
+        semantics,
+      })
+    }
+    for (const name of names.filter((name) => !members.includes(name))) {
+      const symbol = symbols.get(name)
+      const target = aliasedSymbol(checker, symbol)
+      if (
+        target.flags &
+        (ts.SymbolFlags.TypeAlias |
+          ts.SymbolFlags.Interface |
+          ts.SymbolFlags.TypeParameter)
+      ) {
+        const tags = jsDocTags(target)
+        types.push({
+          name,
+          family,
+          exportPath: './beta',
+          deprecated: Object.hasOwn(tags, 'deprecated'),
+          description: jsDoc(checker, target) || null,
+        })
+      }
+    }
+  }
+  components.sort((a, b) => a.name.localeCompare(b.name))
+  exports.sort(
+    (a, b) => a.name.localeCompare(b.name) || a.family.localeCompare(b.family)
+  )
+  types.sort(
+    (a, b) => a.name.localeCompare(b.name) || a.family.localeCompare(b.family)
+  )
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    package: packageInfo(packageDir),
+    source: sourceInfo('src/beta/index.ts'),
+    exports,
+    components,
+    types,
+  }
+}
+
+function toPascalCase(value) {
+  return value.replace(/(^|[-_])(.)/g, (_, __, character) =>
+    character.toUpperCase()
+  )
+}
+
+export function generateIconsManifest() {
+  const packageDir = join(rootDir, 'packages/bezier-icons')
+  const iconsDir = join(packageDir, 'icons')
+  const icons = readdirSync(iconsDir)
+    .filter((name) => name.endsWith('.svg'))
+    .sort((a, b) => a.localeCompare(b))
+    .map((fileName) => {
+      const source = readFileSync(join(iconsDir, fileName), 'utf8')
+      const name = fileName.slice(0, -4)
+      const viewBox = source.match(/viewBox=["']([^"']+)["']/)?.[1] ?? null
+      const width =
+        source.match(/<svg[^>]*\bwidth=["']([^"']+)["']/)?.[1] ?? null
+      const height =
+        source.match(/<svg[^>]*\bheight=["']([^"']+)["']/)?.[1] ?? null
+      return {
+        name,
+        componentName: `${toPascalCase(name)}Icon`,
+        aliases: [],
+        geometry: { viewBox, width, height },
+      }
+    })
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    package: packageInfo(packageDir),
+    source: sourceInfo('icons/*.svg'),
+    icons,
+  }
+}
+
+function walkFiles(directory) {
+  return readdirSync(directory)
+    .flatMap((name) => {
+      const path = join(directory, name)
+      return statSync(path).isDirectory() ? walkFiles(path) : [path]
+    })
+    .sort((a, b) => a.localeCompare(b))
+}
+
+function flattenTokens(node, path = [], output = []) {
+  for (const [name, value] of Object.entries(node)) {
+    const tokenPath = [...path, name]
+    if (value && typeof value === 'object' && Object.hasOwn(value, 'value')) {
+      output.push({
+        name: tokenPath.join('.'),
+        category: tokenPath[0],
+        valueType: value.type ?? typeof value.value,
+        deprecated: Boolean(value.deprecated),
+      })
+    } else if (value && typeof value === 'object') {
+      flattenTokens(value, tokenPath, output)
+    }
+  }
+  return output
+}
+
+export function generateTokensManifest() {
+  const packageDir = join(rootDir, 'packages/bezier-tokens')
+  const sourceDir = join(packageDir, 'src')
+  const tokens = walkFiles(sourceDir)
+    .filter((path) => path.endsWith('.json'))
+    .flatMap((path) =>
+      flattenTokens(readJson(path)).map((token) => ({
+        ...token,
+        source: relative(packageDir, path),
+      }))
+    )
+    .sort(
+      (a, b) => a.name.localeCompare(b.name) || a.source.localeCompare(b.source)
+    )
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    package: packageInfo(packageDir),
+    source: sourceInfo('src/**/*.json'),
+    tokens,
+  }
+}
+
+const generators = {
+  react: [generateReactManifest, 'packages/bezier-react/dist/manifest.json'],
+  icons: [generateIconsManifest, 'packages/bezier-icons/dist/manifest.json'],
+  tokens: [generateTokensManifest, 'packages/bezier-tokens/dist/manifest.json'],
+}
+
+export function run({
+  packages = Object.keys(generators),
+  check = false,
+} = {}) {
+  for (const packageName of packages) {
+    const entry = generators[packageName]
+    if (!entry) throw new Error(`Unknown manifest package: ${packageName}`)
+    const [generate, output] = entry
+    writeOrCheck(join(rootDir, output), generate(), check)
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const packageIndex = process.argv.indexOf('--package')
+  const packages =
+    packageIndex === -1 ? undefined : [process.argv[packageIndex + 1]]
+  try {
+    run({ packages, check: process.argv.includes('--check') })
+  } catch (error) {
+    console.error(error.message)
+    process.exitCode = 1
+  }
+}

--- a/scripts/manifests/generate.test.mjs
+++ b/scripts/manifests/generate.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { validateFamilyMetadata } from './generate.mjs'
+
+const valid = {
+  model: 'compound',
+  root: 'Tabs',
+  parts: {
+    TabList: { requiresAncestor: ['Tabs'] },
+    TabItem: { requiresAncestor: ['Tabs', 'TabList'] },
+  },
+  independent: {},
+}
+
+test('rejects a newly exported public component without classification', () => {
+  assert.throws(
+    () => validateFamilyMetadata('Tabs', ['Tabs', 'TabList', 'TabItem', 'TabBadge'], valid),
+    /unclassified public member.*TabBadge/
+  )
+})
+
+test('rejects stale metadata after a component rename or deletion', () => {
+  assert.throws(
+    () => validateFamilyMetadata('Tabs', ['Tabs', 'TabList'], valid),
+    /stale\/unknown member.*TabItem/
+  )
+})
+
+test('rejects unknown ancestors', () => {
+  assert.throws(
+    () =>
+      validateFamilyMetadata('Tabs', ['Tabs', 'TabList'], {
+        ...valid,
+        parts: { TabList: { requiresAncestor: ['Missing'] } },
+      }),
+    /unknown ancestor Missing/
+  )
+})
+
+test('rejects ancestor cycles', () => {
+  assert.throws(
+    () =>
+      validateFamilyMetadata('Tabs', ['Tabs', 'TabList', 'TabItem'], {
+        ...valid,
+        parts: {
+          TabList: { requiresAncestor: ['TabItem'] },
+          TabItem: { requiresAncestor: ['TabList'] },
+        },
+      }),
+    /ancestor cycle/
+  )
+})
+
+test('keeps multi-export independent members explicit', () => {
+  const metadata = validateFamilyMetadata('Toast', ['Toast', 'ToastProvider'], {
+    model: 'independent',
+    root: 'Toast',
+    parts: {},
+    independent: { ToastProvider: {} },
+  })
+  assert.equal(metadata.model, 'independent')
+  assert.deepEqual(Object.keys(metadata.independent), ['ToastProvider'])
+})
+
+test('keeps a storyless single component semantic model unknown', () => {
+  assert.equal(
+    validateFamilyMetadata('BaseButton', ['BaseButton'], null, false).model,
+    'unknown'
+  )
+})

--- a/scripts/manifests/schemas/icons.schema.json
+++ b/scripts/manifests/schemas/icons.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bezier.channel.io/schemas/icons-manifest-1.json",
+  "title": "Bezier Icons manifest",
+  "type": "object",
+  "required": ["schemaVersion", "package", "source", "icons"],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "package": { "type": "object" },
+    "source": { "type": "object" },
+    "icons": { "type": "array", "items": { "type": "object" } }
+  },
+  "additionalProperties": false
+}

--- a/scripts/manifests/schemas/react.schema.json
+++ b/scripts/manifests/schemas/react.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bezier.channel.io/schemas/react-manifest-1.json",
+  "title": "Bezier React manifest",
+  "type": "object",
+  "required": ["schemaVersion", "package", "source", "exports", "components", "types"],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "package": { "$ref": "#/$defs/package" },
+    "source": { "$ref": "#/$defs/source" },
+    "exports": { "type": "array", "items": { "type": "object" } },
+    "components": { "type": "array", "items": { "type": "object" } },
+    "types": { "type": "array", "items": { "type": "object" } }
+  },
+  "$defs": {
+    "package": {
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "source": {
+      "type": "object",
+      "required": ["repository", "commit", "entrypoint"],
+      "properties": {
+        "repository": { "type": "string" },
+        "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "entrypoint": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/manifests/schemas/tokens.schema.json
+++ b/scripts/manifests/schemas/tokens.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bezier.channel.io/schemas/tokens-manifest-1.json",
+  "title": "Bezier Tokens manifest",
+  "type": "object",
+  "required": ["schemaVersion", "package", "source", "tokens"],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "package": { "type": "object" },
+    "source": { "type": "object" },
+    "tokens": { "type": "array", "items": { "type": "object" } }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and followed the **Conventional Commits** specification.
- [x] A **changeset is intentionally omitted** because CP1 establishes the manifest contract without publishing packages. Release intent will be added with `@channel.io/bezier-toolkit` in CP2.
- [x] Documentation changes are not required for this internal package contract.
- [x] I added tests for manifest completeness and invalid metadata counterexamples.
- [x] Browser testing is not applicable because this change does not alter component runtime behavior or rendered UI.

## Related Issue

- WEB-12724

## Summary

- Generate deterministic manifests for `@channel.io/bezier-react`, `@channel.io/bezier-icons`, and `@channel.io/bezier-tokens` from their source/build inputs.
- Add typed Storybook metadata for compound and independent component relationships.
- Validate manifest completeness in CI and expose each generated manifest through `./manifest.json`.

## Details

- Uses the TypeScript compiler API to derive React public exports, components, authored props, JSDoc, deprecations, and literal values.
- Derives icon metadata from SVG inputs and token metadata from Style Dictionary JSON inputs.
- Requires exhaustive metadata for multi-component families and rejects missing/stale members, unknown ancestors, and cycles.
- Keeps semantics unknown for storyless single-component families instead of inferring relationships.
- Includes no Pilot beta.7 fixture, migration golden, runtime fallback, or package changeset.

### Verification

- Full repository build, typecheck, lint, and tests
- Storybook production build
- Manifest counterexamples: 6/6
- Deterministic repeated generation
- React manifest: 259 exports, 89 components, 796 authored props
- Icons manifest: 598 icons
- Tokens manifest: 786 tokens
- Clean tarball manifest export/read smoke for all three packages

### Breaking change? (Yes/No)

No.

## References

- CP1 of WEB-12724. Toolkit implementation and release versioning are intentionally deferred to CP2.
