### PR TITLE
feat: add Bezier ESLint and Stylelint rules

### DIFF
--- a/.changeset/web-12725-bezier-lint-rules.md
+++ b/.changeset/web-12725-bezier-lint-rules.md
@@ -1,0 +1,6 @@
+---
+'@channel.io/eslint-plugin-bezier': minor
+'@channel.io/stylelint-bezier': minor
+---
+
+Add opt-in Bezier ESLint and Stylelint rules for public API, composition, style, layout, text, icon, and suppression contracts.

--- a/packages/eslint-plugin-bezier/.eslintrc.cjs
+++ b/packages/eslint-plugin-bezier/.eslintrc.cjs
@@ -1,6 +1,4 @@
-/**
- * @type {import('eslint').Linter.Config}
- */
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
   root: true,
   ignorePatterns: ['coverage'],

--- a/packages/eslint-plugin-bezier/README.md
+++ b/packages/eslint-plugin-bezier/README.md
@@ -1,0 +1,47 @@
+# `@channel.io/eslint-plugin-bezier`
+
+Opt-in ESLint rules derived from the installed
+`@channel.io/bezier-react/manifest.json` public contract.
+
+```sh
+yarn add --dev --exact @channel.io/eslint-plugin-bezier@next
+```
+
+The package exports rules only. It does not export a recommended preset or
+choose severity for consumers.
+
+```js
+module.exports = {
+  plugins: ['@channel.io/bezier'],
+  rules: {
+    '@channel.io/bezier/no-private-entrypoint': 'error',
+    '@channel.io/bezier/no-orphan-compound-child': 'error',
+    '@channel.io/bezier/no-unsafe-prop-type-escape': 'error',
+    '@channel.io/bezier/no-internal-descendant-selector': 'error',
+    '@channel.io/bezier/review-unresolved-compound-owner': 'warn',
+    '@channel.io/bezier/prefer-layout-component': 'warn',
+  },
+}
+```
+
+Flat config can register the same plugin object explicitly. Product-specific
+aliases, activation, severity, and CI warning policy remain consumer-owned.
+
+## Rules
+
+- `no-legacy-root-import`, `no-private-entrypoint`: public entrypoint boundary
+- `no-orphan-compound-child`: manifest-declared compound ownership
+- `review-unresolved-compound-owner`: advisory for dynamic wrapper ancestry
+- `no-unsafe-prop-type-escape`, `no-public-style-prop-bypass`: preserve public prop contracts
+- `no-native-control-bypass`: native control review
+- `prefer-layout-component`, `prefer-text-for-plain-text`: conservative migration candidates
+- `no-icon-wrapper-in-owner-slot`, `no-inline-svg`, `no-icon-like-glyph`, `no-manual-icon-styled-template`: installed icon ownership
+- `no-internal-descendant-selector`: private descendant ownership in styled Bezier components
+- `require-suppression-reason`: narrow, reasoned exceptions
+
+Product aliases, raw color and typography policy, activation, severity, and CI
+warning policy remain consumer-owned.
+
+Cross-file TypeScript wrapper-origin tracing uses the consumer's installed
+`@typescript-eslint/parser`. When it is unavailable, unresolved wrappers stay
+advisory instead of being guessed as blocking errors.

--- a/packages/eslint-plugin-bezier/jest.config.cjs
+++ b/packages/eslint-plugin-bezier/jest.config.cjs
@@ -1,0 +1,12 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  cacheDirectory: '.jestcache',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[t|j]sx?$': ['@swc/jest'],
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  testMatch: ['**/*.test.ts'],
+}

--- a/packages/eslint-plugin-bezier/package.json
+++ b/packages/eslint-plugin-bezier/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@channel.io/eslint-plugin-bezier",
+  "version": "0.0.0",
+  "description": "Opt-in ESLint rules for Bezier public API and composition contracts.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/channel-io/bezier-react",
+    "directory": "packages/eslint-plugin-bezier"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc --build --verbose",
+    "dev": "tsc --watch",
+    "lint": "TIMING=1 eslint --cache .",
+    "typecheck": "tsc --noEmit",
+    "test": "jest --coverage",
+    "clean": "rm -rf dist node_modules .turbo .eslintcache .jestcache coverage tsconfig.tsbuildinfo"
+  },
+  "engines": {
+    "node": ">=18.18.0"
+  },
+  "author": "Channel Corp.",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "@channel.io/bezier-react": "^4.0.0-next.17",
+    "@typescript-eslint/parser": ">=8.17.0 <9",
+    "eslint": ">=8.57.0 <10"
+  },
+  "peerDependenciesMeta": {
+    "@typescript-eslint/parser": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/eslint": "^8.56.12",
+    "@types/node": "^22.10.2",
+    "@typescript-eslint/parser": "8.17.0",
+    "eslint": "^8.57.1",
+    "eslint-config-bezier": "workspace:*",
+    "tsconfig": "workspace:*",
+    "typescript": "^5.7.2"
+  },
+  "keywords": [
+    "bezier",
+    "design-system",
+    "eslint"
+  ]
+}

