### PR TITLE
fix(stylelint-bezier): require styled syntax peer

### DIFF
--- a/.changeset/bundle-styled-syntax.md
+++ b/.changeset/bundle-styled-syntax.md
@@ -1,0 +1,5 @@
+---
+'@channel.io/stylelint-bezier': patch
+---
+
+Bundle the styled-components custom syntax so TypeScript and TSX linting works without consumers installing `postcss-styled-syntax` directly.

--- a/.changeset/bundle-styled-syntax.md
+++ b/.changeset/bundle-styled-syntax.md
@@ -2,4 +2,4 @@
 '@channel.io/stylelint-bezier': patch
 ---
 
-Bundle the styled-components custom syntax so TypeScript and TSX linting works without consumers installing `postcss-styled-syntax` directly.
+Bundle the styled-components custom syntax so TypeScript and TSX linting works without consumers installing `postcss-styled-syntax` directly. Require `postcss@^8.5.1` and `stylelint@>=16.14.1` as peer dependencies so the parser and Stylelint use a compatible PostCSS host.

--- a/.changeset/bundle-styled-syntax.md
+++ b/.changeset/bundle-styled-syntax.md
@@ -2,4 +2,4 @@
 '@channel.io/stylelint-bezier': patch
 ---
 
-Bundle the styled-components custom syntax so TypeScript and TSX linting works without consumers installing `postcss-styled-syntax` directly. Require `postcss@^8.5.1` and `stylelint@>=16.14.1` as peer dependencies so the parser and Stylelint use a compatible PostCSS host.
+Declare the styled-components custom syntax as a required peer so Stylelint can load it from the consumer environment for TypeScript and TSX files. Require compatible `postcss`, `postcss-styled-syntax`, and `stylelint` versions as runtime peers.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "knip": "^5.39.4",
     "npm-run-all2": "^7.0.1",
     "prettier": "^3.4.2",
-    "stylelint": "^16.11.0",
+    "stylelint": "16.14.1",
     "syncpack": "^13.0.0",
     "ts-node": "^10.9.2",
     "turbo": "^2.3.3",

--- a/packages/bezier-react/package.json
+++ b/packages/bezier-react/package.json
@@ -110,7 +110,7 @@
     "lightningcss": "^1.28.2",
     "minimatch": "^10.0.1",
     "paths.macro": "^3.0.1",
-    "postcss": "^8.4.49",
+    "postcss": "^8.5.1",
     "postcss-preset-env": "^10.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/stylelint-bezier/README.md
+++ b/packages/stylelint-bezier/README.md
@@ -7,13 +7,13 @@ Stylelint configuration for Bezier design system.
 ### npm
 
 ```bash
-npm i -D @channel.io/stylelint-bezier postcss@^8.5.1 stylelint@^16.14.1
+npm i -D @channel.io/stylelint-bezier postcss@^8.5.1 postcss-styled-syntax@^0.7.2 stylelint@^16.14.1
 ```
 
 ### yarn
 
 ```bash
-yarn add -D @channel.io/stylelint-bezier postcss@^8.5.1 stylelint@^16.14.1
+yarn add -D @channel.io/stylelint-bezier postcss@^8.5.1 postcss-styled-syntax@^0.7.2 stylelint@^16.14.1
 ```
 
 ## Usage
@@ -26,15 +26,11 @@ Extend @channel.io/stylelint-bezier in your stylelint config.
 }
 ```
 
-The package bundles and directly configures `postcss-styled-syntax` for
-TypeScript and TSX files. Consumers do not need to install or configure that
-custom syntax separately. `postcss@^8.5.1` and `stylelint@>=16.14.1` are
-required peer dependencies and must be installed by the consuming project so
-Stylelint and the custom syntax can share a compatible PostCSS host.
-
-`postcss-styled-syntax` is pinned to the CommonJS-compatible `0.7.1` release.
-Upgrading to an ESM-only release requires migrating this config package away
-from CommonJS first.
+The package configures `postcss-styled-syntax` for TypeScript and TSX files.
+`postcss@^8.5.1`, `postcss-styled-syntax@^0.7.2`, and
+`stylelint@>=16.14.1` are required peer dependencies and must be installed by
+the consuming project. Stylelint loads the custom syntax from the consumer
+environment and shares the compatible PostCSS host.
 
 ## Rules
 

--- a/packages/stylelint-bezier/README.md
+++ b/packages/stylelint-bezier/README.md
@@ -7,13 +7,13 @@ Stylelint configuration for Bezier design system.
 ### npm
 
 ```bash
-npm i -D @channel.io/stylelint-bezier
+npm i -D @channel.io/stylelint-bezier postcss@^8.5.1 stylelint@^16.14.1
 ```
 
 ### yarn
 
 ```bash
