### PR TITLE
feat: add repo-local Bezier Toolkit

### DIFF
--- a/.changeset/web-12724-bezier-toolkit.md
+++ b/.changeset/web-12724-bezier-toolkit.md
@@ -1,0 +1,8 @@
+---
+'@channel.io/bezier-toolkit': minor
+'@channel.io/bezier-react': minor
+'@channel.io/bezier-icons': minor
+'@channel.io/bezier-tokens': minor
+---
+
+Add the repo-local Bezier Toolkit and publish source-derived React, icon, and token manifests for installed-package lookup and diagnostics.

--- a/packages/bezier-toolkit/.eslintrc.cjs
+++ b/packages/bezier-toolkit/.eslintrc.cjs
@@ -1,0 +1,12 @@
+/**
+ * @type {import('eslint').Linter.Config}
+ */
+module.exports = {
+  root: true,
+  extends: ['bezier'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.eslint.json',
+  },
+  ignorePatterns: ['coverage'],
+}

--- a/packages/bezier-toolkit/README.md
+++ b/packages/bezier-toolkit/README.md
@@ -1,0 +1,19 @@
+# `@channel.io/bezier-toolkit`
+
+Repo-local CLI and library for reading Bezier manifests from packages installed in a consumer repository.
+
+```sh
+yarn bezier lookup Tabs
+yarn bezier doctor
+yarn bezier version
+```
+
+Every command emits deterministic JSON. `lookup` reads
+`@channel.io/bezier-react/manifest.json`,
+`@channel.io/bezier-icons/manifest.json`, and
+`@channel.io/bezier-tokens/manifest.json` through Node package resolution rooted at
+the consumer working directory.
+
+The Toolkit does not read a Bezier source checkout, a bundled catalog, Pilot
+fixtures, or a global Homebrew installation. Missing packages and unsupported
+manifest schema majors are reported explicitly by `doctor`.

--- a/packages/bezier-toolkit/README.md
+++ b/packages/bezier-toolkit/README.md
@@ -2,11 +2,14 @@
 
 Repo-local CLI and library for reading Bezier manifests from packages installed in a consumer repository.
 
-Install the Toolkit with the React, icon, and token packages whose manifests it
-will inspect. Pin the resolved versions in the consumer lockfile.
+Install the Toolkit with `@channel.io/bezier-react` and
+`@channel.io/bezier-icons`, whose manifests it will inspect. Pin the resolved
+versions in the consumer lockfile. You do not need to install
+`@channel.io/bezier-tokens` separately: the Toolkit reads the token package that
+the installed `@channel.io/bezier-react` depends on.
 
 ```sh
-yarn add --exact @channel.io/bezier-react@next @channel.io/bezier-icons@next @channel.io/bezier-tokens@next
+yarn add --exact @channel.io/bezier-react@next @channel.io/bezier-icons@next
 yarn add --dev --exact @channel.io/bezier-toolkit@next
 ```
 
@@ -16,11 +19,19 @@ yarn bezier doctor
 yarn bezier version
 ```
 
-Every command emits deterministic JSON. `lookup` reads
-`@channel.io/bezier-react/manifest.json`,
-`@channel.io/bezier-icons/manifest.json`, and
-`@channel.io/bezier-tokens/manifest.json` through Node package resolution rooted at
-the consumer working directory.
+Every command emits deterministic JSON. The Toolkit resolves
+`@channel.io/bezier-react/manifest.json` and
+`@channel.io/bezier-icons/manifest.json` from the consumer working directory.
+It then resolves `@channel.io/bezier-tokens/manifest.json` through that resolved
+`@channel.io/bezier-react` package, so the catalog uses the same token package as
+React even when the dependency is nested or provided by Yarn Plug'n'Play.
+
+The three validated manifests are merged into one in-memory catalog. Its cache
+key includes package versions, source commits, schema versions, and resolved
+manifest paths. `lookup` searches names, aliases, deprecations, replacements,
+and component semantics; `doctor` reports environment, lockfile, manifest,
+provenance, and compatibility diagnostics; `version` prints the resolved
+Toolkit and Bezier package tuple.
 
 The Toolkit does not read a Bezier source checkout, a bundled catalog, Pilot
 fixtures, or a global Homebrew installation. Missing packages and unsupported

--- a/packages/bezier-toolkit/README.md
+++ b/packages/bezier-toolkit/README.md
@@ -2,6 +2,14 @@
 
 Repo-local CLI and library for reading Bezier manifests from packages installed in a consumer repository.
 
+Install the Toolkit with the React, icon, and token packages whose manifests it
+will inspect. Pin the resolved versions in the consumer lockfile.
+
+```sh
+yarn add --exact @channel.io/bezier-react@next @channel.io/bezier-icons@next @channel.io/bezier-tokens@next
+yarn add --dev --exact @channel.io/bezier-toolkit@next
+```
+
 ```sh
 yarn bezier lookup Tabs
 yarn bezier doctor

--- a/packages/bezier-toolkit/jest.config.cjs
+++ b/packages/bezier-toolkit/jest.config.cjs
@@ -1,0 +1,12 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  cacheDirectory: '.jestcache',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[t|j]sx?$': ['@swc/jest'],
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  testMatch: ['**/*.test.ts'],
+}

--- a/packages/bezier-toolkit/package.json
+++ b/packages/bezier-toolkit/package.json
@@ -39,8 +39,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@channel.io/bezier-icons": "^0.57.0 || ^0.58.0-next.0",
-    "@channel.io/bezier-react": "^4.0.0-next.17",
-    "@channel.io/bezier-tokens": "^1.0.0-next.5"
+    "@channel.io/bezier-react": "^4.0.0-next.17"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/packages/bezier-toolkit/package.json
+++ b/packages/bezier-toolkit/package.json
@@ -37,6 +37,11 @@
   },
   "author": "Channel Corp.",
   "license": "Apache-2.0",
+  "peerDependencies": {
+    "@channel.io/bezier-icons": "^0.57.0 || ^0.58.0-next.0",
+    "@channel.io/bezier-react": "^4.0.0-next.17",
+    "@channel.io/bezier-tokens": "^1.0.0-next.5"
+  },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "eslint-config-bezier": "workspace:*",

