### PR TITLE
fix: let beta Icon inherit color when the color prop is omitted

### DIFF
--- a/.changeset/web-13096-icon-inherit-color.md
+++ b/.changeset/web-13096-icon-inherit-color.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/bezier-react': patch
+---
+
+Let beta `Icon` inherit its color when `color` is omitted. It previously always wrote `icon-neutral` into the inline `--b-beta-icon-color`, which shadowed the `initial` value the stylesheet relies on and left consumers unable to color an icon from its parent.

--- a/packages/bezier-react/src/beta/Icon/Icon.stories.tsx
+++ b/packages/bezier-react/src/beta/Icon/Icon.stories.tsx
@@ -53,9 +53,6 @@ const meta: Meta<typeof Icon> = {
     // left as a free-text control rather than a restricted option list.
     color: {
       control: 'text',
-      table: {
-        defaultValue: { summary: '"icon-neutral"' },
-      },
     },
   },
 }

--- a/packages/bezier-react/src/beta/Icon/Icon.test.tsx
+++ b/packages/bezier-react/src/beta/Icon/Icon.test.tsx
@@ -27,9 +27,7 @@ describe('Icon', () => {
 
     expect(rendered).toHaveClass(styles.Icon)
     expect(rendered).toHaveClass(styles['size-24'])
-    expect(rendered).toHaveStyle(
-      `--b-beta-icon-color: ${colorTokenCssVar('icon-neutral')}`
-    )
+    expect(rendered?.style.getPropertyValue('--b-beta-icon-color')).toBe('')
     expect(rendered).toHaveAttribute('aria-hidden', 'true')
     expect(rendered).toHaveAttribute('focusable', 'false')
     expect(rendered).not.toHaveAttribute('role')

--- a/packages/bezier-react/src/beta/Icon/Icon.tsx
+++ b/packages/bezier-react/src/beta/Icon/Icon.tsx
@@ -8,7 +8,6 @@ import classNames from 'classnames'
 
 
 import { getMarginStyles, splitByMarginProps } from '~/src/types/props-helpers'
-import { type SemanticColor } from '~/src/types/tokens'
 import { colorTokenCssVar } from '~/src/utils/style'
 
 import { type IconProps } from './Icon.types'
@@ -17,11 +16,10 @@ import styles from './Icon.module.scss'
 
 
 
-const DEFAULT_ICON_COLOR = 'icon-neutral' satisfies SemanticColor
-
 /**
  * `Icon` renders a Bezier icon as an SVG element.
  * Inject an icon component from the `@channel.io/bezier-icons` package into the `source` prop.
+ * Without `color`, the icon inherits the color of its parent.
  * @example
  *
  * ```tsx
@@ -42,7 +40,7 @@ export const Icon = memo(
     const {
       className,
       size = '24',
-      color = DEFAULT_ICON_COLOR,
+      color,
       source: SourceElement,
       style,
       role,


### PR DESCRIPTION
## Self Checklist

- [x] I wrote a PR title in **English** and added an appropriate **label** to the PR.
- [x] I wrote the commit message in **English** and to follow [**the Conventional Commits specification**](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I [added the **changeset**](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) about the changes that needed to be released. (or didn't have to)
- [x] I wrote or updated **documentation** related to the changes. (or didn't have to)
- [x] I wrote or updated **tests** related to the changes. (or didn't have to)
- [ ] I tested the changes in various browsers. (or didn't have to)

## Related Issue

WEB-13096

## Summary

Beta `Icon` always wrote `icon-neutral` into the inline `--b-beta-icon-color`, so an icon could never take its color from the parent. This removes that default and lets the value fall back to the `initial` the stylesheet already declares.

## Details

`Icon.module.scss` opens the variable for inheritance:

```scss
.Icon {
  --b-beta-icon-color: initial;
  color: var(--b-beta-icon-color);
}
```

The component then filled it on every render, so the `initial` branch was unreachable:

```tsx
const DEFAULT_ICON_COLOR = 'icon-neutral' satisfies SemanticColor
const { color = DEFAULT_ICON_COLOR, ... } = marginRest
style={{ '--b-beta-icon-color': colorTokenCssVar(color), ... }}
```

Because that declaration is inline, a consumer could not override it from an ancestor. Setting `color` on the parent loses, and so does a descendant rule such as `button svg { color: ... }` — the only thing that wins is `!important` on the private variable, which is not a usable escape hatch:

| attempt | result (dark theme) |
| --- | --- |
| `color` on the parent element | `rgba(255,255,255,0.4)` |
| `button svg { color: ... }` | `rgba(255,255,255,0.4)` |
| `button svg { --b-beta-icon-color: ... !important }` | `rgba(255,255,255,0.8)` |

Dropping the default makes `colorTokenCssVar(undefined)` return `undefined`, React omits the declaration, and the icon inherits — which is how the deprecated `components/Icon` has always behaved.

### Breaking change? (Yes/No)

No new API, but rendered output changes for anyone who omits `color`: such icons inherit instead of resolving to `icon-neutral`. In practice the blast radius is small, and every case it touches is one where the icon is currently ignoring a color its parent meant to set.

Inside this repo nothing moves in production code. Every beta component that renders `Icon` either passes `color` explicitly or overrides the variable itself — `Banner` sets `--b-beta-icon-color: var(--b-beta-banner-icon-color)` through the `style` prop, which is spread after the default and already wins today. Two Storybook-only renders do change (`Icon.stories` icon gallery, `Emoji.stories`), which is what Chromatic picked up.

Across the Desk monorepo and every micro-frontend remote that consumes beta `Icon` (186 files), 38 call sites omit `color`. I read all of them: in each one an ancestor already declares a color that the inline default is shadowing, so this change makes them render as their authors intended rather than regressing them.

| where | sites | what the parent already declares |
| --- | --- | --- |
| `cht-notebook` | 28 | `icon-neutral-heavy` (annotated with the DES-20044 spec), `text-neutral`, `text-neutral-lighter`, and `ListItem`'s `active` state color |
| `ch-app-store` | 8 | `DetailIconRow` passes `textSecondary` / `textMuted`, and a `danger` override for failed calls |
| `ch-desk-web`, `cht-ai-marketing` | 2 | an edit badge over a thumbnail, `text-neutral-light` with a `:hover` step to `text-neutral` |

Three of those are state-dependent — a selected `ListItem`'s check icon should turn accent blue, the edit badge should darken on hover, and a failed call row should turn red. None of them can do that today.

Consumers that genuinely want the old look can pass `color="icon-neutral"`.

## References

Found while building a mobile webview header in ch-desk-web: three nav icons rendered at 40% white while the surrounding text was at 80%, and there was no way to correct it from the header's own styles.