--- a/packages/eslint-plugin-bezier/src/ast.ts
+++ b/packages/eslint-plugin-bezier/src/ast.ts
@@ -1,0 +1,341 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { readFileSync, statSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, extname, join, resolve as resolvePath } from 'node:path'
+
+export type AstNode = any
+
+interface ImportBinding {
+  imported: string
+  source: string
+}
+
+interface CachedModule {
+  mtimeMs: number
+  size: number
+  state: ProgramState
+}
+
+const BEZIER_ENTRYPOINTS = new Set([
+  '@channel.io/bezier-react',
+  '@channel.io/bezier-react/beta',
+])
+const SOURCE_EXTENSIONS = [
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mts',
+  '.cts',
+  '.mjs',
+  '.cjs',
+]
+const moduleCache = new Map<string, CachedModule>()
+
+export function jsxName(node: AstNode): string | null {
+  if (!node) return null
+  if (node.type === 'JSXIdentifier') return node.name
+  if (node.type === 'JSXMemberExpression') {
+    const object = jsxName(node.object)
+    const property = jsxName(node.property)
+    return object && property ? `${object}.${property}` : null
+  }
+  return null
+}
+
+export function propertyName(node: AstNode): string | null {
+  if (!node || node.computed) return null
+  if (node.key?.type === 'Identifier') return node.key.name
+  if (node.key?.type === 'Literal') return String(node.key.value)
+  return null
+}
+
+export function jsxAttribute(node: AstNode, name: string) {
+  return node.attributes?.find(
+    (attribute: AstNode) =>
+      attribute.type === 'JSXAttribute' && attribute.name?.name === name
+  )
+}
+
+export function staticObjectProperties(node: AstNode) {
+  if (node?.type !== 'ObjectExpression') return null
+  const result = new Map<string, unknown>()
+  for (const property of node.properties ?? []) {
+    if (property.type !== 'Property' || property.computed) return null
+    const name = propertyName(property)
+    if (!name) return null
+    const value = property.value
+    if (value.type === 'Literal') {
+      result.set(name, value.value)
+    } else if (value.type === 'TemplateLiteral' && value.expressions.length === 0) {
+      result.set(name, value.quasis[0]?.value.cooked ?? '')
+    } else {
+      return null
+    }
+  }
+  return result
+}
+
+export function expressionName(node: AstNode): string | null {
+  let expression = node
+  while (
+    expression &&
+    [
+      'ChainExpression',
+      'TSAsExpression',
+      'TSNonNullExpression',
+      'TSTypeAssertion',
+    ].includes(expression.type)
+  ) {
+    expression = expression.expression
+  }
+  if (expression?.type === 'Identifier') return expression.name
+  if (
+    expression?.type === 'MemberExpression' &&
+    !expression.computed &&
+    expression.object?.type === 'Identifier' &&
+    expression.property?.type === 'Identifier'
+  ) {
+    return `${expression.object.name}.${expression.property.name}`
+  }
+  return null
+}
+
+function unwrapStyledTag(tag: AstNode) {
+  let expression = tag
+  while (
+    expression?.type === 'CallExpression' &&
+    expression.callee?.type === 'MemberExpression' &&
+    !expression.callee.computed &&
+    expression.callee.property?.name === 'attrs'
+  ) {
+    expression = expression.callee.object
+  }
+  return expression
+}
+
+function resolveRelativeModule(importer: string | null, source: string) {
+  if (!importer || !source.startsWith('.')) return null
+  const base = resolvePath(dirname(importer), source)
+  const extension = extname(base)
+  const stem = SOURCE_EXTENSIONS.includes(extension)
+    ? base.slice(0, -extension.length)
+    : base
+  const candidates = [
+    base,
+    ...SOURCE_EXTENSIONS.map((value) => `${stem}${value}`),
+    ...SOURCE_EXTENSIONS.map((value) => join(base, `index${value}`)),
+  ]
+  for (const candidate of new Set(candidates)) {
+    try {
+      if (statSync(candidate).isFile()) return candidate
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+function loadModule(filename: string, cwd: string) {
+  try {
+    const stat = statSync(filename)
+    const cached = moduleCache.get(filename)
+    if (cached?.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+      return cached.state
+    }
+    const consumerRequire = createRequire(join(resolvePath(cwd), 'package.json'))
+    const parser = consumerRequire('@typescript-eslint/parser') as {
+      parse: (code: string, options: Record<string, unknown>) => AstNode
+    }
+    const program = parser.parse(readFileSync(filename, 'utf8'), {
+      ecmaFeatures: { jsx: /\.[cm]?[jt]sx$/u.test(filename) },
+      ecmaVersion: 2024,
+      filePath: filename,
+      sourceType: 'module',
+    })
+    const state = ProgramState.fromProgram(filename, cwd, program)
+    moduleCache.set(filename, {
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      state,
+    })
+    return state
+  } catch {
+    return null
+  }
+}
+
+export class ProgramState {
+  private readonly declarations = new Map<string, AstNode>()
+  private readonly exportBindings = new Map<string, string>()
+  private readonly imports = new Map<string, ImportBinding>()
+  private readonly styledBindings = new Set<string>()
+
+  constructor(
+    private readonly filename: string | null = null,
+    private readonly cwd = process.cwd()
+  ) {}
+
+  static fromProgram(filename: string, cwd: string, program: AstNode) {
+    const state = new ProgramState(filename, cwd)
+    for (const statement of program.body ?? []) state.visitStatement(statement)
+    return state
+  }
+
+  private visitStatement(statement: AstNode) {
+    if (statement.type === 'ImportDeclaration') {
+      this.visitImport(statement)
+      return
+    }
+    if (statement.type === 'ExportNamedDeclaration') {
+      this.visitExport(statement)
+      return
+    }
+    if (statement.type === 'VariableDeclaration') {
+      for (const declaration of statement.declarations ?? []) {
+        this.visitVariable(declaration)
+      }
+    }
+  }
+
+  visitImport(node: AstNode) {
+    const source = String(node.source.value)
+    for (const specifier of node.specifiers ?? []) {
+      if (specifier.type === 'ImportSpecifier') {
+        this.imports.set(specifier.local.name, {
+          imported: specifier.imported.name ?? specifier.imported.value,
+          source,
+        })
+      } else if (specifier.type === 'ImportNamespaceSpecifier') {
+        this.imports.set(specifier.local.name, { imported: '*', source })
+      } else if (specifier.type === 'ImportDefaultSpecifier') {
+        this.imports.set(specifier.local.name, { imported: 'default', source })
+      }
+      if (
+        source === 'styled-components' &&
+        (specifier.type === 'ImportDefaultSpecifier' ||
+          specifier.type === 'ImportNamespaceSpecifier' ||
+          (specifier.type === 'ImportSpecifier' &&
+            (specifier.imported.name ?? specifier.imported.value) === 'styled'))
+      ) {
+        this.styledBindings.add(specifier.local.name)
+      }
+    }
+  }
+
+  visitVariable(node: AstNode) {
+    if (node.id?.type === 'Identifier' && node.init) {
+      this.declarations.set(node.id.name, node.init)
+    }
+  }
+
+  visitExport(node: AstNode) {
+    const declaration = node.declaration
+    if (declaration?.type === 'VariableDeclaration') {
+      for (const value of declaration.declarations ?? []) {
+        this.visitVariable(value)
+        if (value.id?.type === 'Identifier') {
+          this.exportBindings.set(value.id.name, value.id.name)
+        }
+      }
+    }
+    if (!declaration) {
+      for (const specifier of node.specifiers ?? []) {
+        if (specifier.type !== 'ExportSpecifier') continue
+        const local = specifier.local.name ?? String(specifier.local.value)
+        const exported = specifier.exported.name ?? String(specifier.exported.value)
+        this.exportBindings.set(exported, local)
+      }
+    }
+  }
+
+  importSource(name: string | null) {
+    if (!name) return null
+    const [root] = name.split('.')
+    return this.imports.get(root)?.source ?? null
+  }
+
+  isStyledTemplate(tag: AstNode) {
+    const expression = unwrapStyledTag(tag)
+    const root = expressionName(
+      expression?.type === 'CallExpression' ? expression.callee : expression
+    )?.split('.')[0]
+    return Boolean(root && this.styledBindings.has(root))
+  }
+
+  resolveStyledTarget(tag: AstNode) {
+    const expression = unwrapStyledTag(tag)
+    if (
+      expression?.type === 'MemberExpression' &&
+      !expression.computed &&
+      expression.object?.type === 'Identifier' &&
+      this.styledBindings.has(expression.object.name) &&
+      expression.property?.type === 'Identifier'
+    ) {
+      return expression.property.name
+    }
+    if (expression?.type !== 'CallExpression') return null
+    const styledRoot = expressionName(expression.callee)?.split('.')[0]
+    const target = expression.arguments?.[0]
+    return styledRoot && this.styledBindings.has(styledRoot) && target
+      ? this.resolve(expressionName(target))
+      : null
+  }
+
+  resolve(name: string | null, seen = new Set<string>()): string | null {
+    if (!name) return null
+    if (/^[a-z]/u.test(name)) return name
+    const key = `${this.filename ?? '<input>'}:${name}`
+    if (seen.has(key)) return null
+    const nextSeen = new Set(seen).add(key)
+    const [root, member] = name.split('.', 2)
+    const binding = this.imports.get(root)
+    if (binding) {
+      if (BEZIER_ENTRYPOINTS.has(binding.source)) {
+        return binding.imported === '*' ? member ?? null : binding.imported
+      }
+      const modulePath = resolveRelativeModule(this.filename, binding.source)
+      const exported = binding.imported === '*' ? member : binding.imported
+      return modulePath && exported
+        ? loadModule(modulePath, this.cwd)?.resolveExport(exported, nextSeen) ?? null
+        : null
+    }
+    if (member) return null
+    const initializer = this.declarations.get(root)
+    if (!initializer) return null
+    if (initializer.type === 'TaggedTemplateExpression') {
+      const target = unwrapStyledTag(initializer.tag)
+      if (
+        target?.type === 'MemberExpression' &&
+        !target.computed &&
+        target.object?.type === 'Identifier' &&
+        this.styledBindings.has(target.object.name) &&
+        target.property?.type === 'Identifier'
+      ) {
+        return target.property.name
+      }
+      if (target?.type !== 'CallExpression') return null
+      const styledRoot = expressionName(target.callee)?.split('.')[0]
+      const wrapped = target.arguments?.[0]
+      return styledRoot && this.styledBindings.has(styledRoot) && wrapped
+        ? this.resolve(expressionName(wrapped), nextSeen)
+        : null
+    }
+    return this.resolve(expressionName(initializer), nextSeen)
+  }
+
+  private resolveExport(exported: string, seen: Set<string>) {
+    const local = this.exportBindings.get(exported)
+    return local ? this.resolve(local, seen) : null
+  }
+}
+
+export function contextCwd(context: AstNode) {
+  return context.cwd ?? context.getCwd?.() ?? process.cwd()
+}
+
+export function contextFilename(context: AstNode) {
+  const filename = context.filename ?? context.getFilename?.() ?? null
+  return filename && !String(filename).startsWith('<') ? String(filename) : null
+}

--- a/packages/eslint-plugin-bezier/src/index.test.ts
+++ b/packages/eslint-plugin-bezier/src/index.test.ts
@@ -1,0 +1,368 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { RuleTester } from 'eslint'
+
+import plugin = require('./index')
+
+const tester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true },
+  },
+})
+
+const beta = '@channel.io/bezier-react/beta'
+const testRequire = createRequire(__filename)
+const crossFileRoot = mkdtempSync(join(tmpdir(), 'bezier-eslint-wrapper-'))
+
+writeFileSync(
+  join(crossFileRoot, 'wrappers.tsx'),
+  `import styled from 'styled-components'
+   import { Box, TabList, Tabs } from '${beta}'
+   export const Root = styled(Tabs).attrs({ role: 'tablist' })\`display: block;\`
+   export const List = styled(TabList)\`display: block;\`
+   export const BoxOwner = styled(Box)\`display: block;\``
+)
+
+afterAll(() => rmSync(crossFileRoot, { force: true, recursive: true }))
+
+tester.run('no-private-entrypoint', plugin.rules['no-private-entrypoint'], {
+  valid: [`import { Tabs } from '${beta}'`],
+  invalid: [
+    {
+      code: "import { Tabs } from '@channel.io/bezier-react/dist/beta/Tabs'",
+      errors: [{ messageId: 'rejected' }],
+    },
+  ],
+})
+
+tester.run('no-legacy-root-import', plugin.rules['no-legacy-root-import'], {
+  valid: [
+    `import {} from '@channel.io/bezier-react'`,
+    `import { Button } from '${beta}'`,
+  ],
+  invalid: [
+    {
+      code: "import { Button as LegacyButton } from '@channel.io/bezier-react'",
+      errors: [{ messageId: 'exact' }],
+    },
+    {
+      code: "import * as Bezier from '@channel.io/bezier-react'",
+      errors: [{ messageId: 'namespace' }],
+    },
+  ],
+})
+
+const validCompound = [
+  `import { Tabs, TabList, TabItem } from '${beta}'
+   const value = <Tabs><TabList><TabItem /></TabList></Tabs>`,
+  `import { Tabs as Root, TabList as List, TabItem as Item } from '${beta}'
+   const value = <Root><List><Item /></List></Root>`,
+  `import * as Bezier from '${beta}'
+   const value = <Bezier.Tabs><Bezier.TabList><Bezier.TabItem /></Bezier.TabList></Bezier.Tabs>`,
+  `import styled from 'styled-components'
+   import { Tabs, TabList, TabItem } from '${beta}'
+   const StyledTabs = styled(Tabs)\`color: red;\`
+   const WrappedTabs = styled(StyledTabs)\`display: block;\`
+   const StyledList = styled(TabList)\`display: block;\`
+   const value = <WrappedTabs><StyledList><TabItem /></StyledList></WrappedTabs>`,
+  `import { Tabs, TabItem } from '${beta}'
+   const DynamicOwner = withOwner(Tabs)
+   const value = <DynamicOwner><TabItem /></DynamicOwner>`,
+  {
+    filename: join(crossFileRoot, 'consumer.tsx'),
+    code: `import * as Styled from './wrappers'
+           import { TabItem } from '${beta}'
+           const value = <Styled.Root><Styled.List><TabItem /></Styled.List></Styled.Root>`,
+  },
+]
+
+tester.run(
+  'no-orphan-compound-child',
+  plugin.rules['no-orphan-compound-child'],
+  {
+    valid: validCompound,
+    invalid: [
+      {
+        code: `import { TabItem } from '${beta}'; const value = <div><TabItem /></div>`,
+        errors: [{ messageId: 'rejected' }],
+      },
+      {
+        code: `import styled from 'styled-components'
+               import { Box, TabItem } from '${beta}'
+               const Owner = styled(Box)\`display: block;\`
+               const value = <Owner><TabItem /></Owner>`,
+        errors: [{ messageId: 'rejected' }],
+      },
+      {
+        filename: join(crossFileRoot, 'consumer.tsx'),
+        code: `import { BoxOwner as Owner } from './wrappers'
+               import { TabItem } from '${beta}'
+               const value = <Owner><TabItem /></Owner>`,
+        errors: [{ messageId: 'rejected' }],
+      },
+    ],
+  }
+)
+
+tester.run(
+  'review-unresolved-compound-owner',
+  plugin.rules['review-unresolved-compound-owner'],
+  {
+    valid: validCompound.filter((_, index) => index !== 4),
+    invalid: [
+      {
+        code: `import { Tabs, TabItem } from '${beta}'
+               const DynamicOwner = withOwner(Tabs)
+               const value = <DynamicOwner><TabItem /></DynamicOwner>`,
+        errors: [{ messageId: 'rejected' }],
+      },
+    ],
+  }
+)
+
+tester.run(
+  'no-icon-wrapper-in-owner-slot',
+  plugin.rules['no-icon-wrapper-in-owner-slot'],
+  {
+    valid: [
+      `import { IconButton } from '${beta}'
+       import { AddIcon } from '@channel.io/bezier-icons'
+       const value = <IconButton content={AddIcon} />`,
+    ],
+    invalid: [
+      {
+        code: `import { Icon, IconButton } from '${beta}'
+               import { AddIcon } from '@channel.io/bezier-icons'
+               const value = <IconButton content={<Icon source={AddIcon} />} />`,
+        errors: [{ messageId: 'rejected' }],
+      },
+    ],
+  }
+)
+
+tester.run(
+  'no-internal-descendant-selector',
+  plugin.rules['no-internal-descendant-selector'],
+  {
+    valid: [
+      `import styled from 'styled-components'
+       const AppButton = () => null
+       const StyledButton = styled(AppButton)\`svg { width: 16px; }\``,
+      `import styled from 'styled-components'
+       import { IconButton } from '${beta}'
+       const selector = 'svg'
+       const StyledButton = styled(IconButton)\`\${selector} { width: 16px; }\``,
+    ],
+    invalid: [
+      {
+        code: `import styled from 'styled-components'
+               import { IconButton } from '${beta}'
+               const StyledButton = styled(IconButton)\`
+                 svg, path { width: 16px; }
+               \``,
+        errors: [{ messageId: 'rejected' }],
+      },
+      {
+        code: `import styled from 'styled-components'
+               import { Button } from '${beta}'
+               const StyledButton = styled(Button)\`
+                 .IconWrapper { color: red; }
+               \``,
+        errors: [{ messageId: 'rejected' }],
+      },
+    ],
+  }
+)
+
+tester.run(
+  'no-manual-icon-styled-template',
+  plugin.rules['no-manual-icon-styled-template'],
+  {
+    valid: [
+      `import styled from 'styled-components'
+       const Panel = styled.div\`width: 20px; height: 20px; border: 1px solid; transform: rotate(45deg);\``,
+      `import styled from 'styled-components'
+       const ArrowIcon = styled.div\`width: 20px; color: red;\``,
+    ],
+    invalid: [
+      {
+        code: `import styled from 'styled-components'
+               const ChevronIcon = styled.div\`
+                 width: 12px;
+                 height: 12px;
+                 border-right: 2px solid;
+                 transform: rotate(45deg);
+               \``,
+        errors: [{ messageId: 'rejected' }],
+      },
+    ],
+  }
+)
+
+const typescriptTester = new RuleTester({
+  parser: testRequire.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true },
+  },
+})
+
+typescriptTester.run(
+  'no-unsafe-prop-type-escape',
+  plugin.rules['no-unsafe-prop-type-escape'],
+  {
+    valid: [
+      `import { Box } from '${beta}'
+       const value = <Box padding={4 as number} />`,
+      'const value = <AppBox padding={4 as any} />',
+    ],
+    invalid: [
+      {
+        code: `import styled from 'styled-components'
+               import { Box } from '${beta}'
+               const Surface = styled(Box)\`display: block;\`
+               const value = <Surface padding={4 as any} />`,
+        errors: [{ messageId: 'rejected' }],
+      },
+    ],
+  }
+)
+
+tester.run(
+  'no-public-style-prop-bypass',
+  plugin.rules['no-public-style-prop-bypass'],
+  {
+    valid: [
+      `import { Box } from '${beta}'; const value = <Box padding={4} />`,
+      `const value = <Box style={{ padding: 4 }} />`,
+    ],
+    invalid: [
+      {
+        code: `import { Box as Surface } from '${beta}'; const value = <Surface style={{ padding: 4, width: 20 }} />`,
+        errors: [{ messageId: 'rejected' }],
+      },
+      {
+        code: `import * as B from '${beta}'; const value = <B.Box style={{ margin: 4 }} />`,
+        errors: [{ messageId: 'rejected' }],
+      },
+      {
+        code: `import styled from 'styled-components'
+               import { Box } from '${beta}'
+               const Surface = styled(Box)\`display: block;\`
+               const value = <Surface style={{ padding: 4 }} />`,
+        errors: [{ messageId: 'rejected' }],
+      },
+    ],
+  }
+)
+
+tester.run(
+  'no-native-control-bypass',
+  plugin.rules['no-native-control-bypass'],
+  {
+    valid: ['<input type="text" />', '<div role="button" />'],
+    invalid: [
+      { code: '<button />', errors: [{ messageId: 'rejected' }] },
+      {
+        code: '<input type="checkbox" />',
+        errors: [{ messageId: 'rejected' }],
+      },
+      { code: '<select />', errors: [{ messageId: 'rejected' }] },
+    ],
+  }
+)
+
+tester.run(
+  'prefer-layout-component',
+  plugin.rules['prefer-layout-component'],
+  {
+    valid: [
+      '<div role="region" style={{ display: "flex" }} />',
+      '<div onClick={click} style={{ display: "flex" }} />',
+      '<div style={{ display: "grid" }} />',
+      '<div style={{ overflow: "auto", display: "flex" }} />',
+      '<div style={{ display: responsiveDisplay }} />',
+      '<div style={{ position: "absolute", width: 20 }} />',
+    ],
+    invalid: [
+      {
+        code: '<div style={{ display: "flex", flexDirection: "column", padding: 4 }} />',
+        errors: [{ messageId: 'candidate' }],
+      },
+      {
+        code: '<div style={{ width: 20, padding: 4 }} />',
+        errors: [{ messageId: 'candidate' }],
+      },
+    ],
+  }
+)
+
+tester.run(
+  'prefer-text-for-plain-text',
+  plugin.rules['prefer-text-for-plain-text'],
+  {
+    valid: [
+      '<button><span>Save</span></button>',
+      `import { Button } from '${beta}'; const value = <Button><span>Save</span></Button>`,
+      `import styled from 'styled-components'
+       import { Button } from '${beta}'
+       const Action = styled(Button)\`display: inline-flex;\`
+       const value = <Action><span>Save</span></Action>`,
+      '<span><strong>Nested only</strong></span>',
+    ],
+    invalid: [
+      { code: '<span>Hello</span>', errors: [{ messageId: 'rejected' }] },
+      { code: '<p>{t("hello")}</p>', errors: [{ messageId: 'rejected' }] },
+    ],
+  }
+)
+
+tester.run('no-inline-svg', plugin.rules['no-inline-svg'], {
+  valid: ['<Icon />'],
+  invalid: [
+    {
+      code: '<svg><path d="M0 0" /></svg>',
+      errors: [{ messageId: 'rejected' }],
+    },
+  ],
+})
+
+tester.run('no-icon-like-glyph', plugin.rules['no-icon-like-glyph'], {
+  valid: ['<div>Continue → next step</div>', '<div>→</div>'],
+  invalid: [
+    { code: '<span>→</span>', errors: [{ messageId: 'rejected' }] },
+    {
+      code: '<i aria-hidden="true">✓</i>',
+      errors: [{ messageId: 'rejected' }],
+    },
+  ],
+})
+
+tester.run(
+  'require-suppression-reason',
+  plugin.rules['require-suppression-reason'],
+  {
+    valid: [
+      `// eslint-disable-next-line no-unused-vars -- Bezier external signed asset must preserve source SVG
+       const unused = <svg />`,
+    ],
+    invalid: [
+      {
+        code: `/* eslint-disable no-unused-vars -- Bezier exception */
+               const value = <svg />`,
+        errors: [{ messageId: 'blanket' }],
+      },
+      {
+        code: `// eslint-disable-next-line no-unused-vars -- Bezier bad
+               const value = <svg />`,
+        errors: [{ messageId: 'reason' }],
+      },
+    ],
+  }
+)