--- a/packages/bezier-toolkit/package.json
+++ b/packages/bezier-toolkit/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@channel.io/bezier-toolkit",
+  "version": "0.0.0",
+  "description": "Installed-package lookup and diagnostics for Bezier manifests.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/channel-io/bezier-react",
+    "directory": "packages/bezier-toolkit"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "bin": {
+    "bezier": "./dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc --build --verbose",
+    "dev": "tsc --watch",
+    "lint": "TIMING=1 eslint --cache .",
+    "typecheck": "tsc --noEmit",
+    "test": "jest --coverage",
+    "clean": "rm -rf dist node_modules .turbo .eslintcache .jestcache coverage tsconfig.tsbuildinfo"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "author": "Channel Corp.",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "eslint-config-bezier": "workspace:*",
+    "tsconfig": "workspace:*"
+  },
+  "keywords": [
+    "bezier",
+    "design-system",
+    "manifest"
+  ]
+}

--- a/packages/bezier-toolkit/src/catalog.test.ts
+++ b/packages/bezier-toolkit/src/catalog.test.ts
@@ -1,0 +1,82 @@
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { clearCatalogCache, loadInstalledCatalog } from './catalog.js'
+import { lookup } from './lookup.js'
+import { defaultManifests, fixtureConsumer } from './test-utils.js'
+
+describe('installed manifest catalog', () => {
+  beforeEach(() => clearCatalogCache())
+
+  it('looks up current-contract component, icon alias, replacement, and unknown results', () => {
+    const loaded = loadInstalledCatalog(fixtureConsumer())
+    expect(loaded.ok).toBe(true)
+    if (!loaded.ok) return
+
+    const component = lookup(loaded.catalog, 'Tabs')
+    expect(component).toMatchObject({
+      found: true,
+      exact: true,
+      matches: [
+        {
+          kind: 'component',
+          name: 'Tabs',
+          data: { semantics: { model: 'compound', root: 'Tabs' } },
+        },
+      ],
+    })
+    expect(lookup(loaded.catalog, 'MagicIcon')).toMatchObject({
+      found: true,
+      matches: [{ kind: 'icon', name: 'AiIcon', matchedBy: 'alias' }],
+    })
+    expect(lookup(loaded.catalog, 'color.old')).toMatchObject({
+      found: true,
+      matches: [{ kind: 'token', deprecated: true, replacement: 'color.new' }],
+    })
+    expect(lookup(loaded.catalog, 'DefinitelyUnknown')).toEqual({
+      found: false,
+      query: 'DefinitelyUnknown',
+      reason: 'unknown',
+      matches: [],
+    })
+    expect(lookup(loaded.catalog, '   ')).toEqual({
+      found: false,
+      query: '   ',
+      reason: 'unknown',
+      matches: [],
+    })
+    expect(lookup(loaded.catalog, 'color')).toMatchObject({
+      found: true,
+      exact: false,
+      matches: [{ matchedBy: 'substring' }, { matchedBy: 'substring' }],
+    })
+  })
+
+  it('reuses only the same installed package tuple and manifest paths', () => {
+    const cwd = fixtureConsumer()
+    const first = loadInstalledCatalog(cwd)
+    const second = loadInstalledCatalog(cwd)
+    expect(first.ok && first.cacheHit).toBe(false)
+    expect(second.ok && second.cacheHit).toBe(true)
+    if (!first.ok || !second.ok) return
+
+    const changed = defaultManifests()
+    const icons = changed['@channel.io/bezier-icons']
+    icons.package.version = '0.59.0-next.0'
+    writeFileSync(
+      join(
+        cwd,
+        'node_modules',
+        '@channel.io',
+        'bezier-icons',
+        'dist',
+        'manifest.json'
+      ),
+      `${JSON.stringify(icons, null, 2)}\n`
+    )
+    const third = loadInstalledCatalog(cwd)
+    expect(third.ok && third.cacheHit).toBe(false)
+    if (!third.ok) return
+    expect(third.catalog.packageTuple).not.toBe(first.catalog.packageTuple)
+  })
+})

--- a/packages/bezier-toolkit/src/catalog.ts
+++ b/packages/bezier-toolkit/src/catalog.ts
@@ -1,0 +1,127 @@
+import { readAllInstalledManifests } from './manifests.js'
+import {
+  type BezierCatalog,
+  type BezierManifest,
+  type CatalogEntity,
+  type CatalogEntityKind,
+  type CatalogLoadResult,
+  type InstalledManifest,
+  type ManifestCollection,
+} from './types.js'
+
+const catalogCache = new Map<string, BezierCatalog>()
+
+function stringValue(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string')
+    : []
+}
+
+function replacementFor(entity: Record<string, unknown>): string | null {
+  const direct = stringValue(entity.replacement)
+  if (direct) return direct
+  if (
+    typeof entity.deprecated === 'object' &&
+    entity.deprecated !== null &&
+    !Array.isArray(entity.deprecated)
+  ) {
+    return stringValue(
+      (entity.deprecated as Record<string, unknown>).replacement
+    )
+  }
+  return null
+}
+
+function isDeprecated(entity: Record<string, unknown>): boolean {
+  return entity.deprecated === true || replacementFor(entity) !== null
+}
+
+function collectionFor(
+  manifest: BezierManifest,
+  collection: ManifestCollection
+): Record<string, unknown>[] {
+  return manifest[collection] ?? []
+}
+
+function catalogEntity(
+  kind: CatalogEntityKind,
+  packageName: string,
+  entity: Record<string, unknown>
+): CatalogEntity | null {
+  const rawName = stringValue(entity.name)
+  if (!rawName) return null
+  const componentName = stringValue(entity.componentName)
+  return {
+    kind,
+    name: componentName ?? rawName,
+    canonicalName: rawName,
+    packageName,
+    aliases: stringArray(entity.aliases),
+    deprecated: isDeprecated(entity),
+    replacement: replacementFor(entity),
+    data: entity,
+  }
+}
+
+function tupleFor(manifests: InstalledManifest[]): string {
+  return manifests
+    .map(
+      ({ manifest }) =>
+        `${manifest.package.name}@${manifest.package.version}` +
+        `#${manifest.source.commit}:schema-${manifest.schemaVersion}`
+    )
+    .join('|')
+}
+
+function cacheKeyFor(manifests: InstalledManifest[], tuple: string): string {
+  return `${tuple}|paths:${manifests.map(({ path }) => path).join('|')}`
+}
+
+export function clearCatalogCache() {
+  catalogCache.clear()
+}
+
+export function loadInstalledCatalog(cwd = process.cwd()): CatalogLoadResult {
+  const resolutions = readAllInstalledManifests(cwd)
+  const issues = resolutions.flatMap(({ result }) =>
+    result.ok ? [] : [result.issue]
+  )
+  if (issues.length > 0) return { ok: false, issues }
+
+  const manifests = resolutions.flatMap(({ result }) =>
+    result.ok ? [result.value] : []
+  )
+  const packageTuple = tupleFor(manifests)
+  const cacheKey = cacheKeyFor(manifests, packageTuple)
+  const cached = catalogCache.get(cacheKey)
+  if (cached) return { ok: true, catalog: cached, cacheHit: true }
+
+  const packages = manifests.map(({ kind, manifest, path }) => ({
+    kind,
+    name: manifest.package.name,
+    version: manifest.package.version,
+    schemaVersion: manifest.schemaVersion,
+    source: manifest.source,
+    manifestPath: path,
+  }))
+  const entities = resolutions.flatMap(({ spec, result }) => {
+    if (!result.ok) return []
+    return collectionFor(result.value.manifest, spec.collection).flatMap(
+      (entity) => {
+        const normalized = catalogEntity(
+          spec.kind,
+          result.value.manifest.package.name,
+          entity
+        )
+        return normalized ? [normalized] : []
+      }
+    )
+  })
+  const catalog = { cacheKey, packageTuple, packages, entities }
+  catalogCache.set(cacheKey, catalog)
+  return { ok: true, catalog, cacheHit: false }
+}