-yarn add -D @channel.io/stylelint-bezier
+yarn add -D @channel.io/stylelint-bezier postcss@^8.5.1 stylelint@^16.14.1
 ```
 
 ## Usage
@@ -28,8 +28,9 @@ Extend @channel.io/stylelint-bezier in your stylelint config.
 
 The package bundles and directly configures `postcss-styled-syntax` for
 TypeScript and TSX files. Consumers do not need to install or configure that
-custom syntax separately. `stylelint` remains a peer dependency and must be
-installed by the consuming project.
+custom syntax separately. `postcss@^8.5.1` and `stylelint@>=16.14.1` are
+required peer dependencies and must be installed by the consuming project so
+Stylelint and the custom syntax can share a compatible PostCSS host.
 
 `postcss-styled-syntax` is pinned to the CommonJS-compatible `0.7.1` release.
 Upgrading to an ESM-only release requires migrating this config package away

--- a/packages/stylelint-bezier/README.md
+++ b/packages/stylelint-bezier/README.md
@@ -26,6 +26,15 @@ Extend @channel.io/stylelint-bezier in your stylelint config.
 }
 ```
 
+The package bundles and directly configures `postcss-styled-syntax` for
+TypeScript and TSX files. Consumers do not need to install or configure that
+custom syntax separately. `stylelint` remains a peer dependency and must be
+installed by the consuming project.
+
+`postcss-styled-syntax` is pinned to the CommonJS-compatible `0.7.1` release.
+Upgrading to an ESM-only release requires migrating this config package away
+from CommonJS first.
+
 ## Rules
 
 ### validate-token

--- a/packages/stylelint-bezier/package.json
+++ b/packages/stylelint-bezier/package.json
@@ -39,13 +39,10 @@
   "peerDependencies": {
     "@channel.io/bezier-react": "^4.0.0-next.17",
     "postcss": "^8.5.1",
-    "stylelint": ">=16.0.0"
+    "stylelint": ">=16.14.1"
   },
   "peerDependenciesMeta": {
     "@channel.io/bezier-react": {
-      "optional": true
-    },
-    "postcss": {
       "optional": true
     }
   }

--- a/packages/stylelint-bezier/package.json
+++ b/packages/stylelint-bezier/package.json
@@ -27,20 +27,25 @@
   "author": "Channel Corp.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@channel.io/bezier-tokens": "1.0.0-next.6"
+    "@channel.io/bezier-tokens": "1.0.0-next.6",
+    "postcss-styled-syntax": "0.7.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "eslint-config-bezier": "workspace:*",
-    "postcss-styled-syntax": "^0.7.0",
+    "postcss": "^8.5.1",
     "tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "@channel.io/bezier-react": "^4.0.0-next.17",
+    "postcss": "^8.5.1",
     "stylelint": ">=16.0.0"
   },
   "peerDependenciesMeta": {
     "@channel.io/bezier-react": {
+      "optional": true
+    },
+    "postcss": {
       "optional": true
     }
   }

--- a/packages/stylelint-bezier/package.json
+++ b/packages/stylelint-bezier/package.json
@@ -19,7 +19,7 @@
     "dev": "tsc --watch",
     "lint": "TIMING=1 eslint --cache .",
     "typecheck": "tsc --noEmit",
-    "test": "jest --coverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "clean": "run-s 'clean:*'",
     "clean:build": "rm -rf dist",
     "clean:cache": "rm -rf node_modules .turbo .eslintcache stats.html"
@@ -27,18 +27,19 @@
   "author": "Channel Corp.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@channel.io/bezier-tokens": "1.0.0-next.6",
-    "postcss-styled-syntax": "0.7.1"
+    "@channel.io/bezier-tokens": "1.0.0-next.6"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "eslint-config-bezier": "workspace:*",
     "postcss": "^8.5.1",
+    "postcss-styled-syntax": "0.7.2",
     "tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "@channel.io/bezier-react": "^4.0.0-next.17",
     "postcss": "^8.5.1",