--- a/packages/eslint-plugin-bezier/src/index.ts
+++ b/packages/eslint-plugin-bezier/src/index.ts
@@ -1,0 +1,42 @@
+import { noIconLikeGlyph } from './rules/no-icon-like-glyph.js'
+import { noIconWrapperInOwnerSlot } from './rules/no-icon-wrapper-in-owner-slot.js'
+import { noInlineSvg } from './rules/no-inline-svg.js'
+import { noInternalDescendantSelector } from './rules/no-internal-descendant-selector.js'
+import { noLegacyRootImport } from './rules/no-legacy-root-import.js'
+import { noManualIconStyledTemplate } from './rules/no-manual-icon-styled-template.js'
+import { noNativeControlBypass } from './rules/no-native-control-bypass.js'
+import {
+  noOrphanCompoundChild,
+  reviewUnresolvedCompoundOwner,
+} from './rules/no-orphan-compound-child.js'
+import { noPrivateEntrypoint } from './rules/no-private-entrypoint.js'
+import { noPublicStylePropBypass } from './rules/no-public-style-prop-bypass.js'
+import { noUnsafePropTypeEscape } from './rules/no-unsafe-prop-type-escape.js'
+import { preferLayoutComponent } from './rules/prefer-layout-component.js'
+import { preferTextForPlainText } from './rules/prefer-text-for-plain-text.js'
+import { requireSuppressionReason } from './rules/require-suppression-reason.js'
+
+const rules = {
+  'no-icon-like-glyph': noIconLikeGlyph,
+  'no-icon-wrapper-in-owner-slot': noIconWrapperInOwnerSlot,
+  'no-inline-svg': noInlineSvg,
+  'no-internal-descendant-selector': noInternalDescendantSelector,
+  'no-legacy-root-import': noLegacyRootImport,
+  'no-manual-icon-styled-template': noManualIconStyledTemplate,
+  'no-native-control-bypass': noNativeControlBypass,
+  'no-orphan-compound-child': noOrphanCompoundChild,
+  'no-private-entrypoint': noPrivateEntrypoint,
+  'no-public-style-prop-bypass': noPublicStylePropBypass,
+  'no-unsafe-prop-type-escape': noUnsafePropTypeEscape,
+  'prefer-layout-component': preferLayoutComponent,
+  'prefer-text-for-plain-text': preferTextForPlainText,
+  'review-unresolved-compound-owner': reviewUnresolvedCompoundOwner,
+  'require-suppression-reason': requireSuppressionReason,
+}
+
+const plugin = {
+  meta: { name: '@channel.io/eslint-plugin-bezier' },
+  rules,
+}
+
+export = plugin

--- a/packages/eslint-plugin-bezier/src/manifest.ts
+++ b/packages/eslint-plugin-bezier/src/manifest.ts
@@ -1,0 +1,86 @@
+import { readFileSync, statSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join, resolve } from 'node:path'
+
+export interface ComponentContract {
+  name: string
+  props: Set<string>
+  requiredAncestors: string[]
+}
+
+interface ManifestComponent {
+  name?: unknown
+  props?: { name?: unknown }[]
+  semantics?: {
+    parts?: Record<string, { requiresAncestor?: unknown }>
+  }
+}
+
+interface CachedContracts {
+  mtimeMs: number
+  path: string
+  size: number
+  value: Map<string, ComponentContract>
+}
+
+const cache = new Map<string, CachedContracts>()
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string')
+}
+
+export function loadComponentContracts(cwd: string) {
+  const root = resolve(cwd)
+  const consumerRequire = createRequire(join(root, 'package.json'))
+  const manifestPath = consumerRequire.resolve(
+    '@channel.io/bezier-react/manifest.json'
+  )
+  const stat = statSync(manifestPath)
+  const cached = cache.get(root)
+  if (
+    cached?.path === manifestPath &&
+    cached.mtimeMs === stat.mtimeMs &&
+    cached.size === stat.size
+  ) {
+    return cached.value
+  }
+
+  const parsed = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+    schemaVersion?: unknown
+    components?: unknown
+  }
+  if (
+    typeof parsed.schemaVersion !== 'string' ||
+    !parsed.schemaVersion.startsWith('1.') ||
+    !Array.isArray(parsed.components)
+  ) {
+    throw new Error(
+      `Unsupported @channel.io/bezier-react manifest at ${manifestPath}.`
+    )
+  }
+
+  const contracts = new Map<string, ComponentContract>()
+  for (const value of parsed.components as ManifestComponent[]) {
+    if (typeof value.name !== 'string') continue
+    const part = value.semantics?.parts?.[value.name]
+    const requiredAncestors = isStringArray(part?.requiresAncestor)
+      ? part.requiresAncestor
+      : []
+    contracts.set(value.name, {
+      name: value.name,
+      props: new Set(
+        (value.props ?? []).flatMap((prop) =>
+          typeof prop.name === 'string' ? [prop.name] : []
+        )
+      ),
+      requiredAncestors,
+    })
+  }
+  cache.set(root, {
+    mtimeMs: stat.mtimeMs,
+    path: manifestPath,
+    size: stat.size,
+    value: contracts,
+  })
+  return contracts
+}