--- a/packages/bezier-toolkit/src/cli-core.ts
+++ b/packages/bezier-toolkit/src/cli-core.ts
@@ -1,0 +1,112 @@
+import { resolve } from 'node:path'
+
+import { loadInstalledCatalog } from './catalog.js'
+import { inspectInstallation } from './doctor.js'
+import { lookup } from './lookup.js'
+
+const HELP = `Usage: bezier <command> [options]
+
+Commands:
+  lookup <query>  Search installed component, icon, and token manifests
+  doctor          Diagnose package, schema, Node, and lockfile compatibility
+  version         Print Toolkit and installed Bezier package versions
+
+Options:
+  --cwd <path>    Resolve packages from this consumer directory
+  --help          Show this help
+`
+
+export interface CliIo {
+  cwd: string
+  stdout: (value: string) => void
+  stderr: (value: string) => void
+}
+
+function defaultIo(): CliIo {
+  return {
+    cwd: process.cwd(),
+    stdout: (value) => process.stdout.write(value),
+    stderr: (value) => process.stderr.write(value),
+  }
+}
+
+function json(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`
+}
+
+function parsedArguments(args: string[], defaultCwd: string) {
+  const cwdIndex = args.indexOf('--cwd')
+  if (cwdIndex === -1) return { cwd: resolve(defaultCwd), args }
+  const cwd = args[cwdIndex + 1]
+  if (!cwd) return { cwd: null, args }
+  return {
+    cwd: resolve(defaultCwd, cwd),
+    args: args.filter(
+      (_, index) => index !== cwdIndex && index !== cwdIndex + 1
+    ),
+  }
+}
+
+export function runCli(rawArgs: string[], io: CliIo = defaultIo()): number {
+  const parsed = parsedArguments(rawArgs, io.cwd)
+  if (!parsed.cwd) {
+    io.stderr(json({ error: 'missing_cwd', message: '--cwd requires a path.' }))
+    return 1
+  }
+  const [command, ...args] = parsed.args
+  if (!command || command === '--help' || command === 'help') {
+    io.stdout(HELP)
+    return 0
+  }
+
+  if (command === 'doctor') {
+    const report = inspectInstallation({ cwd: parsed.cwd })
+    io.stdout(json(report))
+    return report.ok ? 0 : 1
+  }
+
+  if (command === 'version') {
+    const report = inspectInstallation({ cwd: parsed.cwd })
+    io.stdout(
+      json({
+        toolkit: report.toolkit,
+        packageTuple: report.packageTuple,
+        packages: report.manifests.map((manifest) => ({
+          packageName: manifest.packageName,
+          status: manifest.status,
+          version: 'version' in manifest ? manifest.version : null,
+          schemaVersion:
+            'schemaVersion' in manifest ? manifest.schemaVersion : null,
+        })),
+      })
+    )
+    return report.packageTuple ? 0 : 1
+  }
+
+  if (command === 'lookup') {
+    const query = args.join(' ').trim()
+    if (!query) {
+      io.stderr(
+        json({ error: 'missing_query', message: 'lookup requires a query.' })
+      )
+      return 1
+    }
+    const loaded = loadInstalledCatalog(parsed.cwd)
+    if (!loaded.ok) {
+      io.stderr(json({ error: 'catalog_unavailable', issues: loaded.issues }))
+      return 1
+    }
+    const result = lookup(loaded.catalog, query)
+    io.stdout(
+      json({
+        ...result,
+        packageTuple: loaded.catalog.packageTuple,
+        cacheKey: loaded.catalog.cacheKey,
+      })
+    )
+    return result.found ? 0 : 2
+  }
+
+  io.stderr(json({ error: 'unknown_command', command }))
+  return 1
+}

--- a/packages/bezier-toolkit/src/cli.ts
+++ b/packages/bezier-toolkit/src/cli.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { basename } from 'node:path'
+
+import { type CliIo, runCli } from './cli-core.js'
+
+export { runCli, type CliIo } from './cli-core.js'
+
+export function main(rawArgs = process.argv.slice(2), io?: CliIo): number {
+  return runCli(rawArgs, io)
+}
+
+export function isCliEntrypoint(path: string | undefined): boolean {
+  const filename = basename(path ?? '')
+  return filename === 'bezier' || filename === 'cli.js'
+}
+
+if (isCliEntrypoint(process.argv[1])) {
+  process.exitCode = main()
+}

--- a/packages/bezier-toolkit/src/doctor.test.ts
+++ b/packages/bezier-toolkit/src/doctor.test.ts
@@ -1,0 +1,154 @@
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { type CliIo, isCliEntrypoint, main, runCli } from './cli.js'
+import { inspectInstallation } from './doctor.js'
+import { fixtureConsumer } from './test-utils.js'
+
+describe('doctor and CLI contracts', () => {
+  it('accepts Node capabilities without requiring the repository exact Node', () => {
+    const report = inspectInstallation({
+      cwd: fixtureConsumer(),
+      nodeVersion: '20.10.0',
+    })
+    expect(report).toMatchObject({
+      ok: true,
+      node: { supported: true, requirement: '>=18' },
+      lockfile: { packageManager: 'yarn' },
+      toolkit: { version: '0.1.0-next.0', resolution: 'repo-local' },
+    })
+    expect(report.packageTuple).toContain('@channel.io/bezier-react@')
+  })
+
+  it('fails doctor when the consumer lockfile is absent', () => {
+    const cwd = fixtureConsumer()
+    rmSync(join(cwd, 'yarn.lock'))
+    expect(inspectInstallation({ cwd })).toMatchObject({
+      ok: false,
+      lockfile: null,
+    })
+  })
+
+  it('fails doctor when Node does not provide the minimum capability', () => {
+    expect(
+      inspectInstallation({ cwd: fixtureConsumer(), nodeVersion: '16.20.0' })
+    ).toMatchObject({ ok: false, node: { supported: false } })
+  })
+
+  it('runs lookup from the explicit consumer cwd', () => {
+    const output: string[] = []
+    const errors: string[] = []
+    const io: CliIo = {
+      cwd: fixtureConsumer(),
+      stdout: (value) => output.push(value),
+      stderr: (value) => errors.push(value),
+    }
+    expect(runCli(['lookup', 'Tabs'], io)).toBe(0)
+    expect(JSON.parse(output.join(''))).toMatchObject({
+      found: true,
+      matches: [{ kind: 'component', name: 'Tabs' }],
+    })
+    expect(errors).toEqual([])
+  })
+
+  it.each([
+    ['doctor', 0, { ok: true }],
+    ['version', 0, { toolkit: { version: '0.1.0-next.0' } }],
+  ])('runs the %s command', (command, expectedCode, expectedOutput) => {
+    const output: string[] = []
+    const io: CliIo = {
+      cwd: fixtureConsumer(),
+      stdout: (value) => output.push(value),
+      stderr: () => undefined,
+    }
+    expect(runCli([command], io)).toBe(expectedCode)
+    expect(JSON.parse(output.join(''))).toMatchObject(expectedOutput)
+  })
+
+  it('returns an unknown lookup result with a distinct exit code', () => {
+    const output: string[] = []
+    const io: CliIo = {
+      cwd: fixtureConsumer(),
+      stdout: (value) => output.push(value),
+      stderr: () => undefined,
+    }
+    expect(runCli(['lookup', 'DoesNotExist'], io)).toBe(2)
+    expect(JSON.parse(output.join(''))).toMatchObject({
+      found: false,
+      reason: 'unknown',
+    })
+  })
+
+  it('reports unavailable catalogs without falling back', () => {
+    const cwd = fixtureConsumer()
+    rmSync(
+      join(
+        cwd,
+        'node_modules',
+        '@channel.io',
+        'bezier-icons',
+        'dist',
+        'manifest.json'
+      )
+    )
+    const errors: string[] = []
+    const io: CliIo = {
+      cwd,
+      stdout: () => undefined,
+      stderr: (value) => errors.push(value),
+    }
+    expect(runCli(['lookup', 'Tabs'], io)).toBe(1)
+    expect(JSON.parse(errors.join(''))).toMatchObject({
+      error: 'catalog_unavailable',
+      issues: [{ code: 'missing_manifest' }],
+    })
+  })
+
+  it.each([
+    [[], 0, 'Usage: bezier'],
+    [['--help'], 0, 'Usage: bezier'],
+  ])('prints help for %p', (args, expectedCode, expectedOutput) => {
+    const output: string[] = []
+    const io: CliIo = {
+      cwd: fixtureConsumer(),
+      stdout: (value) => output.push(value),
+      stderr: () => undefined,
+    }
+    expect(runCli(args, io)).toBe(expectedCode)
+    expect(output.join('')).toContain(expectedOutput)
+  })
+
+  it('exposes the CLI entrypoint for embedded runners', () => {
+    const output: string[] = []
+    expect(
+      main(['--help'], {
+        cwd: fixtureConsumer(),
+        stdout: (value) => output.push(value),
+        stderr: () => undefined,
+      })
+    ).toBe(0)
+    expect(output.join('')).toContain('Usage: bezier')
+  })
+
+  it('recognizes direct file and package-manager bin entrypoints', () => {
+    expect(isCliEntrypoint('/package/dist/cli.js')).toBe(true)
+    expect(isCliEntrypoint('/consumer/node_modules/.bin/bezier')).toBe(true)
+    expect(isCliEntrypoint('/node_modules/jest/bin/jest.js')).toBe(false)
+    expect(isCliEntrypoint(undefined)).toBe(false)
+  })
+
+  it.each([
+    [['lookup'], 'missing_query'],
+    [['unknown'], 'unknown_command'],
+    [['doctor', '--cwd'], 'missing_cwd'],
+  ])('reports invalid CLI input %p', (args, expectedError) => {
+    const errors: string[] = []
+    const io: CliIo = {
+      cwd: fixtureConsumer(),
+      stdout: () => undefined,
+      stderr: (value) => errors.push(value),
+    }
+    expect(runCli(args, io)).toBe(1)
+    expect(JSON.parse(errors.join(''))).toMatchObject({ error: expectedError })
+  })
+})

--- a/packages/bezier-toolkit/src/doctor.ts
+++ b/packages/bezier-toolkit/src/doctor.ts
@@ -1,0 +1,109 @@
+import { existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join, resolve } from 'node:path'
+
+import { loadInstalledCatalog } from './catalog.js'
+import { readAllInstalledManifests } from './manifests.js'
+
+const LOCKFILES = [
+  ['yarn', 'yarn.lock'],
+  ['pnpm', 'pnpm-lock.yaml'],
+  ['npm', 'package-lock.json'],
+  ['bun', 'bun.lock'],
+  ['bun', 'bun.lockb'],
+] as const
+
+function supportsNode(nodeVersion: string): boolean {
+  const major = Number(nodeVersion.split('.')[0])
+  return Number.isInteger(major) && major >= 18
+}
+
+function resolveToolkitPackageJson(cwd: string): string | null {
+  const consumerRequire = createRequire(join(resolve(cwd), 'package.json'))
+  try {
+    return consumerRequire.resolve('@channel.io/bezier-toolkit/package.json')
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error.code === 'MODULE_NOT_FOUND' ||
+        error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED')
+    ) {
+      return null
+    }
+    throw error
+  }
+}
+
+function toolkitVersion(cwd: string): { path: string | null; version: string } {
+  const packagePath = resolveToolkitPackageJson(cwd)
+  if (!packagePath) return { path: null, version: 'unknown' }
+  const consumerRequire = createRequire(join(resolve(cwd), 'package.json'))
+  const packageJson = consumerRequire(packagePath) as { version?: unknown }
+  return {
+    path: packagePath,
+    version:
+      typeof packageJson.version === 'string' ? packageJson.version : 'unknown',
+  }
+}
+
+function lockfile(cwd: string) {
+  for (const [packageManager, filename] of LOCKFILES) {
+    const path = join(resolve(cwd), filename)
+    if (existsSync(path)) return { packageManager, path }
+  }
+  return null
+}
+
+export interface DoctorOptions {
+  cwd?: string
+  nodeVersion?: string
+}
+
+export function inspectInstallation(options: DoctorOptions = {}) {
+  const cwd = resolve(options.cwd ?? process.cwd())
+  const nodeVersion = options.nodeVersion ?? process.versions.node
+  const node = {
+    version: nodeVersion,
+    supported: supportsNode(nodeVersion),
+    requirement: '>=18',
+  }
+  const installed = readAllInstalledManifests(cwd)
+  const manifests = installed.map(({ spec, result }) =>
+    result.ok
+      ? {
+          packageName: spec.name,
+          status: 'ready' as const,
+          path: result.value.path,
+          version: result.value.manifest.package.version,
+          schemaVersion: result.value.manifest.schemaVersion,
+          sourceCommit: result.value.manifest.source.commit,
+        }
+      : {
+          packageName: spec.name,
+          status: result.issue.code,
+          path: result.issue.path,
+          message: result.issue.message,
+        }
+  )
+  const catalog = loadInstalledCatalog(cwd)
+  const resolvedLockfile = lockfile(cwd)
+  const toolkit = toolkitVersion(cwd)
+  return {
+    ok:
+      node.supported &&
+      resolvedLockfile !== null &&
+      manifests.every(({ status }) => status === 'ready'),
+    cwd,
+    node,
+    toolkit: {
+      ...toolkit,
+      resolution: toolkit.path ? 'repo-local' : 'unresolved',
+    },
+    lockfile: resolvedLockfile,
+    manifests,
+    packageTuple: catalog.ok ? catalog.catalog.packageTuple : null,
+    cacheKey: catalog.ok ? catalog.catalog.cacheKey : null,
+  }
+}

--- a/packages/bezier-toolkit/src/index.ts
+++ b/packages/bezier-toolkit/src/index.ts
@@ -1,0 +1,16 @@
+export { clearCatalogCache, loadInstalledCatalog } from './catalog.js'
+export { inspectInstallation, type DoctorOptions } from './doctor.js'
+export { lookup } from './lookup.js'
+export {
+  readAllInstalledManifests,
+  readInstalledManifest,
+} from './manifests.js'
+export {
+  BEZIER_PACKAGES,
+  SUPPORTED_MANIFEST_SCHEMA_MAJOR,
+  type BezierCatalog,
+  type CatalogEntity,
+  type CatalogLoadResult,
+  type LookupResult,
+  type ManifestIssue,
+} from './types.js'

--- a/packages/bezier-toolkit/src/lookup.ts
+++ b/packages/bezier-toolkit/src/lookup.ts
@@ -1,0 +1,70 @@
+import type {
+  BezierCatalog,
+  CatalogEntity,
+  LookupMatch,
+  LookupResult,
+} from './types.js'
+
+function normalized(value: string): string {
+  return value.trim().toLocaleLowerCase('en-US')
+}
+
+function exactMatch(
+  entity: CatalogEntity,
+  query: string
+): LookupMatch['matchedBy'] | null {
+  if (normalized(entity.name) === query) return 'name'
+  if (normalized(entity.canonicalName) === query) return 'canonical'
+  if (entity.aliases.some((alias) => normalized(alias) === query))
+    return 'alias'
+  return null
+}
+
+function includesQuery(entity: CatalogEntity, query: string): boolean {
+  return [entity.name, entity.canonicalName, ...entity.aliases].some((value) =>
+    normalized(value).includes(query)
+  )
+}
+
+function sortMatches(a: LookupMatch, b: LookupMatch): number {
+  return (
+    a.kind.localeCompare(b.kind) ||
+    a.name.localeCompare(b.name) ||
+    a.packageName.localeCompare(b.packageName)
+  )
+}
+
+export function lookup(catalog: BezierCatalog, rawQuery: string): LookupResult {
+  const query = normalized(rawQuery)
+  if (!query) {
+    return { found: false, query: rawQuery, reason: 'unknown', matches: [] }
+  }
+  const exact = catalog.entities.flatMap((entity) => {
+    const matchedBy = exactMatch(entity, query)
+    return matchedBy ? [{ ...entity, matchedBy }] : []
+  })
+  if (exact.length > 0) {
+    return {
+      found: true,
+      query: rawQuery,
+      exact: true,
+      matches: exact.sort(sortMatches),
+    }
+  }
+
+  const partial = catalog.entities
+    .filter((entity) => includesQuery(entity, query))
+    .slice(0, 20)
+    .map((entity): LookupMatch => ({ ...entity, matchedBy: 'substring' }))
+    .sort(sortMatches)
+  if (partial.length > 0) {
+    return {
+      found: true,
+      query: rawQuery,
+      exact: false,
+      matches: partial,
+    }
+  }
+
+  return { found: false, query: rawQuery, reason: 'unknown', matches: [] }
+}

--- a/packages/bezier-toolkit/src/manifests.test.ts
+++ b/packages/bezier-toolkit/src/manifests.test.ts
@@ -1,0 +1,68 @@
+import { rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { loadInstalledCatalog } from './catalog.js'
+import { defaultManifests, fixtureConsumer } from './test-utils.js'
+
+describe('installed manifest resolution', () => {
+  it('reports a missing manifest without a source-checkout fallback', () => {
+    const cwd = fixtureConsumer()
+    rmSync(
+      join(
+        cwd,
+        'node_modules',
+        '@channel.io',
+        'bezier-icons',
+        'dist',
+        'manifest.json'
+      )
+    )
+    const result = loadInstalledCatalog(cwd)
+    expect(result).toMatchObject({
+      ok: false,
+      issues: [
+        { code: 'missing_manifest', packageName: '@channel.io/bezier-icons' },
+      ],
+    })
+  })
+
+  it('reports an unsupported schema major explicitly', () => {
+    const manifests = defaultManifests()
+    manifests['@channel.io/bezier-react'].schemaVersion = '2.0.0'
+    const cwd = fixtureConsumer(manifests)
+    const result = loadInstalledCatalog(cwd)
+    expect(result).toMatchObject({
+      ok: false,
+      issues: [
+        {
+          code: 'schema_mismatch',
+          packageName: '@channel.io/bezier-react',
+          actualSchemaVersion: '2.0.0',
+          supportedSchemaMajor: 1,
+        },
+      ],
+    })
+  })
+
+  it('reports invalid JSON separately from compatibility mismatches', () => {
+    const cwd = fixtureConsumer()
+    writeFileSync(
+      join(
+        cwd,
+        'node_modules',
+        '@channel.io',
+        'bezier-tokens',
+        'dist',
+        'manifest.json'
+      ),
+      '{invalid'
+    )
+    const result = loadInstalledCatalog(cwd)
+    expect(result).toMatchObject({
+      ok: false,
+      issues: [
+        { code: 'invalid_manifest', packageName: '@channel.io/bezier-tokens' },
+      ],
+    })
+  })
+})

--- a/packages/bezier-toolkit/src/manifests.test.ts
+++ b/packages/bezier-toolkit/src/manifests.test.ts
@@ -1,10 +1,46 @@
-import { rmSync, writeFileSync } from 'node:fs'
+import {
+  cpSync,
+  mkdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { join } from 'node:path'
 
 import { loadInstalledCatalog } from './catalog.js'
 import { defaultManifests, fixtureConsumer } from './test-utils.js'
 
 describe('installed manifest resolution', () => {
+  it('resolves tokens through the installed React dependency tree', () => {
+    const cwd = fixtureConsumer()
+    const rootTokenDirectory = join(
+      cwd,
+      'node_modules',
+      '@channel.io',
+      'bezier-tokens'
+    )
+    const nestedTokenDirectory = join(
+      cwd,
+      'node_modules',
+      '@channel.io',
+      'bezier-react',
+      'node_modules',
+      '@channel.io',
+      'bezier-tokens'
+    )
+    mkdirSync(join(nestedTokenDirectory, '..'), { recursive: true })
+    cpSync(rootTokenDirectory, nestedTokenDirectory, { recursive: true })
+
+    const result = loadInstalledCatalog(cwd)
+    expect(result).toMatchObject({ ok: true })
+    if (!result.ok) return
+    expect(
+      result.catalog.packages.find(
+        ({ name }) => name === '@channel.io/bezier-tokens'
+      )?.manifestPath
+    ).toBe(realpathSync(join(nestedTokenDirectory, 'dist', 'manifest.json')))
+  })
+
   it('reports a missing manifest without a source-checkout fallback', () => {
     const cwd = fixtureConsumer()
     rmSync(

--- a/packages/bezier-toolkit/src/manifests.ts
+++ b/packages/bezier-toolkit/src/manifests.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join, resolve } from 'node:path'
+
+import {
+  BEZIER_PACKAGES,
+  type BezierManifest,
+  type BezierPackageSpec,
+  type InstalledManifestResult,
+  SUPPORTED_MANIFEST_SCHEMA_MAJOR,
+} from './types.js'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isStringProperty(
+  value: Record<string, unknown>,
+  property: string
+): boolean {
+  return typeof value[property] === 'string'
+}
+
+function isModuleResolutionError(error: unknown): boolean {
+  if (!isRecord(error)) return false
+  return (
+    error.code === 'MODULE_NOT_FOUND' ||
+    error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+  )
+}
+
+function validateManifestShape(
+  value: unknown,
+  spec: BezierPackageSpec
+): value is BezierManifest {
+  if (!isRecord(value)) return false
+  if (!isStringProperty(value, 'schemaVersion')) return false
+  if (!isRecord(value.package)) return false
+  if (!isStringProperty(value.package, 'name')) return false
+  if (!isStringProperty(value.package, 'version')) return false
+  if (value.package.name !== spec.name) return false
+  if (!isRecord(value.source)) return false
+  if (!isStringProperty(value.source, 'repository')) return false
+  if (!isStringProperty(value.source, 'commit')) return false
+  if (!isStringProperty(value.source, 'entrypoint')) return false
+  return Array.isArray(value[spec.collection])
+}
+
+function schemaMajor(schemaVersion: string): number | null {
+  const match = /^(\d+)\./.exec(schemaVersion)
+  return match ? Number(match[1]) : null
+}
+
+export function readInstalledManifest(
+  spec: BezierPackageSpec,
+  cwd = process.cwd()
+): InstalledManifestResult {
+  const consumerRequire = createRequire(join(resolve(cwd), 'package.json'))
+  const manifestSpecifier = `${spec.name}/manifest.json`
+  let manifestPath: string
+
+  try {
+    manifestPath = consumerRequire.resolve(manifestSpecifier)
+  } catch (error) {
+    if (!isModuleResolutionError(error)) throw error
+    return {
+      ok: false,
+      issue: {
+        code: 'missing_manifest',
+        packageName: spec.name,
+        path: null,
+        message: `Cannot resolve ${manifestSpecifier} from ${resolve(cwd)}.`,
+      },
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, 'utf8'))
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error
+    return {
+      ok: false,
+      issue: {
+        code: 'invalid_manifest',
+        packageName: spec.name,
+        path: manifestPath,
+        message: `${manifestSpecifier} is not valid JSON.`,
+      },
+    }
+  }
+
+  if (!validateManifestShape(parsed, spec)) {
+    return {
+      ok: false,
+      issue: {
+        code: 'invalid_manifest',
+        packageName: spec.name,
+        path: manifestPath,
+        message: `${manifestSpecifier} does not match the required manifest shape.`,
+      },
+    }
+  }
+
+  const actualMajor = schemaMajor(parsed.schemaVersion)
+  if (actualMajor !== SUPPORTED_MANIFEST_SCHEMA_MAJOR) {
+    return {
+      ok: false,
+      issue: {
+        code: 'schema_mismatch',
+        packageName: spec.name,
+        path: manifestPath,
+        actualSchemaVersion: parsed.schemaVersion,
+        supportedSchemaMajor: SUPPORTED_MANIFEST_SCHEMA_MAJOR,
+        message: `${manifestSpecifier} uses schema ${parsed.schemaVersion}; supported major is ${SUPPORTED_MANIFEST_SCHEMA_MAJOR}.`,
+      },
+    }
+  }
+
+  return {
+    ok: true,
+    value: {
+      kind: spec.kind,
+      path: manifestPath,
+      manifest: parsed,
+    },
+  }
+}
+
+export function readAllInstalledManifests(cwd = process.cwd()) {
+  return BEZIER_PACKAGES.map((spec) => ({
+    spec,
+    result: readInstalledManifest(spec, cwd),
+  }))
+}

--- a/packages/bezier-toolkit/src/manifests.ts
+++ b/packages/bezier-toolkit/src/manifests.ts
@@ -57,10 +57,15 @@ export function readInstalledManifest(
 ): InstalledManifestResult {
   const consumerRequire = createRequire(join(resolve(cwd), 'package.json'))
   const manifestSpecifier = `${spec.name}/manifest.json`
+  let manifestRequire = consumerRequire
   let manifestPath: string
 
   try {
-    manifestPath = consumerRequire.resolve(manifestSpecifier)
+    if ('resolveFrom' in spec) {
+      const resolutionAnchor = consumerRequire.resolve(spec.resolveFrom)
+      manifestRequire = createRequire(resolutionAnchor)
+    }
+    manifestPath = manifestRequire.resolve(manifestSpecifier)
   } catch (error) {
     if (!isModuleResolutionError(error)) throw error
     return {
@@ -69,7 +74,10 @@ export function readInstalledManifest(
         code: 'missing_manifest',
         packageName: spec.name,
         path: null,
-        message: `Cannot resolve ${manifestSpecifier} from ${resolve(cwd)}.`,
+        message:
+          'resolveFrom' in spec
+            ? `Cannot resolve ${manifestSpecifier} through ${spec.resolveFrom} from ${resolve(cwd)}.`
+            : `Cannot resolve ${manifestSpecifier} from ${resolve(cwd)}.`,
       },
     }
   }

--- a/packages/bezier-toolkit/src/test-utils.ts
+++ b/packages/bezier-toolkit/src/test-utils.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { BEZIER_PACKAGES, type BezierManifest } from './types.js'
+
+const COMMIT = '1234567890abcdef1234567890abcdef12345678'
+
+export function defaultManifests(): Record<string, BezierManifest> {
+  return {
+    '@channel.io/bezier-react': {
+      schemaVersion: '1.0.0',
+      package: { name: '@channel.io/bezier-react', version: '4.0.0-next.18' },
+      source: {
+        repository: 'https://example.com/react',
+        commit: COMMIT,
+        entrypoint: 'src/beta/index.ts',
+      },
+      components: [
+        {
+          name: 'Tabs',
+          family: 'Tabs',
+          semantics: {
+            model: 'compound',
+            root: 'Tabs',
+            parts: { TabList: { requiresAncestor: ['Tabs'] } },
+            independent: {},
+          },
+        },
+      ],
+    },
+    '@channel.io/bezier-icons': {
+      schemaVersion: '1.0.0',
+      package: { name: '@channel.io/bezier-icons', version: '0.58.0-next.0' },
+      source: {
+        repository: 'https://example.com/icons',
+        commit: COMMIT,
+        entrypoint: 'icons/*.svg',
+      },
+      icons: [{ name: 'ai', componentName: 'AiIcon', aliases: ['MagicIcon'] }],
+    },
+    '@channel.io/bezier-tokens': {
+      schemaVersion: '1.0.0',
+      package: { name: '@channel.io/bezier-tokens', version: '1.1.0-next.0' },
+      source: {
+        repository: 'https://example.com/tokens',
+        commit: COMMIT,
+        entrypoint: 'src/**/*.json',
+      },
+      tokens: [
+        {
+          name: 'color.old',
+          category: 'color',
+          deprecated: true,
+          replacement: 'color.new',
+        },
+        { name: 'color.new', category: 'color', deprecated: false },
+      ],
+    },
+  }
+}
+
+export function fixtureConsumer(
+  manifests: Record<string, BezierManifest> = defaultManifests()
+): string {
+  const root = mkdtempSync(join(tmpdir(), 'bezier-toolkit-'))
+  writeFileSync(join(root, 'package.json'), '{"private":true}\n')
+  writeFileSync(join(root, 'yarn.lock'), '# fixture\n')
+  for (const spec of BEZIER_PACKAGES) {
+    const packageDir = join(root, 'node_modules', ...spec.name.split('/'))
+    mkdirSync(join(packageDir, 'dist'), { recursive: true })
+    writeFileSync(
+      join(packageDir, 'package.json'),
+      `${JSON.stringify({
+        name: spec.name,
+        version: manifests[spec.name]?.package.version ?? '0.0.0',
+        exports: { './manifest.json': './dist/manifest.json' },
+      })}\n`
+    )
+    const manifest = manifests[spec.name]
+    if (manifest) {
+      writeFileSync(
+        join(packageDir, 'dist', 'manifest.json'),
+        `${JSON.stringify(manifest, null, 2)}\n`
+      )
+    }
+  }
+  const toolkitDir = join(root, 'node_modules', '@channel.io', 'bezier-toolkit')
+  mkdirSync(toolkitDir, { recursive: true })
+  writeFileSync(
+    join(toolkitDir, 'package.json'),
+    `${JSON.stringify({
+      name: '@channel.io/bezier-toolkit',
+      version: '0.1.0-next.0',
+      exports: { './package.json': './package.json' },
+    })}\n`
+  )
+  return root
+}

--- a/packages/bezier-toolkit/src/types.ts
+++ b/packages/bezier-toolkit/src/types.ts
@@ -1,0 +1,116 @@
+export const SUPPORTED_MANIFEST_SCHEMA_MAJOR = 1
+
+export const BEZIER_PACKAGES = [
+  {
+    kind: 'component',
+    name: '@channel.io/bezier-react',
+    collection: 'components',
+  },
+  {
+    kind: 'icon',
+    name: '@channel.io/bezier-icons',
+    collection: 'icons',
+  },
+  {
+    kind: 'token',
+    name: '@channel.io/bezier-tokens',
+    collection: 'tokens',
+  },
+] as const
+
+export type BezierPackageSpec = (typeof BEZIER_PACKAGES)[number]
+export type CatalogEntityKind = BezierPackageSpec['kind']
+export type ManifestCollection = BezierPackageSpec['collection']
+
+export interface ManifestPackage {
+  name: string
+  version: string
+}
+
+export interface ManifestSource {
+  repository: string
+  commit: string
+  entrypoint: string
+}
+
+export interface BezierManifest {
+  schemaVersion: string
+  package: ManifestPackage
+  source: ManifestSource
+  components?: Record<string, unknown>[]
+  icons?: Record<string, unknown>[]
+  tokens?: Record<string, unknown>[]
+}
+
+export type ManifestIssueCode =
+  | 'invalid_manifest'
+  | 'missing_manifest'
+  | 'schema_mismatch'
+
+export interface ManifestIssue {
+  code: ManifestIssueCode
+  packageName: string
+  message: string
+  path: string | null
+  actualSchemaVersion?: string
+  supportedSchemaMajor?: number
+}
+
+export interface InstalledManifest {
+  kind: CatalogEntityKind
+  path: string
+  manifest: BezierManifest
+}
+
+export type InstalledManifestResult =
+  | { ok: true; value: InstalledManifest }
+  | { ok: false; issue: ManifestIssue }
+
+export interface CatalogPackage {
+  kind: CatalogEntityKind
+  name: string
+  version: string
+  schemaVersion: string
+  source: ManifestSource
+  manifestPath: string
+}
+
+export interface CatalogEntity {
+  kind: CatalogEntityKind
+  name: string
+  canonicalName: string
+  packageName: string
+  aliases: string[]
+  deprecated: boolean
+  replacement: string | null
+  data: Record<string, unknown>
+}
+
+export interface BezierCatalog {
+  cacheKey: string
+  packageTuple: string
+  packages: CatalogPackage[]
+  entities: CatalogEntity[]
+}
+
+export type CatalogLoadResult =
+  | { ok: true; catalog: BezierCatalog; cacheHit: boolean }
+  | { ok: false; issues: ManifestIssue[] }
+
+export interface LookupMatch extends CatalogEntity {
+  matchedBy: 'alias' | 'canonical' | 'name' | 'substring'
+}
+
+export type LookupResult =
+  | {
+      found: true
+      query: string
+      exact: boolean
+      matches: LookupMatch[]
+    }
+  | {
+      found: false
+      query: string
+      reason: 'unknown'
+      matches: []
+    }

--- a/packages/bezier-toolkit/src/types.ts
+++ b/packages/bezier-toolkit/src/types.ts
@@ -15,6 +15,7 @@ export const BEZIER_PACKAGES = [
     kind: 'token',
     name: '@channel.io/bezier-tokens',
     collection: 'tokens',
+    resolveFrom: '@channel.io/bezier-react/manifest.json',
   },
 ] as const
 

--- a/packages/bezier-toolkit/tsconfig.eslint.json
+++ b/packages/bezier-toolkit/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "*.cjs"],
+  "exclude": []
+}

--- a/packages/bezier-toolkit/tsconfig.json
+++ b/packages/bezier-toolkit/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "tsconfig/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "target": "ES2022"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/test-utils.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,6 +2396,10 @@ __metadata:
     "@types/node": "npm:^22.10.2"
     eslint-config-bezier: "workspace:*"
     tsconfig: "workspace:*"
+  peerDependencies:
+    "@channel.io/bezier-icons": ^0.57.0 || ^0.58.0-next.0
+    "@channel.io/bezier-react": ^4.0.0-next.17
+    "@channel.io/bezier-tokens": ^1.0.0-next.5
   bin:
     bezier: ./dist/cli.js
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,6 +2389,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@channel.io/bezier-toolkit@workspace:packages/bezier-toolkit":
+  version: 0.0.0-use.local
+  resolution: "@channel.io/bezier-toolkit@workspace:packages/bezier-toolkit"
+  dependencies:
+    "@types/node": "npm:^22.10.2"
+    eslint-config-bezier: "workspace:*"
+    tsconfig: "workspace:*"
+  bin:
+    bezier: ./dist/cli.js
+  languageName: unknown
+  linkType: soft
+
 "@channel.io/eslint-config@npm:^2.1.0":
   version: 2.1.0
   resolution: "@channel.io/eslint-config@npm:2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2399,7 +2399,6 @@ __metadata:
   peerDependencies:
     "@channel.io/bezier-icons": ^0.57.0 || ^0.58.0-next.0
     "@channel.io/bezier-react": ^4.0.0-next.17
-    "@channel.io/bezier-tokens": ^1.0.0-next.5
   bin:
     bezier: ./dist/cli.js
   languageName: unknown


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] The commits follow the **Conventional Commits** specification.
- [x] I added a **changeset** for the packages released by this feature.
- [x] I wrote package documentation for the new CLI and library.
- [x] I added tests for catalog lookup, diagnostics, compatibility, cache isolation, package resolution, and CLI behavior.
- [x] Browser testing is not applicable because this change adds Node.js tooling and does not alter rendered UI.

## Related Issue

- WEB-12724

## Summary

- Add the repo-local `@channel.io/bezier-toolkit` workspace package.
- Read and merge React, icon, and token manifests installed in the consumer repository.
- Keep `@channel.io/bezier-react` and `@channel.io/bezier-icons` as required peers selected by the consumer.
- Resolve `@channel.io/bezier-tokens` through the installed React package so consumers do not need to declare React's exact token dependency themselves.
- Provide `bezier lookup`, `bezier doctor`, and `bezier version` as deterministic JSON commands.
- Declare the Toolkit and manifest package release intent in one changeset.

## Details

- Resolves React and icon manifests from the consumer working directory, then resolves the token manifest from the resolved React package's dependency context.
- Selects the token copy React actually consumes even when another copy is available at the consumer root or the install uses Yarn Plug'n'Play.
- Uses prerelease-aware React and icon peer ranges that cover the current source tuple and the first manifest release train.
- Reports missing manifests, invalid JSON/shape, and unsupported schema majors as explicit discriminated results without falling back to a source checkout or global Homebrew state.
- Keys catalog caching by installed package versions, source commits, schema versions, and resolved manifest paths.
- Diagnoses the repo-local Toolkit version, Node `>=18` capability, lockfile, manifest provenance, package tuple, and cache key.
- Keeps the CP2 public surface limited to lookup, doctor, and version. A Guardrail extension API and a separate paths command are intentionally not included.
- Includes no Pilot beta.7 fixture, migration source, bundled catalog, or checkout fallback.

### Verification

- Toolkit build, lint, typecheck, and tests: 3 suites / 21 tests
- Toolkit line coverage: 94.66%
- Full repository build, lint, typecheck, and tests
- React tests: 124 suites / 1041 tests
- Manifest counterexamples: 6/6
- Changeset status: Toolkit/icons/tokens minor; React follows the existing v4 major prerelease intent
- Nested `node_modules` counterexample chooses React's token dependency instead of the consumer-root copy
- Fresh Yarn Plug'n'Play tarball consumer directly declares only React, icons, and Toolkit; doctor, token lookup, and version succeed with the release-train token artifact resolved transitively
- Missing icon manifest: exit 1 with `missing_manifest`, no fallback

### Release boundary

The changeset is included in this feature PR. Merging the generated Changesets release PR and publishing npm prereleases remain deferred until the WEB-12724 CP5 clean-consumer integration gate.

### Breaking change? (Yes/No)

No.

## References

- CP2 of WEB-12724
- Builds on the source-derived manifests merged in #2900