+    "postcss-styled-syntax": "^0.7.2",
     "stylelint": ">=16.14.1"
   },
   "peerDependenciesMeta": {

--- a/packages/stylelint-bezier/src/index.test.ts
+++ b/packages/stylelint-bezier/src/index.test.ts
@@ -2,7 +2,10 @@ import postcssStyledSyntax from 'postcss-styled-syntax'
 import stylelint, { type Rule } from 'stylelint'
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const config = require('./index') as { rules: Record<string, unknown> }
+const config = require('./index') as {
+  rules: Record<string, unknown>
+  overrides: Array<{ customSyntax?: unknown }>
+}
 import {
   rule as componentOverride,
   ruleName as componentOverrideName,
@@ -46,6 +49,10 @@ async function warnings(
 
 test('the shared config activates only the existing token rule', () => {
   expect(config.rules).toEqual({ 'bezier/validate-token': true })
+})
+
+test('the shared config bundles the styled syntax implementation', () => {
+  expect(config.overrides[0]?.customSyntax).toBe(postcssStyledSyntax)
 })
 
 test('validate-token preserves invalid token diagnostics', async () => {
@@ -135,8 +142,6 @@ test('suppression hygiene requires a scoped concrete reason', async () => {
     '/* stylelint-disable bezier/no-component-style-override */\n.a { color: red; }'
   const valid =
     '/* stylelint-disable-next-line bezier/no-component-style-override -- Third-party widget requires this fixed width */\n.a { width: 10px; }'
-  expect(
-    await warnings(invalid, suppressionName, suppression)
-  ).toHaveLength(1)
+  expect(await warnings(invalid, suppressionName, suppression)).toHaveLength(1)
   expect(await warnings(valid, suppressionName, suppression)).toHaveLength(0)
 })

--- a/packages/stylelint-bezier/src/index.test.ts
+++ b/packages/stylelint-bezier/src/index.test.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-import postcssStyledSyntax from 'postcss-styled-syntax'
 import stylelint, { type Rule } from 'stylelint'
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -48,7 +47,7 @@ async function warnings(
     config: {
       customSyntax: codeFilename.endsWith('.css')
         ? undefined
-        : postcssStyledSyntax,
+        : 'postcss-styled-syntax',
       plugins: [{ ruleName, rule }],
       rules: { [ruleName]: true },
     },
@@ -60,16 +59,20 @@ test('the shared config activates only the existing token rule', () => {
   expect(config.rules).toEqual({ 'bezier/validate-token': true })
 })
 
-test('the shared config bundles the styled syntax implementation', () => {
-  expect(config.overrides[0]?.customSyntax).toBe(postcssStyledSyntax)
+test('the shared config delegates styled syntax loading to Stylelint', () => {
+  expect(config.overrides[0]?.customSyntax).toBe('postcss-styled-syntax')
 })
 
-test('the shared config requires a compatible PostCSS host', () => {
+test('the shared config requires compatible Stylelint runtime peers', () => {
   expect(packageJson.peerDependencies).toMatchObject({
     postcss: '^8.5.1',
+    'postcss-styled-syntax': '^0.7.2',
     stylelint: '>=16.14.1',
   })
   expect(packageJson.peerDependenciesMeta.postcss).toBeUndefined()
+  expect(
+    packageJson.peerDependenciesMeta['postcss-styled-syntax']
+  ).toBeUndefined()
 })
 
 test('validate-token preserves invalid token diagnostics', async () => {

--- a/packages/stylelint-bezier/src/index.test.ts
+++ b/packages/stylelint-bezier/src/index.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import postcssStyledSyntax from 'postcss-styled-syntax'
 import stylelint, { type Rule } from 'stylelint'
 
@@ -5,6 +8,12 @@ import stylelint, { type Rule } from 'stylelint'
 const config = require('./index') as {
   rules: Record<string, unknown>
   overrides: Array<{ customSyntax?: unknown }>
+}
+const packageJson = JSON.parse(
+  readFileSync(join(__dirname, '../package.json'), 'utf8')
+) as {
+  peerDependencies: Record<string, string>
+  peerDependenciesMeta: Record<string, unknown>
 }
 import {
   rule as componentOverride,
@@ -53,6 +62,14 @@ test('the shared config activates only the existing token rule', () => {
 
 test('the shared config bundles the styled syntax implementation', () => {
   expect(config.overrides[0]?.customSyntax).toBe(postcssStyledSyntax)
+})
+
+test('the shared config requires a compatible PostCSS host', () => {
+  expect(packageJson.peerDependencies).toMatchObject({
+    postcss: '^8.5.1',
+    stylelint: '>=16.14.1',
+  })
+  expect(packageJson.peerDependenciesMeta.postcss).toBeUndefined()
 })
 
 test('validate-token preserves invalid token diagnostics', async () => {

--- a/packages/stylelint-bezier/src/index.ts
+++ b/packages/stylelint-bezier/src/index.ts
@@ -1,3 +1,5 @@
+import postcssStyledSyntax from 'postcss-styled-syntax'
+
 module.exports = {
   plugins: [
     './plugins/no-component-style-override',
@@ -12,7 +14,7 @@ module.exports = {
   overrides: [
     {
       files: ['**/*.{ts,tsx}'],
-      customSyntax: 'postcss-styled-syntax',
+      customSyntax: postcssStyledSyntax,
     },
   ],
 }

--- a/packages/stylelint-bezier/src/index.ts
+++ b/packages/stylelint-bezier/src/index.ts
@@ -1,5 +1,3 @@
-import postcssStyledSyntax from 'postcss-styled-syntax'
-
 module.exports = {
   plugins: [
     './plugins/no-component-style-override',
@@ -14,7 +12,7 @@ module.exports = {
   overrides: [
     {
       files: ['**/*.{ts,tsx}'],
-      customSyntax: postcssStyledSyntax,
+      customSyntax: 'postcss-styled-syntax',
     },
   ],
 }

--- a/packages/stylelint-bezier/src/postcss-styled-syntax.d.ts
+++ b/packages/stylelint-bezier/src/postcss-styled-syntax.d.ts
@@ -1,6 +1,0 @@
-declare module 'postcss-styled-syntax' {
-  import { type Syntax } from 'postcss'
-
-  const syntax: Syntax
-  export default syntax
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,11 +2490,12 @@ __metadata:
     "@types/node": "npm:^22.10.2"
     eslint-config-bezier: "workspace:*"
     postcss: "npm:^8.5.1"
-    postcss-styled-syntax: "npm:0.7.1"
+    postcss-styled-syntax: "npm:0.7.2"
     tsconfig: "workspace:*"
   peerDependencies:
     "@channel.io/bezier-react": ^4.0.0-next.17
     postcss: ^8.5.1
+    postcss-styled-syntax: ^0.7.2
     stylelint: ">=16.14.1"
   peerDependenciesMeta:
     "@channel.io/bezier-react":
@@ -16067,14 +16068,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-styled-syntax@npm:0.7.1":
-  version: 0.7.1
-  resolution: "postcss-styled-syntax@npm:0.7.1"
+"postcss-styled-syntax@npm:0.7.2":
+  version: 0.7.2
+  resolution: "postcss-styled-syntax@npm:0.7.2"
   dependencies:
-    typescript: "npm:^5.7.3"
+    typescript: "npm:^6.0.3"
   peerDependencies:
     postcss: ^8.5.1
-  checksum: 10/285a714f7dd28fc4b7677fc36cd2248ae8e9f610f1f6cea46a739968562a1978d48f42cdd7c41b51764b2080ed01f9379e2c845d7ca556c8accbb6003b5a41d1
+  checksum: 10/1d05342c41f0976505b09901f09870a53d92cce19e30a5aa3802815107b97ebd069ed494d978dde602b3210651c776ce034db18f13af973bd31c4a7fb1a7c3ac
   languageName: node
   linkType: hard
 
@@ -18948,7 +18949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.3.3, typescript@npm:^5.7.3":
+"typescript@npm:^5.3.3":
   version: 5.7.3
   resolution: "typescript@npm:5.7.3"
   bin:
@@ -18968,6 +18969,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/0ef2357a4cffd916b52b683a021cdab0f81eea4e9aa35f2d254581c9a5106da02224e3392e1b0ed42b7a48f80c966e5f52b8e1a27941fa0523c1705a9c2e0330
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
@@ -18978,7 +18989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
   version: 5.7.3
   resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
   bin:
@@ -18995,6 +19006,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/d75ca10141afc64fd3474b41a8b082b640555bed388d237558aed64e5827ddadb48f90932c7f4205883f18f5bcab8b6a739a2cfac95855604b0dfeb34bc2f3eb
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/22b67a18dafedf9b1468b64ca20d9aa02ea61d449b65413d8aa6552aeb63f52ef369e86beb25b6b4c91a803d9726ee5c196f391a9b64201263263410a4223ee6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2369,7 +2369,7 @@ __metadata:
     lightningcss: "npm:^1.28.2"
     minimatch: "npm:^10.0.1"
     paths.macro: "npm:^3.0.1"
-    postcss: "npm:^8.4.49"
+    postcss: "npm:^8.5.1"
     postcss-preset-env: "npm:^10.1.1"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
@@ -16120,7 +16120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.0.0, postcss@npm:^8.4.32, postcss@npm:^8.4.33, postcss@npm:^8.4.35, postcss@npm:^8.4.49, postcss@npm:^8.5.1":
+"postcss@npm:^8.0.0, postcss@npm:^8.4.32, postcss@npm:^8.4.33, postcss@npm:^8.4.35, postcss@npm:^8.5.1":
   version: 8.5.26
   resolution: "postcss@npm:8.5.26"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,13 +2467,17 @@ __metadata:
     "@channel.io/bezier-tokens": "npm:1.0.0-next.6"
     "@types/node": "npm:^22.10.2"
     eslint-config-bezier: "workspace:*"
-    postcss-styled-syntax: "npm:^0.7.0"
+    postcss: "npm:^8.5.1"
+    postcss-styled-syntax: "npm:0.7.1"
     tsconfig: "workspace:*"
   peerDependencies:
     "@channel.io/bezier-react": ^4.0.0-next.17
+    postcss: ^8.5.1
     stylelint: ">=16.0.0"
   peerDependenciesMeta:
     "@channel.io/bezier-react":
+      optional: true
+    postcss:
       optional: true
   languageName: unknown
   linkType: soft
@@ -14319,12 +14323,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.7":
-  version: 3.3.7
-  resolution: "nanoid@npm:3.3.7"
+"nanoid@npm:^3.3.17":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/ac1eb60f615b272bccb0e2b9cd933720dad30bf9708424f691b8113826bb91aca7e9d14ef5d9415a6ba15c266b37817256f58d8ce980c82b0ba3185352565679
+  checksum: 10/1b3b4fdac831b92b56d1dbe8b1e63a372432faf86ea383134e3b53141ef8108a60b7f84343b5cefecac9550bb74edf8164da93ea07d1c4f757039bc75d8a5d9e
   languageName: node
   linkType: hard
 
@@ -15978,6 +15982,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-styled-syntax@npm:0.7.1":
+  version: 0.7.1
+  resolution: "postcss-styled-syntax@npm:0.7.1"
+  dependencies:
+    typescript: "npm:^5.7.3"
+  peerDependencies:
+    postcss: ^8.5.1
+  checksum: 10/285a714f7dd28fc4b7677fc36cd2248ae8e9f610f1f6cea46a739968562a1978d48f42cdd7c41b51764b2080ed01f9379e2c845d7ca556c8accbb6003b5a41d1
+  languageName: node
+  linkType: hard
+
 "postcss-styled-syntax@npm:^0.6.4":
   version: 0.6.4
   resolution: "postcss-styled-syntax@npm:0.6.4"
@@ -15986,17 +16001,6 @@ __metadata:
   peerDependencies:
     postcss: ^8.4.21
   checksum: 10/435bc414cc68d2d2297bb6354230226f554b88efb38610c0c35575eefc241edbabf12a4d4662957204e92091443fa25c85cb943916b61023c222e30a1127b1ff
-  languageName: node
-  linkType: hard
-
-"postcss-styled-syntax@npm:^0.7.0":
-  version: 0.7.1
-  resolution: "postcss-styled-syntax@npm:0.7.1"
-  dependencies:
-    typescript: "npm:^5.7.3"
-  peerDependencies:
-    postcss: ^8.5.1
-  checksum: 10/285a714f7dd28fc4b7677fc36cd2248ae8e9f610f1f6cea46a739968562a1978d48f42cdd7c41b51764b2080ed01f9379e2c845d7ca556c8accbb6003b5a41d1
   languageName: node
   linkType: hard
 
@@ -16030,14 +16034,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.0.0, postcss@npm:^8.4.32, postcss@npm:^8.4.33, postcss@npm:^8.4.35, postcss@npm:^8.4.49":
-  version: 8.4.49
-  resolution: "postcss@npm:8.4.49"
+"postcss@npm:^8.0.0, postcss@npm:^8.4.32, postcss@npm:^8.4.33, postcss@npm:^8.4.35, postcss@npm:^8.4.49, postcss@npm:^8.5.1":
+  version: 8.5.26
+  resolution: "postcss@npm:8.5.26"
   dependencies:
-    nanoid: "npm:^3.3.7"
+    nanoid: "npm:^3.3.17"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/28fe1005b1339870e0a5006375ba5ac1213fd69800f79e7db09c398e074421ba6e162898e94f64942fed554037fd292db3811d87835d25ab5ef7f3c9daacb6ca
+  checksum: 10/842a624f822f77cb37264cc24f0cf97c0a69dd8d6f7b4a6d76b5a8dc95355899dd044f33a2d4e890da858293de570fce18dff453f3b629ff14cac67a3591895a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1993,6 +1993,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cacheable/memory@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@cacheable/memory@npm:2.2.0"
+  dependencies:
+    "@cacheable/utils": "npm:^2.5.0"
+    "@keyv/bigmap": "npm:^1.3.1"
+    hookified: "npm:^1.15.1"
+    keyv: "npm:^5.6.0"
+  checksum: 10/97db83d7a74979accca9de56cf278e42c22b4273e752d7e23c44fbec4a47450716c4920903424fd19184a7bee6325064b6c453afc6f96bf92b39eecfe0b40648
+  languageName: node
+  linkType: hard
+
+"@cacheable/utils@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "@cacheable/utils@npm:2.5.0"
+  dependencies:
+    hashery: "npm:^1.5.1"
+    keyv: "npm:^5.6.0"
+  checksum: 10/a77a7e682926b984cb28b6993f4595638ce8799de3223dbdcdb796a077a02de763687bdc5669779019aba44d27693260ef92d860a19330d7eaa4dfcca3433c3b
+  languageName: node
+  linkType: hard
+
 "@changesets/apply-release-plan@npm:^7.0.13":
   version: 7.0.13
   resolution: "@changesets/apply-release-plan@npm:7.0.13"
@@ -2473,11 +2495,9 @@ __metadata:
   peerDependencies:
     "@channel.io/bezier-react": ^4.0.0-next.17
     postcss: ^8.5.1
-    stylelint: ">=16.0.0"
+    stylelint: ">=16.14.1"
   peerDependenciesMeta:
     "@channel.io/bezier-react":
-      optional: true
-    postcss:
       optional: true
   languageName: unknown
   linkType: soft
@@ -3994,6 +4014,25 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10/64e1ce0dc3a9e56b0118eaf1b2f50746fd59a36de37516cc6855b5370d5f367aa8229e1237536d738262e252c70ee229619cb04e3f3b822146ee3eb1b7ab297f
+  languageName: node
+  linkType: hard
+
+"@keyv/bigmap@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@keyv/bigmap@npm:1.3.1"
+  dependencies:
+    hashery: "npm:^1.4.0"
+    hookified: "npm:^1.15.0"
+  peerDependencies:
+    keyv: ^5.6.0
+  checksum: 10/9745786a94729117460b5399a964ec151e94a89db0e5ed573419c4c620f0595f05d7ad87d596bb7e212a4f3ad2335271694fddcfaa8400013f7b64e11669a884
+  languageName: node
+  linkType: hard
+
+"@keyv/serialize@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@keyv/serialize@npm:1.1.1"
+  checksum: 10/e3b2cb1377863342acedd5ff785af3e69269bee9b44707c617d1c8bc14eeb5ac763159d6455903ffe92f143c2238e1e783c4f113f9c8910eacccf172894472da
   languageName: node
   linkType: hard
 
@@ -7963,7 +8002,7 @@ __metadata:
     knip: "npm:^5.39.4"
     npm-run-all2: "npm:^7.0.1"
     prettier: "npm:^3.4.2"
-    stylelint: "npm:^16.11.0"
+    stylelint: "npm:16.14.1"
     syncpack: "npm:^13.0.0"
     ts-node: "npm:^10.9.2"
     turbo: "npm:^2.3.3"
@@ -8146,6 +8185,19 @@ __metadata:
     tar: "npm:^6.1.11"
     unique-filename: "npm:^3.0.0"
   checksum: 10/5ca58464f785d4d64ac2019fcad95451c8c89bea25949f63acd8987fcc3493eaef1beccc0fa39e673506d879d3fc1ab420760f8a14f8ddf46ea2d121805a5e96
+  languageName: node
+  linkType: hard
+
+"cacheable@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "cacheable@npm:2.5.0"
+  dependencies:
+    "@cacheable/memory": "npm:^2.2.0"
+    "@cacheable/utils": "npm:^2.5.0"
+    hookified: "npm:^1.15.0"
+    keyv: "npm:^5.6.0"
+    qified: "npm:^0.10.1"
+  checksum: 10/216a896e17dfa9c598a69e2fff31216126e94286f6c0ceb1bfab1d34e6c1a8791e8dc34dbd28660ec72a84f1d370c3733a9fc481e00a5512fd4e0cfc35775db6
   languageName: node
   linkType: hard
 
@@ -9123,13 +9175,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-tree@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "css-tree@npm:3.0.1"
+"css-tree@npm:^3.1.0":
+  version: 3.2.1
+  resolution: "css-tree@npm:3.2.1"
   dependencies:
-    mdn-data: "npm:2.12.1"
-    source-map-js: "npm:^1.0.1"
-  checksum: 10/877a77669739f94e57589c94c1ea8b7b105e373d4855e94375638b411e2913337a900120dc45c13511d0f7c339b73cecf8dc61ce28034984dbf75993dac756b0
+    mdn-data: "npm:2.27.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10/9945b387bdec756738c34d64b8287f05ca6645f51d1c8abaaa5822ec3e74533604103aaad164b8100afd8495e92120be7c1c6afbe5be89f867acc5b456ddd79c
   languageName: node
   linkType: hard
 
@@ -10802,21 +10854,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-entry-cache@npm:^10.0.5":
+  version: 10.1.4
+  resolution: "file-entry-cache@npm:10.1.4"
+  dependencies:
+    flat-cache: "npm:^6.1.13"
+  checksum: 10/286fc7d632a7c62665baf8c794ab7aaa6ea30111da2f22bdb68b1b467e7393630737f637fe93298ef3d9d1ce149233fd739508a12c16c1555fbd85fe9d225ff0
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^6.0.1":
   version: 6.0.1
   resolution: "file-entry-cache@npm:6.0.1"
   dependencies:
     flat-cache: "npm:^3.0.4"
   checksum: 10/099bb9d4ab332cb93c48b14807a6918a1da87c45dce91d4b61fd40e6505d56d0697da060cb901c729c90487067d93c9243f5da3dc9c41f0358483bfdebca736b
-  languageName: node
-  linkType: hard
-
-"file-entry-cache@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "file-entry-cache@npm:9.1.0"
-  dependencies:
-    flat-cache: "npm:^5.0.0"
-  checksum: 10/fd67a9552f272ac4a1731c545e1350bd135e208659144cc5311baac6b8bbf55da7c8c3a0bf25c71ed78eff2bdd26d2a3a8f9ba3d8bec968fe8d1eeba6ab14a96
   languageName: node
   linkType: hard
 
@@ -10954,13 +11006,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flat-cache@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "flat-cache@npm:5.0.0"
+"flat-cache@npm:^6.1.13":
+  version: 6.1.23
+  resolution: "flat-cache@npm:6.1.23"
   dependencies:
-    flatted: "npm:^3.3.1"
-    keyv: "npm:^4.5.4"
-  checksum: 10/42570762052b17a1dec221d73a1e417d0ba07137de6debaabb51389cac265a12a027a895dc84e1725bc5cdde04fe8b706ad836860b05488e9a04bda9301d2529
+    cacheable: "npm:^2.5.0"
+    flatted: "npm:^3.4.2"
+    hookified: "npm:^1.15.0"
+  checksum: 10/63ad3682f399e3e7b7255493b07469f80c418034a10e12e1c7043b41d666ff69b20be924984a0b91cd767a4f71540e4fb4421651d15adc736fca1c04b8505758
   languageName: node
   linkType: hard
 
@@ -10973,10 +11026,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.2.9, flatted@npm:^3.3.1":
+"flatted@npm:^3.2.9":
   version: 3.3.1
   resolution: "flatted@npm:3.3.1"
   checksum: 10/7b8376061d5be6e0d3658bbab8bde587647f68797cf6bfeae9dea0e5137d9f27547ab92aaff3512dd9d1299086a6d61be98e9d48a56d17531b634f77faadbc49
+  languageName: node
+  linkType: hard
+
+"flatted@npm:^3.4.2":
+  version: 3.4.4
+  resolution: "flatted@npm:3.4.4"
+  checksum: 10/5a6682ab87ed15e125419c61352c4bef26f310adceece03eae5f22c119d64ed47bfc0ee1948a77d0122559eaa86395ea06ef45b59bfe3db4fb13fb4cdff876de
   languageName: node
   linkType: hard
 
@@ -11577,6 +11637,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hashery@npm:^1.4.0, hashery@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "hashery@npm:1.5.1"
+  dependencies:
+    hookified: "npm:^1.15.0"
+  checksum: 10/34eebad3e4d4041ae5c2457f129169b7be8d067fce4717ec6b903017e82b420263808a4d89f15cc77fa21822ae36d16841dc06d945392b6833b49082d3653e82
+  languageName: node
+  linkType: hard
+
 "hasown@npm:^2.0.0, hasown@npm:^2.0.1":
   version: 2.0.1
   resolution: "hasown@npm:2.0.1"
@@ -11620,6 +11689,20 @@ __metadata:
   dependencies:
     parse-passwd: "npm:^1.0.0"
   checksum: 10/18dd4db87052c6a2179d1813adea0c4bfcfa4f9996f0e226fefb29eb3d548e564350fa28ec46b0bf1fbc0a1d2d6922ceceb80093115ea45ff8842a4990139250
+  languageName: node
+  linkType: hard
+
+"hookified@npm:^1.15.0, hookified@npm:^1.15.1":
+  version: 1.15.1
+  resolution: "hookified@npm:1.15.1"
+  checksum: 10/ecaee63506d9a213e8b78dfdb92346227f951d3bcd8ef60d14105c5590f61d466f130a908274e1ec87ee3b3668bd87d9250cad64547cf15cfa69932bcdbbea8f
+  languageName: node
+  linkType: hard
+
+"hookified@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "hookified@npm:2.2.0"
+  checksum: 10/36be80a9645161c9747c90a0a26f75f074470984cf221fb73cf0e2f367667e0d4680797f7b4f27b83d1f4cd4a3b5913f685c91132b5d6eeb05522674081657a8
   languageName: node
   linkType: hard
 
@@ -11875,13 +11958,6 @@ __metadata:
   version: 5.3.1
   resolution: "ignore@npm:5.3.1"
   checksum: 10/0a884c2fbc8c316f0b9f92beaf84464253b73230a4d4d286697be45fca081199191ca33e1c2e82d9e5f851f5e9a48a78e25a35c951e7eb41e59f150db3530065
-  languageName: node
-  linkType: hard
-
-"ignore@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "ignore@npm:6.0.2"
-  checksum: 10/af39e49996cd989763920e445eff897d0ae1e36b5f27b0e09e14a4fd2df89b362f92e720ecf06ef729056842366527db8561d310e904718810b92ffbcd23056d
   languageName: node
   linkType: hard
 
@@ -13416,12 +13492,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:^4.5.3, keyv@npm:^4.5.4":
+"keyv@npm:^4.5.3":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
   dependencies:
     json-buffer: "npm:3.0.1"
   checksum: 10/167eb6ef64cc84b6fa0780ee50c9de456b422a1e18802209234f7c2cf7eae648c7741f32e50d7e24ccb22b24c13154070b01563d642755b156c357431a191e75
+  languageName: node
+  linkType: hard
+
+"keyv@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "keyv@npm:5.6.0"
+  dependencies:
+    "@keyv/serialize": "npm:^1.1.1"
+  checksum: 10/f1de999fdf635d703d091981a0a3844fb20081e01d45c6743ada7d01f3a6570dc47d1882e10d0a98d31075b342db8e62b4ebe4f5bf473dcd0903064d718709c1
   languageName: node
   linkType: hard
 
@@ -14038,10 +14123,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdn-data@npm:2.12.1":
-  version: 2.12.1
-  resolution: "mdn-data@npm:2.12.1"
-  checksum: 10/7928cfc828b0ebbde84ce56be2e3aa729c1770bfbc83ef1dadf5f98346ab003ca0a1b3339076115d77acf623719efa3f9f2be8c69f73c453fe887cb982bfa625
+"mdn-data@npm:2.27.1":
+  version: 2.27.1
+  resolution: "mdn-data@npm:2.27.1"
+  checksum: 10/5046dc83a961b8ea82a5d6d8331d07df6b15faec61519ce2f83e49766702358e7e6af96413be977ff89080534be6762c1d5963b5dd1180c208a47c0a663226b2
   languageName: node
   linkType: hard
 
@@ -16205,6 +16290,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qified@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "qified@npm:0.10.1"
+  dependencies:
+    hookified: "npm:^2.1.1"
+  checksum: 10/65eda075defad24a3c53a0bcb0056fdaffb8355ca5dbe33bffaf3143e767dd1f0ddb403a4d9402e3bd0bc54b8efdec934055fb13eb5b6e7070835a80bf517f79
+  languageName: node
+  linkType: hard
+
 "qs@npm:^6.11.2":
   version: 6.11.2
   resolution: "qs@npm:6.11.2"
@@ -17984,9 +18078,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint@npm:^16.11.0":
-  version: 16.11.0
-  resolution: "stylelint@npm:16.11.0"
+"stylelint@npm:16.14.1":
+  version: 16.14.1
+  resolution: "stylelint@npm:16.14.1"
   dependencies:
     "@csstools/css-parser-algorithms": "npm:^3.0.4"
     "@csstools/css-tokenizer": "npm:^3.0.3"
@@ -17997,16 +18091,16 @@ __metadata:
     colord: "npm:^2.9.3"
     cosmiconfig: "npm:^9.0.0"
     css-functions-list: "npm:^3.2.3"
-    css-tree: "npm:^3.0.1"
+    css-tree: "npm:^3.1.0"
     debug: "npm:^4.3.7"
-    fast-glob: "npm:^3.3.2"
+    fast-glob: "npm:^3.3.3"
     fastest-levenshtein: "npm:^1.0.16"
-    file-entry-cache: "npm:^9.1.0"
+    file-entry-cache: "npm:^10.0.5"
     global-modules: "npm:^2.0.0"
     globby: "npm:^11.1.0"
     globjoin: "npm:^0.1.4"
     html-tags: "npm:^3.3.1"
-    ignore: "npm:^6.0.2"
+    ignore: "npm:^7.0.3"
     imurmurhash: "npm:^0.1.4"
     is-plain-object: "npm:^5.0.0"
     known-css-properties: "npm:^0.35.0"
@@ -18015,7 +18109,7 @@ __metadata:
     micromatch: "npm:^4.0.8"
     normalize-path: "npm:^3.0.0"
     picocolors: "npm:^1.1.1"
-    postcss: "npm:^8.4.49"
+    postcss: "npm:^8.5.1"
     postcss-resolve-nested-selector: "npm:^0.1.6"
     postcss-safe-parser: "npm:^7.0.1"
     postcss-selector-parser: "npm:^7.0.0"
@@ -18024,11 +18118,11 @@ __metadata:
     string-width: "npm:^4.2.3"
     supports-hyperlinks: "npm:^3.1.0"
     svg-tags: "npm:^1.0.0"
-    table: "npm:^6.8.2"
+    table: "npm:^6.9.0"
     write-file-atomic: "npm:^5.0.1"
   bin:
     stylelint: bin/stylelint.mjs
-  checksum: 10/5865450e8729fcd53f85ded56e8f7fa8e0fe7a35eb8339ebc9d3b6735f48bbf9199fb6c751df07c5ee8389977d6af339501c77e57a0a4b5c621ee34360ac2f60
+  checksum: 10/2c0c95e5ee77d946efdbe58573da75ff4b12bc89c220e78b69f0c2f94251f5e5a1096f5ab583f28f56ae14f298b1335e212d52fe066719d63b8a41d6cc8083b6
   languageName: node
   linkType: hard
 
@@ -18199,16 +18293,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"table@npm:^6.8.2":
-  version: 6.8.2
-  resolution: "table@npm:6.8.2"
+"table@npm:^6.9.0":
+  version: 6.9.0
+  resolution: "table@npm:6.9.0"
   dependencies:
     ajv: "npm:^8.0.1"
     lodash.truncate: "npm:^4.4.2"
     slice-ansi: "npm:^4.0.0"
     string-width: "npm:^4.2.3"
     strip-ansi: "npm:^6.0.1"
-  checksum: 10/2946162eb87a91b9bf4283214d26830db96f09cf517eff18e7501d47a4770c529b432bb54c9394337c3dfd6c8dbf66581f76edb37e9838beb6ec394080af4ac2
+  checksum: 10/976da6d89841566e39628d1ba107ffab126964c9390a0a877a7c54ebb08820bf388d28fe9f8dcf354b538f19634a572a506c38a3762081640013a149cc862af9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- keep the TS/TSX override as `customSyntax: 'postcss-styled-syntax'`, so Stylelint owns parser resolution and loading
- declare `postcss-styled-syntax@^0.7.2`, `postcss@^8.5.1`, and `stylelint@>=16.14.1` as required runtime peers
- keep exact `postcss-styled-syntax@0.7.2` and compatible PostCSS as development dependencies for package verification
- align the workspace Stylelint host to `16.14.1` and the Bezier React PostCSS development range to `^8.5.1`
- document the consumer install contract and add exported-config/package-contract regression tests
- enable Jest VM modules only for this package's tests so the ESM syntax can be loaded through the same string path used in production

## Why

`@channel.io/stylelint-bezier` exports the parser name but does not execute the parser implementation itself. Stylelint resolves and dynamically imports that name from the consumer environment after merging the shared config. The syntax package is therefore part of the consumer's runtime contract and belongs in required `peerDependencies`, with a development copy used only to build and test this package.

Keeping PostCSS as a required peer makes the shared host contract explicit. It avoids hiding an incompatible package-local PostCSS and lets Stylelint and `postcss-styled-syntax` resolve the same instance under strict package-manager layouts.

## Verification

- repository build, lint (including syncpack), and typecheck passed
- repository tests passed; Bezier React: 124 suites / 1,041 tests, Stylelint Bezier: 8/8 tests
- Jest: 8/8 passed
- Prettier check passed
- packed the actual package archive and tested pnpm 10 fixtures with `node-linker=isolated`, `strict-peer-dependencies=true`, `auto-install-peers=false`, and no `configBasedir` override
- all runtime peers missing: install fails and reports all three peers
- syntax missing: install fails and reports `postcss-styled-syntax`
- syntax `0.7.1`: install fails the `^0.7.2` peer contract
- PostCSS `8.4.49`: install fails the `^8.5.1` peer contract for both the config and syntax
- PostCSS `8.5.6` + syntax `0.7.2` + Stylelint `16.14.1`: install succeeds and TSX styled-components lint passes
- the valid fixture resolves host, Stylelint, and syntax to the same PostCSS realpath (`singleton: true`)

Related: WEB-13130