--- a/packages/eslint-plugin-bezier/src/rule.ts
+++ b/packages/eslint-plugin-bezier/src/rule.ts
@@ -1,0 +1,17 @@
+import { type Rule } from 'eslint'
+
+export function createRule(
+  description: string,
+  messages: Record<string, string>,
+  create: Rule.RuleModule['create']
+): Rule.RuleModule {
+  return {
+    meta: {
+      type: 'problem',
+      docs: { description },
+      schema: [],
+      messages,
+    },
+    create,
+  }
+}

--- a/packages/eslint-plugin-bezier/src/rules/no-icon-like-glyph.ts
+++ b/packages/eslint-plugin-bezier/src/rules/no-icon-like-glyph.ts
@@ -1,0 +1,31 @@
+import { type AstNode, jsxAttribute, jsxName } from '../ast.js'
+import { createRule } from '../rule.js'
+
+const ICON_GLYPH_PATTERN = /[\u2190-\u2bff\u{1f300}-\u{1faff}]/u
+
+export const noIconLikeGlyph = createRule(
+  'Disallow short Unicode glyphs used as visual icons.',
+  {
+    rejected:
+      'HOST-ICON-002: A Unicode glyph is used as an icon. Search the installed icon catalog and use its named source.',
+  },
+  (context) => ({
+    JSXElement(node: AstNode) {
+      const text = (node.children ?? [])
+        .filter((child: AstNode) => child.type === 'JSXText')
+        .map((child: AstNode) => child.value)
+        .join('')
+        .trim()
+      if (!text || [...text].length > 3 || !ICON_GLYPH_PATTERN.test(text)) return
+      const opening = node.openingElement
+      const className = jsxAttribute(opening, 'className')?.value?.value
+      if (
+        jsxName(opening.name) === 'span' ||
+        jsxAttribute(opening, 'aria-hidden') ||
+        /(?:icon|arrow|chevron|caret|glyph)/iu.test(String(className ?? ''))
+      ) {
+        context.report({ node: opening, messageId: 'rejected' })
+      }
+    },
+  })
+)

--- a/packages/eslint-plugin-bezier/src/rules/no-icon-wrapper-in-owner-slot.ts
+++ b/packages/eslint-plugin-bezier/src/rules/no-icon-wrapper-in-owner-slot.ts
@@ -1,0 +1,39 @@
+import {
+  type AstNode,
+  ProgramState,
+  contextCwd,
+  contextFilename,
+  jsxAttribute,
+  jsxName,
+} from '../ast.js'
+import { createRule } from '../rule.js'
+
+export const noIconWrapperInOwnerSlot = createRule(
+  'Pass icon sources directly to owner-sized icon slots.',
+  {
+    rejected:
+      'BZR-ICON-001: Pass the Bezier icon source directly to `IconButton.content`; the owner controls icon size.',
+  },
+  (context) => {
+    const state = new ProgramState(
+      contextFilename(context),
+      contextCwd(context)
+    )
+    return {
+      ImportDeclaration: (node: AstNode) => state.visitImport(node),
+      ExportNamedDeclaration: (node: AstNode) => state.visitExport(node),
+      VariableDeclarator: (node: AstNode) => state.visitVariable(node),
+      JSXOpeningElement(node: AstNode) {
+        if (state.resolve(jsxName(node.name)) !== 'IconButton') return
+        const content = jsxAttribute(node, 'content')
+        const expression = content?.value?.expression
+        if (
+          expression?.type === 'JSXElement' &&
+          state.resolve(jsxName(expression.openingElement.name)) === 'Icon'
+        ) {
+          context.report({ node: content, messageId: 'rejected' })
+        }
+      },
+    }
+  }
+)

--- a/packages/eslint-plugin-bezier/src/rules/no-inline-svg.ts
+++ b/packages/eslint-plugin-bezier/src/rules/no-inline-svg.ts
@@ -1,0 +1,17 @@
+import { type AstNode, jsxName } from '../ast.js'
+import { createRule } from '../rule.js'
+
+export const noInlineSvg = createRule(
+  'Require asset ownership review for hand-authored inline SVG.',
+  {
+    rejected:
+      'HOST-ICON-001: Inline SVG requires asset ownership review. Search installed Bezier icons before reconstructing paths.',
+  },
+  (context) => ({
+    JSXOpeningElement(node: AstNode) {
+      if (jsxName(node.name) === 'svg') {
+        context.report({ node, messageId: 'rejected' })
+      }
+    },
+  })
+)

--- a/packages/eslint-plugin-bezier/src/rules/no-internal-descendant-selector.ts
+++ b/packages/eslint-plugin-bezier/src/rules/no-internal-descendant-selector.ts
@@ -1,0 +1,73 @@
+import {
+  type AstNode,
+  ProgramState,
+  contextCwd,
+  contextFilename,
+} from '../ast.js'
+import { loadComponentContracts } from '../manifest.js'
+import { createRule } from '../rule.js'
+
+const DYNAMIC_SELECTOR = '__BEZIER_DYNAMIC_SELECTOR__'
+
+function templateCss(node: AstNode) {
+  return (node.quasi?.quasis ?? [])
+    .map((quasi: AstNode) => quasi.value.cooked ?? quasi.value.raw)
+    .join(` ${DYNAMIC_SELECTOR} `)
+}
+
+function internalKind(selector: string) {
+  if (
+    /\[\s*class(?:Name)?\s*(?:\*=|\^=|\$=|\|=|~=|=)\s*["'][^"']*(?:IconWrapper|bezier-)[^"']*["']\s*\]/iu.test(
+      selector
+    ) ||
+    /\.(?:[\w-]*IconWrapper|bezier-[\w-]*)\b/u.test(selector)
+  ) {
+    return 'Bezier internal class'
+  }
+  return /(?:^|[\s>+~,(])(?:svg|path)(?=$|[\s>+~.#:[),])/iu.test(selector)
+    ? 'internal SVG element'
+    : null
+}
+
+function firstInternalSelector(css: string) {
+  const pattern = /(?:^|[;{}])\s*([^@;{}][^;{}]*?)\s*\{/gmu
+  for (const match of css.matchAll(pattern)) {
+    const selector = match[1].trim()
+    if (!selector || selector.includes(DYNAMIC_SELECTOR)) continue
+    const kind = internalKind(selector)
+    if (kind) return { kind, selector }
+  }
+  return null
+}
+
+export const noInternalDescendantSelector = createRule(
+  "Disallow static selectors that reach into a styled Bezier component's private descendants.",
+  {
+    rejected:
+      'BZR-API-003: `{{component}}` selector `{{selector}}` depends on a private Bezier descendant ({{kind}}). Use a public prop, slot, or consumer-owned wrapper.',
+  },
+  (context) => {
+    const cwd = contextCwd(context)
+    const state = new ProgramState(contextFilename(context), cwd)
+    return {
+      ImportDeclaration: (node: AstNode) => state.visitImport(node),
+      ExportNamedDeclaration: (node: AstNode) => state.visitExport(node),
+      VariableDeclarator: (node: AstNode) => state.visitVariable(node),
+      TaggedTemplateExpression(node: AstNode) {
+        const component = state.resolveStyledTarget(node.tag)
+        if (!component || !loadComponentContracts(cwd).has(component)) return
+        const evidence = firstInternalSelector(templateCss(node))
+        if (!evidence) return
+        context.report({
+          node,
+          messageId: 'rejected',
+          data: {
+            component,
+            kind: evidence.kind,
+            selector: evidence.selector.replace(/\s+/gu, ' ').slice(0, 120),
+          },
+        })
+      },
+    }
+  }
+)

--- a/packages/eslint-plugin-bezier/src/rules/no-legacy-root-import.ts
+++ b/packages/eslint-plugin-bezier/src/rules/no-legacy-root-import.ts
@@ -1,0 +1,46 @@
+import { type AstNode, contextCwd } from '../ast.js'
+import { loadComponentContracts } from '../manifest.js'
+import { createRule } from '../rule.js'
+
+export const noLegacyRootImport = createRule(
+  'Require public beta components instead of the legacy package root.',
+  {
+    exact:
+      'BZR-API-001: `{{name}}` is available from `@channel.io/bezier-react/beta`; import that public contract instead of the legacy root.',
+    directional:
+      'BZR-API-001: `{{name}}` is a legacy layout component. Use beta `HStack` or `VStack` after reviewing its direction.',
+    namespace:
+      'BZR-API-001: namespace import `{{name}}` exposes legacy root APIs. Import verified beta components explicitly.',
+    unknown:
+      'BZR-API-001: `{{name}}` is a legacy root API without a proven beta replacement. Review it instead of preserving or guessing a migration.',
+  },
+  (context) => ({
+    ImportDeclaration(node: AstNode) {
+      if (node.source.value !== '@channel.io/bezier-react') return
+      if (node.importKind === 'type') return
+      const contracts = loadComponentContracts(contextCwd(context))
+      for (const specifier of node.specifiers ?? []) {
+        if (specifier.importKind === 'type') continue
+        if (specifier.type === 'ImportNamespaceSpecifier') {
+          context.report({
+            node: specifier,
+            messageId: 'namespace',
+            data: { name: specifier.local.name },
+          })
+          continue
+        }
+        const name =
+          specifier.type === 'ImportSpecifier'
+            ? specifier.imported.name ?? String(specifier.imported.value)
+            : 'default'
+        const messageId =
+          name === 'Stack' || name === 'LegacyStack'
+            ? 'directional'
+            : contracts.has(name)
+              ? 'exact'
+              : 'unknown'
+        context.report({ node: specifier, messageId, data: { name } })
+      }
+    },
+  })
+)

--- a/packages/eslint-plugin-bezier/src/rules/no-manual-icon-styled-template.ts
+++ b/packages/eslint-plugin-bezier/src/rules/no-manual-icon-styled-template.ts
@@ -1,0 +1,81 @@
+import {
+  type AstNode,
+  ProgramState,
+  contextCwd,
+  contextFilename,
+} from '../ast.js'
+import { createRule } from '../rule.js'
+
+const ICON_NAME = /(?:icon|arrow|chevron|caret|glyph|check)/iu
+const SHAPE_PROPERTIES = new Set([
+  'border',
+  'border-bottom',
+  'border-left',
+  'border-right',
+  'border-top',
+  'clip-path',
+  'height',
+  'mask',
+  'transform',
+  'width',
+])
+const SHAPE_SIGNATURES = new Set([
+  'border',
+  'border-bottom',
+  'border-left',
+  'border-right',
+  'border-top',
+  'clip-path',
+  'mask',
+  'transform',
+])
+
+function variableName(node: AstNode) {
+  const declarator = node.parent
+  return declarator?.type === 'VariableDeclarator' &&
+    declarator.id?.type === 'Identifier'
+    ? declarator.id.name
+    : null
+}
+
+function cssProperties(node: AstNode) {
+  const css = (node.quasi?.quasis ?? [])
+    .map((quasi: AstNode) => quasi.value.cooked ?? quasi.value.raw)
+    .join('\n')
+  return new Set(
+    [...css.matchAll(/(?:^|[;\n])\s*([a-z-]+)\s*:/gimu)].map((match) =>
+      match[1].toLowerCase()
+    )
+  )
+}
+
+export const noManualIconStyledTemplate = createRule(
+  'Require review for styled-components templates that reconstruct icon geometry.',
+  {
+    rejected:
+      'HOST-ICON-003: `{{name}}` appears to reconstruct an icon in CSS. Search the installed icon catalog before drawing glyph geometry.',
+  },
+  (context) => {
+    const state = new ProgramState(
+      contextFilename(context),
+      contextCwd(context)
+    )
+    return {
+      ImportDeclaration: (node: AstNode) => state.visitImport(node),
+      TaggedTemplateExpression(node: AstNode) {
+        if (!state.isStyledTemplate(node.tag)) return
+        const name = variableName(node)
+        if (!name || !ICON_NAME.test(name)) return
+        const properties = [...cssProperties(node)].filter((property) =>
+          SHAPE_PROPERTIES.has(property)
+        )
+        if (
+          properties.length >= 3 &&
+          properties.some((property) => SHAPE_SIGNATURES.has(property))
+        ) {
+          context.report({ node, messageId: 'rejected', data: { name } })
+        }
+      },
+    }
+  }
+)

--- a/packages/eslint-plugin-bezier/src/rules/no-native-control-bypass.ts
+++ b/packages/eslint-plugin-bezier/src/rules/no-native-control-bypass.ts
@@ -1,0 +1,29 @@
+import { type AstNode, jsxAttribute, jsxName } from '../ast.js'
+import { createRule } from '../rule.js'
+
+const CONTROLS = new Set(['button', 'select', 'textarea'])
+
+export const noNativeControlBypass = createRule(
+  'Require review when native controls bypass a Bezier control family.',
+  {
+    rejected:
+      'BZR-CMP-003: Native `{{name}}` bypasses an installed Bezier control family. Use the public control or a reasoned line suppression.',
+  },
+  (context) => ({
+    JSXOpeningElement(node: AstNode) {
+      const name = jsxName(node.name)
+      let bypass = Boolean(name && CONTROLS.has(name))
+      if (name === 'input') {
+        const type = jsxAttribute(node, 'type')?.value?.value
+        bypass = type === 'checkbox' || type === 'radio'
+      }
+      if (bypass) {
+        context.report({
+          node,
+          messageId: 'rejected',
+          data: { name: name ?? '' },
+        })
+      }
+    },
+  })
+)

--- a/packages/eslint-plugin-bezier/src/rules/no-orphan-compound-child.ts
+++ b/packages/eslint-plugin-bezier/src/rules/no-orphan-compound-child.ts
@@ -1,0 +1,75 @@
+import {
+  type AstNode,
+  ProgramState,
+  contextCwd,
+  contextFilename,
+  jsxName,
+} from '../ast.js'
+import { loadComponentContracts } from '../manifest.js'
+import { createRule } from '../rule.js'
+
+type Verdict = 'orphan' | 'uncertain'
+
+function verdictFor(
+  node: AstNode,
+  requiredAncestors: string[],
+  state: ProgramState
+): Verdict | 'valid' {
+  const found = new Set<string>()
+  let uncertain = false
+  let parent = node.parent
+  while (parent) {
+    if (parent.type === 'JSXElement') {
+      const name = jsxName(parent.openingElement.name)
+      const resolved = state.resolve(name)
+      if (resolved) found.add(resolved)
+      else if (name && /^[A-Z]/u.test(name)) uncertain = true
+    }
+    parent = parent.parent
+  }
+  if (requiredAncestors.every((name) => found.has(name))) return 'valid'
+  return uncertain ? 'uncertain' : 'orphan'
+}
+
+function compoundRule(verdict: Verdict, description: string, message: string) {
+  return createRule(description, { rejected: message }, (context) => {
+    const state = new ProgramState(
+      contextFilename(context),
+      contextCwd(context)
+    )
+    const candidates: AstNode[] = []
+    return {
+      ImportDeclaration: (node: AstNode) => state.visitImport(node),
+      ExportNamedDeclaration: (node: AstNode) => state.visitExport(node),
+      VariableDeclarator: (node: AstNode) => state.visitVariable(node),
+      JSXElement: (node: AstNode) => candidates.push(node),
+      'Program:exit': function programExit() {
+        const contracts = loadComponentContracts(contextCwd(context))
+        for (const node of candidates) {
+          const component = state.resolve(jsxName(node.openingElement.name))
+          if (!component) continue
+          const required = contracts.get(component)?.requiredAncestors ?? []
+          if (required.length === 0) continue
+          if (verdictFor(node, required, state) !== verdict) continue
+          context.report({
+            node: node.openingElement,
+            messageId: 'rejected',
+            data: { child: component, owners: required.join(' > ') },
+          })
+        }
+      },
+    }
+  })
+}
+
+export const noOrphanCompoundChild = compoundRule(
+  'orphan',
+  'Require compound children to render under every manifest-declared owner.',
+  'BZR-CMP-001: `{{child}}` must render under `{{owners}}`. Review the public compound recipe.'
+)
+
+export const reviewUnresolvedCompoundOwner = compoundRule(
+  'uncertain',
+  'Request review when a compound owner is hidden by an unresolved wrapper.',
+  'BZR-CMP-002: `{{child}}` requires `{{owners}}`, but an ancestor origin could not be proven statically. Review wrapper ownership; this finding is advisory.'
+)

--- a/packages/eslint-plugin-bezier/src/rules/no-private-entrypoint.ts
+++ b/packages/eslint-plugin-bezier/src/rules/no-private-entrypoint.ts
@@ -1,0 +1,30 @@
+import { type AstNode } from '../ast.js'
+import { createRule } from '../rule.js'
+
+const PUBLIC_ENTRYPOINTS = new Set([
+  '@channel.io/bezier-react/beta',
+  '@channel.io/bezier-react/styles.css',
+])
+
+export const noPrivateEntrypoint = createRule(
+  'Disallow private Bezier React entrypoints.',
+  {
+    rejected:
+      'BZR-API-002: `{{path}}` is not a supported public Bezier entrypoint. Use the package root or `/beta`.',
+  },
+  (context) => ({
+    ImportDeclaration(node: AstNode) {
+      const source = String(node.source.value)
+      if (
+        source.startsWith('@channel.io/bezier-react/') &&
+        !PUBLIC_ENTRYPOINTS.has(source)
+      ) {
+        context.report({
+          node: node.source,
+          messageId: 'rejected',
+          data: { path: source },
+        })
+      }
+    },
+  })
+)

--- a/packages/eslint-plugin-bezier/src/rules/no-public-style-prop-bypass.ts
+++ b/packages/eslint-plugin-bezier/src/rules/no-public-style-prop-bypass.ts
@@ -1,0 +1,51 @@
+import {
+  type AstNode,
+  ProgramState,
+  contextCwd,
+  contextFilename,
+  jsxAttribute,
+  jsxName,
+  propertyName,
+} from '../ast.js'
+import { loadComponentContracts } from '../manifest.js'
+import { createRule } from '../rule.js'
+
+export const noPublicStylePropBypass = createRule(
+  'Prefer public Bezier props over equivalent static inline style keys.',
+  {
+    rejected:
+      'BZR-PROP-004: `{{component}}` exposes public props for {{props}}. Use those props or a reasoned line suppression.',
+  },
+  (context) => {
+    const state = new ProgramState(
+      contextFilename(context),
+      contextCwd(context)
+    )
+    return {
+      ImportDeclaration: (node: AstNode) => state.visitImport(node),
+      ExportNamedDeclaration: (node: AstNode) => state.visitExport(node),
+      VariableDeclarator: (node: AstNode) => state.visitVariable(node),
+      JSXOpeningElement(node: AstNode) {
+        const component = state.resolve(jsxName(node.name))
+        if (!component) return
+        const contract = loadComponentContracts(contextCwd(context)).get(component)
+        if (!contract) return
+        const style = jsxAttribute(node, 'style')
+        const expression = style?.value?.expression
+        if (expression?.type !== 'ObjectExpression') return
+        const matches = expression.properties
+          .filter((property: AstNode) => property.type === 'Property')
+          .map(propertyName)
+          .filter((name: string | null): name is string =>
+            Boolean(name && contract.props.has(name))
+          )
+        if (matches.length === 0) return
+        context.report({
+          node: style,
+          messageId: 'rejected',
+          data: { component, props: [...new Set(matches)].join(', ') },
+        })
+      },
+    }
+  }
+)

--- a/packages/eslint-plugin-bezier/src/rules/no-unsafe-prop-type-escape.ts
+++ b/packages/eslint-plugin-bezier/src/rules/no-unsafe-prop-type-escape.ts
@@ -1,0 +1,39 @@
+import {
+  type AstNode,
+  ProgramState,
+  contextCwd,
+  contextFilename,
+  jsxName,
+} from '../ast.js'
+import { loadComponentContracts } from '../manifest.js'
+import { createRule } from '../rule.js'
+
+export const noUnsafePropTypeEscape = createRule(
+  'Disallow hiding invalid Bezier JSX props behind any casts.',
+  {
+    rejected:
+      'BZR-PROP-001: Do not hide a Bezier prop contract with `as any`; query the installed component contract and fix the prop.',
+  },
+  (context) => {
+    const cwd = contextCwd(context)
+    const state = new ProgramState(contextFilename(context), cwd)
+
+    function check(node: AstNode) {
+      if (node.typeAnnotation?.type !== 'TSAnyKeyword') return
+      let current = node.parent
+      while (current && current.type !== 'JSXAttribute') current = current.parent
+      if (!current) return
+      const component = state.resolve(jsxName(current.parent?.name))
+      if (!component || !loadComponentContracts(cwd).has(component)) return
+      context.report({ node, messageId: 'rejected' })
+    }
+
+    return {
+      ImportDeclaration: (node: AstNode) => state.visitImport(node),
+      ExportNamedDeclaration: (node: AstNode) => state.visitExport(node),
+      TSAsExpression: check,
+      TSTypeAssertion: check,
+      VariableDeclarator: (node: AstNode) => state.visitVariable(node),
+    }
+  }
+)

--- a/packages/eslint-plugin-bezier/src/rules/prefer-layout-component.ts
+++ b/packages/eslint-plugin-bezier/src/rules/prefer-layout-component.ts
@@ -1,0 +1,121 @@
+import {
+  type AstNode,
+  jsxAttribute,
+  jsxName,
+  staticObjectProperties,
+} from '../ast.js'
+import { createRule } from '../rule.js'
+
+const OWNER_ATTRIBUTES = new Set([
+  'contentEditable',
+  'dangerouslySetInnerHTML',
+  'ref',
+  'role',
+  'tabIndex',
+])
+
+const BOX_STYLE_PROPERTIES = new Set([
+  'backgroundColor',
+  'borderBottomWidth',
+  'borderColor',
+  'borderLeftWidth',
+  'borderRadius',
+  'borderRightWidth',
+  'borderTopWidth',
+  'borderWidth',
+  'bottom',
+  'display',
+  'height',
+  'inset',
+  'left',
+  'margin',
+  'marginBottom',
+  'marginLeft',
+  'marginRight',
+  'marginTop',
+  'maxHeight',
+  'maxWidth',
+  'minHeight',
+  'minWidth',
+  'overflow',
+  'overflowX',
+  'overflowY',
+  'padding',
+  'paddingBottom',
+  'paddingLeft',
+  'paddingRight',
+  'paddingTop',
+  'position',
+  'right',
+  'top',
+  'width',
+])
+
+function candidate(node: AstNode) {
+  if (jsxName(node.name) !== 'div') return null
+  for (const attribute of node.attributes ?? []) {
+    if (attribute.type === 'JSXSpreadAttribute') return null
+    const name = attribute.name?.name
+    if (
+      OWNER_ATTRIBUTES.has(name) ||
+      name === 'className' ||
+      name === 'css' ||
+      /^on[A-Z]/u.test(name)
+    ) {
+      return null
+    }
+  }
+  const style = jsxAttribute(node, 'style')
+  const properties = staticObjectProperties(style?.value?.expression)
+  if (!style || !properties || properties.size === 0) return null
+  const display = String(properties.get('display') ?? '').toLowerCase()
+  const position = String(properties.get('position') ?? '').toLowerCase()
+  const overflow = [
+    properties.get('overflow'),
+    properties.get('overflowX'),
+    properties.get('overflowY'),
+  ].map((value) => String(value ?? '').toLowerCase())
+  if (
+    display === 'grid' ||
+    display === 'inline-grid' ||
+    position === 'absolute' ||
+    position === 'fixed' ||
+    overflow.some((value) => value === 'auto' || value === 'scroll') ||
+    [...properties.keys()].some((name) => name.startsWith('grid'))
+  ) {
+    return null
+  }
+  if (display === 'flex' || display === 'inline-flex') {
+    const direction = String(properties.get('flexDirection') ?? 'row').toLowerCase()
+    if (!/^(?:row|row-reverse|column|column-reverse)$/u.test(direction)) return null
+    return {
+      component: direction.startsWith('column') ? 'VStack' : 'HStack',
+      detail: `flex-direction: ${direction}`,
+      style,
+    }
+  }
+  if ([...properties.keys()].every((name) => BOX_STYLE_PROPERTIES.has(name))) {
+    return { component: 'Box', detail: 'static Box-supported style', style }
+  }
+  return null
+}
+
+export const preferLayoutComponent = createRule(
+  'Suggest Bezier layout components for conservative native div candidates.',
+  {
+    candidate:
+      'BZR-LAYOUT-002: This div is an advisory `{{component}}` candidate ({{detail}}). Review semantic, scroll, grid, and responsive ownership.',
+  },
+  (context) => ({
+    JSXOpeningElement(node: AstNode) {
+      const value = candidate(node)
+      if (value) {
+        context.report({
+          node: value.style,
+          messageId: 'candidate',
+          data: value,
+        })
+      }
+    },
+  })
+)

--- a/packages/eslint-plugin-bezier/src/rules/prefer-text-for-plain-text.ts
+++ b/packages/eslint-plugin-bezier/src/rules/prefer-text-for-plain-text.ts
@@ -1,0 +1,81 @@
+import {
+  type AstNode,
+  ProgramState,
+  contextCwd,
+  contextFilename,
+  jsxName,
+} from '../ast.js'
+import { createRule } from '../rule.js'
+
+const SEMANTIC_OWNERS = new Set([
+  'a',
+  'button',
+  'label',
+  'option',
+  'Badge',
+  'Banner',
+  'Button',
+  'Checkbox',
+  'DropdownMenuItem',
+  'DropdownMenuSubTrigger',
+  'IconButton',
+  'SectionItem',
+  'SegmentedControlItem',
+  'Tag',
+])
+
+function hasDirectText(node: AstNode) {
+  return (node.children ?? []).some((child: AstNode) => {
+    if (child.type === 'JSXText') return child.value.trim().length > 0
+    if (child.type !== 'JSXExpressionContainer') return false
+    const expression = child.expression
+    if (expression.type === 'Literal') return typeof expression.value === 'string'
+    if (expression.type === 'TemplateLiteral') return true
+    if (expression.type !== 'CallExpression') return false
+    const callee = expression.callee
+    if (callee.type === 'Identifier') return /^(?:t|translate|translator)$/u.test(callee.name)
+    return (
+      callee.type === 'MemberExpression' &&
+      !callee.computed &&
+      /^(?:t|translate)$/u.test(callee.property.name)
+    )
+  })
+}
+
+export const preferTextForPlainText = createRule(
+  'Suggest Bezier Text for unowned plain span and p text.',
+  {
+    rejected:
+      'BZR-TEXT-002: Plain `{{name}}` directly owns text. Use Bezier `Text` unless DOM semantics or a semantic owner requires it.',
+  },
+  (context) => {
+    const state = new ProgramState(
+      contextFilename(context),
+      contextCwd(context)
+    )
+    return {
+      ImportDeclaration: (node: AstNode) => state.visitImport(node),
+      ExportNamedDeclaration: (node: AstNode) => state.visitExport(node),
+      VariableDeclarator: (node: AstNode) => state.visitVariable(node),
+      JSXElement(node: AstNode) {
+        const name = jsxName(node.openingElement.name)
+        if (!name || !['p', 'span'].includes(name) || !hasDirectText(node)) return
+        let parent = node.parent
+        while (parent) {
+          if (parent.type === 'JSXElement') {
+            const ancestor =
+              state.resolve(jsxName(parent.openingElement.name)) ??
+              jsxName(parent.openingElement.name)
+            if (ancestor && SEMANTIC_OWNERS.has(ancestor)) return
+          }
+          parent = parent.parent
+        }
+        context.report({
+          node: node.openingElement,
+          messageId: 'rejected',
+          data: { name },
+        })
+      },
+    }
+  }
+)

--- a/packages/eslint-plugin-bezier/src/rules/require-suppression-reason.ts
+++ b/packages/eslint-plugin-bezier/src/rules/require-suppression-reason.ts
@@ -1,0 +1,28 @@
+import { type AstNode } from '../ast.js'
+import { createRule } from '../rule.js'
+
+export const requireSuppressionReason = createRule(
+  'Require line-scoped, reasoned suppressions for Bezier rules.',
+  {
+    blanket:
+      'BZR-ENG-001: File-wide Bezier suppression is forbidden. Suppress one line and record a concrete reason.',
+    reason:
+      'BZR-ENG-001: Bezier suppression must use `-- <specific reason>` explaining why the public alternative is unsafe.',
+  },
+  (context) => ({
+    Program() {
+      for (const comment of context.getSourceCode().getAllComments()) {
+        const value = comment.value.trim()
+        if (!/eslint-disable/u.test(value) || !/bezier/iu.test(value)) continue
+        if (/^eslint-disable(?:\s|$)/u.test(value)) {
+          context.report({ node: comment as AstNode, messageId: 'blanket' })
+          continue
+        }
+        const reason = value.split(/\s--\s/u)[1]?.trim() ?? ''
+        if (reason.length < 12) {
+          context.report({ node: comment as AstNode, messageId: 'reason' })
+        }
+      }
+    },
+  })
+)

--- a/packages/eslint-plugin-bezier/tsconfig.eslint.json
+++ b/packages/eslint-plugin-bezier/tsconfig.eslint.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false
+    "noEmit": true
   },
-  "include": ["src", ".*.js"],
+  "include": ["src", "*.cjs"],
   "exclude": []
 }

--- a/packages/eslint-plugin-bezier/tsconfig.json
+++ b/packages/eslint-plugin-bezier/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "tsconfig/node.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "target": "ES2022"
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts"]

--- a/packages/stylelint-bezier/README.md
+++ b/packages/stylelint-bezier/README.md
@@ -61,6 +61,22 @@ Deprecated beta tokens should keep their token value but add `deprecated` or `$d
 }
 ```
 
+### Opt-in Bezier rules
+
+The package registers the following rules without enabling them. Consumers own
+activation and severity; extending this package continues to enable only
+`bezier/validate-token`.
+
+- `bezier/no-internal-selector`
+- `bezier/no-component-style-override`
+- `bezier/prefer-layout-component`
+- `bezier/require-suppression-reason`
+
+`no-component-style-override` reads the installed
+`@channel.io/bezier-react/manifest.json` contract only when that rule is
+enabled. Product aliases and product-specific exception policy are not part of
+this package.
+
 ## Version Matchups
 
 | @channel.io/stylelint-bezier | @channel.io/bezier-react |

--- a/packages/stylelint-bezier/jest.config.cjs
+++ b/packages/stylelint-bezier/jest.config.cjs
@@ -1,0 +1,9 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  cacheDirectory: '.jestcache',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[t|j]sx?$': ['@swc/jest'],
+  },
+  testMatch: ['**/*.test.ts'],
+}

--- a/packages/stylelint-bezier/package.json
+++ b/packages/stylelint-bezier/package.json
@@ -8,11 +8,18 @@
     "directory": "packages/stylelint-bezier"
   },
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "!dist/*.tsbuildinfo",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc --build --verbose",
     "dev": "tsc --watch",
     "lint": "TIMING=1 eslint --cache .",
     "typecheck": "tsc --noEmit",
+    "test": "jest --coverage",
     "clean": "run-s 'clean:*'",
     "clean:build": "rm -rf dist",
     "clean:cache": "rm -rf node_modules .turbo .eslintcache stats.html"
@@ -23,11 +30,18 @@
     "@channel.io/bezier-tokens": "1.0.0-next.5"
   },
   "devDependencies": {
+    "@types/node": "^22.10.2",
     "eslint-config-bezier": "workspace:*",
     "postcss-styled-syntax": "^0.7.0",
     "tsconfig": "workspace:*"
   },
   "peerDependencies": {
+    "@channel.io/bezier-react": "^4.0.0-next.17",
     "stylelint": ">=16.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@channel.io/bezier-react": {
+      "optional": true
+    }
   }
 }

--- a/packages/stylelint-bezier/src/index.test.ts
+++ b/packages/stylelint-bezier/src/index.test.ts
@@ -1,0 +1,142 @@
+import postcssStyledSyntax from 'postcss-styled-syntax'
+import stylelint, { type Rule } from 'stylelint'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const config = require('./index') as { rules: Record<string, unknown> }
+import {
+  rule as componentOverride,
+  ruleName as componentOverrideName,
+} from './plugins/no-component-style-override'
+import {
+  rule as internalSelector,
+  ruleName as internalSelectorName,
+} from './plugins/no-internal-selector'
+import {
+  rule as layout,
+  ruleName as layoutName,
+} from './plugins/prefer-layout-component'
+import {
+  rule as suppression,
+  ruleName as suppressionName,
+} from './plugins/require-suppression-reason'
+import {
+  rule as validateToken,
+  ruleName as validateTokenName,
+} from './plugins/validate-token'
+
+async function warnings(
+  code: string,
+  ruleName: string,
+  rule: Rule,
+  codeFilename = 'fixture.css'
+) {
+  const result = await stylelint.lint({
+    code,
+    codeFilename,
+    config: {
+      customSyntax: codeFilename.endsWith('.css')
+        ? undefined
+        : postcssStyledSyntax,
+      plugins: [{ ruleName, rule }],
+      rules: { [ruleName]: true },
+    },
+  })
+  return result.results[0].warnings
+}
+
+test('the shared config activates only the existing token rule', () => {
+  expect(config.rules).toEqual({ 'bezier/validate-token': true })
+})
+
+test('validate-token preserves invalid token diagnostics', async () => {
+  const result = await warnings(
+    '.sample { color: var(--not-a-bezier-token); }',
+    validateTokenName,
+    validateToken
+  )
+  expect(result).toHaveLength(1)
+  expect(result[0].text).toContain('Invalid token')
+})
+
+test('no-internal-selector rejects private test selectors', async () => {
+  expect(
+    await warnings(
+      `import styled from 'styled-components'
+       const Wrapped = styled.div\`
+         & [data-testid="bezier-button-content"] { color: red; }
+       \``,
+      internalSelectorName,
+      internalSelector,
+      'fixture.styles.tsx'
+    )
+  ).toHaveLength(1)
+})
+
+test('component overrides use the installed public prop contract', async () => {
+  const invalid = `
+    import { Box as Surface } from '@channel.io/bezier-react/beta'
+    import styled from 'styled-components'
+    export const StyledSurface = styled(Surface)\`
+      padding: 4px;
+    \`
+  `
+  const valid = `
+    import { Button } from '@channel.io/bezier-react/beta'
+    import styled from 'styled-components'
+    export const StyledButton = styled(Button)\`
+      text-transform: uppercase;
+    \`
+  `
+  expect(
+    await warnings(
+      invalid,
+      componentOverrideName,
+      componentOverride,
+      'fixture.styles.tsx'
+    )
+  ).toHaveLength(1)
+  expect(
+    await warnings(
+      valid,
+      componentOverrideName,
+      componentOverride,
+      'fixture.styles.ts'
+    )
+  ).toHaveLength(0)
+})
+
+test('layout candidates exclude dynamic, grid, scroll, and responsive ownership', async () => {
+  const candidate = `
+    import styled from 'styled-components'
+    export const Row = styled.div\`
+      display: flex;
+      padding: 4px;
+    \`
+  `
+  const excluded = [
+    'display: grid;',
+    'display: flex; overflow: auto;',
+    'display: flex; padding: ${responsivePadding};',
+    'display: flex; @media (width > 600px) { display: block; }',
+  ]
+  expect(
+    await warnings(candidate, layoutName, layout, 'fixture.styles.tsx')
+  ).toHaveLength(1)
+  for (const declarations of excluded) {
+    const code = `import styled from 'styled-components'; const Row = styled.div\`${declarations}\``
+    expect(
+      await warnings(code, layoutName, layout, 'fixture.styles.tsx')
+    ).toHaveLength(0)
+  }
+})
+
+test('suppression hygiene requires a scoped concrete reason', async () => {
+  const invalid =
+    '/* stylelint-disable bezier/no-component-style-override */\n.a { color: red; }'
+  const valid =
+    '/* stylelint-disable-next-line bezier/no-component-style-override -- Third-party widget requires this fixed width */\n.a { width: 10px; }'
+  expect(
+    await warnings(invalid, suppressionName, suppression)
+  ).toHaveLength(1)
+  expect(await warnings(valid, suppressionName, suppression)).toHaveLength(0)
+})

--- a/packages/stylelint-bezier/src/index.ts
+++ b/packages/stylelint-bezier/src/index.ts
@@ -1,5 +1,11 @@
 module.exports = {
-  plugins: ['./plugins/validate-token'],
+  plugins: [
+    './plugins/no-component-style-override',
+    './plugins/no-internal-selector',
+    './plugins/prefer-layout-component',
+    './plugins/require-suppression-reason',
+    './plugins/validate-token',
+  ],
   rules: {
     'bezier/validate-token': true,
   },

--- a/packages/stylelint-bezier/src/manifest.ts
+++ b/packages/stylelint-bezier/src/manifest.ts
@@ -1,0 +1,68 @@
+import { readFileSync, statSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join, resolve } from 'node:path'
+
+export interface ComponentContract {
+  name: string
+  props: Set<string>
+}
+
+interface CachedContracts {
+  mtimeMs: number
+  path: string
+  size: number
+  value: Map<string, ComponentContract>
+}
+
+const cache = new Map<string, CachedContracts>()
+
+export function loadComponentContracts(cwd = process.cwd()) {
+  const root = resolve(cwd)
+  const consumerRequire = createRequire(join(root, 'package.json'))
+  const manifestPath = consumerRequire.resolve(
+    '@channel.io/bezier-react/manifest.json'
+  )
+  const stat = statSync(manifestPath)
+  const cached = cache.get(root)
+  if (
+    cached?.path === manifestPath &&
+    cached.mtimeMs === stat.mtimeMs &&
+    cached.size === stat.size
+  ) {
+    return cached.value
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+    schemaVersion?: unknown
+    components?: { name?: unknown; props?: { name?: unknown }[] }[]
+  }
+  if (
+    typeof manifest.schemaVersion !== 'string' ||
+    !manifest.schemaVersion.startsWith('1.') ||
+    !Array.isArray(manifest.components)
+  ) {
+    throw new Error(
+      `Unsupported @channel.io/bezier-react manifest at ${manifestPath}.`
+    )
+  }
+
+  const contracts = new Map<string, ComponentContract>()
+  for (const component of manifest.components) {
+    if (typeof component.name !== 'string') continue
+    contracts.set(component.name, {
+      name: component.name,
+      props: new Set(
+        (component.props ?? []).flatMap((prop) =>
+          typeof prop.name === 'string' ? [prop.name] : []
+        )
+      ),
+    })
+  }
+  cache.set(root, {
+    mtimeMs: stat.mtimeMs,
+    path: manifestPath,
+    size: stat.size,
+    value: contracts,
+  })
+  return contracts
+}

--- a/packages/stylelint-bezier/src/plugins/no-component-style-override/index.ts
+++ b/packages/stylelint-bezier/src/plugins/no-component-style-override/index.ts
@@ -1,0 +1,73 @@
+import { type Document, type Root } from 'postcss'
+
+import { loadComponentContracts } from '../../manifest'
+import { booleanPlugin, report } from '../utils'
+
+export const ruleName = 'bezier/no-component-style-override'
+export const messages = {
+  rejected:
+    'BZR-PROP-004: `{{component}}` exposes a public `{{prop}}` prop. Use it instead of overriding the component declaration, or add a reasoned line suppression.',
+}
+
+function importBindings(code: string) {
+  const bindings = new Map<string, string>()
+  const named =
+    /import\s*\{([^}]+)\}\s*from\s*["']@channel\.io\/bezier-react\/beta["']/gu
+  for (const match of code.matchAll(named)) {
+    for (const entry of match[1].split(',')) {
+      const normalized = entry.trim().replace(/^type\s+/u, '')
+      const parts = normalized.split(/\s+as\s+/u).map((value) => value.trim())
+      if (parts[0]) bindings.set(parts[1] ?? parts[0], parts[0])
+    }
+  }
+  const namespace =
+    /import\s*\*\s*as\s*([\w$]+)\s*from\s*["']@channel\.io\/bezier-react\/beta["']/gu
+  for (const match of code.matchAll(namespace)) bindings.set(match[1], '*')
+  return bindings
+}
+
+function styledComponent(root: Root) {
+  const code = root.raws.codeBefore ?? ''
+  const target = code.match(
+    /styled\s*\(\s*([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\s*\)(?:\s*\.\s*attrs[\s\S]*)?\s*`?\s*$/u
+  )?.[1]
+  if (!target) return null
+  const [local, member] = target.split('.')
+  const binding = importBindings(code).get(local)
+  return binding === '*' ? member ?? null : binding ?? null
+}
+
+function camelCase(property: string) {
+  return property.replace(/-([a-z])/gu, (_, letter: string) =>
+    letter.toUpperCase()
+  )
+}
+
+export const rule = booleanPlugin(
+  ruleName,
+  messages.rejected,
+  (document: Root | Document, result) => {
+    const contracts = loadComponentContracts()
+    const roots = document.type === 'document' ? document.nodes : [document]
+    for (const node of roots) {
+      if (node.type !== 'root') continue
+      const component = styledComponent(node)
+      const contract = component ? contracts.get(component) : null
+      if (!component || !contract) continue
+      for (const child of node.nodes ?? []) {
+        if (child.type !== 'decl' || child.prop.startsWith('--')) continue
+        const prop = camelCase(child.prop.toLowerCase())
+        if (!contract.props.has(prop)) continue
+        report(
+          result,
+          ruleName,
+          messages.rejected
+            .replace('{{component}}', component)
+            .replace('{{prop}}', prop),
+          child,
+          child.prop
+        )
+      }
+    }
+  }
+)

--- a/packages/stylelint-bezier/src/plugins/no-internal-selector/index.ts
+++ b/packages/stylelint-bezier/src/plugins/no-internal-selector/index.ts
@@ -1,0 +1,20 @@
+import { booleanPlugin, report } from '../utils'
+
+export const ruleName = 'bezier/no-internal-selector'
+export const messages = {
+  rejected:
+    'BZR-API-003: Bezier internal data-testid is not public API. Use a public prop, slot, or consumer-owned wrapper.',
+}
+
+export const rule = booleanPlugin(
+  ruleName,
+  messages.rejected,
+  (root, result, message) => {
+    root.walkRules((cssRule) => {
+      const match = cssRule.selector.match(
+        /\[data-testid\s*(?:=|\^=|\|=)\s*["']?bezier-/iu
+      )
+      if (match) report(result, ruleName, message, cssRule, match[0])
+    })
+  }
+)

--- a/packages/stylelint-bezier/src/plugins/prefer-layout-component/index.ts
+++ b/packages/stylelint-bezier/src/plugins/prefer-layout-component/index.ts
@@ -1,0 +1,35 @@
+import { type Root, type Rule } from 'postcss'
+
+import { booleanPlugin, report } from '../utils'
+
+import { layoutCandidate } from './layout-candidates'
+
+export const ruleName = 'bezier/prefer-layout-component'
+export const messages = {
+  rejected:
+    'BZR-LAYOUT-002: This styled.div is an advisory Bezier layout candidate. Review semantic, scroll, grid, and responsive ownership.',
+}
+
+export const rule = booleanPlugin(
+  ruleName,
+  messages.rejected,
+  (root, result) => {
+    const containers = new Set<Root | Rule>()
+    root.walkDecls((decl) => {
+      const parent = decl.parent
+      if (parent?.type === 'root' || parent?.type === 'rule') {
+        containers.add(parent as Root | Rule)
+      }
+    })
+    for (const container of containers) {
+      const candidate = layoutCandidate(container)
+      if (!candidate) continue
+      report(
+        result,
+        ruleName,
+        `BZR-LAYOUT-002: This is an advisory \`${candidate.component}\` candidate (${candidate.detail}). Review semantic, scroll, grid, and responsive ownership.`,
+        candidate.declaration
+      )
+    }
+  }
+)

--- a/packages/stylelint-bezier/src/plugins/prefer-layout-component/layout-candidates.ts
+++ b/packages/stylelint-bezier/src/plugins/prefer-layout-component/layout-candidates.ts
@@ -1,0 +1,113 @@
+import {
+  type Container,
+  type Declaration,
+  type Root,
+  type Rule,
+} from 'postcss'
+
+const BOX_PROPERTIES = new Set([
+  'background-color',
+  'border-bottom-width',
+  'border-color',
+  'border-left-width',
+  'border-radius',
+  'border-right-width',
+  'border-top-width',
+  'border-width',
+  'bottom',
+  'display',
+  'height',
+  'left',
+  'margin',
+  'margin-bottom',
+  'margin-left',
+  'margin-right',
+  'margin-top',
+  'max-height',
+  'max-width',
+  'min-height',
+  'min-width',
+  'overflow',
+  'overflow-x',
+  'overflow-y',
+  'padding',
+  'padding-bottom',
+  'padding-left',
+  'padding-right',
+  'padding-top',
+  'position',
+  'right',
+  'top',
+  'width',
+])
+
+function declarations(container: Container) {
+  return (container.nodes ?? []).filter(
+    (node): node is Declaration => node.type === 'decl'
+  )
+}
+
+function isStyledDiv(root: Root) {
+  return /styled\s*(?:\.\s*div|\(\s*["']div["']\s*\))(?:\s*\.\s*attrs[\s\S]*)?\s*`?\s*$/u.test(
+    root.raws.codeBefore ?? ''
+  )
+}
+
+export function layoutCandidate(container: Root | Rule) {
+  if (container.type === 'rule' && /::?[\w-]+/u.test(container.selector)) return null
+  if (container.type === 'root' && !isStyledDiv(container)) return null
+  const values = declarations(container)
+  if (
+    values.length === 0 ||
+    (container.nodes ?? []).some(
+      (node) => node.type === 'atrule' || node.type === 'rule'
+    ) ||
+    values.some((decl) => /\$\{/u.test(decl.value))
+  ) {
+    return null
+  }
+  const disqualified = values.some((decl) => {
+    const property = decl.prop.toLowerCase()
+    const value = decl.value.trim().toLowerCase()
+    return (
+      (property === 'position' && /^(?:absolute|fixed)$/u.test(value)) ||
+      (property === 'display' && /^(?:inline-)?grid$/u.test(value)) ||
+      property === 'grid' ||
+      property.startsWith('grid-') ||
+      property === 'animation' ||
+      property.startsWith('animation-') ||
+      (/^overflow(?:-[xy])?$/u.test(property) &&
+        /(?:^|\s)(?:auto|scroll)(?:\s|$)/u.test(value))
+    )
+  })
+  if (disqualified) return null
+  const display = values.find(
+    (decl) =>
+      decl.prop.toLowerCase() === 'display' &&
+      /^(?:inline-)?flex$/u.test(decl.value.trim())
+  )
+  if (display) {
+    const direction =
+      values
+        .find((decl) => decl.prop.toLowerCase() === 'flex-direction')
+        ?.value.trim()
+        .toLowerCase() ?? 'row'
+    if (!/^(?:row|row-reverse|column|column-reverse)$/u.test(direction)) return null
+    return {
+      component: direction.startsWith('column') ? 'VStack' : 'HStack',
+      declaration: display,
+      detail: `flex-direction: ${direction}`,
+    }
+  }
+  if (
+    container.type === 'root' &&
+    values.every((decl) => BOX_PROPERTIES.has(decl.prop.toLowerCase()))
+  ) {
+    return {
+      component: 'Box',
+      declaration: values[0],
+      detail: 'static Box-supported declarations',
+    }
+  }
+  return null
+}

--- a/packages/stylelint-bezier/src/plugins/require-suppression-reason/index.ts
+++ b/packages/stylelint-bezier/src/plugins/require-suppression-reason/index.ts
@@ -1,0 +1,23 @@
+import { booleanPlugin, report } from '../utils'
+
+export const ruleName = 'bezier/require-suppression-reason'
+export const messages = {
+  rejected:
+    'BZR-ENG-001: Bezier suppression must be line-scoped and include `-- <specific reason>` explaining why the public alternative is unsafe.',
+}
+
+export const rule = booleanPlugin(
+  ruleName,
+  messages.rejected,
+  (root, result, message) => {
+    root.walkComments((comment) => {
+      const value = comment.text.trim()
+      if (!/stylelint-disable/u.test(value) || !/bezier/iu.test(value)) return
+      const fileWide = /^stylelint-disable(?:\s|$)/u.test(value)
+      const reason = value.split(/\s--\s/u)[1]?.trim() ?? ''
+      if (fileWide || reason.length < 12) {
+        report(result, ruleName, message, comment)
+      }
+    })
+  }
+)

--- a/packages/stylelint-bezier/src/plugins/utils.ts
+++ b/packages/stylelint-bezier/src/plugins/utils.ts
@@ -1,0 +1,34 @@
+import { type ChildNode, type Document, type Root } from 'postcss'
+import stylelint, { type PostcssResult, type Rule } from 'stylelint'
+
+export function booleanPlugin(
+  ruleName: string,
+  message: string,
+  visitor: (
+    root: Root | Document,
+    result: PostcssResult,
+    message: string
+  ) => void
+) {
+  const messages = stylelint.utils.ruleMessages(ruleName, { rejected: message })
+  const pluginRule: Rule<boolean> = (primary) => (root, result) => {
+    const valid = stylelint.utils.validateOptions(result, ruleName, {
+      actual: primary,
+      possible: [true, false],
+    })
+    if (valid && primary) visitor(root, result, messages.rejected)
+  }
+  pluginRule.ruleName = ruleName
+  pluginRule.messages = messages
+  return pluginRule
+}
+
+export function report(
+  result: PostcssResult,
+  ruleName: string,
+  message: string,
+  node: ChildNode,
+  word?: string
+) {
+  stylelint.utils.report({ result, ruleName, message, node, word })
+}

--- a/packages/stylelint-bezier/src/postcss-styled-syntax.d.ts
+++ b/packages/stylelint-bezier/src/postcss-styled-syntax.d.ts
@@ -1,0 +1,6 @@
+declare module 'postcss-styled-syntax' {
+  import { type Syntax } from 'postcss'
+
+  const syntax: Syntax
+  export default syntax
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2425,6 +2425,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@channel.io/eslint-plugin-bezier@workspace:packages/eslint-plugin-bezier":
+  version: 0.0.0-use.local
+  resolution: "@channel.io/eslint-plugin-bezier@workspace:packages/eslint-plugin-bezier"
+  dependencies:
+    "@types/eslint": "npm:^8.56.12"
+    "@types/node": "npm:^22.10.2"
+    "@typescript-eslint/parser": "npm:8.17.0"
+    eslint: "npm:^8.57.1"
+    eslint-config-bezier: "workspace:*"
+    tsconfig: "workspace:*"
+    typescript: "npm:^5.7.2"
+  peerDependencies:
+    "@channel.io/bezier-react": ^4.0.0-next.17
+    "@typescript-eslint/parser": ">=8.17.0 <9"
+    eslint: ">=8.57.0 <10"
+  peerDependenciesMeta:
+    "@typescript-eslint/parser":
+      optional: true
+  languageName: unknown
+  linkType: soft
+
 "@channel.io/eslint-plugin@npm:^1.2.3":
   version: 1.2.3
   resolution: "@channel.io/eslint-plugin@npm:1.2.3"
@@ -2444,11 +2465,16 @@ __metadata:
   resolution: "@channel.io/stylelint-bezier@workspace:packages/stylelint-bezier"
   dependencies:
     "@channel.io/bezier-tokens": "npm:1.0.0-next.5"
+    "@types/node": "npm:^22.10.2"
     eslint-config-bezier: "workspace:*"
     postcss-styled-syntax: "npm:^0.7.0"
     tsconfig: "workspace:*"
   peerDependencies:
+    "@channel.io/bezier-react": ^4.0.0-next.17
     stylelint: ">=16.0.0"
+  peerDependenciesMeta:
+    "@channel.io/bezier-react":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -6447,6 +6473,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/eslint@npm:^8.56.12":
+  version: 8.56.12
+  resolution: "@types/eslint@npm:8.56.12"
+  dependencies:
+    "@types/estree": "npm:*"
+    "@types/json-schema": "npm:*"
+  checksum: 10/bd998b5d3f98ac430ec8db6223f1cff1820774c1e72eabda05463256875d97065fd357fba7379dd25e6bfbeb73296f28faff6f4dcbc320f890bb49b09087644d
+  languageName: node
+  linkType: hard
+
 "@types/estree@npm:*, @types/estree@npm:^1.0.0":
   version: 1.0.5
   resolution: "@types/estree@npm:1.0.5"
@@ -6714,7 +6750,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^8.0.1":
+"@typescript-eslint/parser@npm:8.17.0, @typescript-eslint/parser@npm:^8.0.1":
   version: 8.17.0
   resolution: "@typescript-eslint/parser@npm:8.17.0"
   dependencies:


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] The commit follows the **Conventional Commits** specification.
- [x] I added a **changeset** for the packages released by this feature.
- [x] I documented the opt-in ESLint and Stylelint rules.
- [x] I added positive, counterexample, parser, and package compatibility tests.
- [x] Browser testing is not applicable because this change adds lint tooling and does not alter rendered UI.

## Related Issue

- WEB-12725

## Summary

- Add the repo-local `@channel.io/eslint-plugin-bezier` package with 15 opt-in rules derived from the installed Bezier React manifest and static host evidence.
- Extend `@channel.io/stylelint-bezier` with four opt-in Bezier rules while preserving `bezier/validate-token` as the only rule enabled by default.
- Trace direct, aliased, namespace, relative, `styled()`, `.attrs()`, and exported wrapper origins without treating dynamic or unresolved wrappers as blocking errors.
- Keep product aliases, raw color and typography policy, activation, severity, and CI failure policy consumer-owned.

## Details

- Covers public entrypoint, compound ownership, public prop/type contracts, native controls, conservative layout/text candidates, icon ownership, private descendant selectors, and suppression hygiene.
- Resolves installed React manifest data when a rule needs component or compound ownership instead of embedding a duplicate catalog.
- Uses the consumer's optional `@typescript-eslint/parser` for cross-file TypeScript wrapper tracing and keeps unresolved ancestry advisory when the parser is unavailable.
- Preserves ESLint 8 legacy plugin resolution and ESLint 9 flat-config usage through the conventional scoped plugin name.
- Registers Stylelint rules for internal selectors, component-owned style overrides, layout candidates, and reasoned suppressions without adding a recommended preset.
- Includes no Pilot beta.7 source, fixture, runtime dependency, expected output, or product-specific `Bezier/*` alias.

### Verification

- ESLint package build, lint, typecheck, and tests: 1 suite / 66 tests
- ESLint coverage: statements 89.57%, lines 93.54%
- Stylelint package build, lint, typecheck, and tests: 1 suite / 6 tests
- Stylelint coverage: statements 86.04%, lines 91.80%
- Full repository build, lint, typecheck, and tests
- Manifest counterexamples: 6/6
- Clean consumers: ESLint 8.57 legacy + parser 8.17, ESLint 9.35 flat + parser 8.39, Stylelint 16.23 with `.styles.tsx`
- Changeset simulation: ESLint `0.1.0-next.0`, Stylelint `0.4.0-next.7`
- Final package archives exclude coverage, caches, and `tsbuildinfo`

### Release boundary

The changeset is included in this feature PR. Merging the generated Changesets release PR and publishing npm prereleases remain deferred until the WEB-12724 CP5 clean-consumer integration gate.

### Breaking change? (Yes/No)

No. All new rules are opt-in, and the existing Stylelint token rule remains the only default rule.

## References

- CP3 of the WEB-12724 distribution plan
- Builds on the source-derived manifests in #2900 and the repo-local Toolkit in #2901
